### PR TITLE
Correct implementation identity for MBM and .NET compatibility

### DIFF
--- a/crates/libs/bindgen/src/helpers.rs
+++ b/crates/libs/bindgen/src/helpers.rs
@@ -310,15 +310,11 @@ pub fn gen_runtime_name(def: &TypeDef, cfg: &Cfg, gen: &Gen) -> TokenStream {
                 const NAME: &'static str = #runtime_name;
             }
         }
-    } else if def.vtable_types().iter().any(|e| e == &Type::IInspectable) {
+    } else {
         quote! {
             #cfg
-            impl ::windows::core::RuntimeName for #name {
-                const NAME: &'static str = "";
-            }
+            impl ::windows::core::RuntimeName for #name {}
         }
-    } else {
-        quote! {}
     }
 }
 

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -14,6 +14,12 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
         #(#generics: ::windows::core::RuntimeType + 'static,)*
     };
 
+    let identity_type = if let Some(first) = attributes.implement.get(0) {
+        first.to_ident()
+    } else {
+        quote! { ::windows::core::IInspectable }
+    };
+
     let original_type2 = original_type.clone();
     let original_ident = TokenStream(syn::parse_macro_input!(original_type2 as syn::ItemStruct).ident.to_string());
     let impl_ident = original_ident.join("_Impl");
@@ -75,7 +81,7 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
         }
         impl <#constraints> #impl_ident::<#(#generics,)*> {
             const VTABLES: (#(#vtbl_idents2,)*) = (#(#vtable_news,)*);
-            const IDENTITY: ::windows::core::IInspectableVtbl = ::windows::core::IInspectableVtbl::new::<Self, ::windows::core::IInspectable, -1>();
+            const IDENTITY: ::windows::core::IInspectableVtbl = ::windows::core::IInspectableVtbl::new::<Self, #identity_type, -1>();
             fn new(this: #original_ident::<#(#generics,)*>) -> Self {
                 Self {
                     base: ::core::option::Option::None,

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -85,6 +85,7 @@ impl Interface {
                 type Vtable = #vtable_name;
                 const IID: ::windows::core::GUID = #guid;
             }
+            impl ::windows::core::RuntimeName for #name {}
 
             #com_trait
             #vtable

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/impl.rs
@@ -7,6 +7,8 @@ pub trait IDMLBindingTable_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Impl 
     fn Reset(&self, desc: *const DML_BINDING_TABLE_DESC) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for IDMLBindingTable {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IDMLBindingTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLBindingTable_Impl, const OFFSET: isize>() -> IDMLBindingTable_Vtbl {
         unsafe extern "system" fn BindInputs<Identity: ::windows::core::IUnknownImpl, Impl: IDMLBindingTable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bindingcount: u32, bindings: *const DML_BINDING_DESC) {
@@ -52,6 +54,8 @@ pub trait IDMLCommandRecorder_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Im
     fn RecordDispatch(&self, commandlist: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12CommandList>, dispatchable: &::core::option::Option<IDMLDispatchable>, bindings: &::core::option::Option<IDMLBindingTable>);
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for IDMLCommandRecorder {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IDMLCommandRecorder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLCommandRecorder_Impl, const OFFSET: isize>() -> IDMLCommandRecorder_Vtbl {
         unsafe extern "system" fn RecordDispatch<Identity: ::windows::core::IUnknownImpl, Impl: IDMLCommandRecorder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, commandlist: ::windows::core::RawPtr, dispatchable: ::windows::core::RawPtr, bindings: ::windows::core::RawPtr) {
@@ -66,6 +70,7 @@ impl IDMLCommandRecorder_Vtbl {
     }
 }
 pub trait IDMLCompiledOperator_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Impl + IDMLPageable_Impl + IDMLDispatchable_Impl {}
+impl ::windows::core::RuntimeName for IDMLCompiledOperator {}
 impl IDMLCompiledOperator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLCompiledOperator_Impl, const OFFSET: isize>() -> IDMLCompiledOperator_Vtbl {
         Self { base__: IDMLDispatchable_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -78,6 +83,8 @@ impl IDMLCompiledOperator_Vtbl {
 pub trait IDMLDebugDevice_Impl: Sized {
     fn SetMuteDebugOutput(&self, mute: super::super::super::Foundation::BOOL);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDMLDebugDevice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDMLDebugDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDebugDevice_Impl, const OFFSET: isize>() -> IDMLDebugDevice_Vtbl {
@@ -105,6 +112,8 @@ pub trait IDMLDevice_Impl: Sized + IDMLObject_Impl {
     fn GetDeviceRemovedReason(&self) -> ::windows::core::Result<()>;
     fn GetParentDevice(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for IDMLDevice {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IDMLDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDevice_Impl, const OFFSET: isize>() -> IDMLDevice_Vtbl {
@@ -181,6 +190,8 @@ pub trait IDMLDevice1_Impl: Sized + IDMLObject_Impl + IDMLDevice_Impl {
     fn CompileGraph(&self, desc: *const DML_GRAPH_DESC, flags: DML_EXECUTION_FLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for IDMLDevice1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IDMLDevice1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDevice1_Impl, const OFFSET: isize>() -> IDMLDevice1_Vtbl {
         unsafe extern "system" fn CompileGraph<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDevice1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, desc: *const DML_GRAPH_DESC, flags: DML_EXECUTION_FLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -197,6 +208,7 @@ impl IDMLDevice1_Vtbl {
 pub trait IDMLDeviceChild_Impl: Sized + IDMLObject_Impl {
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDMLDeviceChild {}
 impl IDMLDeviceChild_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDeviceChild_Impl, const OFFSET: isize>() -> IDMLDeviceChild_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDeviceChild_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -213,6 +225,7 @@ impl IDMLDeviceChild_Vtbl {
 pub trait IDMLDispatchable_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Impl + IDMLPageable_Impl {
     fn GetBindingProperties(&self) -> DML_BINDING_PROPERTIES;
 }
+impl ::windows::core::RuntimeName for IDMLDispatchable {}
 impl IDMLDispatchable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDispatchable_Impl, const OFFSET: isize>() -> IDMLDispatchable_Vtbl {
         unsafe extern "system" fn GetBindingProperties<Identity: ::windows::core::IUnknownImpl, Impl: IDMLDispatchable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut DML_BINDING_PROPERTIES) {
@@ -232,6 +245,7 @@ pub trait IDMLObject_Impl: Sized {
     fn SetPrivateDataInterface(&self, guid: *const ::windows::core::GUID, data: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetName(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDMLObject {}
 impl IDMLObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLObject_Impl, const OFFSET: isize>() -> IDMLObject_Vtbl {
         unsafe extern "system" fn GetPrivateData<Identity: ::windows::core::IUnknownImpl, Impl: IDMLObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, datasize: *mut u32, data: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -267,6 +281,7 @@ impl IDMLObject_Vtbl {
     }
 }
 pub trait IDMLOperator_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Impl {}
+impl ::windows::core::RuntimeName for IDMLOperator {}
 impl IDMLOperator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLOperator_Impl, const OFFSET: isize>() -> IDMLOperator_Vtbl {
         Self { base__: IDMLDeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -278,6 +293,7 @@ impl IDMLOperator_Vtbl {
 pub trait IDMLOperatorInitializer_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Impl + IDMLPageable_Impl + IDMLDispatchable_Impl {
     fn Reset(&self, operatorcount: u32, operators: *const ::core::option::Option<IDMLCompiledOperator>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDMLOperatorInitializer {}
 impl IDMLOperatorInitializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLOperatorInitializer_Impl, const OFFSET: isize>() -> IDMLOperatorInitializer_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDMLOperatorInitializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, operatorcount: u32, operators: *const ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -292,6 +308,7 @@ impl IDMLOperatorInitializer_Vtbl {
     }
 }
 pub trait IDMLPageable_Impl: Sized + IDMLObject_Impl + IDMLDeviceChild_Impl {}
+impl ::windows::core::RuntimeName for IDMLPageable {}
 impl IDMLPageable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMLPageable_Impl, const OFFSET: isize>() -> IDMLPageable_Vtbl {
         Self { base__: IDMLDeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
@@ -4,6 +4,7 @@ pub trait IMLOperatorAttributes_Impl: Sized {
     fn GetStringAttributeElementLength(&self, name: &::windows::core::PCSTR, elementindex: u32) -> ::windows::core::Result<u32>;
     fn GetStringAttributeElement(&self, name: &::windows::core::PCSTR, elementindex: u32, attributeelementbytesize: u32, attributeelement: ::windows::core::PSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorAttributes {}
 impl IMLOperatorAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorAttributes_Impl, const OFFSET: isize>() -> IMLOperatorAttributes_Vtbl {
         unsafe extern "system" fn GetAttributeElementCount<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorAttributes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, r#type: MLOperatorAttributeType, elementcount: *mut u32) -> ::windows::core::HRESULT {
@@ -53,6 +54,7 @@ impl IMLOperatorAttributes_Vtbl {
 pub trait IMLOperatorKernel_Impl: Sized {
     fn Compute(&self, context: &::core::option::Option<IMLOperatorKernelContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorKernel {}
 impl IMLOperatorKernel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernel_Impl, const OFFSET: isize>() -> IMLOperatorKernel_Vtbl {
         unsafe extern "system" fn Compute<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -73,6 +75,7 @@ pub trait IMLOperatorKernelContext_Impl: Sized {
     fn AllocateTemporaryData(&self, size: usize) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetExecutionInterface(&self, executionobject: *mut ::core::option::Option<::windows::core::IUnknown>);
 }
+impl ::windows::core::RuntimeName for IMLOperatorKernelContext {}
 impl IMLOperatorKernelContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernelContext_Impl, const OFFSET: isize>() -> IMLOperatorKernelContext_Vtbl {
         unsafe extern "system" fn GetInputTensor<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernelContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputindex: u32, tensor: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -148,6 +151,7 @@ pub trait IMLOperatorKernelCreationContext_Impl: Sized + IMLOperatorAttributes_I
     fn GetTensorShapeDescription(&self) -> ::windows::core::Result<IMLOperatorTensorShapeDescription>;
     fn GetExecutionInterface(&self, executionobject: *mut ::core::option::Option<::windows::core::IUnknown>);
 }
+impl ::windows::core::RuntimeName for IMLOperatorKernelCreationContext {}
 impl IMLOperatorKernelCreationContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernelCreationContext_Impl, const OFFSET: isize>() -> IMLOperatorKernelCreationContext_Vtbl {
         unsafe extern "system" fn GetInputCount<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernelCreationContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -233,6 +237,7 @@ impl IMLOperatorKernelCreationContext_Vtbl {
 pub trait IMLOperatorKernelFactory_Impl: Sized {
     fn CreateKernel(&self, context: &::core::option::Option<IMLOperatorKernelCreationContext>) -> ::windows::core::Result<IMLOperatorKernel>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorKernelFactory {}
 impl IMLOperatorKernelFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernelFactory_Impl, const OFFSET: isize>() -> IMLOperatorKernelFactory_Vtbl {
         unsafe extern "system" fn CreateKernel<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorKernelFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr, kernel: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -256,6 +261,7 @@ pub trait IMLOperatorRegistry_Impl: Sized {
     fn RegisterOperatorSetSchema(&self, operatorsetid: *const MLOperatorSetId, baselineversion: i32, schema: *const *const MLOperatorSchemaDescription, schemacount: u32, typeinferrer: &::core::option::Option<IMLOperatorTypeInferrer>, shapeinferrer: &::core::option::Option<IMLOperatorShapeInferrer>) -> ::windows::core::Result<()>;
     fn RegisterOperatorKernel(&self, operatorkernel: *const MLOperatorKernelDescription, operatorkernelfactory: &::core::option::Option<IMLOperatorKernelFactory>, shapeinferrer: &::core::option::Option<IMLOperatorShapeInferrer>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorRegistry {}
 impl IMLOperatorRegistry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorRegistry_Impl, const OFFSET: isize>() -> IMLOperatorRegistry_Vtbl {
         unsafe extern "system" fn RegisterOperatorSetSchema<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorRegistry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, operatorsetid: *const MLOperatorSetId, baselineversion: i32, schema: *const *const MLOperatorSchemaDescription, schemacount: u32, typeinferrer: ::windows::core::RawPtr, shapeinferrer: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -288,6 +294,7 @@ pub trait IMLOperatorShapeInferenceContext_Impl: Sized + IMLOperatorAttributes_I
     fn GetInputTensorShape(&self, inputindex: u32, dimensioncount: u32, dimensions: *mut u32) -> ::windows::core::Result<()>;
     fn SetOutputTensorShape(&self, outputindex: u32, dimensioncount: u32, dimensions: *const u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorShapeInferenceContext {}
 impl IMLOperatorShapeInferenceContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorShapeInferenceContext_Impl, const OFFSET: isize>() -> IMLOperatorShapeInferenceContext_Vtbl {
         unsafe extern "system" fn GetInputCount<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorShapeInferenceContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -361,6 +368,7 @@ impl IMLOperatorShapeInferenceContext_Vtbl {
 pub trait IMLOperatorShapeInferrer_Impl: Sized {
     fn InferOutputShapes(&self, context: &::core::option::Option<IMLOperatorShapeInferenceContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorShapeInferrer {}
 impl IMLOperatorShapeInferrer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorShapeInferrer_Impl, const OFFSET: isize>() -> IMLOperatorShapeInferrer_Vtbl {
         unsafe extern "system" fn InferOutputShapes<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorShapeInferrer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -383,6 +391,7 @@ pub trait IMLOperatorTensor_Impl: Sized {
     fn GetData(&self) -> *mut ::core::ffi::c_void;
     fn GetDataInterface(&self, datainterface: *mut ::core::option::Option<::windows::core::IUnknown>);
 }
+impl ::windows::core::RuntimeName for IMLOperatorTensor {}
 impl IMLOperatorTensor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTensor_Impl, const OFFSET: isize>() -> IMLOperatorTensor_Vtbl {
         unsafe extern "system" fn GetDimensionCount<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTensor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -442,6 +451,7 @@ pub trait IMLOperatorTensorShapeDescription_Impl: Sized {
     fn GetOutputTensorDimensionCount(&self, outputindex: u32) -> ::windows::core::Result<u32>;
     fn GetOutputTensorShape(&self, outputindex: u32, dimensioncount: u32, dimensions: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorTensorShapeDescription {}
 impl IMLOperatorTensorShapeDescription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTensorShapeDescription_Impl, const OFFSET: isize>() -> IMLOperatorTensorShapeDescription_Vtbl {
         unsafe extern "system" fn GetInputTensorDimensionCount<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTensorShapeDescription_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputindex: u32, dimensioncount: *mut u32) -> ::windows::core::HRESULT {
@@ -502,6 +512,7 @@ pub trait IMLOperatorTypeInferenceContext_Impl: Sized + IMLOperatorAttributes_Im
     fn GetInputEdgeDescription(&self, inputindex: u32) -> ::windows::core::Result<MLOperatorEdgeDescription>;
     fn SetOutputEdgeDescription(&self, outputindex: u32, edgedescription: *const MLOperatorEdgeDescription) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorTypeInferenceContext {}
 impl IMLOperatorTypeInferenceContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTypeInferenceContext_Impl, const OFFSET: isize>() -> IMLOperatorTypeInferenceContext_Vtbl {
         unsafe extern "system" fn GetInputCount<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTypeInferenceContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -557,6 +568,7 @@ impl IMLOperatorTypeInferenceContext_Vtbl {
 pub trait IMLOperatorTypeInferrer_Impl: Sized {
     fn InferOutputTypes(&self, context: &::core::option::Option<IMLOperatorTypeInferenceContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLOperatorTypeInferrer {}
 impl IMLOperatorTypeInferrer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTypeInferrer_Impl, const OFFSET: isize>() -> IMLOperatorTypeInferrer_Vtbl {
         unsafe extern "system" fn InferOutputTypes<Identity: ::windows::core::IUnknownImpl, Impl: IMLOperatorTypeInferrer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -576,6 +588,8 @@ pub trait IWinMLEvaluationContext_Impl: Sized {
     fn GetValueByName(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<*mut WINML_BINDING_DESC>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for IWinMLEvaluationContext {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IWinMLEvaluationContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinMLEvaluationContext_Impl, const OFFSET: isize>() -> IWinMLEvaluationContext_Vtbl {
@@ -618,6 +632,8 @@ pub trait IWinMLModel_Impl: Sized {
     fn EnumerateModelInputs(&self, index: u32) -> ::windows::core::Result<*mut WINML_VARIABLE_DESC>;
     fn EnumerateModelOutputs(&self, index: u32) -> ::windows::core::Result<*mut WINML_VARIABLE_DESC>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWinMLModel {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWinMLModel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinMLModel_Impl, const OFFSET: isize>() -> IWinMLModel_Vtbl {
@@ -678,6 +694,8 @@ pub trait IWinMLRuntime_Impl: Sized {
     fn EvaluateModel(&self, pcontext: &::core::option::Option<IWinMLEvaluationContext>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for IWinMLRuntime {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IWinMLRuntime_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinMLRuntime_Impl, const OFFSET: isize>() -> IWinMLRuntime_Vtbl {
         unsafe extern "system" fn LoadModel<Identity: ::windows::core::IUnknownImpl, Impl: IWinMLRuntime_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, ppmodel: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -721,6 +739,7 @@ impl IWinMLRuntime_Vtbl {
 pub trait IWinMLRuntimeFactory_Impl: Sized {
     fn CreateRuntime(&self, runtimetype: WINML_RUNTIME_TYPE) -> ::windows::core::Result<IWinMLRuntime>;
 }
+impl ::windows::core::RuntimeName for IWinMLRuntimeFactory {}
 impl IWinMLRuntimeFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinMLRuntimeFactory_Impl, const OFFSET: isize>() -> IWinMLRuntimeFactory_Vtbl {
         unsafe extern "system" fn CreateRuntime<Identity: ::windows::core::IUnknownImpl, Impl: IWinMLRuntimeFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, runtimetype: WINML_RUNTIME_TYPE, ppruntime: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
@@ -7,6 +7,8 @@ pub trait IITDatabase_Impl: Sized {
     fn GetObjectPersistence(&self, lpwszobject: &::windows::core::PCWSTR, dwobjinstance: u32, ppvpersistence: *mut *mut ::core::ffi::c_void, fstream: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IITDatabase {}
+#[cfg(feature = "Win32_Foundation")]
 impl IITDatabase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IITDatabase_Impl, const OFFSET: isize>() -> IITDatabase_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IITDatabase_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpszhost: ::windows::core::PCWSTR, lpszmoniker: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT {
@@ -68,6 +70,8 @@ pub trait IITPropList_Impl: Sized + super::super::System::Com::IPersist_Impl + s
     fn LoadFromMem(&self, lpvdata: *mut ::core::ffi::c_void, dwbufsize: u32) -> ::windows::core::Result<()>;
     fn SaveToMem(&self, lpvdata: *mut ::core::ffi::c_void, dwbufsize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IITPropList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IITPropList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IITPropList_Impl, const OFFSET: isize>() -> IITPropList_Vtbl {
@@ -220,6 +224,8 @@ pub trait IITResultSet_Impl: Sized {
     fn GetRowStatus(&self, lrowfirst: i32, crows: i32, lprowstatus: *mut ROWSTATUS) -> ::windows::core::Result<()>;
     fn GetColumnStatus(&self, lpcolstatus: *mut COLUMNSTATUS) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IITResultSet {}
 #[cfg(feature = "Win32_Foundation")]
 impl IITResultSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IITResultSet_Impl, const OFFSET: isize>() -> IITResultSet_Vtbl {
@@ -428,6 +434,8 @@ pub trait IITWordWheel_Impl: Sized {
     fn GetDataColumns(&self, prs: &::core::option::Option<IITResultSet>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IITWordWheel {}
+#[cfg(feature = "Win32_Foundation")]
 impl IITWordWheel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IITWordWheel_Impl, const OFFSET: isize>() -> IITWordWheel_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IITWordWheel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpitdb: ::windows::core::RawPtr, lpszmoniker: ::windows::core::PCWSTR, dwflags: WORD_WHEEL_OPEN_FLAGS) -> ::windows::core::HRESULT {
@@ -520,6 +528,7 @@ pub trait IStemSink_Impl: Sized {
     fn PutAltWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
     fn PutWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStemSink {}
 impl IStemSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStemSink_Impl, const OFFSET: isize>() -> IStemSink_Vtbl {
         unsafe extern "system" fn PutAltWord<Identity: ::windows::core::IUnknownImpl, Impl: IStemSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwcinbuf: ::windows::core::PCWSTR, cwc: u32) -> ::windows::core::HRESULT {
@@ -550,6 +559,8 @@ pub trait IStemmerConfig_Impl: Sized {
     fn GetControlInfo(&self, pgrfstemflags: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
     fn LoadExternalStemmerData(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>, dwextdatatype: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IStemmerConfig {}
 #[cfg(feature = "Win32_System_Com")]
 impl IStemmerConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStemmerConfig_Impl, const OFFSET: isize>() -> IStemmerConfig_Vtbl {
@@ -603,6 +614,8 @@ pub trait IWordBreakerConfig_Impl: Sized {
     fn SetWordStemmer(&self, rclsid: *const ::windows::core::GUID, pstemmer: &::core::option::Option<super::super::System::Search::IStemmer>) -> ::windows::core::Result<()>;
     fn GetWordStemmer(&self) -> ::windows::core::Result<super::super::System::Search::IStemmer>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search"))]
+impl ::windows::core::RuntimeName for IWordBreakerConfig {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search"))]
 impl IWordBreakerConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWordBreakerConfig_Impl, const OFFSET: isize>() -> IWordBreakerConfig_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
@@ -13,6 +13,8 @@ pub trait IMXAttributes_Impl: Sized + super::super::super::System::Com::IDispatc
     fn setValue(&self, nindex: i32, strvalue: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMXAttributes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMXAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXAttributes_Impl, const OFFSET: isize>() -> IMXAttributes_Vtbl {
         unsafe extern "system" fn addAttribute<Identity: ::windows::core::IUnknownImpl, Impl: IMXAttributes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, struri: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strlocalname: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strqname: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strtype: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strvalue: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -103,6 +105,8 @@ pub trait IMXNamespaceManager_Impl: Sized {
     fn getURI(&self, pwchprefix: &::windows::core::PCWSTR, pcontextnode: &::core::option::Option<IXMLDOMNode>, pwchuri: ::windows::core::PWSTR, pcchuri: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMXNamespaceManager {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMXNamespaceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXNamespaceManager_Impl, const OFFSET: isize>() -> IMXNamespaceManager_Vtbl {
         unsafe extern "system" fn putAllowOverride<Identity: ::windows::core::IUnknownImpl, Impl: IMXNamespaceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, foverride: i16) -> ::windows::core::HRESULT {
@@ -186,6 +190,8 @@ pub trait IMXNamespacePrefixes_Impl: Sized + super::super::super::System::Com::I
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMXNamespacePrefixes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMXNamespacePrefixes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXNamespacePrefixes_Impl, const OFFSET: isize>() -> IMXNamespacePrefixes_Vtbl {
         unsafe extern "system" fn get_item<Identity: ::windows::core::IUnknownImpl, Impl: IMXNamespacePrefixes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, prefix: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -239,6 +245,8 @@ pub trait IMXReaderControl_Impl: Sized + super::super::super::System::Com::IDisp
     fn suspend(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMXReaderControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMXReaderControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXReaderControl_Impl, const OFFSET: isize>() -> IMXReaderControl_Vtbl {
         unsafe extern "system" fn abort<Identity: ::windows::core::IUnknownImpl, Impl: IMXReaderControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -271,6 +279,8 @@ impl IMXReaderControl_Vtbl {
 pub trait IMXSchemaDeclHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn schemaElementDecl(&self, oschemaelement: &::core::option::Option<ISchemaElement>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMXSchemaDeclHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMXSchemaDeclHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXSchemaDeclHandler_Impl, const OFFSET: isize>() -> IMXSchemaDeclHandler_Vtbl {
@@ -308,6 +318,8 @@ pub trait IMXWriter_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn disableOutputEscaping(&self) -> ::windows::core::Result<i16>;
     fn flush(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMXWriter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMXWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXWriter_Impl, const OFFSET: isize>() -> IMXWriter_Vtbl {
@@ -485,6 +497,8 @@ pub trait IMXXMLFilter_Impl: Sized + super::super::super::System::Com::IDispatch
     fn putref_errorHandler(&self, ohandler: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMXXMLFilter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMXXMLFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMXXMLFilter_Impl, const OFFSET: isize>() -> IMXXMLFilter_Vtbl {
         unsafe extern "system" fn getFeature<Identity: ::windows::core::IUnknownImpl, Impl: IMXXMLFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strname: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, fvalue: *mut i16) -> ::windows::core::HRESULT {
@@ -618,6 +632,7 @@ pub trait ISAXAttributes_Impl: Sized {
     fn getValueFromName(&self, pwchuri: &::windows::core::PCWSTR, cchuri: i32, pwchlocalname: &::windows::core::PCWSTR, cchlocalname: i32, ppwchvalue: *mut *mut u16, pcchvalue: *mut i32) -> ::windows::core::Result<()>;
     fn getValueFromQName(&self, pwchqname: &::windows::core::PCWSTR, cchqname: i32, ppwchvalue: *mut *mut u16, pcchvalue: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISAXAttributes {}
 impl ISAXAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXAttributes_Impl, const OFFSET: isize>() -> ISAXAttributes_Vtbl {
         unsafe extern "system" fn getLength<Identity: ::windows::core::IUnknownImpl, Impl: ISAXAttributes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnlength: *mut i32) -> ::windows::core::HRESULT {
@@ -737,6 +752,7 @@ pub trait ISAXContentHandler_Impl: Sized {
     fn processingInstruction(&self, pwchtarget: &::windows::core::PCWSTR, cchtarget: i32, pwchdata: &::windows::core::PCWSTR, cchdata: i32) -> ::windows::core::Result<()>;
     fn skippedEntity(&self, pwchname: &::windows::core::PCWSTR, cchname: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISAXContentHandler {}
 impl ISAXContentHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXContentHandler_Impl, const OFFSET: isize>() -> ISAXContentHandler_Vtbl {
         unsafe extern "system" fn putDocumentLocator<Identity: ::windows::core::IUnknownImpl, Impl: ISAXContentHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plocator: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -817,6 +833,7 @@ pub trait ISAXDTDHandler_Impl: Sized {
     fn notationDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchpublicid: &::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: &::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::Result<()>;
     fn unparsedEntityDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchpublicid: &::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: &::windows::core::PCWSTR, cchsystemid: i32, pwchnotationname: &::windows::core::PCWSTR, cchnotationname: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISAXDTDHandler {}
 impl ISAXDTDHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXDTDHandler_Impl, const OFFSET: isize>() -> ISAXDTDHandler_Vtbl {
         unsafe extern "system" fn notationDecl<Identity: ::windows::core::IUnknownImpl, Impl: ISAXDTDHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchpublicid: ::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: ::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::HRESULT {
@@ -845,6 +862,7 @@ pub trait ISAXDeclHandler_Impl: Sized {
     fn internalEntityDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchvalue: &::windows::core::PCWSTR, cchvalue: i32) -> ::windows::core::Result<()>;
     fn externalEntityDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchpublicid: &::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: &::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISAXDeclHandler {}
 impl ISAXDeclHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXDeclHandler_Impl, const OFFSET: isize>() -> ISAXDeclHandler_Vtbl {
         unsafe extern "system" fn elementDecl<Identity: ::windows::core::IUnknownImpl, Impl: ISAXDeclHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchmodel: ::windows::core::PCWSTR, cchmodel: i32) -> ::windows::core::HRESULT {
@@ -884,6 +902,8 @@ pub trait ISAXEntityResolver_Impl: Sized {
     fn resolveEntity(&self, pwchpublicid: &::windows::core::PCWSTR, pwchsystemid: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISAXEntityResolver {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISAXEntityResolver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXEntityResolver_Impl, const OFFSET: isize>() -> ISAXEntityResolver_Vtbl {
         unsafe extern "system" fn resolveEntity<Identity: ::windows::core::IUnknownImpl, Impl: ISAXEntityResolver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwchpublicid: ::windows::core::PCWSTR, pwchsystemid: ::windows::core::PCWSTR, pvarinput: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -908,6 +928,7 @@ pub trait ISAXErrorHandler_Impl: Sized {
     fn fatalError(&self, plocator: &::core::option::Option<ISAXLocator>, pwcherrormessage: &::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn ignorableWarning(&self, plocator: &::core::option::Option<ISAXLocator>, pwcherrormessage: &::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISAXErrorHandler {}
 impl ISAXErrorHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXErrorHandler_Impl, const OFFSET: isize>() -> ISAXErrorHandler_Vtbl {
         unsafe extern "system" fn error<Identity: ::windows::core::IUnknownImpl, Impl: ISAXErrorHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plocator: ::windows::core::RawPtr, pwcherrormessage: ::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -945,6 +966,7 @@ pub trait ISAXLexicalHandler_Impl: Sized {
     fn endCDATA(&self) -> ::windows::core::Result<()>;
     fn comment(&self, pwchchars: &::windows::core::PCWSTR, cchchars: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISAXLexicalHandler {}
 impl ISAXLexicalHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXLexicalHandler_Impl, const OFFSET: isize>() -> ISAXLexicalHandler_Vtbl {
         unsafe extern "system" fn startDTD<Identity: ::windows::core::IUnknownImpl, Impl: ISAXLexicalHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchpublicid: ::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: ::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::HRESULT {
@@ -1003,6 +1025,7 @@ pub trait ISAXLocator_Impl: Sized {
     fn getPublicId(&self) -> ::windows::core::Result<*mut u16>;
     fn getSystemId(&self) -> ::windows::core::Result<*mut u16>;
 }
+impl ::windows::core::RuntimeName for ISAXLocator {}
 impl ISAXLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXLocator_Impl, const OFFSET: isize>() -> ISAXLocator_Vtbl {
         unsafe extern "system" fn getColumnNumber<Identity: ::windows::core::IUnknownImpl, Impl: ISAXLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pncolumn: *mut i32) -> ::windows::core::HRESULT {
@@ -1067,6 +1090,8 @@ pub trait ISAXXMLFilter_Impl: Sized + ISAXXMLReader_Impl {
     fn putParent(&self, preader: &::core::option::Option<ISAXXMLReader>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISAXXMLFilter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISAXXMLFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXXMLFilter_Impl, const OFFSET: isize>() -> ISAXXMLFilter_Vtbl {
         unsafe extern "system" fn getParent<Identity: ::windows::core::IUnknownImpl, Impl: ISAXXMLFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppreader: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1116,6 +1141,8 @@ pub trait ISAXXMLReader_Impl: Sized {
     fn parse(&self, varinput: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn parseURL(&self, pwchurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISAXXMLReader {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISAXXMLReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISAXXMLReader_Impl, const OFFSET: isize>() -> ISAXXMLReader_Vtbl {
@@ -1296,6 +1323,8 @@ pub trait ISchema_Impl: Sized + super::super::super::System::Com::IDispatch_Impl
     fn schemaLocations(&self) -> ::windows::core::Result<ISchemaStringCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchema {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchema_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchema_Impl, const OFFSET: isize>() -> ISchema_Vtbl {
         unsafe extern "system" fn targetNamespace<Identity: ::windows::core::IUnknownImpl, Impl: ISchema_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetnamespace: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1420,6 +1449,8 @@ pub trait ISchemaAny_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn processContents(&self) -> ::windows::core::Result<SCHEMAPROCESSCONTENTS>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaAny {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaAny_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaAny_Impl, const OFFSET: isize>() -> ISchemaAny_Vtbl {
         unsafe extern "system" fn namespaces<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaAny_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, namespaces: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1463,6 +1494,8 @@ pub trait ISchemaAttribute_Impl: Sized + super::super::super::System::Com::IDisp
     fn r#use(&self) -> ::windows::core::Result<SCHEMAUSE>;
     fn isReference(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaAttribute {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaAttribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaAttribute_Impl, const OFFSET: isize>() -> ISchemaAttribute_Vtbl {
@@ -1552,6 +1585,8 @@ pub trait ISchemaAttributeGroup_Impl: Sized + super::super::super::System::Com::
     fn attributes(&self) -> ::windows::core::Result<ISchemaItemCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaAttributeGroup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaAttributeGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaAttributeGroup_Impl, const OFFSET: isize>() -> ISchemaAttributeGroup_Vtbl {
         unsafe extern "system" fn anyAttribute<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaAttributeGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, anyattribute: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1595,6 +1630,8 @@ pub trait ISchemaComplexType_Impl: Sized + super::super::super::System::Com::IDi
     fn contentModel(&self) -> ::windows::core::Result<ISchemaModelGroup>;
     fn prohibitedSubstitutions(&self) -> ::windows::core::Result<SCHEMADERIVATIONMETHOD>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaComplexType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaComplexType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaComplexType_Impl, const OFFSET: isize>() -> ISchemaComplexType_Vtbl {
@@ -1692,6 +1729,8 @@ pub trait ISchemaElement_Impl: Sized + super::super::super::System::Com::IDispat
     fn isAbstract(&self) -> ::windows::core::Result<i16>;
     fn isReference(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaElement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaElement_Impl, const OFFSET: isize>() -> ISchemaElement_Vtbl {
@@ -1842,6 +1881,8 @@ pub trait ISchemaIdentityConstraint_Impl: Sized + super::super::super::System::C
     fn referencedKey(&self) -> ::windows::core::Result<ISchemaIdentityConstraint>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaIdentityConstraint {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaIdentityConstraint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaIdentityConstraint_Impl, const OFFSET: isize>() -> ISchemaIdentityConstraint_Vtbl {
         unsafe extern "system" fn selector<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaIdentityConstraint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, selector: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1898,6 +1939,8 @@ pub trait ISchemaItem_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn unhandledAttributes(&self) -> ::windows::core::Result<IVBSAXAttributes>;
     fn writeAnnotation(&self, annotationsink: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaItem_Impl, const OFFSET: isize>() -> ISchemaItem_Vtbl {
@@ -2002,6 +2045,8 @@ pub trait ISchemaItemCollection_Impl: Sized + super::super::super::System::Com::
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaItemCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaItemCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaItemCollection_Impl, const OFFSET: isize>() -> ISchemaItemCollection_Vtbl {
         unsafe extern "system" fn get_item<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaItemCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, item: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2077,6 +2122,8 @@ pub trait ISchemaModelGroup_Impl: Sized + super::super::super::System::Com::IDis
     fn particles(&self) -> ::windows::core::Result<ISchemaItemCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaModelGroup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaModelGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaModelGroup_Impl, const OFFSET: isize>() -> ISchemaModelGroup_Vtbl {
         unsafe extern "system" fn particles<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaModelGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, particles: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2101,6 +2148,8 @@ pub trait ISchemaNotation_Impl: Sized + super::super::super::System::Com::IDispa
     fn systemIdentifier(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn publicIdentifier(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaNotation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaNotation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaNotation_Impl, const OFFSET: isize>() -> ISchemaNotation_Vtbl {
@@ -2142,6 +2191,8 @@ pub trait ISchemaParticle_Impl: Sized + super::super::super::System::Com::IDispa
     fn maxOccurs(&self) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaParticle {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaParticle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaParticle_Impl, const OFFSET: isize>() -> ISchemaParticle_Vtbl {
         unsafe extern "system" fn minOccurs<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaParticle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, minoccurs: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2182,6 +2233,8 @@ pub trait ISchemaStringCollection_Impl: Sized + super::super::super::System::Com
     fn length(&self) -> ::windows::core::Result<i32>;
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaStringCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaStringCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaStringCollection_Impl, const OFFSET: isize>() -> ISchemaStringCollection_Vtbl {
@@ -2249,6 +2302,8 @@ pub trait ISchemaType_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn whitespace(&self) -> ::windows::core::Result<SCHEMAWHITESPACE>;
     fn patterns(&self) -> ::windows::core::Result<ISchemaStringCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchemaType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchemaType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaType_Impl, const OFFSET: isize>() -> ISchemaType_Vtbl {
@@ -2472,6 +2527,8 @@ pub trait IServerXMLHTTPRequest_Impl: Sized + super::super::super::System::Com::
     fn setOption(&self, option: SERVERXMLHTTP_OPTION, value: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IServerXMLHTTPRequest {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IServerXMLHTTPRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServerXMLHTTPRequest_Impl, const OFFSET: isize>() -> IServerXMLHTTPRequest_Vtbl {
         unsafe extern "system" fn setTimeouts<Identity: ::windows::core::IUnknownImpl, Impl: IServerXMLHTTPRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resolvetimeout: i32, connecttimeout: i32, sendtimeout: i32, receivetimeout: i32) -> ::windows::core::HRESULT {
@@ -2524,6 +2581,8 @@ pub trait IServerXMLHTTPRequest2_Impl: Sized + super::super::super::System::Com:
     fn setProxyCredentials(&self, bstrusername: &super::super::super::Foundation::BSTR, bstrpassword: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IServerXMLHTTPRequest2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IServerXMLHTTPRequest2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServerXMLHTTPRequest2_Impl, const OFFSET: isize>() -> IServerXMLHTTPRequest2_Vtbl {
         unsafe extern "system" fn setProxy<Identity: ::windows::core::IUnknownImpl, Impl: IServerXMLHTTPRequest2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, proxysetting: SXH_PROXY_SETTING, varproxyserver: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>, varbypasslist: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -2560,6 +2619,8 @@ pub trait IVBMXNamespaceManager_Impl: Sized + super::super::super::System::Com::
     fn getURI(&self, prefix: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
     fn getURIFromNode(&self, strprefix: &super::super::super::Foundation::BSTR, contextnode: &::core::option::Option<IXMLDOMNode>) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBMXNamespaceManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBMXNamespaceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBMXNamespaceManager_Impl, const OFFSET: isize>() -> IVBMXNamespaceManager_Vtbl {
@@ -2682,6 +2743,8 @@ pub trait IVBSAXAttributes_Impl: Sized + super::super::super::System::Com::IDisp
     fn getValueFromName(&self, struri: &super::super::super::Foundation::BSTR, strlocalname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn getValueFromQName(&self, strqname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXAttributes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXAttributes_Impl, const OFFSET: isize>() -> IVBSAXAttributes_Vtbl {
@@ -2852,6 +2915,8 @@ pub trait IVBSAXContentHandler_Impl: Sized + super::super::super::System::Com::I
     fn skippedEntity(&self, strname: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXContentHandler {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXContentHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXContentHandler_Impl, const OFFSET: isize>() -> IVBSAXContentHandler_Vtbl {
         unsafe extern "system" fn putref_documentLocator<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXContentHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, olocator: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2934,6 +2999,8 @@ pub trait IVBSAXDTDHandler_Impl: Sized + super::super::super::System::Com::IDisp
     fn unparsedEntityDecl(&self, strname: *mut super::super::super::Foundation::BSTR, strpublicid: *mut super::super::super::Foundation::BSTR, strsystemid: *mut super::super::super::Foundation::BSTR, strnotationname: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXDTDHandler {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXDTDHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXDTDHandler_Impl, const OFFSET: isize>() -> IVBSAXDTDHandler_Vtbl {
         unsafe extern "system" fn notationDecl<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXDTDHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strname: *mut super::super::super::Foundation::BSTR, strpublicid: *mut super::super::super::Foundation::BSTR, strsystemid: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2963,6 +3030,8 @@ pub trait IVBSAXDeclHandler_Impl: Sized + super::super::super::System::Com::IDis
     fn internalEntityDecl(&self, strname: *mut super::super::super::Foundation::BSTR, strvalue: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn externalEntityDecl(&self, strname: *mut super::super::super::Foundation::BSTR, strpublicid: *mut super::super::super::Foundation::BSTR, strsystemid: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXDeclHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXDeclHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXDeclHandler_Impl, const OFFSET: isize>() -> IVBSAXDeclHandler_Vtbl {
@@ -3003,6 +3072,8 @@ pub trait IVBSAXEntityResolver_Impl: Sized + super::super::super::System::Com::I
     fn resolveEntity(&self, strpublicid: *mut super::super::super::Foundation::BSTR, strsystemid: *mut super::super::super::Foundation::BSTR, varinput: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXEntityResolver {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXEntityResolver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXEntityResolver_Impl, const OFFSET: isize>() -> IVBSAXEntityResolver_Vtbl {
         unsafe extern "system" fn resolveEntity<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXEntityResolver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strpublicid: *mut super::super::super::Foundation::BSTR, strsystemid: *mut super::super::super::Foundation::BSTR, varinput: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3025,6 +3096,8 @@ pub trait IVBSAXErrorHandler_Impl: Sized + super::super::super::System::Com::IDi
     fn fatalError(&self, olocator: &::core::option::Option<IVBSAXLocator>, strerrormessage: *mut super::super::super::Foundation::BSTR, nerrorcode: i32) -> ::windows::core::Result<()>;
     fn ignorableWarning(&self, olocator: &::core::option::Option<IVBSAXLocator>, strerrormessage: *mut super::super::super::Foundation::BSTR, nerrorcode: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXErrorHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXErrorHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXErrorHandler_Impl, const OFFSET: isize>() -> IVBSAXErrorHandler_Vtbl {
@@ -3064,6 +3137,8 @@ pub trait IVBSAXLexicalHandler_Impl: Sized + super::super::super::System::Com::I
     fn endCDATA(&self) -> ::windows::core::Result<()>;
     fn comment(&self, strchars: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXLexicalHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXLexicalHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXLexicalHandler_Impl, const OFFSET: isize>() -> IVBSAXLexicalHandler_Vtbl {
@@ -3124,6 +3199,8 @@ pub trait IVBSAXLocator_Impl: Sized + super::super::super::System::Com::IDispatc
     fn publicId(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn systemId(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXLocator_Impl, const OFFSET: isize>() -> IVBSAXLocator_Vtbl {
@@ -3189,6 +3266,8 @@ pub trait IVBSAXXMLFilter_Impl: Sized + super::super::super::System::Com::IDispa
     fn putref_parent(&self, oreader: &::core::option::Option<IVBSAXXMLReader>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXXMLFilter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXXMLFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXXMLFilter_Impl, const OFFSET: isize>() -> IVBSAXXMLFilter_Vtbl {
         unsafe extern "system" fn parent<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXXMLFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, oreader: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3238,6 +3317,8 @@ pub trait IVBSAXXMLReader_Impl: Sized + super::super::super::System::Com::IDispa
     fn parse(&self, varinput: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn parseURL(&self, strurl: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVBSAXXMLReader {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVBSAXXMLReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBSAXXMLReader_Impl, const OFFSET: isize>() -> IVBSAXXMLReader_Vtbl {
@@ -3411,6 +3492,8 @@ pub trait IXMLAttribute_Impl: Sized + super::super::super::System::Com::IDispatc
     fn value(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLAttribute {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLAttribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLAttribute_Impl, const OFFSET: isize>() -> IXMLAttribute_Vtbl {
         unsafe extern "system" fn name<Identity: ::windows::core::IUnknownImpl, Impl: IXMLAttribute_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, n: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3452,6 +3535,8 @@ pub trait IXMLDOMAttribute_Impl: Sized + super::super::super::System::Com::IDisp
     fn Setvalue(&self, attributevalue: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMAttribute {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMAttribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMAttribute_Impl, const OFFSET: isize>() -> IXMLDOMAttribute_Vtbl {
         unsafe extern "system" fn name<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMAttribute_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, attributename: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3483,6 +3568,8 @@ impl IXMLDOMAttribute_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMCDATASection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl + IXMLDOMNode_Impl + IXMLDOMCharacterData_Impl + IXMLDOMText_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMCDATASection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMCDATASection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMCDATASection_Impl, const OFFSET: isize>() -> IXMLDOMCDATASection_Vtbl {
         Self { base__: IXMLDOMText_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3502,6 +3589,8 @@ pub trait IXMLDOMCharacterData_Impl: Sized + super::super::super::System::Com::I
     fn deleteData(&self, offset: i32, count: i32) -> ::windows::core::Result<()>;
     fn replaceData(&self, offset: i32, count: i32, data: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMCharacterData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMCharacterData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMCharacterData_Impl, const OFFSET: isize>() -> IXMLDOMCharacterData_Vtbl {
@@ -3564,6 +3653,8 @@ impl IXMLDOMCharacterData_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMComment_Impl: Sized + super::super::super::System::Com::IDispatch_Impl + IXMLDOMNode_Impl + IXMLDOMCharacterData_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMComment {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMComment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMComment_Impl, const OFFSET: isize>() -> IXMLDOMComment_Vtbl {
         Self { base__: IXMLDOMCharacterData_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3608,6 +3699,8 @@ pub trait IXMLDOMDocument_Impl: Sized + super::super::super::System::Com::IDispa
     fn Setondataavailable(&self, ondataavailablesink: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Setontransformnode(&self, ontransformnodesink: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMDocument {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocument_Impl, const OFFSET: isize>() -> IXMLDOMDocument_Vtbl {
@@ -3917,6 +4010,8 @@ pub trait IXMLDOMDocument2_Impl: Sized + super::super::super::System::Com::IDisp
     fn getProperty(&self, name: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMDocument2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMDocument2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocument2_Impl, const OFFSET: isize>() -> IXMLDOMDocument2_Vtbl {
         unsafe extern "system" fn namespaces<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocument2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, namespacecollection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3993,6 +4088,8 @@ pub trait IXMLDOMDocument3_Impl: Sized + super::super::super::System::Com::IDisp
     fn importNode(&self, node: &::core::option::Option<IXMLDOMNode>, deep: i16) -> ::windows::core::Result<IXMLDOMNode>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMDocument3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMDocument3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocument3_Impl, const OFFSET: isize>() -> IXMLDOMDocument3_Vtbl {
         unsafe extern "system" fn validateNode<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocument3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, node: ::windows::core::RawPtr, errorobj: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4030,6 +4127,8 @@ impl IXMLDOMDocument3_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMDocumentFragment_Impl: Sized + super::super::super::System::Com::IDispatch_Impl + IXMLDOMNode_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMDocumentFragment {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMDocumentFragment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocumentFragment_Impl, const OFFSET: isize>() -> IXMLDOMDocumentFragment_Vtbl {
         Self { base__: IXMLDOMNode_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -4044,6 +4143,8 @@ pub trait IXMLDOMDocumentType_Impl: Sized + super::super::super::System::Com::ID
     fn entities(&self) -> ::windows::core::Result<IXMLDOMNamedNodeMap>;
     fn notations(&self) -> ::windows::core::Result<IXMLDOMNamedNodeMap>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMDocumentType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMDocumentType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMDocumentType_Impl, const OFFSET: isize>() -> IXMLDOMDocumentType_Vtbl {
@@ -4097,6 +4198,8 @@ pub trait IXMLDOMElement_Impl: Sized + super::super::super::System::Com::IDispat
     fn getElementsByTagName(&self, tagname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IXMLDOMNodeList>;
     fn normalize(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMElement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMElement_Impl, const OFFSET: isize>() -> IXMLDOMElement_Vtbl {
@@ -4193,6 +4296,8 @@ pub trait IXMLDOMEntity_Impl: Sized + super::super::super::System::Com::IDispatc
     fn notationName(&self, name: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMEntity {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMEntity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMEntity_Impl, const OFFSET: isize>() -> IXMLDOMEntity_Vtbl {
         unsafe extern "system" fn publicId<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMEntity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, publicid: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4224,6 +4329,8 @@ impl IXMLDOMEntity_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMEntityReference_Impl: Sized + super::super::super::System::Com::IDispatch_Impl + IXMLDOMNode_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMEntityReference {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMEntityReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMEntityReference_Impl, const OFFSET: isize>() -> IXMLDOMEntityReference_Vtbl {
         Self { base__: IXMLDOMNode_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -4236,6 +4343,8 @@ impl IXMLDOMEntityReference_Vtbl {
 pub trait IXMLDOMImplementation_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn hasFeature(&self, feature: &super::super::super::Foundation::BSTR, version: &super::super::super::Foundation::BSTR, hasfeature: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMImplementation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMImplementation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMImplementation_Impl, const OFFSET: isize>() -> IXMLDOMImplementation_Vtbl {
@@ -4263,6 +4372,8 @@ pub trait IXMLDOMNamedNodeMap_Impl: Sized + super::super::super::System::Com::ID
     fn reset(&self) -> ::windows::core::Result<()>;
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMNamedNodeMap {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMNamedNodeMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMNamedNodeMap_Impl, const OFFSET: isize>() -> IXMLDOMNamedNodeMap_Vtbl {
@@ -4421,6 +4532,8 @@ pub trait IXMLDOMNode_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn baseName(&self, namestring: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn transformNodeToObject(&self, stylesheet: &::core::option::Option<IXMLDOMNode>, outputobject: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMNode {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMNode_Impl, const OFFSET: isize>() -> IXMLDOMNode_Vtbl {
@@ -4753,6 +4866,8 @@ pub trait IXMLDOMNodeList_Impl: Sized + super::super::super::System::Com::IDispa
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMNodeList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMNodeList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMNodeList_Impl, const OFFSET: isize>() -> IXMLDOMNodeList_Vtbl {
         unsafe extern "system" fn get_item<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMNodeList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, listitem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4817,6 +4932,8 @@ pub trait IXMLDOMNotation_Impl: Sized + super::super::super::System::Com::IDispa
     fn systemId(&self, systemid: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMNotation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMNotation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMNotation_Impl, const OFFSET: isize>() -> IXMLDOMNotation_Vtbl {
         unsafe extern "system" fn publicId<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMNotation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, publicid: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4849,6 +4966,8 @@ pub trait IXMLDOMParseError_Impl: Sized + super::super::super::System::Com::IDis
     fn linepos(&self, lineposition: *mut i32) -> ::windows::core::Result<()>;
     fn filepos(&self, fileposition: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMParseError {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMParseError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMParseError_Impl, const OFFSET: isize>() -> IXMLDOMParseError_Vtbl {
@@ -4909,6 +5028,8 @@ pub trait IXMLDOMParseError2_Impl: Sized + super::super::super::System::Com::IDi
     fn errorParameters(&self, index: i32) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn errorParametersCount(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMParseError2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMParseError2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMParseError2_Impl, const OFFSET: isize>() -> IXMLDOMParseError2_Vtbl {
@@ -4976,6 +5097,8 @@ pub trait IXMLDOMParseErrorCollection_Impl: Sized + super::super::super::System:
     fn reset(&self) -> ::windows::core::Result<()>;
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMParseErrorCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMParseErrorCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMParseErrorCollection_Impl, const OFFSET: isize>() -> IXMLDOMParseErrorCollection_Vtbl {
@@ -5048,6 +5171,8 @@ pub trait IXMLDOMProcessingInstruction_Impl: Sized + super::super::super::System
     fn Setdata(&self, value: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMProcessingInstruction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMProcessingInstruction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMProcessingInstruction_Impl, const OFFSET: isize>() -> IXMLDOMProcessingInstruction_Vtbl {
         unsafe extern "system" fn target<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMProcessingInstruction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5086,6 +5211,8 @@ pub trait IXMLDOMSchemaCollection_Impl: Sized + super::super::super::System::Com
     fn addCollection(&self, othercollection: &::core::option::Option<IXMLDOMSchemaCollection>) -> ::windows::core::Result<()>;
     fn _newEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMSchemaCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMSchemaCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMSchemaCollection_Impl, const OFFSET: isize>() -> IXMLDOMSchemaCollection_Vtbl {
@@ -5172,6 +5299,8 @@ pub trait IXMLDOMSchemaCollection2_Impl: Sized + super::super::super::System::Co
     fn getDeclaration(&self, node: &::core::option::Option<IXMLDOMNode>) -> ::windows::core::Result<ISchemaItem>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMSchemaCollection2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMSchemaCollection2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMSchemaCollection2_Impl, const OFFSET: isize>() -> IXMLDOMSchemaCollection2_Vtbl {
         unsafe extern "system" fn validate<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMSchemaCollection2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5244,6 +5373,8 @@ pub trait IXMLDOMSelection_Impl: Sized + super::super::super::System::Com::IDisp
     fn getProperty(&self, name: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
     fn setProperty(&self, name: &super::super::super::Foundation::BSTR, value: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMSelection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMSelection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMSelection_Impl, const OFFSET: isize>() -> IXMLDOMSelection_Vtbl {
@@ -5368,6 +5499,8 @@ pub trait IXMLDOMText_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn splitText(&self, offset: i32) -> ::windows::core::Result<IXMLDOMText>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDOMText {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDOMText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMText_Impl, const OFFSET: isize>() -> IXMLDOMText_Vtbl {
         unsafe extern "system" fn splitText<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDOMText_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offset: i32, righthandtextnode: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5395,6 +5528,8 @@ pub trait IXMLDSOControl_Impl: Sized + super::super::super::System::Com::IDispat
     fn SetJavaDSOCompatible(&self, fjavadsocompatible: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn readyState(&self, state: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDSOControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDSOControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDSOControl_Impl, const OFFSET: isize>() -> IXMLDSOControl_Vtbl {
@@ -5459,6 +5594,8 @@ pub trait IXMLDocument_Impl: Sized + super::super::super::System::Com::IDispatch
     fn dtdURL(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn createElement(&self, vtype: &super::super::super::System::Com::VARIANT, var1: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<IXMLElement>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDocument {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDocument_Impl, const OFFSET: isize>() -> IXMLDocument_Vtbl {
@@ -5645,6 +5782,8 @@ pub trait IXMLDocument2_Impl: Sized + super::super::super::System::Com::IDispatc
     fn r#async(&self) -> ::windows::core::Result<i16>;
     fn Setasync(&self, f: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLDocument2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLDocument2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLDocument2_Impl, const OFFSET: isize>() -> IXMLDocument2_Vtbl {
@@ -5846,6 +5985,8 @@ pub trait IXMLElement_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn removeChild(&self, pchildelem: &::core::option::Option<IXMLElement>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLElement {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLElement_Impl, const OFFSET: isize>() -> IXMLElement_Vtbl {
         unsafe extern "system" fn tagName<Identity: ::windows::core::IUnknownImpl, Impl: IXMLElement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, p: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5980,6 +6121,8 @@ pub trait IXMLElement2_Impl: Sized + super::super::super::System::Com::IDispatch
     fn removeChild(&self, pchildelem: &::core::option::Option<IXMLElement2>) -> ::windows::core::Result<()>;
     fn attributes(&self) -> ::windows::core::Result<IXMLElementCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLElement2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLElement2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLElement2_Impl, const OFFSET: isize>() -> IXMLElement2_Vtbl {
@@ -6119,6 +6262,8 @@ pub trait IXMLElementCollection_Impl: Sized + super::super::super::System::Com::
     fn item(&self, var1: &super::super::super::System::Com::VARIANT, var2: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::super::System::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLElementCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLElementCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLElementCollection_Impl, const OFFSET: isize>() -> IXMLElementCollection_Vtbl {
         unsafe extern "system" fn Setlength<Identity: ::windows::core::IUnknownImpl, Impl: IXMLElementCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, v: i32) -> ::windows::core::HRESULT {
@@ -6176,6 +6321,8 @@ pub trait IXMLError_Impl: Sized {
     fn GetErrorInfo(&self, perrorreturn: *mut XML_ERROR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXMLError {}
+#[cfg(feature = "Win32_Foundation")]
 impl IXMLError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLError_Impl, const OFFSET: isize>() -> IXMLError_Vtbl {
         unsafe extern "system" fn GetErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: IXMLError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, perrorreturn: *mut XML_ERROR) -> ::windows::core::HRESULT {
@@ -6206,6 +6353,8 @@ pub trait IXMLHTTPRequest_Impl: Sized + super::super::super::System::Com::IDispa
     fn readyState(&self) -> ::windows::core::Result<i32>;
     fn Setonreadystatechange(&self, preadystatesink: &::core::option::Option<super::super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLHTTPRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLHTTPRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest_Impl, const OFFSET: isize>() -> IXMLHTTPRequest_Vtbl {
@@ -6369,6 +6518,8 @@ pub trait IXMLHTTPRequest2_Impl: Sized {
     fn GetResponseHeader(&self, pwszheader: &::windows::core::PCWSTR) -> ::windows::core::Result<*mut u16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXMLHTTPRequest2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXMLHTTPRequest2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest2_Impl, const OFFSET: isize>() -> IXMLHTTPRequest2_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszmethod: ::windows::core::PCWSTR, pwszurl: ::windows::core::PCWSTR, pstatuscallback: ::windows::core::RawPtr, pwszusername: ::windows::core::PCWSTR, pwszpassword: ::windows::core::PCWSTR, pwszproxyusername: ::windows::core::PCWSTR, pwszproxypassword: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -6466,6 +6617,8 @@ pub trait IXMLHTTPRequest2Callback_Impl: Sized {
     fn OnError(&self, pxhr: &::core::option::Option<IXMLHTTPRequest2>, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IXMLHTTPRequest2Callback {}
+#[cfg(feature = "Win32_System_Com")]
 impl IXMLHTTPRequest2Callback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest2Callback_Impl, const OFFSET: isize>() -> IXMLHTTPRequest2Callback_Vtbl {
         unsafe extern "system" fn OnRedirect<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest2Callback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pxhr: ::windows::core::RawPtr, pwszredirecturl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -6511,6 +6664,8 @@ pub trait IXMLHTTPRequest3_Impl: Sized + IXMLHTTPRequest2_Impl {
     fn SetClientCertificate(&self, cbclientcertificatehash: u32, pbclientcertificatehash: *const u8, pwszpin: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXMLHTTPRequest3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXMLHTTPRequest3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest3_Impl, const OFFSET: isize>() -> IXMLHTTPRequest3_Vtbl {
         unsafe extern "system" fn SetClientCertificate<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbclientcertificatehash: u32, pbclientcertificatehash: *const u8, pwszpin: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -6529,6 +6684,8 @@ pub trait IXMLHTTPRequest3Callback_Impl: Sized + IXMLHTTPRequest2Callback_Impl {
     fn OnServerCertificateReceived(&self, pxhr: &::core::option::Option<IXMLHTTPRequest3>, dwcertificateerrors: u32, cservercertificatechain: u32, rgservercertificatechain: *const XHR_CERT) -> ::windows::core::Result<()>;
     fn OnClientCertificateRequested(&self, pxhr: &::core::option::Option<IXMLHTTPRequest3>, cissuerlist: u32, rgpwszissuerlist: *const *const u16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IXMLHTTPRequest3Callback {}
 #[cfg(feature = "Win32_System_Com")]
 impl IXMLHTTPRequest3Callback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHTTPRequest3Callback_Impl, const OFFSET: isize>() -> IXMLHTTPRequest3Callback_Vtbl {
@@ -6569,6 +6726,8 @@ pub trait IXMLHttpRequest_Impl: Sized + super::super::super::System::Com::IDispa
     fn readyState(&self) -> ::windows::core::Result<i32>;
     fn Setonreadystatechange(&self, preadystatesink: &::core::option::Option<super::super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXMLHttpRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXMLHttpRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLHttpRequest_Impl, const OFFSET: isize>() -> IXMLHttpRequest_Vtbl {
@@ -6736,6 +6895,8 @@ pub trait IXSLProcessor_Impl: Sized + super::super::super::System::Com::IDispatc
     fn stylesheet(&self) -> ::windows::core::Result<IXMLDOMNode>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXSLProcessor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXSLProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXSLProcessor_Impl, const OFFSET: isize>() -> IXSLProcessor_Vtbl {
         unsafe extern "system" fn Setinput<Identity: ::windows::core::IUnknownImpl, Impl: IXSLProcessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, var: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -6885,6 +7046,8 @@ pub trait IXSLTemplate_Impl: Sized + super::super::super::System::Com::IDispatch
     fn createProcessor(&self) -> ::windows::core::Result<IXSLProcessor>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXSLTemplate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXSLTemplate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXSLTemplate_Impl, const OFFSET: isize>() -> IXSLTemplate_Vtbl {
         unsafe extern "system" fn putref_stylesheet<Identity: ::windows::core::IUnknownImpl, Impl: IXSLTemplate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stylesheet: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6937,6 +7100,8 @@ pub trait IXTLRuntime_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn formatDate(&self, vardate: &super::super::super::System::Com::VARIANT, bstrformat: &super::super::super::Foundation::BSTR, vardestlocale: &super::super::super::System::Com::VARIANT, pbstrformattedstring: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn formatTime(&self, vartime: &super::super::super::System::Com::VARIANT, bstrformat: &super::super::super::Foundation::BSTR, vardestlocale: &super::super::super::System::Com::VARIANT, pbstrformattedstring: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXTLRuntime {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXTLRuntime_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXTLRuntime_Impl, const OFFSET: isize>() -> IXTLRuntime_Vtbl {
@@ -7004,6 +7169,8 @@ impl IXTLRuntime_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait XMLDOMDocumentEvents_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for XMLDOMDocumentEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl XMLDOMDocumentEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: XMLDOMDocumentEvents_Impl, const OFFSET: isize>() -> XMLDOMDocumentEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
@@ -25,6 +25,8 @@ pub trait IXmlReader_Impl: Sized {
     fn IsEOF(&self) -> super::super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXmlReader {}
+#[cfg(feature = "Win32_Foundation")]
 impl IXmlReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXmlReader_Impl, const OFFSET: isize>() -> IXmlReader_Vtbl {
         unsafe extern "system" fn SetInput<Identity: ::windows::core::IUnknownImpl, Impl: IXmlReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinput: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -212,6 +214,7 @@ impl IXmlReader_Vtbl {
 pub trait IXmlResolver_Impl: Sized {
     fn ResolveUri(&self, pwszbaseuri: &::windows::core::PCWSTR, pwszpublicidentifier: &::windows::core::PCWSTR, pwszsystemidentifier: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IXmlResolver {}
 impl IXmlResolver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXmlResolver_Impl, const OFFSET: isize>() -> IXmlResolver_Vtbl {
         unsafe extern "system" fn ResolveUri<Identity: ::windows::core::IUnknownImpl, Impl: IXmlResolver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszbaseuri: ::windows::core::PCWSTR, pwszpublicidentifier: ::windows::core::PCWSTR, pwszsystemidentifier: ::windows::core::PCWSTR, ppresolvedinput: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -263,6 +266,8 @@ pub trait IXmlWriter_Impl: Sized {
     fn WriteWhitespace(&self, pwszwhitespace: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXmlWriter {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXmlWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXmlWriter_Impl, const OFFSET: isize>() -> IXmlWriter_Vtbl {
@@ -485,6 +490,8 @@ pub trait IXmlWriterLite_Impl: Sized {
     fn WriteWhitespace(&self, pwszwhitespace: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXmlWriterLite {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXmlWriterLite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXmlWriterLite_Impl, const OFFSET: isize>() -> IXmlWriterLite_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/impl.rs
@@ -4,6 +4,7 @@ pub trait ICreateDeviceAccessAsync_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn GetResult(&self, riid: *const ::windows::core::GUID, deviceaccess: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICreateDeviceAccessAsync {}
 impl ICreateDeviceAccessAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateDeviceAccessAsync_Impl, const OFFSET: isize>() -> ICreateDeviceAccessAsync_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: ICreateDeviceAccessAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -43,6 +44,7 @@ pub trait IDeviceIoControl_Impl: Sized {
     fn DeviceIoControlAsync(&self, iocontrolcode: u32, inputbuffer: *const u8, inputbuffersize: u32, outputbuffer: *mut u8, outputbuffersize: u32, requestcompletioncallback: &::core::option::Option<IDeviceRequestCompletionCallback>, cancelcontext: *mut usize) -> ::windows::core::Result<()>;
     fn CancelOperation(&self, cancelcontext: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDeviceIoControl {}
 impl IDeviceIoControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceIoControl_Impl, const OFFSET: isize>() -> IDeviceIoControl_Vtbl {
         unsafe extern "system" fn DeviceIoControlSync<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceIoControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iocontrolcode: u32, inputbuffer: *const u8, inputbuffersize: u32, outputbuffer: *mut u8, outputbuffersize: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT {
@@ -74,6 +76,7 @@ impl IDeviceIoControl_Vtbl {
 pub trait IDeviceRequestCompletionCallback_Impl: Sized {
     fn Invoke(&self, requestresult: ::windows::core::HRESULT, bytesreturned: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDeviceRequestCompletionCallback {}
 impl IDeviceRequestCompletionCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceRequestCompletionCallback_Impl, const OFFSET: isize>() -> IDeviceRequestCompletionCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceRequestCompletionCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requestresult: ::windows::core::HRESULT, bytesreturned: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
@@ -6,6 +6,8 @@ pub trait ICloneViewHelper_Impl: Sized {
     fn Commit(&self, ffinalcall: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICloneViewHelper {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICloneViewHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICloneViewHelper_Impl, const OFFSET: isize>() -> ICloneViewHelper_Vtbl {
         unsafe extern "system" fn GetConnectedIDs<Identity: ::windows::core::IUnknownImpl, Impl: ICloneViewHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, pulcount: *mut u32, pulid: *mut u32, ulflags: u32) -> ::windows::core::HRESULT {
@@ -49,6 +51,8 @@ pub trait IViewHelper_Impl: Sized {
     fn SetConfiguration(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<u32>;
     fn GetProceedOnNewConfiguration(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IViewHelper {}
 #[cfg(feature = "Win32_System_Com")]
 impl IViewHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewHelper_Impl, const OFFSET: isize>() -> IViewHelper_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
@@ -2,6 +2,7 @@ pub trait IUPnPAddressFamilyControl_Impl: Sized {
     fn SetAddressFamily(&self, dwflags: i32) -> ::windows::core::Result<()>;
     fn GetAddressFamily(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IUPnPAddressFamilyControl {}
 impl IUPnPAddressFamilyControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPAddressFamilyControl_Impl, const OFFSET: isize>() -> IUPnPAddressFamilyControl_Vtbl {
         unsafe extern "system" fn SetAddressFamily<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPAddressFamilyControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: i32) -> ::windows::core::HRESULT {
@@ -33,6 +34,7 @@ impl IUPnPAddressFamilyControl_Vtbl {
 pub trait IUPnPAsyncResult_Impl: Sized {
     fn AsyncOperationComplete(&self, ullrequestid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUPnPAsyncResult {}
 impl IUPnPAsyncResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPAsyncResult_Impl, const OFFSET: isize>() -> IUPnPAsyncResult_Vtbl {
         unsafe extern "system" fn AsyncOperationComplete<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPAsyncResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ullrequestid: u64) -> ::windows::core::HRESULT {
@@ -56,6 +58,8 @@ pub trait IUPnPDescriptionDocument_Impl: Sized + super::super::super::System::Co
     fn RootDevice(&self) -> ::windows::core::Result<IUPnPDevice>;
     fn DeviceByUDN(&self, bstrudn: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IUPnPDevice>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPDescriptionDocument {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPDescriptionDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDescriptionDocument_Impl, const OFFSET: isize>() -> IUPnPDescriptionDocument_Vtbl {
@@ -136,6 +140,7 @@ impl IUPnPDescriptionDocument_Vtbl {
 pub trait IUPnPDescriptionDocumentCallback_Impl: Sized {
     fn LoadComplete(&self, hrloadresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUPnPDescriptionDocumentCallback {}
 impl IUPnPDescriptionDocumentCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDescriptionDocumentCallback_Impl, const OFFSET: isize>() -> IUPnPDescriptionDocumentCallback_Vtbl {
         unsafe extern "system" fn LoadComplete<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDescriptionDocumentCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrloadresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -171,6 +176,8 @@ pub trait IUPnPDevice_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn IconURL(&self, bstrencodingformat: &super::super::super::Foundation::BSTR, lsizex: i32, lsizey: i32, lbitdepth: i32) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn Services(&self) -> ::windows::core::Result<IUPnPServices>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDevice_Impl, const OFFSET: isize>() -> IUPnPDevice_Vtbl {
@@ -416,6 +423,8 @@ pub trait IUPnPDeviceControl_Impl: Sized {
     fn GetServiceObject(&self, bstrudn: &super::super::super::Foundation::BSTR, bstrserviceid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::System::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUPnPDeviceControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUPnPDeviceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceControl_Impl, const OFFSET: isize>() -> IUPnPDeviceControl_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrxmldesc: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrdeviceidentifier: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrinitstring: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -449,6 +458,8 @@ pub trait IUPnPDeviceControlHttpHeaders_Impl: Sized {
     fn GetAdditionalResponseHeaders(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPDeviceControlHttpHeaders {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUPnPDeviceControlHttpHeaders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceControlHttpHeaders_Impl, const OFFSET: isize>() -> IUPnPDeviceControlHttpHeaders_Vtbl {
         unsafe extern "system" fn GetAdditionalResponseHeaders<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceControlHttpHeaders_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrhttpresponseheaders: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -476,6 +487,8 @@ pub trait IUPnPDeviceDocumentAccess_Impl: Sized {
     fn GetDocumentURL(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPDeviceDocumentAccess {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUPnPDeviceDocumentAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceDocumentAccess_Impl, const OFFSET: isize>() -> IUPnPDeviceDocumentAccess_Vtbl {
         unsafe extern "system" fn GetDocumentURL<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceDocumentAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrdocument: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -499,6 +512,8 @@ impl IUPnPDeviceDocumentAccess_Vtbl {
 pub trait IUPnPDeviceDocumentAccessEx_Impl: Sized {
     fn GetDocument(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPDeviceDocumentAccessEx {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUPnPDeviceDocumentAccessEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceDocumentAccessEx_Impl, const OFFSET: isize>() -> IUPnPDeviceDocumentAccessEx_Vtbl {
@@ -527,6 +542,8 @@ pub trait IUPnPDeviceFinder_Impl: Sized + super::super::super::System::Com::IDis
     fn CancelAsyncFind(&self, lfinddata: i32) -> ::windows::core::Result<()>;
     fn FindByUDN(&self, bstrudn: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IUPnPDevice>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPDeviceFinder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPDeviceFinder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceFinder_Impl, const OFFSET: isize>() -> IUPnPDeviceFinder_Vtbl {
@@ -591,6 +608,8 @@ pub trait IUPnPDeviceFinderAddCallbackWithInterface_Impl: Sized {
     fn DeviceAddedWithInterface(&self, lfinddata: i32, pdevice: &::core::option::Option<IUPnPDevice>, pguidinterface: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUPnPDeviceFinderAddCallbackWithInterface {}
+#[cfg(feature = "Win32_System_Com")]
 impl IUPnPDeviceFinderAddCallbackWithInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceFinderAddCallbackWithInterface_Impl, const OFFSET: isize>() -> IUPnPDeviceFinderAddCallbackWithInterface_Vtbl {
         unsafe extern "system" fn DeviceAddedWithInterface<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceFinderAddCallbackWithInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lfinddata: i32, pdevice: ::windows::core::RawPtr, pguidinterface: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -610,6 +629,8 @@ pub trait IUPnPDeviceFinderCallback_Impl: Sized {
     fn DeviceRemoved(&self, lfinddata: i32, bstrudn: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SearchComplete(&self, lfinddata: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUPnPDeviceFinderCallback {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUPnPDeviceFinderCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceFinderCallback_Impl, const OFFSET: isize>() -> IUPnPDeviceFinderCallback_Vtbl {
@@ -645,6 +666,8 @@ pub trait IUPnPDeviceProvider_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPDeviceProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUPnPDeviceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceProvider_Impl, const OFFSET: isize>() -> IUPnPDeviceProvider_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrinitstring: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -669,6 +692,8 @@ pub trait IUPnPDevices_Impl: Sized + super::super::super::System::Com::IDispatch
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn get_Item(&self, bstrudn: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IUPnPDevice>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPDevices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPDevices_Impl, const OFFSET: isize>() -> IUPnPDevices_Vtbl {
@@ -722,6 +747,8 @@ pub trait IUPnPEventSink_Impl: Sized {
     fn OnStateChangedSafe(&self, varsadispidchanges: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPEventSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPEventSink_Impl, const OFFSET: isize>() -> IUPnPEventSink_Vtbl {
         unsafe extern "system" fn OnStateChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cchanges: u32, rgdispidchanges: *const i32) -> ::windows::core::HRESULT {
@@ -748,6 +775,7 @@ pub trait IUPnPEventSource_Impl: Sized {
     fn Advise(&self, pessubscriber: &::core::option::Option<IUPnPEventSink>) -> ::windows::core::Result<()>;
     fn Unadvise(&self, pessubscriber: &::core::option::Option<IUPnPEventSink>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUPnPEventSource {}
 impl IUPnPEventSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPEventSource_Impl, const OFFSET: isize>() -> IUPnPEventSource_Vtbl {
         unsafe extern "system" fn Advise<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPEventSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pessubscriber: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -775,6 +803,8 @@ pub trait IUPnPHttpHeaderControl_Impl: Sized {
     fn AddRequestHeaders(&self, bstrhttpheaders: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPHttpHeaderControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUPnPHttpHeaderControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPHttpHeaderControl_Impl, const OFFSET: isize>() -> IUPnPHttpHeaderControl_Vtbl {
         unsafe extern "system" fn AddRequestHeaders<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPHttpHeaderControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrhttpheaders: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -797,6 +827,8 @@ pub trait IUPnPRegistrar_Impl: Sized {
     fn UnregisterDevice(&self, bstrdeviceidentifier: &super::super::super::Foundation::BSTR, fpermanent: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn UnregisterDeviceProvider(&self, bstrprovidername: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPRegistrar {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUPnPRegistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPRegistrar_Impl, const OFFSET: isize>() -> IUPnPRegistrar_Vtbl {
@@ -869,6 +901,8 @@ pub trait IUPnPRemoteEndpointInfo_Impl: Sized {
     fn GetGuidValue(&self, bstrvaluename: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<::windows::core::GUID>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPRemoteEndpointInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUPnPRemoteEndpointInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPRemoteEndpointInfo_Impl, const OFFSET: isize>() -> IUPnPRemoteEndpointInfo_Vtbl {
         unsafe extern "system" fn GetDwordValue<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPRemoteEndpointInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrvaluename: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, pdwvalue: *mut u32) -> ::windows::core::HRESULT {
@@ -921,6 +955,8 @@ pub trait IUPnPReregistrar_Impl: Sized {
     fn ReregisterRunningDevice(&self, bstrdeviceidentifier: &super::super::super::Foundation::BSTR, bstrxmldesc: &super::super::super::Foundation::BSTR, punkdevicecontrol: &::core::option::Option<::windows::core::IUnknown>, bstrinitstring: &super::super::super::Foundation::BSTR, bstrresourcepath: &super::super::super::Foundation::BSTR, nlifetime: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPReregistrar {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUPnPReregistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPReregistrar_Impl, const OFFSET: isize>() -> IUPnPReregistrar_Vtbl {
         unsafe extern "system" fn ReregisterDevice<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPReregistrar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrdeviceidentifier: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrxmldesc: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrprogiddevicecontrolclass: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrinitstring: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrcontainerid: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bstrresourcepath: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, nlifetime: i32) -> ::windows::core::HRESULT {
@@ -952,6 +988,8 @@ pub trait IUPnPService_Impl: Sized + super::super::super::System::Com::IDispatch
     fn Id(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn LastTransportStatus(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPService_Impl, const OFFSET: isize>() -> IUPnPService_Vtbl {
@@ -1035,6 +1073,8 @@ pub trait IUPnPServiceAsync_Impl: Sized {
     fn EndSCPDDownload(&self, ullrequestid: u64) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn CancelAsyncOperation(&self, ullrequestid: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPServiceAsync {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPServiceAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServiceAsync_Impl, const OFFSET: isize>() -> IUPnPServiceAsync_Vtbl {
@@ -1136,6 +1176,8 @@ pub trait IUPnPServiceCallback_Impl: Sized {
     fn ServiceInstanceDied(&self, pus: &::core::option::Option<IUPnPService>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPServiceCallback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPServiceCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServiceCallback_Impl, const OFFSET: isize>() -> IUPnPServiceCallback_Vtbl {
         unsafe extern "system" fn StateVariableChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pus: ::windows::core::RawPtr, pcwszstatevarname: ::windows::core::PCWSTR, vavalue: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -1163,6 +1205,8 @@ pub trait IUPnPServiceDocumentAccess_Impl: Sized {
     fn GetDocumentURL(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn GetDocument(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUPnPServiceDocumentAccess {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUPnPServiceDocumentAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServiceDocumentAccess_Impl, const OFFSET: isize>() -> IUPnPServiceDocumentAccess_Vtbl {
@@ -1201,6 +1245,7 @@ impl IUPnPServiceDocumentAccess_Vtbl {
 pub trait IUPnPServiceEnumProperty_Impl: Sized {
     fn SetServiceEnumProperty(&self, dwmask: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUPnPServiceEnumProperty {}
 impl IUPnPServiceEnumProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServiceEnumProperty_Impl, const OFFSET: isize>() -> IUPnPServiceEnumProperty_Vtbl {
         unsafe extern "system" fn SetServiceEnumProperty<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServiceEnumProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmask: u32) -> ::windows::core::HRESULT {
@@ -1220,6 +1265,8 @@ pub trait IUPnPServices_Impl: Sized + super::super::super::System::Com::IDispatc
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn get_Item(&self, bstrserviceid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IUPnPService>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPServices_Impl, const OFFSET: isize>() -> IUPnPServices_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
@@ -6,6 +6,8 @@ pub trait IFaxAccount_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RegisteredEvents(&self) -> ::windows::core::Result<FAX_ACCOUNT_EVENTS_TYPE_ENUM>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccount {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccount_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccount_Impl, const OFFSET: isize>() -> IFaxAccount_Vtbl {
         unsafe extern "system" fn AccountName<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccount_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstraccountname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -65,6 +67,8 @@ pub trait IFaxAccountFolders_Impl: Sized + super::super::System::Com::IDispatch_
     fn IncomingArchive(&self) -> ::windows::core::Result<IFaxAccountIncomingArchive>;
     fn OutgoingArchive(&self) -> ::windows::core::Result<IFaxAccountOutgoingArchive>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountFolders {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountFolders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountFolders_Impl, const OFFSET: isize>() -> IFaxAccountFolders_Vtbl {
@@ -132,6 +136,8 @@ pub trait IFaxAccountIncomingArchive_Impl: Sized + super::super::System::Com::ID
     fn GetMessages(&self, lprefetchsize: i32) -> ::windows::core::Result<IFaxIncomingMessageIterator>;
     fn GetMessage(&self, bstrmessageid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxIncomingMessage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountIncomingArchive {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountIncomingArchive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountIncomingArchive_Impl, const OFFSET: isize>() -> IFaxAccountIncomingArchive_Vtbl {
@@ -203,6 +209,8 @@ pub trait IFaxAccountIncomingQueue_Impl: Sized + super::super::System::Com::IDis
     fn GetJob(&self, bstrjobid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxIncomingJob>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountIncomingQueue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountIncomingQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountIncomingQueue_Impl, const OFFSET: isize>() -> IFaxAccountIncomingQueue_Vtbl {
         unsafe extern "system" fn GetJobs<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountIncomingQueue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxincomingjobs: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -240,6 +248,8 @@ impl IFaxAccountIncomingQueue_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountNotify_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountNotify {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountNotify_Impl, const OFFSET: isize>() -> IFaxAccountNotify_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -256,6 +266,8 @@ pub trait IFaxAccountOutgoingArchive_Impl: Sized + super::super::System::Com::ID
     fn GetMessages(&self, lprefetchsize: i32) -> ::windows::core::Result<IFaxOutgoingMessageIterator>;
     fn GetMessage(&self, bstrmessageid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxOutgoingMessage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountOutgoingArchive {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountOutgoingArchive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountOutgoingArchive_Impl, const OFFSET: isize>() -> IFaxAccountOutgoingArchive_Vtbl {
@@ -327,6 +339,8 @@ pub trait IFaxAccountOutgoingQueue_Impl: Sized + super::super::System::Com::IDis
     fn GetJob(&self, bstrjobid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxOutgoingJob>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountOutgoingQueue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountOutgoingQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountOutgoingQueue_Impl, const OFFSET: isize>() -> IFaxAccountOutgoingQueue_Vtbl {
         unsafe extern "system" fn GetJobs<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountOutgoingQueue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxoutgoingjobs: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -368,6 +382,8 @@ pub trait IFaxAccountSet_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn AddAccount(&self, bstraccountname: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxAccount>;
     fn RemoveAccount(&self, bstraccountname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccountSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccountSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccountSet_Impl, const OFFSET: isize>() -> IFaxAccountSet_Vtbl {
@@ -428,6 +444,8 @@ pub trait IFaxAccounts_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxAccounts {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxAccounts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccounts_Impl, const OFFSET: isize>() -> IFaxAccounts_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxAccounts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -482,6 +500,8 @@ pub trait IFaxActivity_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn QueuedMessages(&self) -> ::windows::core::Result<i32>;
     fn Refresh(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxActivity {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxActivity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxActivity_Impl, const OFFSET: isize>() -> IFaxActivity_Vtbl {
@@ -558,6 +578,8 @@ pub trait IFaxActivityLogging_Impl: Sized + super::super::System::Com::IDispatch
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxActivityLogging {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxActivityLogging_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxActivityLogging_Impl, const OFFSET: isize>() -> IFaxActivityLogging_Vtbl {
@@ -680,6 +702,8 @@ pub trait IFaxConfiguration_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxConfiguration {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxConfiguration_Impl, const OFFSET: isize>() -> IFaxConfiguration_Vtbl {
@@ -1099,6 +1123,8 @@ pub trait IFaxDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AnswerCall(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDevice_Impl, const OFFSET: isize>() -> IFaxDevice_Vtbl {
         unsafe extern "system" fn Id<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plid: *mut i32) -> ::windows::core::HRESULT {
@@ -1365,6 +1391,8 @@ pub trait IFaxDeviceIds_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetOrder(&self, ldeviceid: i32, lneworder: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDeviceIds {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDeviceIds_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDeviceIds_Impl, const OFFSET: isize>() -> IFaxDeviceIds_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDeviceIds_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1444,6 +1472,8 @@ pub trait IFaxDeviceProvider_Impl: Sized + super::super::System::Com::IDispatch_
     fn InitErrorCode(&self) -> ::windows::core::Result<i32>;
     fn DeviceIds(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDeviceProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDeviceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDeviceProvider_Impl, const OFFSET: isize>() -> IFaxDeviceProvider_Vtbl {
@@ -1606,6 +1636,8 @@ pub trait IFaxDeviceProviders_Impl: Sized + super::super::System::Com::IDispatch
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDeviceProviders {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDeviceProviders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDeviceProviders_Impl, const OFFSET: isize>() -> IFaxDeviceProviders_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDeviceProviders_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1659,6 +1691,8 @@ pub trait IFaxDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn get_ItemById(&self, lid: i32) -> ::windows::core::Result<IFaxDevice>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDevices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDevices_Impl, const OFFSET: isize>() -> IFaxDevices_Vtbl {
@@ -1755,6 +1789,8 @@ pub trait IFaxDocument_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AttachFaxToReceipt(&self) -> ::windows::core::Result<i16>;
     fn SetAttachFaxToReceipt(&self, battachfax: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDocument {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDocument_Impl, const OFFSET: isize>() -> IFaxDocument_Vtbl {
@@ -2093,6 +2129,8 @@ pub trait IFaxDocument2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn ConnectedSubmit2(&self, pfaxserver: &::core::option::Option<IFaxServer>, pvfaxoutgoingjobids: *mut super::super::System::Com::VARIANT, plerrorbodyfile: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxDocument2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxDocument2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDocument2_Impl, const OFFSET: isize>() -> IFaxDocument2_Vtbl {
         unsafe extern "system" fn SubmissionId<Identity: ::windows::core::IUnknownImpl, Impl: IFaxDocument2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrsubmissionid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2158,6 +2196,8 @@ pub trait IFaxEventLogging_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxEventLogging {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxEventLogging_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxEventLogging_Impl, const OFFSET: isize>() -> IFaxEventLogging_Vtbl {
@@ -2261,6 +2301,8 @@ pub trait IFaxFolders_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OutgoingArchive(&self) -> ::windows::core::Result<IFaxOutgoingArchive>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxFolders {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxFolders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxFolders_Impl, const OFFSET: isize>() -> IFaxFolders_Vtbl {
         unsafe extern "system" fn OutgoingQueue<Identity: ::windows::core::IUnknownImpl, Impl: IFaxFolders_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxoutgoingqueue: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2325,6 +2367,8 @@ pub trait IFaxInboundRouting_Impl: Sized + super::super::System::Com::IDispatch_
     fn GetMethods(&self) -> ::windows::core::Result<IFaxInboundRoutingMethods>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxInboundRouting {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxInboundRouting_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRouting_Impl, const OFFSET: isize>() -> IFaxInboundRouting_Vtbl {
         unsafe extern "system" fn GetExtensions<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRouting_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxinboundroutingextensions: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2373,6 +2417,8 @@ pub trait IFaxInboundRoutingExtension_Impl: Sized + super::super::System::Com::I
     fn InitErrorCode(&self) -> ::windows::core::Result<i32>;
     fn Methods(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxInboundRoutingExtension {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxInboundRoutingExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRoutingExtension_Impl, const OFFSET: isize>() -> IFaxInboundRoutingExtension_Vtbl {
@@ -2523,6 +2569,8 @@ pub trait IFaxInboundRoutingExtensions_Impl: Sized + super::super::System::Com::
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxInboundRoutingExtensions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxInboundRoutingExtensions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRoutingExtensions_Impl, const OFFSET: isize>() -> IFaxInboundRoutingExtensions_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRoutingExtensions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2581,6 +2629,8 @@ pub trait IFaxInboundRoutingMethod_Impl: Sized + super::super::System::Com::IDis
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxInboundRoutingMethod {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxInboundRoutingMethod_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRoutingMethod_Impl, const OFFSET: isize>() -> IFaxInboundRoutingMethod_Vtbl {
@@ -2689,6 +2739,8 @@ pub trait IFaxInboundRoutingMethods_Impl: Sized + super::super::System::Com::IDi
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxInboundRoutingMethods {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxInboundRoutingMethods_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRoutingMethods_Impl, const OFFSET: isize>() -> IFaxInboundRoutingMethods_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxInboundRoutingMethods_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2756,6 +2808,8 @@ pub trait IFaxIncomingArchive_Impl: Sized + super::super::System::Com::IDispatch
     fn GetMessages(&self, lprefetchsize: i32) -> ::windows::core::Result<IFaxIncomingMessageIterator>;
     fn GetMessage(&self, bstrmessageid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxIncomingMessage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingArchive {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingArchive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingArchive_Impl, const OFFSET: isize>() -> IFaxIncomingArchive_Vtbl {
@@ -2957,6 +3011,8 @@ pub trait IFaxIncomingJob_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn CopyTiff(&self, bstrtiffpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingJob_Impl, const OFFSET: isize>() -> IFaxIncomingJob_Vtbl {
@@ -3185,6 +3241,8 @@ pub trait IFaxIncomingJobs_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingJobs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingJobs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingJobs_Impl, const OFFSET: isize>() -> IFaxIncomingJobs_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingJobs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3247,6 +3305,8 @@ pub trait IFaxIncomingMessage_Impl: Sized + super::super::System::Com::IDispatch
     fn CopyTiff(&self, bstrtiffpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingMessage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingMessage_Impl, const OFFSET: isize>() -> IFaxIncomingMessage_Vtbl {
@@ -3422,6 +3482,8 @@ pub trait IFaxIncomingMessage2_Impl: Sized + super::super::System::Com::IDispatc
     fn Refresh(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingMessage2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingMessage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingMessage2_Impl, const OFFSET: isize>() -> IFaxIncomingMessage2_Vtbl {
         unsafe extern "system" fn Subject<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingMessage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrsubject: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3580,6 +3642,8 @@ pub trait IFaxIncomingMessageIterator_Impl: Sized + super::super::System::Com::I
     fn MoveNext(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingMessageIterator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingMessageIterator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingMessageIterator_Impl, const OFFSET: isize>() -> IFaxIncomingMessageIterator_Vtbl {
         unsafe extern "system" fn Message<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingMessageIterator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxincomingmessage: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3653,6 +3717,8 @@ pub trait IFaxIncomingQueue_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetJobs(&self) -> ::windows::core::Result<IFaxIncomingJobs>;
     fn GetJob(&self, bstrjobid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxIncomingJob>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxIncomingQueue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxIncomingQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxIncomingQueue_Impl, const OFFSET: isize>() -> IFaxIncomingQueue_Vtbl {
@@ -3738,6 +3804,8 @@ pub trait IFaxJobStatus_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn CallerId(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn RoutingInformation(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxJobStatus {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxJobStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxJobStatus_Impl, const OFFSET: isize>() -> IFaxJobStatus_Vtbl {
@@ -3959,6 +4027,8 @@ pub trait IFaxLoggingOptions_Impl: Sized + super::super::System::Com::IDispatch_
     fn ActivityLogging(&self) -> ::windows::core::Result<IFaxActivityLogging>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxLoggingOptions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxLoggingOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxLoggingOptions_Impl, const OFFSET: isize>() -> IFaxLoggingOptions_Vtbl {
         unsafe extern "system" fn EventLogging<Identity: ::windows::core::IUnknownImpl, Impl: IFaxLoggingOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxeventlogging: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3998,6 +4068,8 @@ pub trait IFaxOutboundRouting_Impl: Sized + super::super::System::Com::IDispatch
     fn GetGroups(&self) -> ::windows::core::Result<IFaxOutboundRoutingGroups>;
     fn GetRules(&self) -> ::windows::core::Result<IFaxOutboundRoutingRules>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutboundRouting {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutboundRouting_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutboundRouting_Impl, const OFFSET: isize>() -> IFaxOutboundRouting_Vtbl {
@@ -4039,6 +4111,8 @@ pub trait IFaxOutboundRoutingGroup_Impl: Sized + super::super::System::Com::IDis
     fn Status(&self) -> ::windows::core::Result<FAX_GROUP_STATUS_ENUM>;
     fn DeviceIds(&self) -> ::windows::core::Result<IFaxDeviceIds>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutboundRoutingGroup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutboundRoutingGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutboundRoutingGroup_Impl, const OFFSET: isize>() -> IFaxOutboundRoutingGroup_Vtbl {
@@ -4094,6 +4168,8 @@ pub trait IFaxOutboundRoutingGroups_Impl: Sized + super::super::System::Com::IDi
     fn Add(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxOutboundRoutingGroup>;
     fn Remove(&self, vindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutboundRoutingGroups {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutboundRoutingGroups_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutboundRoutingGroups_Impl, const OFFSET: isize>() -> IFaxOutboundRoutingGroups_Vtbl {
@@ -4173,6 +4249,8 @@ pub trait IFaxOutboundRoutingRule_Impl: Sized + super::super::System::Com::IDisp
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutboundRoutingRule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutboundRoutingRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutboundRoutingRule_Impl, const OFFSET: isize>() -> IFaxOutboundRoutingRule_Vtbl {
@@ -4297,6 +4375,8 @@ pub trait IFaxOutboundRoutingRules_Impl: Sized + super::super::System::Com::IDis
     fn Add(&self, lcountrycode: i32, lareacode: i32, busedevice: i16, bstrgroupname: &super::super::Foundation::BSTR, ldeviceid: i32) -> ::windows::core::Result<IFaxOutboundRoutingRule>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutboundRoutingRules {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutboundRoutingRules_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutboundRoutingRules_Impl, const OFFSET: isize>() -> IFaxOutboundRoutingRules_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutboundRoutingRules_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4400,6 +4480,8 @@ pub trait IFaxOutgoingArchive_Impl: Sized + super::super::System::Com::IDispatch
     fn GetMessages(&self, lprefetchsize: i32) -> ::windows::core::Result<IFaxOutgoingMessageIterator>;
     fn GetMessage(&self, bstrmessageid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxOutgoingMessage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingArchive {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingArchive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingArchive_Impl, const OFFSET: isize>() -> IFaxOutgoingArchive_Vtbl {
@@ -4613,6 +4695,8 @@ pub trait IFaxOutgoingJob_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingJob_Impl, const OFFSET: isize>() -> IFaxOutgoingJob_Vtbl {
@@ -4967,6 +5051,8 @@ pub trait IFaxOutgoingJob2_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn ScheduleType(&self) -> ::windows::core::Result<FAX_SCHEDULE_TYPE_ENUM>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingJob2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingJob2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingJob2_Impl, const OFFSET: isize>() -> IFaxOutgoingJob2_Vtbl {
         unsafe extern "system" fn HasCoverPage<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingJob2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbhascoverpage: *mut i16) -> ::windows::core::HRESULT {
@@ -5019,6 +5105,8 @@ pub trait IFaxOutgoingJobs_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn get_Item(&self, vindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IFaxOutgoingJob>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingJobs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingJobs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingJobs_Impl, const OFFSET: isize>() -> IFaxOutgoingJobs_Vtbl {
@@ -5088,6 +5176,8 @@ pub trait IFaxOutgoingMessage_Impl: Sized + super::super::System::Com::IDispatch
     fn CopyTiff(&self, bstrtiffpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingMessage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingMessage_Impl, const OFFSET: isize>() -> IFaxOutgoingMessage_Vtbl {
@@ -5326,6 +5416,8 @@ pub trait IFaxOutgoingMessage2_Impl: Sized + super::super::System::Com::IDispatc
     fn Refresh(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingMessage2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingMessage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingMessage2_Impl, const OFFSET: isize>() -> IFaxOutgoingMessage2_Vtbl {
         unsafe extern "system" fn HasCoverPage<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingMessage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbhascoverpage: *mut i16) -> ::windows::core::HRESULT {
@@ -5411,6 +5503,8 @@ pub trait IFaxOutgoingMessageIterator_Impl: Sized + super::super::System::Com::I
     fn MoveFirst(&self) -> ::windows::core::Result<()>;
     fn MoveNext(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingMessageIterator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingMessageIterator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingMessageIterator_Impl, const OFFSET: isize>() -> IFaxOutgoingMessageIterator_Vtbl {
@@ -5503,6 +5597,8 @@ pub trait IFaxOutgoingQueue_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetJobs(&self) -> ::windows::core::Result<IFaxOutgoingJobs>;
     fn GetJob(&self, bstrjobid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxOutgoingJob>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxOutgoingQueue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxOutgoingQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxOutgoingQueue_Impl, const OFFSET: isize>() -> IFaxOutgoingQueue_Vtbl {
@@ -5752,6 +5848,8 @@ pub trait IFaxReceiptOptions_Impl: Sized + super::super::System::Com::IDispatch_
     fn SetUseForInboundRouting(&self, buseforinboundrouting: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxReceiptOptions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxReceiptOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxReceiptOptions_Impl, const OFFSET: isize>() -> IFaxReceiptOptions_Vtbl {
         unsafe extern "system" fn AuthenticationType<Identity: ::windows::core::IUnknownImpl, Impl: IFaxReceiptOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut FAX_SMTP_AUTHENTICATION_TYPE_ENUM) -> ::windows::core::HRESULT {
@@ -5926,6 +6024,8 @@ pub trait IFaxRecipient_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetName(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxRecipient {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxRecipient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxRecipient_Impl, const OFFSET: isize>() -> IFaxRecipient_Vtbl {
         unsafe extern "system" fn FaxNumber<Identity: ::windows::core::IUnknownImpl, Impl: IFaxRecipient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrfaxnumber: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5980,6 +6080,8 @@ pub trait IFaxRecipients_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Add(&self, bstrfaxnumber: &super::super::Foundation::BSTR, bstrrecipientname: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFaxRecipient>;
     fn Remove(&self, lindex: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxRecipients {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxRecipients_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxRecipients_Impl, const OFFSET: isize>() -> IFaxRecipients_Vtbl {
@@ -6055,6 +6157,8 @@ pub trait IFaxSecurity_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn InformationType(&self) -> ::windows::core::Result<i32>;
     fn SetInformationType(&self, linformationtype: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxSecurity {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxSecurity_Impl, const OFFSET: isize>() -> IFaxSecurity_Vtbl {
@@ -6136,6 +6240,8 @@ pub trait IFaxSecurity2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn InformationType(&self) -> ::windows::core::Result<i32>;
     fn SetInformationType(&self, linformationtype: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxSecurity2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxSecurity2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxSecurity2_Impl, const OFFSET: isize>() -> IFaxSecurity2_Vtbl {
@@ -6244,6 +6350,8 @@ pub trait IFaxSender_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LoadDefaultSender(&self) -> ::windows::core::Result<()>;
     fn SaveDefaultSender(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxSender {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxSender_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxSender_Impl, const OFFSET: isize>() -> IFaxSender_Vtbl {
@@ -6585,6 +6693,8 @@ pub trait IFaxServer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn APIVersion(&self) -> ::windows::core::Result<FAX_SERVER_APIVERSION_ENUM>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxServer {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxServer_Impl, const OFFSET: isize>() -> IFaxServer_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: IFaxServer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrservername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6867,6 +6977,8 @@ pub trait IFaxServer2_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn Security2(&self) -> ::windows::core::Result<IFaxSecurity2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxServer2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxServer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxServer2_Impl, const OFFSET: isize>() -> IFaxServer2_Vtbl {
         unsafe extern "system" fn Configuration<Identity: ::windows::core::IUnknownImpl, Impl: IFaxServer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppfaxconfiguration: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6928,6 +7040,8 @@ impl IFaxServer2_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxServerNotify_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxServerNotify {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxServerNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxServerNotify_Impl, const OFFSET: isize>() -> IFaxServerNotify_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -6938,6 +7052,8 @@ impl IFaxServerNotify_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxServerNotify2_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFaxServerNotify2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFaxServerNotify2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFaxServerNotify2_Impl, const OFFSET: isize>() -> IFaxServerNotify2_Vtbl {
@@ -6967,6 +7083,8 @@ pub trait IStiDevice_Impl: Sized {
     fn UnSubscribe(&self) -> ::windows::core::Result<()>;
     fn GetLastErrorInfo(&self) -> ::windows::core::Result<_ERROR_INFOW>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
+impl ::windows::core::RuntimeName for IStiDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl IStiDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStiDevice_Impl, const OFFSET: isize>() -> IStiDevice_Vtbl {
@@ -7113,6 +7231,8 @@ pub trait IStiDeviceControl_Impl: Sized {
     fn WriteToErrorLog(&self, dwmessagetype: u32, pszmessage: &::windows::core::PCWSTR, dwerrorcode: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
+impl ::windows::core::RuntimeName for IStiDeviceControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 impl IStiDeviceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStiDeviceControl_Impl, const OFFSET: isize>() -> IStiDeviceControl_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IStiDeviceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwdevicetype: u32, dwmode: u32, pwszportname: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT {
@@ -7208,6 +7328,8 @@ pub trait IStiUSD_Impl: Sized {
     fn GetNotificationData(&self) -> ::windows::core::Result<STINOTIFY>;
     fn GetLastErrorInfo(&self) -> ::windows::core::Result<_ERROR_INFOW>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IStiUSD {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO", feature = "Win32_System_Registry"))]
 impl IStiUSD_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStiUSD_Impl, const OFFSET: isize>() -> IStiUSD_Vtbl {
@@ -7358,6 +7480,8 @@ pub trait IStillImageW_Impl: Sized {
     fn WriteToErrorLog(&self, dwmessagetype: u32, pszmessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStillImageW {}
+#[cfg(feature = "Win32_Foundation")]
 impl IStillImageW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStillImageW_Impl, const OFFSET: isize>() -> IStillImageW_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IStillImageW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hinst: super::super::Foundation::HINSTANCE, dwversion: u32) -> ::windows::core::HRESULT {
@@ -7479,6 +7603,8 @@ pub trait _IFaxAccountNotify_Impl: Sized + super::super::System::Com::IDispatch_
     fn OnServerShutDown(&self, pfaxserver: &::core::option::Option<IFaxServer2>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IFaxAccountNotify {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IFaxAccountNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IFaxAccountNotify_Impl, const OFFSET: isize>() -> _IFaxAccountNotify_Vtbl {
         unsafe extern "system" fn OnIncomingJobAdded<Identity: ::windows::core::IUnknownImpl, Impl: _IFaxAccountNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfaxaccount: ::windows::core::RawPtr, bstrjobid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -7584,6 +7710,8 @@ pub trait _IFaxServerNotify2_Impl: Sized + super::super::System::Com::IDispatch_
     fn OnDeviceStatusChange(&self, pfaxserver: &::core::option::Option<IFaxServer2>, ldeviceid: i32, bpoweredoff: i16, bsending: i16, breceiving: i16, bringing: i16) -> ::windows::core::Result<()>;
     fn OnGeneralServerConfigChanged(&self, pfaxserver: &::core::option::Option<IFaxServer2>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IFaxServerNotify2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IFaxServerNotify2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IFaxServerNotify2_Impl, const OFFSET: isize>() -> _IFaxServerNotify2_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
@@ -8,6 +8,8 @@ pub trait IFunctionDiscovery_Impl: Sized {
     fn RemoveInstance(&self, enumsystemvisibility: SystemVisibilityFlags, pszcategory: &::windows::core::PCWSTR, pszsubcategory: &::windows::core::PCWSTR, pszcategoryidentity: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFunctionDiscovery {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFunctionDiscovery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscovery_Impl, const OFFSET: isize>() -> IFunctionDiscovery_Vtbl {
         unsafe extern "system" fn GetInstanceCollection<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscovery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcategory: ::windows::core::PCWSTR, pszsubcategory: ::windows::core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL, ppifunctioninstancecollection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -79,6 +81,8 @@ pub trait IFunctionDiscoveryNotification_Impl: Sized {
     fn OnEvent(&self, dweventid: u32, fdqcquerycontext: u64, pszprovider: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IFunctionDiscoveryNotification {}
+#[cfg(feature = "Win32_System_Com")]
 impl IFunctionDiscoveryNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryNotification_Impl, const OFFSET: isize>() -> IFunctionDiscoveryNotification_Vtbl {
         unsafe extern "system" fn OnUpdate<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumqueryupdateaction: QueryUpdateAction, fdqcquerycontext: u64, pifunctioninstance: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -118,6 +122,8 @@ pub trait IFunctionDiscoveryProvider_Impl: Sized {
     fn InstanceQueryService(&self, pifunctioninstance: &::core::option::Option<IFunctionInstance>, iproviderinstancecontext: isize, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn InstanceReleased(&self, pifunctioninstance: &::core::option::Option<IFunctionInstance>, iproviderinstancecontext: isize) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFunctionDiscoveryProvider {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFunctionDiscoveryProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryProvider_Impl, const OFFSET: isize>() -> IFunctionDiscoveryProvider_Vtbl {
@@ -208,6 +214,8 @@ pub trait IFunctionDiscoveryProviderFactory_Impl: Sized {
     fn CreateFunctionInstanceCollection(&self) -> ::windows::core::Result<IFunctionInstanceCollection>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFunctionDiscoveryProviderFactory {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFunctionDiscoveryProviderFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryProviderFactory_Impl, const OFFSET: isize>() -> IFunctionDiscoveryProviderFactory_Vtbl {
         unsafe extern "system" fn CreatePropertyStore<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryProviderFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppipropertystore: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -262,6 +270,8 @@ pub trait IFunctionDiscoveryProviderQuery_Impl: Sized {
     fn GetPropertyConstraints(&self) -> ::windows::core::Result<IProviderPropertyConstraintCollection>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFunctionDiscoveryProviderQuery {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFunctionDiscoveryProviderQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryProviderQuery_Impl, const OFFSET: isize>() -> IFunctionDiscoveryProviderQuery_Vtbl {
         unsafe extern "system" fn IsInstanceQuery<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryProviderQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisinstancequery: *mut super::super::Foundation::BOOL, ppszconstraintvalue: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -313,6 +323,8 @@ pub trait IFunctionDiscoveryServiceProvider_Impl: Sized {
     fn Initialize(&self, pifunctioninstance: &::core::option::Option<IFunctionInstance>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IFunctionDiscoveryServiceProvider {}
+#[cfg(feature = "Win32_System_Com")]
 impl IFunctionDiscoveryServiceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryServiceProvider_Impl, const OFFSET: isize>() -> IFunctionDiscoveryServiceProvider_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionDiscoveryServiceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pifunctioninstance: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -333,6 +345,8 @@ pub trait IFunctionInstance_Impl: Sized + super::super::System::Com::IServicePro
     fn OpenPropertyStore(&self, dwstgaccess: super::super::System::Com::StructuredStorage::STGM) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
     fn GetCategory(&self, ppszcomemcategory: *mut *mut u16, ppszcomemsubcategory: *mut *mut u16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFunctionInstance {}
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFunctionInstance_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionInstance_Impl, const OFFSET: isize>() -> IFunctionInstance_Vtbl {
@@ -396,6 +410,8 @@ pub trait IFunctionInstanceCollection_Impl: Sized {
     fn Delete(&self, dwindex: u32) -> ::windows::core::Result<()>;
     fn DeleteAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IFunctionInstanceCollection {}
 #[cfg(feature = "Win32_System_Com")]
 impl IFunctionInstanceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionInstanceCollection_Impl, const OFFSET: isize>() -> IFunctionInstanceCollection_Vtbl {
@@ -474,6 +490,8 @@ pub trait IFunctionInstanceCollectionQuery_Impl: Sized {
     fn Execute(&self) -> ::windows::core::Result<IFunctionInstanceCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFunctionInstanceCollectionQuery {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFunctionInstanceCollectionQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionInstanceCollectionQuery_Impl, const OFFSET: isize>() -> IFunctionInstanceCollectionQuery_Vtbl {
         unsafe extern "system" fn AddQueryConstraint<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionInstanceCollectionQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszconstraintname: ::windows::core::PCWSTR, pszconstraintvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -513,6 +531,8 @@ pub trait IFunctionInstanceQuery_Impl: Sized {
     fn Execute(&self) -> ::windows::core::Result<IFunctionInstance>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IFunctionInstanceQuery {}
+#[cfg(feature = "Win32_System_Com")]
 impl IFunctionInstanceQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionInstanceQuery_Impl, const OFFSET: isize>() -> IFunctionInstanceQuery_Vtbl {
         unsafe extern "system" fn Execute<Identity: ::windows::core::IUnknownImpl, Impl: IFunctionInstanceQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppifunctioninstance: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -537,6 +557,7 @@ pub trait IPNPXAssociation_Impl: Sized {
     fn Unassociate(&self, pszsubcategory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Delete(&self, pszsubcategory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPNPXAssociation {}
 impl IPNPXAssociation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPNPXAssociation_Impl, const OFFSET: isize>() -> IPNPXAssociation_Vtbl {
         unsafe extern "system" fn Associate<Identity: ::windows::core::IUnknownImpl, Impl: IPNPXAssociation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -570,6 +591,7 @@ pub trait IPNPXDeviceAssociation_Impl: Sized {
     fn Unassociate(&self, pszsubcategory: &::windows::core::PCWSTR, pifunctiondiscoverynotification: &::core::option::Option<IFunctionDiscoveryNotification>) -> ::windows::core::Result<()>;
     fn Delete(&self, pszsubcategory: &::windows::core::PCWSTR, pifunctiondiscoverynotification: &::core::option::Option<IFunctionDiscoveryNotification>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPNPXDeviceAssociation {}
 impl IPNPXDeviceAssociation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPNPXDeviceAssociation_Impl, const OFFSET: isize>() -> IPNPXDeviceAssociation_Vtbl {
         unsafe extern "system" fn Associate<Identity: ::windows::core::IUnknownImpl, Impl: IPNPXDeviceAssociation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR, pifunctiondiscoverynotification: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -608,6 +630,8 @@ pub trait IPropertyStoreCollection_Impl: Sized {
     fn Delete(&self, dwindex: u32) -> ::windows::core::Result<()>;
     fn DeleteAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IPropertyStoreCollection {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IPropertyStoreCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreCollection_Impl, const OFFSET: isize>() -> IPropertyStoreCollection_Vtbl {
@@ -687,6 +711,8 @@ pub trait IProviderProperties_Impl: Sized {
     fn SetValue(&self, pifunctioninstance: &::core::option::Option<IFunctionInstance>, iproviderinstancecontext: isize, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, ppropvar: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IProviderProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IProviderProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProviderProperties_Impl, const OFFSET: isize>() -> IProviderProperties_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IProviderProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pifunctioninstance: ::windows::core::RawPtr, iproviderinstancecontext: isize, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -749,6 +775,8 @@ pub trait IProviderPropertyConstraintCollection_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IProviderPropertyConstraintCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IProviderPropertyConstraintCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProviderPropertyConstraintCollection_Impl, const OFFSET: isize>() -> IProviderPropertyConstraintCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IProviderPropertyConstraintCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -807,6 +835,8 @@ pub trait IProviderPublishing_Impl: Sized {
     fn RemoveInstance(&self, enumvisibilityflags: SystemVisibilityFlags, pszsubcategory: &::windows::core::PCWSTR, pszproviderinstanceidentity: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IProviderPublishing {}
+#[cfg(feature = "Win32_System_Com")]
 impl IProviderPublishing_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProviderPublishing_Impl, const OFFSET: isize>() -> IProviderPublishing_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IProviderPublishing_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumvisibilityflags: SystemVisibilityFlags, pszsubcategory: ::windows::core::PCWSTR, pszproviderinstanceidentity: ::windows::core::PCWSTR, ppifunctioninstance: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -843,6 +873,7 @@ pub trait IProviderQueryConstraintCollection_Impl: Sized {
     fn Skip(&self) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProviderQueryConstraintCollection {}
 impl IProviderQueryConstraintCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProviderQueryConstraintCollection_Impl, const OFFSET: isize>() -> IProviderQueryConstraintCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IProviderQueryConstraintCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
@@ -9,6 +9,8 @@ pub trait ICivicAddressReport_Impl: Sized + ILocationReport_Impl {
     fn GetDetailLevel(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ICivicAddressReport {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ICivicAddressReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICivicAddressReport_Impl, const OFFSET: isize>() -> ICivicAddressReport_Vtbl {
         unsafe extern "system" fn GetAddressLine1<Identity: ::windows::core::IUnknownImpl, Impl: ICivicAddressReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstraddress1: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -108,6 +110,8 @@ pub trait ICivicAddressReportFactory_Impl: Sized + super::super::System::Com::ID
     fn CivicAddressReport(&self) -> ::windows::core::Result<IDispCivicAddressReport>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICivicAddressReportFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICivicAddressReportFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICivicAddressReportFactory_Impl, const OFFSET: isize>() -> ICivicAddressReportFactory_Vtbl {
         unsafe extern "system" fn CivicAddressReport<Identity: ::windows::core::IUnknownImpl, Impl: ICivicAddressReportFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -131,6 +135,7 @@ pub trait IDefaultLocation_Impl: Sized {
     fn SetReport(&self, reporttype: *const ::windows::core::GUID, plocationreport: &::core::option::Option<ILocationReport>) -> ::windows::core::Result<()>;
     fn GetReport(&self, reporttype: *const ::windows::core::GUID) -> ::windows::core::Result<ILocationReport>;
 }
+impl ::windows::core::RuntimeName for IDefaultLocation {}
 impl IDefaultLocation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultLocation_Impl, const OFFSET: isize>() -> IDefaultLocation_Vtbl {
         unsafe extern "system" fn SetReport<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultLocation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, plocationreport: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -170,6 +175,8 @@ pub trait IDispCivicAddressReport_Impl: Sized + super::super::System::Com::IDisp
     fn DetailLevel(&self) -> ::windows::core::Result<u32>;
     fn Timestamp(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDispCivicAddressReport {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDispCivicAddressReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispCivicAddressReport_Impl, const OFFSET: isize>() -> IDispCivicAddressReport_Vtbl {
@@ -287,6 +294,8 @@ pub trait IDispLatLongReport_Impl: Sized + super::super::System::Com::IDispatch_
     fn Timestamp(&self) -> ::windows::core::Result<f64>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDispLatLongReport {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDispLatLongReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispLatLongReport_Impl, const OFFSET: isize>() -> IDispLatLongReport_Vtbl {
         unsafe extern "system" fn Latitude<Identity: ::windows::core::IUnknownImpl, Impl: IDispLatLongReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut f64) -> ::windows::core::HRESULT {
@@ -378,6 +387,8 @@ pub trait ILatLongReport_Impl: Sized + ILocationReport_Impl {
     fn GetAltitudeError(&self) -> ::windows::core::Result<f64>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ILatLongReport {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ILatLongReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILatLongReport_Impl, const OFFSET: isize>() -> ILatLongReport_Vtbl {
         unsafe extern "system" fn GetLatitude<Identity: ::windows::core::IUnknownImpl, Impl: ILatLongReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, platitude: *mut f64) -> ::windows::core::HRESULT {
@@ -453,6 +464,8 @@ pub trait ILatLongReportFactory_Impl: Sized + super::super::System::Com::IDispat
     fn LatLongReport(&self) -> ::windows::core::Result<IDispLatLongReport>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILatLongReportFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILatLongReportFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILatLongReportFactory_Impl, const OFFSET: isize>() -> ILatLongReportFactory_Vtbl {
         unsafe extern "system" fn LatLongReport<Identity: ::windows::core::IUnknownImpl, Impl: ILatLongReportFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -484,6 +497,8 @@ pub trait ILocation_Impl: Sized {
     fn SetDesiredAccuracy(&self, reporttype: *const ::windows::core::GUID, desiredaccuracy: super::Sensors::LOCATION_DESIRED_ACCURACY) -> ::windows::core::Result<()>;
     fn RequestPermissions(&self, hparent: super::super::Foundation::HWND, preporttypes: *const ::windows::core::GUID, count: u32, fmodal: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Devices_Sensors", feature = "Win32_Foundation"))]
+impl ::windows::core::RuntimeName for ILocation {}
 #[cfg(all(feature = "Win32_Devices_Sensors", feature = "Win32_Foundation"))]
 impl ILocation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocation_Impl, const OFFSET: isize>() -> ILocation_Vtbl {
@@ -577,6 +592,7 @@ pub trait ILocationEvents_Impl: Sized {
     fn OnLocationChanged(&self, reporttype: *const ::windows::core::GUID, plocationreport: &::core::option::Option<ILocationReport>) -> ::windows::core::Result<()>;
     fn OnStatusChanged(&self, reporttype: *const ::windows::core::GUID, newstatus: LOCATION_REPORT_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILocationEvents {}
 impl ILocationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocationEvents_Impl, const OFFSET: isize>() -> ILocationEvents_Vtbl {
         unsafe extern "system" fn OnLocationChanged<Identity: ::windows::core::IUnknownImpl, Impl: ILocationEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, plocationreport: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -603,6 +619,7 @@ pub trait ILocationPower_Impl: Sized {
     fn Connect(&self) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILocationPower {}
 impl ILocationPower_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocationPower_Impl, const OFFSET: isize>() -> ILocationPower_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: ILocationPower_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -631,6 +648,8 @@ pub trait ILocationReport_Impl: Sized {
     fn GetTimestamp(&self) -> ::windows::core::Result<super::super::Foundation::SYSTEMTIME>;
     fn GetValue(&self, pkey: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ILocationReport {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ILocationReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocationReport_Impl, const OFFSET: isize>() -> ILocationReport_Vtbl {
@@ -689,6 +708,8 @@ pub trait ILocationReportFactory_Impl: Sized + super::super::System::Com::IDispa
     fn SetDesiredAccuracy(&self, desiredaccuracy: u32) -> ::windows::core::Result<()>;
     fn RequestPermissions(&self, hwnd: *const u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILocationReportFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILocationReportFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocationReportFactory_Impl, const OFFSET: isize>() -> ILocationReportFactory_Vtbl {
@@ -769,6 +790,8 @@ impl ILocationReportFactory_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ICivicAddressReportFactoryEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ICivicAddressReportFactoryEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ICivicAddressReportFactoryEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ICivicAddressReportFactoryEvents_Impl, const OFFSET: isize>() -> _ICivicAddressReportFactoryEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -779,6 +802,8 @@ impl _ICivicAddressReportFactoryEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ILatLongReportFactoryEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ILatLongReportFactoryEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ILatLongReportFactoryEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ILatLongReportFactoryEvents_Impl, const OFFSET: isize>() -> _ILatLongReportFactoryEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/impl.rs
@@ -3,6 +3,8 @@ pub trait IDirectInput2A_Impl: Sized + IDirectInputA_Impl {
     fn FindDevice(&self, param0: *const ::windows::core::GUID, param1: &::windows::core::PCSTR, param2: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInput2A {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInput2A_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput2A_Impl, const OFFSET: isize>() -> IDirectInput2A_Vtbl {
         unsafe extern "system" fn FindDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput2A_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: ::windows::core::PCSTR, param2: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -20,6 +22,8 @@ impl IDirectInput2A_Vtbl {
 pub trait IDirectInput2W_Impl: Sized + IDirectInputW_Impl {
     fn FindDevice(&self, param0: *const ::windows::core::GUID, param1: &::windows::core::PCWSTR, param2: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInput2W {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInput2W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput2W_Impl, const OFFSET: isize>() -> IDirectInput2W_Vtbl {
@@ -39,6 +43,8 @@ pub trait IDirectInput7A_Impl: Sized + IDirectInputA_Impl + IDirectInput2A_Impl 
     fn CreateDeviceEx(&self, param0: *const ::windows::core::GUID, param1: *const ::windows::core::GUID, param2: *mut *mut ::core::ffi::c_void, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInput7A {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInput7A_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput7A_Impl, const OFFSET: isize>() -> IDirectInput7A_Vtbl {
         unsafe extern "system" fn CreateDeviceEx<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput7A_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *const ::windows::core::GUID, param2: *mut *mut ::core::ffi::c_void, param3: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -56,6 +62,8 @@ impl IDirectInput7A_Vtbl {
 pub trait IDirectInput7W_Impl: Sized + IDirectInputW_Impl + IDirectInput2W_Impl {
     fn CreateDeviceEx(&self, param0: *const ::windows::core::GUID, param1: *const ::windows::core::GUID, param2: *mut *mut ::core::ffi::c_void, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInput7W {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInput7W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput7W_Impl, const OFFSET: isize>() -> IDirectInput7W_Vtbl {
@@ -81,6 +89,8 @@ pub trait IDirectInput8A_Impl: Sized {
     fn EnumDevicesBySemantics(&self, param0: &::windows::core::PCSTR, param1: *mut DIACTIONFORMATA, param2: &LPDIENUMDEVICESBYSEMANTICSCBA, param3: *mut ::core::ffi::c_void, param4: u32) -> ::windows::core::Result<()>;
     fn ConfigureDevices(&self, param0: &LPDICONFIGUREDEVICESCALLBACK, param1: *mut DICONFIGUREDEVICESPARAMSA, param2: u32, param3: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInput8A {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInput8A_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput8A_Impl, const OFFSET: isize>() -> IDirectInput8A_Vtbl {
@@ -152,6 +162,8 @@ pub trait IDirectInput8W_Impl: Sized {
     fn ConfigureDevices(&self, param0: &LPDICONFIGUREDEVICESCALLBACK, param1: *mut DICONFIGUREDEVICESPARAMSW, param2: u32, param3: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInput8W {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInput8W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput8W_Impl, const OFFSET: isize>() -> IDirectInput8W_Vtbl {
         unsafe extern "system" fn CreateDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInput8W_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut ::windows::core::RawPtr, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -219,6 +231,8 @@ pub trait IDirectInputA_Impl: Sized {
     fn Initialize(&self, param0: super::super::Foundation::HINSTANCE, param1: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputA {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputA_Impl, const OFFSET: isize>() -> IDirectInputA_Vtbl {
         unsafe extern "system" fn CreateDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut ::windows::core::RawPtr, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -271,6 +285,8 @@ pub trait IDirectInputDevice2A_Impl: Sized + IDirectInputDeviceA_Impl {
     fn Poll(&self) -> ::windows::core::Result<()>;
     fn SendDeviceData(&self, param0: u32, param1: *mut DIDEVICEOBJECTDATA, param2: *mut u32, param3: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDevice2A {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDevice2A_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice2A_Impl, const OFFSET: isize>() -> IDirectInputDevice2A_Vtbl {
@@ -349,6 +365,8 @@ pub trait IDirectInputDevice2W_Impl: Sized + IDirectInputDeviceW_Impl {
     fn SendDeviceData(&self, param0: u32, param1: *mut DIDEVICEOBJECTDATA, param2: *mut u32, param3: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDevice2W {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDevice2W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice2W_Impl, const OFFSET: isize>() -> IDirectInputDevice2W_Vtbl {
         unsafe extern "system" fn CreateEffect<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice2W_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut DIEFFECT, param2: *mut ::windows::core::RawPtr, param3: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -419,6 +437,8 @@ pub trait IDirectInputDevice7A_Impl: Sized + IDirectInputDeviceA_Impl + IDirectI
     fn WriteEffectToFile(&self, param0: &::windows::core::PCSTR, param1: u32, param2: *mut DIFILEEFFECT, param3: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDevice7A {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDevice7A_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice7A_Impl, const OFFSET: isize>() -> IDirectInputDevice7A_Vtbl {
         unsafe extern "system" fn EnumEffectsInFile<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice7A_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::PCSTR, param1: ::windows::core::RawPtr, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::HRESULT {
@@ -446,6 +466,8 @@ pub trait IDirectInputDevice7W_Impl: Sized + IDirectInputDeviceW_Impl + IDirectI
     fn EnumEffectsInFile(&self, param0: &::windows::core::PCWSTR, param1: &LPDIENUMEFFECTSINFILECALLBACK, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::Result<()>;
     fn WriteEffectToFile(&self, param0: &::windows::core::PCWSTR, param1: u32, param2: *mut DIFILEEFFECT, param3: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDevice7W {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDevice7W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice7W_Impl, const OFFSET: isize>() -> IDirectInputDevice7W_Vtbl {
@@ -501,6 +523,8 @@ pub trait IDirectInputDevice8A_Impl: Sized {
     fn SetActionMap(&self, param0: *mut DIACTIONFORMATA, param1: &::windows::core::PCSTR, param2: u32) -> ::windows::core::Result<()>;
     fn GetImageInfo(&self, param0: *mut DIDEVICEIMAGEINFOHEADERA) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDevice8A {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDevice8A_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice8A_Impl, const OFFSET: isize>() -> IDirectInputDevice8A_Vtbl {
@@ -719,6 +743,8 @@ pub trait IDirectInputDevice8W_Impl: Sized {
     fn GetImageInfo(&self, param0: *mut DIDEVICEIMAGEINFOHEADERW) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDevice8W {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDevice8W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice8W_Impl, const OFFSET: isize>() -> IDirectInputDevice8W_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDevice8W_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT {
@@ -922,6 +948,8 @@ pub trait IDirectInputDeviceA_Impl: Sized {
     fn Initialize(&self, param0: super::super::Foundation::HINSTANCE, param1: u32, param2: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDeviceA {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDeviceA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDeviceA_Impl, const OFFSET: isize>() -> IDirectInputDeviceA_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDeviceA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT {
@@ -1041,6 +1069,8 @@ pub trait IDirectInputDeviceW_Impl: Sized {
     fn Initialize(&self, param0: super::super::Foundation::HINSTANCE, param1: u32, param2: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputDeviceW {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputDeviceW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDeviceW_Impl, const OFFSET: isize>() -> IDirectInputDeviceW_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputDeviceW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT {
@@ -1155,6 +1185,8 @@ pub trait IDirectInputEffect_Impl: Sized {
     fn Escape(&self, param0: *mut DIEFFESCAPE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputEffect {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectInputEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputEffect_Impl, const OFFSET: isize>() -> IDirectInputEffect_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: super::super::Foundation::HINSTANCE, param1: u32, param2: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1238,6 +1270,7 @@ pub trait IDirectInputEffectDriver_Impl: Sized {
     fn StopEffect(&self, param0: u32, param1: u32) -> ::windows::core::Result<()>;
     fn GetEffectStatus(&self, param0: u32, param1: u32, param2: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectInputEffectDriver {}
 impl IDirectInputEffectDriver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputEffectDriver_Impl, const OFFSET: isize>() -> IDirectInputEffectDriver_Vtbl {
         unsafe extern "system" fn DeviceID<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputEffectDriver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: u32, param1: u32, param2: u32, param3: u32, param4: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1333,6 +1366,8 @@ pub trait IDirectInputJoyConfig_Impl: Sized {
     fn OpenTypeKey(&self, param0: &::windows::core::PCWSTR, param1: u32, param2: *mut super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
     fn OpenConfigKey(&self, param0: u32, param1: u32, param2: *mut super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IDirectInputJoyConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IDirectInputJoyConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputJoyConfig_Impl, const OFFSET: isize>() -> IDirectInputJoyConfig_Vtbl {
@@ -1460,6 +1495,8 @@ pub trait IDirectInputJoyConfig8_Impl: Sized {
     fn OpenAppStatusKey(&self, param0: *mut super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IDirectInputJoyConfig8 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IDirectInputJoyConfig8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputJoyConfig8_Impl, const OFFSET: isize>() -> IDirectInputJoyConfig8_Vtbl {
         unsafe extern "system" fn Acquire<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputJoyConfig8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1574,6 +1611,8 @@ pub trait IDirectInputW_Impl: Sized {
     fn RunControlPanel(&self, param0: super::super::Foundation::HWND, param1: u32) -> ::windows::core::Result<()>;
     fn Initialize(&self, param0: super::super::Foundation::HINSTANCE, param1: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectInputW {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectInputW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectInputW_Impl, const OFFSET: isize>() -> IDirectInputW_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
@@ -7,6 +7,8 @@ pub trait IEnumWIA_DEV_CAPS_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumWIA_DEV_CAPS {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumWIA_DEV_CAPS_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWIA_DEV_CAPS_Impl, const OFFSET: isize>() -> IEnumWIA_DEV_CAPS_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWIA_DEV_CAPS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut WIA_DEV_CAP, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -66,6 +68,7 @@ pub trait IEnumWIA_DEV_INFO_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumWIA_DEV_INFO>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumWIA_DEV_INFO {}
 impl IEnumWIA_DEV_INFO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWIA_DEV_INFO_Impl, const OFFSET: isize>() -> IEnumWIA_DEV_INFO_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWIA_DEV_INFO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -125,6 +128,7 @@ pub trait IEnumWIA_FORMAT_INFO_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumWIA_FORMAT_INFO>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumWIA_FORMAT_INFO {}
 impl IEnumWIA_FORMAT_INFO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWIA_FORMAT_INFO_Impl, const OFFSET: isize>() -> IEnumWIA_FORMAT_INFO_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWIA_FORMAT_INFO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut WIA_FORMAT_INFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -184,6 +188,7 @@ pub trait IEnumWiaItem_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumWiaItem>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumWiaItem {}
 impl IEnumWiaItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWiaItem_Impl, const OFFSET: isize>() -> IEnumWiaItem_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWiaItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppiwiaitem: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -243,6 +248,7 @@ pub trait IEnumWiaItem2_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumWiaItem2>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumWiaItem2 {}
 impl IEnumWiaItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWiaItem2_Impl, const OFFSET: isize>() -> IEnumWiaItem2_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWiaItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppiwiaitem2: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -301,6 +307,8 @@ pub trait IWiaAppErrorHandler_Impl: Sized {
     fn ReportStatus(&self, lflags: i32, pwiaitem2: &::core::option::Option<IWiaItem2>, hrstatus: ::windows::core::HRESULT, lpercentcomplete: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaAppErrorHandler {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaAppErrorHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaAppErrorHandler_Impl, const OFFSET: isize>() -> IWiaAppErrorHandler_Vtbl {
         unsafe extern "system" fn GetWindow<Identity: ::windows::core::IUnknownImpl, Impl: IWiaAppErrorHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -332,6 +340,7 @@ impl IWiaAppErrorHandler_Vtbl {
 pub trait IWiaDataCallback_Impl: Sized {
     fn BandedDataCallback(&self, lmessage: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, lreserved: i32, lreslength: i32, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWiaDataCallback {}
 impl IWiaDataCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDataCallback_Impl, const OFFSET: isize>() -> IWiaDataCallback_Vtbl {
         unsafe extern "system" fn BandedDataCallback<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDataCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lmessage: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, lreserved: i32, lreslength: i32, pbbuffer: *mut u8) -> ::windows::core::HRESULT {
@@ -353,6 +362,8 @@ pub trait IWiaDataTransfer_Impl: Sized {
     fn idtEnumWIA_FORMAT_INFO(&self) -> ::windows::core::Result<IEnumWIA_FORMAT_INFO>;
     fn idtGetExtendedTransferInfo(&self) -> ::windows::core::Result<WIA_EXTENDED_TRANSFER_INFO>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWiaDataTransfer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWiaDataTransfer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDataTransfer_Impl, const OFFSET: isize>() -> IWiaDataTransfer_Vtbl {
@@ -418,6 +429,8 @@ pub trait IWiaDevMgr_Impl: Sized {
     fn RegisterEventCallbackCLSID(&self, lflags: i32, bstrdeviceid: &super::super::Foundation::BSTR, peventguid: *const ::windows::core::GUID, pclsid: *const ::windows::core::GUID, bstrname: &super::super::Foundation::BSTR, bstrdescription: &super::super::Foundation::BSTR, bstricon: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn AddDeviceDlg(&self, hwndparent: super::super::Foundation::HWND, lflags: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaDevMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWiaDevMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDevMgr_Impl, const OFFSET: isize>() -> IWiaDevMgr_Vtbl {
@@ -513,6 +526,8 @@ pub trait IWiaDevMgr2_Impl: Sized {
     fn GetImageDlg(&self, lflags: i32, bstrdeviceid: &super::super::Foundation::BSTR, hwndparent: super::super::Foundation::HWND, bstrfoldername: &super::super::Foundation::BSTR, bstrfilename: &super::super::Foundation::BSTR, plnumfiles: *mut i32, ppbstrfilepaths: *mut *mut super::super::Foundation::BSTR, ppitem: *mut ::core::option::Option<IWiaItem2>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaDevMgr2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaDevMgr2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDevMgr2_Impl, const OFFSET: isize>() -> IWiaDevMgr2_Vtbl {
         unsafe extern "system" fn EnumDeviceInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDevMgr2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, ppienum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -605,6 +620,8 @@ pub trait IWiaDrvItem_Impl: Sized {
     fn GetNextSiblingItem(&self) -> ::windows::core::Result<IWiaDrvItem>;
     fn DumpItemData(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaDrvItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWiaDrvItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaDrvItem_Impl, const OFFSET: isize>() -> IWiaDrvItem_Vtbl {
@@ -760,6 +777,8 @@ pub trait IWiaErrorHandler_Impl: Sized {
     fn GetStatusDescription(&self, lflags: i32, pwiaitem2: &::core::option::Option<IWiaItem2>, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaErrorHandler {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaErrorHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaErrorHandler_Impl, const OFFSET: isize>() -> IWiaErrorHandler_Vtbl {
         unsafe extern "system" fn ReportStatus<Identity: ::windows::core::IUnknownImpl, Impl: IWiaErrorHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, hwndparent: super::super::Foundation::HWND, pwiaitem2: ::windows::core::RawPtr, hrstatus: ::windows::core::HRESULT, lpercentcomplete: i32) -> ::windows::core::HRESULT {
@@ -793,6 +812,8 @@ pub trait IWiaEventCallback_Impl: Sized {
     fn ImageEventCallback(&self, peventguid: *const ::windows::core::GUID, bstreventdescription: &super::super::Foundation::BSTR, bstrdeviceid: &super::super::Foundation::BSTR, bstrdevicedescription: &super::super::Foundation::BSTR, dwdevicetype: u32, bstrfullitemname: &super::super::Foundation::BSTR, puleventtype: *mut u32, ulreserved: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaEventCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaEventCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaEventCallback_Impl, const OFFSET: isize>() -> IWiaEventCallback_Vtbl {
         unsafe extern "system" fn ImageEventCallback<Identity: ::windows::core::IUnknownImpl, Impl: IWiaEventCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventguid: *const ::windows::core::GUID, bstreventdescription: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrdeviceid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrdevicedescription: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, dwdevicetype: u32, bstrfullitemname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, puleventtype: *mut u32, ulreserved: u32) -> ::windows::core::HRESULT {
@@ -813,6 +834,8 @@ pub trait IWiaImageFilter_Impl: Sized {
     fn FilterPreviewImage(&self, lflags: i32, pwiachilditem2: &::core::option::Option<IWiaItem2>, inputimageextents: &super::super::Foundation::RECT, pinputstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
     fn ApplyProperties(&self, pwiapropertystorage: &::core::option::Option<IWiaPropertyStorage>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWiaImageFilter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWiaImageFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaImageFilter_Impl, const OFFSET: isize>() -> IWiaImageFilter_Vtbl {
@@ -866,6 +889,8 @@ pub trait IWiaItem_Impl: Sized {
     fn DumpTreeItemData(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Diagnostic(&self, ulsize: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWiaItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaItem_Impl, const OFFSET: isize>() -> IWiaItem_Vtbl {
@@ -1047,6 +1072,8 @@ pub trait IWiaItem2_Impl: Sized {
     fn Diagnostic(&self, ulsize: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaItem2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaItem2_Impl, const OFFSET: isize>() -> IWiaItem2_Vtbl {
         unsafe extern "system" fn CreateChildItem<Identity: ::windows::core::IUnknownImpl, Impl: IWiaItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, litemflags: i32, lcreationflags: i32, bstritemname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppiwiaitem2: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1220,6 +1247,8 @@ pub trait IWiaItemExtras_Impl: Sized {
     fn CancelPendingIO(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaItemExtras {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaItemExtras_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaItemExtras_Impl, const OFFSET: isize>() -> IWiaItemExtras_Vtbl {
         unsafe extern "system" fn GetExtendedErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWiaItemExtras_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrerrortext: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1261,6 +1290,8 @@ pub trait IWiaLog_Impl: Sized {
     fn Log(&self, lflags: i32, lresid: i32, ldetail: i32, bstrtext: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaLog {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaLog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaLog_Impl, const OFFSET: isize>() -> IWiaLog_Vtbl {
         unsafe extern "system" fn InitializeLog<Identity: ::windows::core::IUnknownImpl, Impl: IWiaLog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hinstance: i32) -> ::windows::core::HRESULT {
@@ -1297,6 +1328,8 @@ pub trait IWiaLogEx_Impl: Sized {
     fn hResultEx(&self, lmethodid: i32, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn LogEx(&self, lmethodid: i32, lflags: i32, lresid: i32, ldetail: i32, bstrtext: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaLogEx {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWiaLogEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaLogEx_Impl, const OFFSET: isize>() -> IWiaLogEx_Vtbl {
@@ -1358,6 +1391,8 @@ pub trait IWiaMiniDrv_Impl: Sized {
     fn drvNotifyPnpEvent(&self, peventguid: *const ::windows::core::GUID, bstrdeviceid: &super::super::Foundation::BSTR, ulreserved: u32) -> ::windows::core::Result<()>;
     fn drvUnInitializeWia(&self, __midl__iwiaminidrv0064: *const u8) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWiaMiniDrv {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWiaMiniDrv_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaMiniDrv_Impl, const OFFSET: isize>() -> IWiaMiniDrv_Vtbl {
@@ -1526,6 +1561,8 @@ pub trait IWiaMiniDrvCallBack_Impl: Sized {
     fn MiniDrvCallback(&self, lreason: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, ptranctx: *const MINIDRV_TRANSFER_CONTEXT, lreserved: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaMiniDrvCallBack {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWiaMiniDrvCallBack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaMiniDrvCallBack_Impl, const OFFSET: isize>() -> IWiaMiniDrvCallBack_Vtbl {
         unsafe extern "system" fn MiniDrvCallback<Identity: ::windows::core::IUnknownImpl, Impl: IWiaMiniDrvCallBack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lreason: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, ptranctx: *const MINIDRV_TRANSFER_CONTEXT, lreserved: i32) -> ::windows::core::HRESULT {
@@ -1544,6 +1581,8 @@ pub trait IWiaMiniDrvTransferCallback_Impl: Sized {
     fn GetNextStream(&self, lflags: i32, bstritemname: &super::super::Foundation::BSTR, bstrfullitemname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::IStream>;
     fn SendMessage(&self, lflags: i32, pwiatransferparams: *const WiaTransferParams) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWiaMiniDrvTransferCallback {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWiaMiniDrvTransferCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaMiniDrvTransferCallback_Impl, const OFFSET: isize>() -> IWiaMiniDrvTransferCallback_Vtbl {
@@ -1576,6 +1615,7 @@ impl IWiaMiniDrvTransferCallback_Vtbl {
 pub trait IWiaNotifyDevMgr_Impl: Sized {
     fn NewDeviceArrival(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWiaNotifyDevMgr {}
 impl IWiaNotifyDevMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaNotifyDevMgr_Impl, const OFFSET: isize>() -> IWiaNotifyDevMgr_Vtbl {
         unsafe extern "system" fn NewDeviceArrival<Identity: ::windows::core::IUnknownImpl, Impl: IWiaNotifyDevMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1595,6 +1635,7 @@ pub trait IWiaPreview_Impl: Sized {
     fn DetectRegions(&self, lflags: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWiaPreview {}
 impl IWiaPreview_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaPreview_Impl, const OFFSET: isize>() -> IWiaPreview_Vtbl {
         unsafe extern "system" fn GetNewPreview<Identity: ::windows::core::IUnknownImpl, Impl: IWiaPreview_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, pwiaitem2: ::windows::core::RawPtr, pwiatransfercallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1648,6 +1689,8 @@ pub trait IWiaPropertyStorage_Impl: Sized {
     fn GetPropertyStream(&self, pcompatibilityid: *mut ::windows::core::GUID, ppistream: *mut ::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
     fn SetPropertyStream(&self, pcompatibilityid: *mut ::windows::core::GUID, pistream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWiaPropertyStorage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWiaPropertyStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaPropertyStorage_Impl, const OFFSET: isize>() -> IWiaPropertyStorage_Vtbl {
@@ -1778,6 +1821,8 @@ pub trait IWiaSegmentationFilter_Impl: Sized {
     fn DetectRegions(&self, lflags: i32, pinputstream: &::core::option::Option<super::super::System::Com::IStream>, pwiaitem2: &::core::option::Option<IWiaItem2>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IWiaSegmentationFilter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IWiaSegmentationFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaSegmentationFilter_Impl, const OFFSET: isize>() -> IWiaSegmentationFilter_Vtbl {
         unsafe extern "system" fn DetectRegions<Identity: ::windows::core::IUnknownImpl, Impl: IWiaSegmentationFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, pinputstream: ::windows::core::RawPtr, pwiaitem2: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1798,6 +1843,8 @@ pub trait IWiaTransfer_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn EnumWIA_FORMAT_INFO(&self) -> ::windows::core::Result<IEnumWIA_FORMAT_INFO>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IWiaTransfer {}
 #[cfg(feature = "Win32_System_Com")]
 impl IWiaTransfer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaTransfer_Impl, const OFFSET: isize>() -> IWiaTransfer_Vtbl {
@@ -1845,6 +1892,8 @@ pub trait IWiaTransferCallback_Impl: Sized {
     fn GetNextStream(&self, lflags: i32, bstritemname: &super::super::Foundation::BSTR, bstrfullitemname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWiaTransferCallback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWiaTransferCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaTransferCallback_Impl, const OFFSET: isize>() -> IWiaTransferCallback_Vtbl {
         unsafe extern "system" fn TransferCallback<Identity: ::windows::core::IUnknownImpl, Impl: IWiaTransferCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, pwiatransferparams: *const WiaTransferParams) -> ::windows::core::HRESULT {
@@ -1880,6 +1929,8 @@ pub trait IWiaUIExtension_Impl: Sized {
     fn GetDeviceBitmapLogo(&self, bstrdeviceid: &super::super::Foundation::BSTR, phbitmap: *mut super::super::Graphics::Gdi::HBITMAP, nmaxwidth: u32, nmaxheight: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IWiaUIExtension {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IWiaUIExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaUIExtension_Impl, const OFFSET: isize>() -> IWiaUIExtension_Vtbl {
         unsafe extern "system" fn DeviceDialog<Identity: ::windows::core::IUnknownImpl, Impl: IWiaUIExtension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevicedialogdata: *const DEVICEDIALOGDATA) -> ::windows::core::HRESULT {
@@ -1913,6 +1964,8 @@ pub trait IWiaUIExtension2_Impl: Sized {
     fn DeviceDialog(&self, pdevicedialogdata: *const DEVICEDIALOGDATA2) -> ::windows::core::Result<()>;
     fn GetDeviceIcon(&self, bstrdeviceid: &super::super::Foundation::BSTR, phicon: *mut super::super::UI::WindowsAndMessaging::HICON, nsize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IWiaUIExtension2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IWiaUIExtension2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaUIExtension2_Impl, const OFFSET: isize>() -> IWiaUIExtension2_Vtbl {
@@ -1952,6 +2005,8 @@ pub trait IWiaVideo_Impl: Sized {
     fn ResizeVideo(&self, bstretchtofitparent: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetCurrentState(&self) -> ::windows::core::Result<WIAVIDEO_STATE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWiaVideo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWiaVideo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWiaVideo_Impl, const OFFSET: isize>() -> IWiaVideo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
@@ -1,6 +1,7 @@
 pub trait IConnectionRequestCallback_Impl: Sized {
     fn OnComplete(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IConnectionRequestCallback {}
 impl IConnectionRequestCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConnectionRequestCallback_Impl, const OFFSET: isize>() -> IConnectionRequestCallback_Vtbl {
         unsafe extern "system" fn OnComplete<Identity: ::windows::core::IUnknownImpl, Impl: IConnectionRequestCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -20,6 +21,7 @@ pub trait IEnumPortableDeviceConnectors_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumPortableDeviceConnectors>;
 }
+impl ::windows::core::RuntimeName for IEnumPortableDeviceConnectors {}
 impl IEnumPortableDeviceConnectors_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPortableDeviceConnectors_Impl, const OFFSET: isize>() -> IEnumPortableDeviceConnectors_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPortableDeviceConnectors_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequested: u32, pconnectors: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -67,6 +69,7 @@ pub trait IEnumPortableDeviceObjectIDs_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumPortableDeviceObjectIDs>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumPortableDeviceObjectIDs {}
 impl IEnumPortableDeviceObjectIDs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPortableDeviceObjectIDs_Impl, const OFFSET: isize>() -> IEnumPortableDeviceObjectIDs_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPortableDeviceObjectIDs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cobjects: u32, pobjids: *mut ::windows::core::PWSTR, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -117,6 +120,7 @@ pub trait IMediaRadioManager_Impl: Sized {
     fn GetRadioInstances(&self) -> ::windows::core::Result<IRadioInstanceCollection>;
     fn OnSystemRadioStateChange(&self, sysradiostate: SYSTEM_RADIO_STATE, utimeoutsec: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMediaRadioManager {}
 impl IMediaRadioManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaRadioManager_Impl, const OFFSET: isize>() -> IMediaRadioManager_Vtbl {
         unsafe extern "system" fn GetRadioInstances<Identity: ::windows::core::IUnknownImpl, Impl: IMediaRadioManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcollection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -151,6 +155,8 @@ pub trait IMediaRadioManagerNotifySink_Impl: Sized {
     fn OnInstanceRemove(&self, bstrradioinstanceid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn OnInstanceRadioChange(&self, bstrradioinstanceid: &super::super::Foundation::BSTR, radiostate: DEVICE_RADIO_STATE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMediaRadioManagerNotifySink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMediaRadioManagerNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaRadioManagerNotifySink_Impl, const OFFSET: isize>() -> IMediaRadioManagerNotifySink_Vtbl {
@@ -191,6 +197,7 @@ pub trait IPortableDevice_Impl: Sized {
     fn Unadvise(&self, pszcookie: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetPnPDeviceID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IPortableDevice {}
 impl IPortableDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevice_Impl, const OFFSET: isize>() -> IPortableDevice_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, pclientinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -299,6 +306,8 @@ pub trait IPortableDeviceCapabilities_Impl: Sized {
     fn GetSupportedEvents(&self) -> ::windows::core::Result<IPortableDevicePropVariantCollection>;
     fn GetEventOptions(&self, event: *const ::windows::core::GUID) -> ::windows::core::Result<IPortableDeviceValues>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IPortableDeviceCapabilities {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IPortableDeviceCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceCapabilities_Impl, const OFFSET: isize>() -> IPortableDeviceCapabilities_Vtbl {
@@ -446,6 +455,8 @@ pub trait IPortableDeviceConnector_Impl: Sized {
     fn GetPnPID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(feature = "Win32_Devices_Properties")]
+impl ::windows::core::RuntimeName for IPortableDeviceConnector {}
+#[cfg(feature = "Win32_Devices_Properties")]
 impl IPortableDeviceConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceConnector_Impl, const OFFSET: isize>() -> IPortableDeviceConnector_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceConnector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -511,6 +522,8 @@ pub trait IPortableDeviceContent_Impl: Sized {
     fn Move(&self, pobjectids: &::core::option::Option<IPortableDevicePropVariantCollection>, pszdestinationfolderobjectid: &::windows::core::PCWSTR, ppresults: *mut ::core::option::Option<IPortableDevicePropVariantCollection>) -> ::windows::core::Result<()>;
     fn Copy(&self, pobjectids: &::core::option::Option<IPortableDevicePropVariantCollection>, pszdestinationfolderobjectid: &::windows::core::PCWSTR, ppresults: *mut ::core::option::Option<IPortableDevicePropVariantCollection>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IPortableDeviceContent {}
 #[cfg(feature = "Win32_System_Com")]
 impl IPortableDeviceContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceContent_Impl, const OFFSET: isize>() -> IPortableDeviceContent_Vtbl {
@@ -611,6 +624,8 @@ pub trait IPortableDeviceContent2_Impl: Sized + IPortableDeviceContent_Impl {
     fn UpdateObjectWithPropertiesAndData(&self, pszobjectid: &::windows::core::PCWSTR, pproperties: &::core::option::Option<IPortableDeviceValues>, ppdata: *mut ::core::option::Option<super::super::System::Com::IStream>, pdwoptimalwritebuffersize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IPortableDeviceContent2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IPortableDeviceContent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceContent2_Impl, const OFFSET: isize>() -> IPortableDeviceContent2_Vtbl {
         unsafe extern "system" fn UpdateObjectWithPropertiesAndData<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceContent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszobjectid: ::windows::core::PCWSTR, pproperties: ::windows::core::RawPtr, ppdata: *mut ::windows::core::RawPtr, pdwoptimalwritebuffersize: *mut u32) -> ::windows::core::HRESULT {
@@ -632,6 +647,8 @@ pub trait IPortableDeviceDataStream_Impl: Sized + super::super::System::Com::ISe
     fn GetObjectID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPortableDeviceDataStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPortableDeviceDataStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceDataStream_Impl, const OFFSET: isize>() -> IPortableDeviceDataStream_Vtbl {
@@ -666,6 +683,8 @@ pub trait IPortableDeviceDispatchFactory_Impl: Sized {
     fn GetDeviceDispatch(&self, pszpnpdeviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IPortableDeviceDispatchFactory {}
+#[cfg(feature = "Win32_System_Com")]
 impl IPortableDeviceDispatchFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceDispatchFactory_Impl, const OFFSET: isize>() -> IPortableDeviceDispatchFactory_Vtbl {
         unsafe extern "system" fn GetDeviceDispatch<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceDispatchFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, ppdevicedispatch: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -688,6 +707,7 @@ impl IPortableDeviceDispatchFactory_Vtbl {
 pub trait IPortableDeviceEventCallback_Impl: Sized {
     fn OnEvent(&self, peventparameters: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceEventCallback {}
 impl IPortableDeviceEventCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceEventCallback_Impl, const OFFSET: isize>() -> IPortableDeviceEventCallback_Vtbl {
         unsafe extern "system" fn OnEvent<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceEventCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventparameters: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -709,6 +729,8 @@ pub trait IPortableDeviceKeyCollection_Impl: Sized {
     fn Clear(&self) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, dwindex: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IPortableDeviceKeyCollection {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IPortableDeviceKeyCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceKeyCollection_Impl, const OFFSET: isize>() -> IPortableDeviceKeyCollection_Vtbl {
@@ -759,6 +781,7 @@ pub trait IPortableDeviceManager_Impl: Sized {
     fn GetDeviceProperty(&self, pszpnpdeviceid: &::windows::core::PCWSTR, pszdevicepropertyname: &::windows::core::PCWSTR, pdata: *mut u8, pcbdata: *mut u32, pdwtype: *mut u32) -> ::windows::core::Result<()>;
     fn GetPrivateDevices(&self, ppnpdeviceids: *mut ::windows::core::PWSTR, pcpnpdeviceids: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceManager {}
 impl IPortableDeviceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceManager_Impl, const OFFSET: isize>() -> IPortableDeviceManager_Vtbl {
         unsafe extern "system" fn GetDevices<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppnpdeviceids: *mut ::windows::core::PWSTR, pcpnpdeviceids: *mut u32) -> ::windows::core::HRESULT {
@@ -821,6 +844,8 @@ pub trait IPortableDevicePropVariantCollection_Impl: Sized {
     fn Clear(&self) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, dwindex: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPortableDevicePropVariantCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPortableDevicePropVariantCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevicePropVariantCollection_Impl, const OFFSET: isize>() -> IPortableDevicePropVariantCollection_Vtbl {
@@ -889,6 +914,8 @@ pub trait IPortableDeviceProperties_Impl: Sized {
     fn Delete(&self, pszobjectid: &::windows::core::PCWSTR, pkeys: &::core::option::Option<IPortableDeviceKeyCollection>) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IPortableDeviceProperties {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IPortableDeviceProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceProperties_Impl, const OFFSET: isize>() -> IPortableDeviceProperties_Vtbl {
@@ -967,6 +994,7 @@ pub trait IPortableDevicePropertiesBulk_Impl: Sized {
     fn Start(&self, pcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Cancel(&self, pcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDevicePropertiesBulk {}
 impl IPortableDevicePropertiesBulk_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevicePropertiesBulk_Impl, const OFFSET: isize>() -> IPortableDevicePropertiesBulk_Vtbl {
         unsafe extern "system" fn QueueGetValuesByObjectList<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevicePropertiesBulk_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobjectids: ::windows::core::RawPtr, pkeys: ::windows::core::RawPtr, pcallback: ::windows::core::RawPtr, pcontext: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1030,6 +1058,7 @@ pub trait IPortableDevicePropertiesBulkCallback_Impl: Sized {
     fn OnProgress(&self, pcontext: *const ::windows::core::GUID, presults: &::core::option::Option<IPortableDeviceValuesCollection>) -> ::windows::core::Result<()>;
     fn OnEnd(&self, pcontext: *const ::windows::core::GUID, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDevicePropertiesBulkCallback {}
 impl IPortableDevicePropertiesBulkCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevicePropertiesBulkCallback_Impl, const OFFSET: isize>() -> IPortableDevicePropertiesBulkCallback_Vtbl {
         unsafe extern "system" fn OnStart<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDevicePropertiesBulkCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1067,6 +1096,8 @@ pub trait IPortableDeviceResources_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn CreateResource(&self, presourceattributes: &::core::option::Option<IPortableDeviceValues>, ppdata: *mut ::core::option::Option<super::super::System::Com::IStream>, pdwoptimalwritebuffersize: *mut u32, ppszcookie: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IPortableDeviceResources {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IPortableDeviceResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceResources_Impl, const OFFSET: isize>() -> IPortableDeviceResources_Vtbl {
@@ -1139,6 +1170,7 @@ pub trait IPortableDeviceService_Impl: Sized {
     fn Unadvise(&self, pszcookie: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SendCommand(&self, dwflags: u32, pparameters: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<IPortableDeviceValues>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceService {}
 impl IPortableDeviceService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceService_Impl, const OFFSET: isize>() -> IPortableDeviceService_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpnpserviceid: ::windows::core::PCWSTR, pclientinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1261,6 +1293,7 @@ pub trait IPortableDeviceServiceActivation_Impl: Sized {
     fn OpenAsync(&self, pszpnpserviceid: &::windows::core::PCWSTR, pclientinfo: &::core::option::Option<IPortableDeviceValues>, pcallback: &::core::option::Option<IPortableDeviceServiceOpenCallback>) -> ::windows::core::Result<()>;
     fn CancelOpenAsync(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceServiceActivation {}
 impl IPortableDeviceServiceActivation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceActivation_Impl, const OFFSET: isize>() -> IPortableDeviceServiceActivation_Vtbl {
         unsafe extern "system" fn OpenAsync<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceActivation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpnpserviceid: ::windows::core::PCWSTR, pclientinfo: ::windows::core::RawPtr, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1302,6 +1335,8 @@ pub trait IPortableDeviceServiceCapabilities_Impl: Sized {
     fn GetCommandOptions(&self, command: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<IPortableDeviceValues>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IPortableDeviceServiceCapabilities {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IPortableDeviceServiceCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceCapabilities_Impl, const OFFSET: isize>() -> IPortableDeviceServiceCapabilities_Vtbl {
@@ -1503,6 +1538,7 @@ pub trait IPortableDeviceServiceManager_Impl: Sized {
     fn GetDeviceServices(&self, pszpnpdeviceid: &::windows::core::PCWSTR, guidservicecategory: *const ::windows::core::GUID, pservices: *mut ::windows::core::PWSTR, pcservices: *mut u32) -> ::windows::core::Result<()>;
     fn GetDeviceForService(&self, pszpnpserviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceServiceManager {}
 impl IPortableDeviceServiceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceManager_Impl, const OFFSET: isize>() -> IPortableDeviceServiceManager_Vtbl {
         unsafe extern "system" fn GetDeviceServices<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, guidservicecategory: *const ::windows::core::GUID, pservices: *mut ::windows::core::PWSTR, pcservices: *mut u32) -> ::windows::core::HRESULT {
@@ -1534,6 +1570,7 @@ impl IPortableDeviceServiceManager_Vtbl {
 pub trait IPortableDeviceServiceMethodCallback_Impl: Sized {
     fn OnComplete(&self, hrstatus: ::windows::core::HRESULT, presults: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceServiceMethodCallback {}
 impl IPortableDeviceServiceMethodCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceMethodCallback_Impl, const OFFSET: isize>() -> IPortableDeviceServiceMethodCallback_Vtbl {
         unsafe extern "system" fn OnComplete<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceMethodCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT, presults: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1552,6 +1589,7 @@ pub trait IPortableDeviceServiceMethods_Impl: Sized {
     fn InvokeAsync(&self, method: *const ::windows::core::GUID, pparameters: &::core::option::Option<IPortableDeviceValues>, pcallback: &::core::option::Option<IPortableDeviceServiceMethodCallback>) -> ::windows::core::Result<()>;
     fn Cancel(&self, pcallback: &::core::option::Option<IPortableDeviceServiceMethodCallback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceServiceMethods {}
 impl IPortableDeviceServiceMethods_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceMethods_Impl, const OFFSET: isize>() -> IPortableDeviceServiceMethods_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceMethods_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, method: *const ::windows::core::GUID, pparameters: ::windows::core::RawPtr, ppresults: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1583,6 +1621,7 @@ impl IPortableDeviceServiceMethods_Vtbl {
 pub trait IPortableDeviceServiceOpenCallback_Impl: Sized {
     fn OnComplete(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceServiceOpenCallback {}
 impl IPortableDeviceServiceOpenCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceOpenCallback_Impl, const OFFSET: isize>() -> IPortableDeviceServiceOpenCallback_Vtbl {
         unsafe extern "system" fn OnComplete<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceServiceOpenCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1600,6 +1639,7 @@ pub trait IPortableDeviceUnitsStream_Impl: Sized {
     fn SeekInUnits(&self, dlibmove: i64, units: WPD_STREAM_UNITS, dworigin: u32) -> ::windows::core::Result<u64>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceUnitsStream {}
 impl IPortableDeviceUnitsStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceUnitsStream_Impl, const OFFSET: isize>() -> IPortableDeviceUnitsStream_Vtbl {
         unsafe extern "system" fn SeekInUnits<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceUnitsStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dlibmove: i64, units: WPD_STREAM_UNITS, dworigin: u32, plibnewposition: *mut u64) -> ::windows::core::HRESULT {
@@ -1671,6 +1711,8 @@ pub trait IPortableDeviceValues_Impl: Sized {
     fn CopyValuesToPropertyStore(&self, pstore: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IPortableDeviceValues {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IPortableDeviceValues_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceValues_Impl, const OFFSET: isize>() -> IPortableDeviceValues_Vtbl {
@@ -2025,6 +2067,7 @@ pub trait IPortableDeviceValuesCollection_Impl: Sized {
     fn Clear(&self) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, dwindex: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPortableDeviceValuesCollection {}
 impl IPortableDeviceValuesCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceValuesCollection_Impl, const OFFSET: isize>() -> IPortableDeviceValuesCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceValuesCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcelems: *const u32) -> ::windows::core::HRESULT {
@@ -2077,6 +2120,8 @@ pub trait IPortableDeviceWebControl_Impl: Sized + super::super::System::Com::IDi
     fn GetDeviceFromIdAsync(&self, deviceid: &super::super::Foundation::BSTR, pcompletionhandler: &::core::option::Option<super::super::System::Com::IDispatch>, perrorhandler: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPortableDeviceWebControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPortableDeviceWebControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceWebControl_Impl, const OFFSET: isize>() -> IPortableDeviceWebControl_Vtbl {
         unsafe extern "system" fn GetDeviceFromId<Identity: ::windows::core::IUnknownImpl, Impl: IPortableDeviceWebControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, deviceid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2115,6 +2160,8 @@ pub trait IRadioInstance_Impl: Sized {
     fn IsMultiComm(&self) -> super::super::Foundation::BOOL;
     fn IsAssociatingDevice(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRadioInstance {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRadioInstance_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRadioInstance_Impl, const OFFSET: isize>() -> IRadioInstance_Vtbl {
@@ -2196,6 +2243,7 @@ pub trait IRadioInstanceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, uindex: u32) -> ::windows::core::Result<IRadioInstance>;
 }
+impl ::windows::core::RuntimeName for IRadioInstanceCollection {}
 impl IRadioInstanceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRadioInstanceCollection_Impl, const OFFSET: isize>() -> IRadioInstanceCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IRadioInstanceCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcinstance: *mut u32) -> ::windows::core::HRESULT {
@@ -2236,6 +2284,7 @@ pub trait IWpdSerializer_Impl: Sized {
     fn GetBufferFromIPortableDeviceValues(&self, psource: &::core::option::Option<IPortableDeviceValues>, ppbuffer: *mut *mut u8, pdwbuffersize: *mut u32) -> ::windows::core::Result<()>;
     fn GetSerializedSize(&self, psource: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IWpdSerializer {}
 impl IWpdSerializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWpdSerializer_Impl, const OFFSET: isize>() -> IWpdSerializer_Vtbl {
         unsafe extern "system" fn GetIPortableDeviceValuesFromBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IWpdSerializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffer: *const u8, dwinputbufferlength: u32, ppparams: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
@@ -4,6 +4,8 @@ pub trait ILocationPermissions_Impl: Sized {
     fn CheckLocationCapability(&self, dwclientthreadid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ILocationPermissions {}
+#[cfg(feature = "Win32_Foundation")]
 impl ILocationPermissions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocationPermissions_Impl, const OFFSET: isize>() -> ILocationPermissions_Vtbl {
         unsafe extern "system" fn GetGlobalLocationPermission<Identity: ::windows::core::IUnknownImpl, Impl: ILocationPermissions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -50,6 +52,8 @@ pub trait ISensor_Impl: Sized {
     fn SetEventInterest(&self, pvalues: *const ::windows::core::GUID, count: u32) -> ::windows::core::Result<()>;
     fn SetEventSink(&self, pevents: &::core::option::Option<ISensorEvents>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Devices_PortableDevices", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISensor {}
 #[cfg(all(feature = "Win32_Devices_PortableDevices", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISensor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensor_Impl, const OFFSET: isize>() -> ISensor_Vtbl {
@@ -231,6 +235,7 @@ pub trait ISensorCollection_Impl: Sized {
     fn RemoveByID(&self, sensorid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISensorCollection {}
 impl ISensorCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensorCollection_Impl, const OFFSET: isize>() -> ISensorCollection_Vtbl {
         unsafe extern "system" fn GetAt<Identity: ::windows::core::IUnknownImpl, Impl: ISensorCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulindex: u32, ppsensor: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -296,6 +301,8 @@ pub trait ISensorDataReport_Impl: Sized {
     fn GetSensorValues(&self, pkeys: &::core::option::Option<super::PortableDevices::IPortableDeviceKeyCollection>) -> ::windows::core::Result<super::PortableDevices::IPortableDeviceValues>;
 }
 #[cfg(all(feature = "Win32_Devices_PortableDevices", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISensorDataReport {}
+#[cfg(all(feature = "Win32_Devices_PortableDevices", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISensorDataReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensorDataReport_Impl, const OFFSET: isize>() -> ISensorDataReport_Vtbl {
         unsafe extern "system" fn GetTimestamp<Identity: ::windows::core::IUnknownImpl, Impl: ISensorDataReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptimestamp: *mut super::super::Foundation::SYSTEMTIME) -> ::windows::core::HRESULT {
@@ -350,6 +357,8 @@ pub trait ISensorEvents_Impl: Sized {
     fn OnLeave(&self, id: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Devices_PortableDevices")]
+impl ::windows::core::RuntimeName for ISensorEvents {}
+#[cfg(feature = "Win32_Devices_PortableDevices")]
 impl ISensorEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensorEvents_Impl, const OFFSET: isize>() -> ISensorEvents_Vtbl {
         unsafe extern "system" fn OnStateChanged<Identity: ::windows::core::IUnknownImpl, Impl: ISensorEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psensor: ::windows::core::RawPtr, state: SensorState) -> ::windows::core::HRESULT {
@@ -392,6 +401,8 @@ pub trait ISensorManager_Impl: Sized {
     fn SetEventSink(&self, pevents: &::core::option::Option<ISensorManagerEvents>) -> ::windows::core::Result<()>;
     fn RequestPermissions(&self, hparent: super::super::Foundation::HWND, psensors: &::core::option::Option<ISensorCollection>, fmodal: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISensorManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISensorManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensorManager_Impl, const OFFSET: isize>() -> ISensorManager_Vtbl {
@@ -454,6 +465,7 @@ impl ISensorManager_Vtbl {
 pub trait ISensorManagerEvents_Impl: Sized {
     fn OnSensorEnter(&self, psensor: &::core::option::Option<ISensor>, state: SensorState) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISensorManagerEvents {}
 impl ISensorManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensorManagerEvents_Impl, const OFFSET: isize>() -> ISensorManagerEvents_Vtbl {
         unsafe extern "system" fn OnSensorEnter<Identity: ::windows::core::IUnknownImpl, Impl: ISensorManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psensor: ::windows::core::RawPtr, state: SensorState) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
@@ -6,6 +6,8 @@ pub trait IEnumACDGroup_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumACDGroup>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumACDGroup {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumACDGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumACDGroup_Impl, const OFFSET: isize>() -> IEnumACDGroup_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumACDGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -53,6 +55,8 @@ pub trait IEnumAddress_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumAddress>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumAddress {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAddress_Impl, const OFFSET: isize>() -> IEnumAddress_Vtbl {
@@ -102,6 +106,8 @@ pub trait IEnumAgent_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumAgent>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumAgent {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumAgent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAgent_Impl, const OFFSET: isize>() -> IEnumAgent_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAgent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -149,6 +155,8 @@ pub trait IEnumAgentHandler_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumAgentHandler>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumAgentHandler {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumAgentHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAgentHandler_Impl, const OFFSET: isize>() -> IEnumAgentHandler_Vtbl {
@@ -198,6 +206,8 @@ pub trait IEnumAgentSession_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumAgentSession>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumAgentSession {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumAgentSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAgentSession_Impl, const OFFSET: isize>() -> IEnumAgentSession_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAgentSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -245,6 +255,8 @@ pub trait IEnumBstr_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumBstr>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumBstr {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnumBstr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBstr_Impl, const OFFSET: isize>() -> IEnumBstr_Vtbl {
@@ -294,6 +306,8 @@ pub trait IEnumCall_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumCall>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumCall {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumCall_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCall_Impl, const OFFSET: isize>() -> IEnumCall_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCall_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -341,6 +355,8 @@ pub trait IEnumCallHub_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumCallHub>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumCallHub {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumCallHub_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCallHub_Impl, const OFFSET: isize>() -> IEnumCallHub_Vtbl {
@@ -390,6 +406,8 @@ pub trait IEnumCallingCard_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumCallingCard>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumCallingCard {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumCallingCard_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCallingCard_Impl, const OFFSET: isize>() -> IEnumCallingCard_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCallingCard_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -437,6 +455,8 @@ pub trait IEnumDialableAddrs_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDialableAddrs>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumDialableAddrs {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnumDialableAddrs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDialableAddrs_Impl, const OFFSET: isize>() -> IEnumDialableAddrs_Vtbl {
@@ -486,6 +506,8 @@ pub trait IEnumDirectory_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumDirectory>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumDirectory {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumDirectory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDirectory_Impl, const OFFSET: isize>() -> IEnumDirectory_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDirectory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -533,6 +555,8 @@ pub trait IEnumDirectoryObject_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDirectoryObject>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumDirectoryObject {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumDirectoryObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDirectoryObject_Impl, const OFFSET: isize>() -> IEnumDirectoryObject_Vtbl {
@@ -582,6 +606,8 @@ pub trait IEnumLocation_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumLocation>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumLocation {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumLocation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumLocation_Impl, const OFFSET: isize>() -> IEnumLocation_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumLocation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -629,6 +655,8 @@ pub trait IEnumMcastScope_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumMcastScope>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumMcastScope {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumMcastScope_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMcastScope_Impl, const OFFSET: isize>() -> IEnumMcastScope_Vtbl {
@@ -678,6 +706,8 @@ pub trait IEnumPhone_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumPhone>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumPhone {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumPhone_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPhone_Impl, const OFFSET: isize>() -> IEnumPhone_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPhone_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -725,6 +755,8 @@ pub trait IEnumPluggableSuperclassInfo_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumPluggableSuperclassInfo>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumPluggableSuperclassInfo {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumPluggableSuperclassInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPluggableSuperclassInfo_Impl, const OFFSET: isize>() -> IEnumPluggableSuperclassInfo_Vtbl {
@@ -774,6 +806,8 @@ pub trait IEnumPluggableTerminalClassInfo_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumPluggableTerminalClassInfo>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumPluggableTerminalClassInfo {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumPluggableTerminalClassInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPluggableTerminalClassInfo_Impl, const OFFSET: isize>() -> IEnumPluggableTerminalClassInfo_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPluggableTerminalClassInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -821,6 +855,8 @@ pub trait IEnumQueue_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumQueue>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumQueue {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumQueue_Impl, const OFFSET: isize>() -> IEnumQueue_Vtbl {
@@ -870,6 +906,8 @@ pub trait IEnumStream_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumStream>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumStream {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumStream_Impl, const OFFSET: isize>() -> IEnumStream_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -917,6 +955,8 @@ pub trait IEnumSubStream_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSubStream>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumSubStream {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumSubStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSubStream_Impl, const OFFSET: isize>() -> IEnumSubStream_Vtbl {
@@ -966,6 +1006,8 @@ pub trait IEnumTerminal_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTerminal>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumTerminal {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumTerminal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTerminal_Impl, const OFFSET: isize>() -> IEnumTerminal_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTerminal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1012,6 +1054,7 @@ pub trait IEnumTerminalClass_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumTerminalClass>;
 }
+impl ::windows::core::RuntimeName for IEnumTerminalClass {}
 impl IEnumTerminalClass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTerminalClass_Impl, const OFFSET: isize>() -> IEnumTerminalClass_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTerminalClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pelements: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1062,6 +1105,8 @@ pub trait IMcastAddressAllocation_Impl: Sized + super::super::System::Com::IDisp
     fn CreateLeaseInfo(&self, leasestarttime: f64, leasestoptime: f64, dwnumaddresses: u32, ppaddresses: *const ::windows::core::PWSTR, prequestid: &::windows::core::PCWSTR, pserveraddress: &::windows::core::PCWSTR) -> ::windows::core::Result<IMcastLeaseInfo>;
     fn CreateLeaseInfoFromVariant(&self, leasestarttime: f64, leasestoptime: f64, vaddresses: &super::super::System::Com::VARIANT, prequestid: &super::super::Foundation::BSTR, pserveraddress: &super::super::Foundation::BSTR) -> ::windows::core::Result<IMcastLeaseInfo>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMcastAddressAllocation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMcastAddressAllocation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMcastAddressAllocation_Impl, const OFFSET: isize>() -> IMcastAddressAllocation_Vtbl {
@@ -1164,6 +1209,8 @@ pub trait IMcastLeaseInfo_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Addresses(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn EnumerateAddresses(&self) -> ::windows::core::Result<IEnumBstr>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMcastLeaseInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMcastLeaseInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMcastLeaseInfo_Impl, const OFFSET: isize>() -> IMcastLeaseInfo_Vtbl {
@@ -1292,6 +1339,8 @@ pub trait IMcastScope_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TTL(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMcastScope {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMcastScope_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMcastScope_Impl, const OFFSET: isize>() -> IMcastScope_Vtbl {
         unsafe extern "system" fn ScopeID<Identity: ::windows::core::IUnknownImpl, Impl: IMcastScope_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pid: *mut i32) -> ::windows::core::HRESULT {
@@ -1369,6 +1418,8 @@ pub trait ITACDGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Queues(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITACDGroup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITACDGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITACDGroup_Impl, const OFFSET: isize>() -> ITACDGroup_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: ITACDGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1421,6 +1472,8 @@ pub trait ITACDGroupEvent_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Event(&self) -> ::windows::core::Result<ACDGROUP_EVENT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITACDGroupEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITACDGroupEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITACDGroupEvent_Impl, const OFFSET: isize>() -> ITACDGroupEvent_Vtbl {
         unsafe extern "system" fn Group<Identity: ::windows::core::IUnknownImpl, Impl: ITACDGroupEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppgroup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1461,6 +1514,8 @@ pub trait ITAMMediaFormat_Impl: Sized {
     fn SetMediaFormat(&self, pmt: *const super::super::Media::DirectShow::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
+impl ::windows::core::RuntimeName for ITAMMediaFormat {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
 impl ITAMMediaFormat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAMMediaFormat_Impl, const OFFSET: isize>() -> ITAMMediaFormat_Vtbl {
         unsafe extern "system" fn MediaFormat<Identity: ::windows::core::IUnknownImpl, Impl: ITAMMediaFormat_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmt: *mut *mut super::super::Media::DirectShow::AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -1495,6 +1550,8 @@ pub trait ITASRTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch_
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
     fn Error(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITASRTerminalEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITASRTerminalEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITASRTerminalEvent_Impl, const OFFSET: isize>() -> ITASRTerminalEvent_Vtbl {
@@ -1560,6 +1617,8 @@ pub trait ITAddress_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetDoNotDisturb(&self, fdonotdisturb: i16) -> ::windows::core::Result<()>;
     fn DoNotDisturb(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddress {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddress_Impl, const OFFSET: isize>() -> ITAddress_Vtbl {
@@ -1747,6 +1806,8 @@ pub trait ITAddress2_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn NegotiateExtVersion(&self, llowversion: i32, lhighversion: i32) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddress2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddress2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddress2_Impl, const OFFSET: isize>() -> ITAddress2_Vtbl {
         unsafe extern "system" fn Phones<Identity: ::windows::core::IUnknownImpl, Impl: ITAddress2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pphones: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1871,6 +1932,8 @@ pub trait ITAddressCapabilities_Impl: Sized + super::super::System::Com::IDispat
     fn EnumerateDeviceClasses(&self) -> ::windows::core::Result<IEnumBstr>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddressCapabilities {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddressCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressCapabilities_Impl, const OFFSET: isize>() -> ITAddressCapabilities_Vtbl {
         unsafe extern "system" fn get_AddressCapability<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, addresscap: ADDRESS_CAPABILITY, plcapability: *mut i32) -> ::windows::core::HRESULT {
@@ -1986,6 +2049,8 @@ pub trait ITAddressDeviceSpecificEvent_Impl: Sized + super::super::System::Com::
     fn lParam3(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddressDeviceSpecificEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddressDeviceSpecificEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressDeviceSpecificEvent_Impl, const OFFSET: isize>() -> ITAddressDeviceSpecificEvent_Vtbl {
         unsafe extern "system" fn Address<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressDeviceSpecificEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppaddress: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2063,6 +2128,8 @@ pub trait ITAddressEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Terminal(&self) -> ::windows::core::Result<ITTerminal>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddressEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddressEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressEvent_Impl, const OFFSET: isize>() -> ITAddressEvent_Vtbl {
         unsafe extern "system" fn Address<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppaddress: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2118,6 +2185,8 @@ pub trait ITAddressTranslation_Impl: Sized + super::super::System::Com::IDispatc
     fn EnumerateCallingCards(&self) -> ::windows::core::Result<IEnumCallingCard>;
     fn CallingCards(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddressTranslation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddressTranslation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressTranslation_Impl, const OFFSET: isize>() -> ITAddressTranslation_Vtbl {
@@ -2203,6 +2272,8 @@ pub trait ITAddressTranslationInfo_Impl: Sized + super::super::System::Com::IDis
     fn DestinationCountryCode(&self) -> ::windows::core::Result<i32>;
     fn TranslationResults(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAddressTranslationInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAddressTranslationInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAddressTranslationInfo_Impl, const OFFSET: isize>() -> ITAddressTranslationInfo_Vtbl {
@@ -2294,6 +2365,8 @@ pub trait ITAgent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TotalWrapUpTime(&self) -> ::windows::core::Result<i32>;
     fn AgentSessions(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAgent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAgent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAgent_Impl, const OFFSET: isize>() -> ITAgent_Vtbl {
@@ -2503,6 +2576,8 @@ pub trait ITAgentEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Event(&self) -> ::windows::core::Result<AGENT_EVENT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAgentEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAgentEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentEvent_Impl, const OFFSET: isize>() -> ITAgentEvent_Vtbl {
         unsafe extern "system" fn Agent<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppagent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2547,6 +2622,8 @@ pub trait ITAgentHandler_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn ACDGroups(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn UsableAddresses(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAgentHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAgentHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentHandler_Impl, const OFFSET: isize>() -> ITAgentHandler_Vtbl {
@@ -2648,6 +2725,8 @@ pub trait ITAgentHandlerEvent_Impl: Sized + super::super::System::Com::IDispatch
     fn Event(&self) -> ::windows::core::Result<AGENTHANDLER_EVENT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAgentHandlerEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAgentHandlerEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentHandlerEvent_Impl, const OFFSET: isize>() -> ITAgentHandlerEvent_Vtbl {
         unsafe extern "system" fn AgentHandler<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentHandlerEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppagenthandler: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2702,6 +2781,8 @@ pub trait ITAgentSession_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn LongestTimeToAnswer(&self) -> ::windows::core::Result<i32>;
     fn AverageTimeToAnswer(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAgentSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAgentSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentSession_Impl, const OFFSET: isize>() -> ITAgentSession_Vtbl {
@@ -2917,6 +2998,8 @@ pub trait ITAgentSessionEvent_Impl: Sized + super::super::System::Com::IDispatch
     fn Event(&self) -> ::windows::core::Result<AGENT_SESSION_EVENT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAgentSessionEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAgentSessionEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentSessionEvent_Impl, const OFFSET: isize>() -> ITAgentSessionEvent_Vtbl {
         unsafe extern "system" fn Session<Identity: ::windows::core::IUnknownImpl, Impl: ITAgentSessionEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsession: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2960,6 +3043,8 @@ pub trait ITAllocatorProperties_Impl: Sized {
     fn SetBufferSize(&self, buffersize: u32) -> ::windows::core::Result<()>;
     fn GetBufferSize(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
+impl ::windows::core::RuntimeName for ITAllocatorProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
 impl ITAllocatorProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAllocatorProperties_Impl, const OFFSET: isize>() -> ITAllocatorProperties_Vtbl {
@@ -3060,6 +3145,8 @@ pub trait ITAutomatedPhoneControl_Impl: Sized + super::super::System::Com::IDisp
     fn EnumerateSelectedCalls(&self) -> ::windows::core::Result<IEnumCall>;
     fn SelectedCalls(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITAutomatedPhoneControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITAutomatedPhoneControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITAutomatedPhoneControl_Impl, const OFFSET: isize>() -> ITAutomatedPhoneControl_Vtbl {
@@ -3361,6 +3448,8 @@ pub trait ITBasicAudioTerminal_Impl: Sized + super::super::System::Com::IDispatc
     fn Balance(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITBasicAudioTerminal {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITBasicAudioTerminal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITBasicAudioTerminal_Impl, const OFFSET: isize>() -> ITBasicAudioTerminal_Vtbl {
         unsafe extern "system" fn SetVolume<Identity: ::windows::core::IUnknownImpl, Impl: ITBasicAudioTerminal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lvolume: i32) -> ::windows::core::HRESULT {
@@ -3428,6 +3517,8 @@ pub trait ITBasicCallControl_Impl: Sized + super::super::System::Com::IDispatch_
     fn Finish(&self, finishmode: FINISH_MODE) -> ::windows::core::Result<()>;
     fn RemoveFromConference(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITBasicCallControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITBasicCallControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITBasicCallControl_Impl, const OFFSET: isize>() -> ITBasicCallControl_Vtbl {
@@ -3560,6 +3651,8 @@ pub trait ITBasicCallControl2_Impl: Sized + super::super::System::Com::IDispatch
     fn UnselectTerminalOnCall(&self, pterminal: &::core::option::Option<ITTerminal>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITBasicCallControl2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITBasicCallControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITBasicCallControl2_Impl, const OFFSET: isize>() -> ITBasicCallControl2_Vtbl {
         unsafe extern "system" fn RequestTerminal<Identity: ::windows::core::IUnknownImpl, Impl: ITBasicCallControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrterminalclassguid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lmediatype: i32, direction: TERMINAL_DIRECTION, ppterminal: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3602,6 +3695,8 @@ pub trait ITCallHub_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn NumCalls(&self) -> ::windows::core::Result<i32>;
     fn State(&self) -> ::windows::core::Result<CALLHUB_STATE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallHub {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallHub_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallHub_Impl, const OFFSET: isize>() -> ITCallHub_Vtbl {
@@ -3674,6 +3769,8 @@ pub trait ITCallHubEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallHubEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallHubEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallHubEvent_Impl, const OFFSET: isize>() -> ITCallHubEvent_Vtbl {
         unsafe extern "system" fn Event<Identity: ::windows::core::IUnknownImpl, Impl: ITCallHubEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pevent: *mut CALLHUB_EVENT) -> ::windows::core::HRESULT {
@@ -3736,6 +3833,8 @@ pub trait ITCallInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetCallInfoBuffer(&self, callinfobuffer: CALLINFO_BUFFER, dwsize: u32, pcallinfobuffer: *const u8) -> ::windows::core::Result<()>;
     fn ReleaseUserUserInfo(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallInfo_Impl, const OFFSET: isize>() -> ITCallInfo_Vtbl {
@@ -3873,6 +3972,8 @@ pub trait ITCallInfo2_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn put_EventFilter(&self, tapievent: TAPI_EVENT, lsubevent: i32, benable: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallInfo2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallInfo2_Impl, const OFFSET: isize>() -> ITCallInfo2_Vtbl {
         unsafe extern "system" fn get_EventFilter<Identity: ::windows::core::IUnknownImpl, Impl: ITCallInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tapievent: TAPI_EVENT, lsubevent: i32, penable: *mut i16) -> ::windows::core::HRESULT {
@@ -3907,6 +4008,8 @@ pub trait ITCallInfoChangeEvent_Impl: Sized + super::super::System::Com::IDispat
     fn Cause(&self) -> ::windows::core::Result<CALLINFOCHANGE_CAUSE>;
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallInfoChangeEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallInfoChangeEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallInfoChangeEvent_Impl, const OFFSET: isize>() -> ITCallInfoChangeEvent_Vtbl {
@@ -3963,6 +4066,8 @@ pub trait ITCallMediaEvent_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn Stream(&self) -> ::windows::core::Result<ITStream>;
     fn Cause(&self) -> ::windows::core::Result<CALL_MEDIA_EVENT_CAUSE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallMediaEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallMediaEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallMediaEvent_Impl, const OFFSET: isize>() -> ITCallMediaEvent_Vtbl {
@@ -4053,6 +4158,8 @@ pub trait ITCallNotificationEvent_Impl: Sized + super::super::System::Com::IDisp
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallNotificationEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallNotificationEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallNotificationEvent_Impl, const OFFSET: isize>() -> ITCallNotificationEvent_Vtbl {
         unsafe extern "system" fn Call<Identity: ::windows::core::IUnknownImpl, Impl: ITCallNotificationEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcall: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4106,6 +4213,8 @@ pub trait ITCallStateEvent_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn Cause(&self) -> ::windows::core::Result<CALL_STATE_EVENT_CAUSE>;
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallStateEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallStateEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallStateEvent_Impl, const OFFSET: isize>() -> ITCallStateEvent_Vtbl {
@@ -4175,6 +4284,8 @@ pub trait ITCallingCard_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn LongDistanceDialingRule(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn InternationalDialingRule(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCallingCard {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCallingCard_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCallingCard_Impl, const OFFSET: isize>() -> ITCallingCard_Vtbl {
@@ -4277,6 +4388,8 @@ pub trait ITCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCollection_Impl, const OFFSET: isize>() -> ITCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ITCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lcount: *mut i32) -> ::windows::core::HRESULT {
@@ -4329,6 +4442,8 @@ pub trait ITCollection2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Remove(&self, index: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCollection2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCollection2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCollection2_Impl, const OFFSET: isize>() -> ITCollection2_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: ITCollection2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pvariant: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4358,6 +4473,8 @@ pub trait ITCustomTone_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Volume(&self) -> ::windows::core::Result<i32>;
     fn SetVolume(&self, lvolume: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITCustomTone {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITCustomTone_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITCustomTone_Impl, const OFFSET: isize>() -> ITCustomTone_Vtbl {
@@ -4451,6 +4568,8 @@ pub trait ITDetectTone_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn put_Frequency(&self, index: i32, lfrequency: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDetectTone {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDetectTone_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDetectTone_Impl, const OFFSET: isize>() -> ITDetectTone_Vtbl {
         unsafe extern "system" fn AppSpecific<Identity: ::windows::core::IUnknownImpl, Impl: ITDetectTone_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plappspecific: *mut i32) -> ::windows::core::HRESULT {
@@ -4523,6 +4642,8 @@ pub trait ITDigitDetectionEvent_Impl: Sized + super::super::System::Com::IDispat
     fn TickCount(&self) -> ::windows::core::Result<i32>;
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDigitDetectionEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDigitDetectionEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDigitDetectionEvent_Impl, const OFFSET: isize>() -> ITDigitDetectionEvent_Vtbl {
@@ -4602,6 +4723,8 @@ pub trait ITDigitGenerationEvent_Impl: Sized + super::super::System::Com::IDispa
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDigitGenerationEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDigitGenerationEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDigitGenerationEvent_Impl, const OFFSET: isize>() -> ITDigitGenerationEvent_Vtbl {
         unsafe extern "system" fn Call<Identity: ::windows::core::IUnknownImpl, Impl: ITDigitGenerationEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcallinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4668,6 +4791,8 @@ pub trait ITDigitsGatheredEvent_Impl: Sized + super::super::System::Com::IDispat
     fn TickCount(&self) -> ::windows::core::Result<i32>;
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDigitsGatheredEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDigitsGatheredEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDigitsGatheredEvent_Impl, const OFFSET: isize>() -> ITDigitsGatheredEvent_Vtbl {
@@ -4756,6 +4881,8 @@ pub trait ITDirectory_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_DirectoryObjects(&self, directoryobjecttype: DIRECTORY_OBJECT_TYPE, pname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn EnumerateDirectoryObjects(&self, directoryobjecttype: DIRECTORY_OBJECT_TYPE, pname: &super::super::Foundation::BSTR) -> ::windows::core::Result<IEnumDirectoryObject>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDirectory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDirectory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDirectory_Impl, const OFFSET: isize>() -> ITDirectory_Vtbl {
@@ -4898,6 +5025,8 @@ pub trait ITDirectoryObject_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetSecurityDescriptor(&self, psecdes: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDirectoryObject {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDirectoryObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDirectoryObject_Impl, const OFFSET: isize>() -> ITDirectoryObject_Vtbl {
         unsafe extern "system" fn ObjectType<Identity: ::windows::core::IUnknownImpl, Impl: ITDirectoryObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobjecttype: *mut DIRECTORY_OBJECT_TYPE) -> ::windows::core::HRESULT {
@@ -4998,6 +5127,8 @@ pub trait ITDirectoryObjectConference_Impl: Sized + super::super::System::Com::I
     fn StopTime(&self) -> ::windows::core::Result<f64>;
     fn SetStopTime(&self, date: f64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDirectoryObjectConference {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDirectoryObjectConference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDirectoryObjectConference_Impl, const OFFSET: isize>() -> ITDirectoryObjectConference_Vtbl {
@@ -5153,6 +5284,8 @@ pub trait ITDirectoryObjectUser_Impl: Sized + super::super::System::Com::IDispat
     fn SetIPPhonePrimary(&self, pname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDirectoryObjectUser {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDirectoryObjectUser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDirectoryObjectUser_Impl, const OFFSET: isize>() -> ITDirectoryObjectUser_Vtbl {
         unsafe extern "system" fn IPPhonePrimary<Identity: ::windows::core::IUnknownImpl, Impl: ITDirectoryObjectUser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5186,6 +5319,8 @@ pub trait ITDispatchMapper_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn QueryDispatchInterface(&self, piid: &super::super::Foundation::BSTR, pinterfacetomap: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITDispatchMapper {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITDispatchMapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITDispatchMapper_Impl, const OFFSET: isize>() -> ITDispatchMapper_Vtbl {
         unsafe extern "system" fn QueryDispatchInterface<Identity: ::windows::core::IUnknownImpl, Impl: ITDispatchMapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pinterfacetomap: ::windows::core::RawPtr, ppreturnedinterface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5217,6 +5352,8 @@ pub trait ITFileTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch
     fn Cause(&self) -> ::windows::core::Result<FT_STATE_EVENT_CAUSE>;
     fn Error(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITFileTerminalEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITFileTerminalEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITFileTerminalEvent_Impl, const OFFSET: isize>() -> ITFileTerminalEvent_Vtbl {
@@ -5310,6 +5447,8 @@ pub trait ITFileTrack_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EmptyAudioFormatForScripting(&self) -> ::windows::core::Result<ITScriptableAudioFormat>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITFileTrack {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITFileTrack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITFileTrack_Impl, const OFFSET: isize>() -> ITFileTrack_Vtbl {
         unsafe extern "system" fn Format<Identity: ::windows::core::IUnknownImpl, Impl: ITFileTrack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmt: *mut *mut super::super::Media::DirectShow::AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -5391,6 +5530,8 @@ pub trait ITForwardInformation_Impl: Sized + super::super::System::Com::IDispatc
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITForwardInformation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITForwardInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITForwardInformation_Impl, const OFFSET: isize>() -> ITForwardInformation_Vtbl {
         unsafe extern "system" fn SetNumRingsNoAnswer<Identity: ::windows::core::IUnknownImpl, Impl: ITForwardInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnumrings: i32) -> ::windows::core::HRESULT {
@@ -5469,6 +5610,8 @@ pub trait ITForwardInformation2_Impl: Sized + super::super::System::Com::IDispat
     fn get_ForwardTypeCallerAddressType(&self, forwardtype: i32) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITForwardInformation2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITForwardInformation2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITForwardInformation2_Impl, const OFFSET: isize>() -> ITForwardInformation2_Vtbl {
         unsafe extern "system" fn SetForwardType2<Identity: ::windows::core::IUnknownImpl, Impl: ITForwardInformation2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, forwardtype: i32, pdestaddress: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, destaddresstype: i32, pcalleraddress: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, calleraddresstype: i32) -> ::windows::core::HRESULT {
@@ -5521,6 +5664,8 @@ pub trait ITILSConfig_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetPort(&self, port: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITILSConfig {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITILSConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITILSConfig_Impl, const OFFSET: isize>() -> ITILSConfig_Vtbl {
         unsafe extern "system" fn Port<Identity: ::windows::core::IUnknownImpl, Impl: ITILSConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pport: *mut i32) -> ::windows::core::HRESULT {
@@ -5556,6 +5701,8 @@ pub trait ITLegacyAddressMediaControl_Impl: Sized {
     fn SetDevConfig(&self, pdeviceclass: &super::super::Foundation::BSTR, dwsize: u32, pdeviceconfig: *const u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITLegacyAddressMediaControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITLegacyAddressMediaControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyAddressMediaControl_Impl, const OFFSET: isize>() -> ITLegacyAddressMediaControl_Vtbl {
         unsafe extern "system" fn GetID<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyAddressMediaControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdeviceclass: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pdwsize: *mut u32, ppdeviceid: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -5590,6 +5737,8 @@ pub trait ITLegacyAddressMediaControl2_Impl: Sized + ITLegacyAddressMediaControl
     fn ConfigDialogEdit(&self, hwndowner: super::super::Foundation::HWND, pdeviceclass: &super::super::Foundation::BSTR, dwsizein: u32, pdeviceconfigin: *const u8, pdwsizeout: *mut u32, ppdeviceconfigout: *mut *mut u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITLegacyAddressMediaControl2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITLegacyAddressMediaControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyAddressMediaControl2_Impl, const OFFSET: isize>() -> ITLegacyAddressMediaControl2_Vtbl {
         unsafe extern "system" fn ConfigDialog<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyAddressMediaControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND, pdeviceclass: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -5620,6 +5769,8 @@ pub trait ITLegacyCallMediaControl_Impl: Sized + super::super::System::Com::IDis
     fn SetMediaType(&self, lmediatype: i32) -> ::windows::core::Result<()>;
     fn MonitorMedia(&self, lmediatype: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITLegacyCallMediaControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITLegacyCallMediaControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyCallMediaControl_Impl, const OFFSET: isize>() -> ITLegacyCallMediaControl_Vtbl {
@@ -5674,6 +5825,8 @@ pub trait ITLegacyCallMediaControl2_Impl: Sized + super::super::System::Com::IDi
     fn CreateCustomToneObject(&self) -> ::windows::core::Result<ITCustomTone>;
     fn GetIDAsVariant(&self, bstrdeviceclass: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITLegacyCallMediaControl2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITLegacyCallMediaControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyCallMediaControl2_Impl, const OFFSET: isize>() -> ITLegacyCallMediaControl2_Vtbl {
@@ -5768,6 +5921,8 @@ pub trait ITLegacyWaveSupport_Impl: Sized + super::super::System::Com::IDispatch
     fn IsFullDuplex(&self) -> ::windows::core::Result<FULLDUPLEX_SUPPORT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITLegacyWaveSupport {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITLegacyWaveSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyWaveSupport_Impl, const OFFSET: isize>() -> ITLegacyWaveSupport_Vtbl {
         unsafe extern "system" fn IsFullDuplex<Identity: ::windows::core::IUnknownImpl, Impl: ITLegacyWaveSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psupport: *mut FULLDUPLEX_SUPPORT) -> ::windows::core::HRESULT {
@@ -5801,6 +5956,8 @@ pub trait ITLocationInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn TollPrefixList(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn CancelCallWaitingCode(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITLocationInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITLocationInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITLocationInfo_Impl, const OFFSET: isize>() -> ITLocationInfo_Vtbl {
@@ -5952,6 +6109,7 @@ pub trait ITMSPAddress_Impl: Sized {
     fn ReceiveTSPData(&self, pmspcall: &::core::option::Option<::windows::core::IUnknown>, pbuffer: *const u8, dwsize: u32) -> ::windows::core::Result<()>;
     fn GetEvent(&self, pdwsize: *mut u32, peventbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITMSPAddress {}
 impl ITMSPAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITMSPAddress_Impl, const OFFSET: isize>() -> ITMSPAddress_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ITMSPAddress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hevent: *const i32) -> ::windows::core::HRESULT {
@@ -6012,6 +6170,8 @@ pub trait ITMediaControl_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn MediaState(&self) -> ::windows::core::Result<TERMINAL_MEDIA_STATE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITMediaControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITMediaControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaControl_Impl, const OFFSET: isize>() -> ITMediaControl_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6058,6 +6218,8 @@ pub trait ITMediaPlayback_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn PlayList(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITMediaPlayback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITMediaPlayback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaPlayback_Impl, const OFFSET: isize>() -> ITMediaPlayback_Vtbl {
         unsafe extern "system" fn SetPlayList<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaPlayback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, playlistvariant: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -6092,6 +6254,8 @@ pub trait ITMediaRecord_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn FileName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITMediaRecord {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITMediaRecord_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaRecord_Impl, const OFFSET: isize>() -> ITMediaRecord_Vtbl {
         unsafe extern "system" fn SetFileName<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaRecord_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrfilename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6125,6 +6289,8 @@ pub trait ITMediaSupport_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn MediaTypes(&self) -> ::windows::core::Result<i32>;
     fn QueryMediaType(&self, lmediatype: i32) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITMediaSupport {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITMediaSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITMediaSupport_Impl, const OFFSET: isize>() -> ITMediaSupport_Vtbl {
@@ -6169,6 +6335,8 @@ pub trait ITMultiTrackTerminal_Impl: Sized + super::super::System::Com::IDispatc
     fn DirectionsInUse(&self) -> ::windows::core::Result<TERMINAL_DIRECTION>;
     fn RemoveTrackTerminal(&self, ptrackterminaltoremove: &::core::option::Option<ITTerminal>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITMultiTrackTerminal {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITMultiTrackTerminal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITMultiTrackTerminal_Impl, const OFFSET: isize>() -> ITMultiTrackTerminal_Vtbl {
@@ -6282,6 +6450,8 @@ pub trait ITPhone_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeviceSpecificVariant(&self, vardevspecificbytearray: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn NegotiateExtVersion(&self, llowversion: i32, lhighversion: i32) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITPhone {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITPhone_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPhone_Impl, const OFFSET: isize>() -> ITPhone_Vtbl {
@@ -6619,6 +6789,8 @@ pub trait ITPhoneDeviceSpecificEvent_Impl: Sized + super::super::System::Com::ID
     fn lParam3(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITPhoneDeviceSpecificEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITPhoneDeviceSpecificEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPhoneDeviceSpecificEvent_Impl, const OFFSET: isize>() -> ITPhoneDeviceSpecificEvent_Vtbl {
         unsafe extern "system" fn Phone<Identity: ::windows::core::IUnknownImpl, Impl: ITPhoneDeviceSpecificEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppphone: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6689,6 +6861,8 @@ pub trait ITPhoneEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn NumberGathered(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITPhoneEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITPhoneEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPhoneEvent_Impl, const OFFSET: isize>() -> ITPhoneEvent_Vtbl {
@@ -6819,6 +6993,8 @@ pub trait ITPluggableTerminalClassInfo_Impl: Sized + super::super::System::Com::
     fn MediaTypes(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITPluggableTerminalClassInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITPluggableTerminalClassInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalClassInfo_Impl, const OFFSET: isize>() -> ITPluggableTerminalClassInfo_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalClassInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -6918,6 +7094,8 @@ pub trait ITPluggableTerminalEventSink_Impl: Sized {
     fn FireEvent(&self, pmspeventinfo: *const MSP_EVENT_INFO) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITPluggableTerminalEventSink {}
+#[cfg(feature = "Win32_System_Com")]
 impl ITPluggableTerminalEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalEventSink_Impl, const OFFSET: isize>() -> ITPluggableTerminalEventSink_Vtbl {
         unsafe extern "system" fn FireEvent<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmspeventinfo: *const MSP_EVENT_INFO) -> ::windows::core::HRESULT {
@@ -6935,6 +7113,7 @@ pub trait ITPluggableTerminalEventSinkRegistration_Impl: Sized {
     fn RegisterSink(&self, peventsink: &::core::option::Option<ITPluggableTerminalEventSink>) -> ::windows::core::Result<()>;
     fn UnregisterSink(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITPluggableTerminalEventSinkRegistration {}
 impl ITPluggableTerminalEventSinkRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalEventSinkRegistration_Impl, const OFFSET: isize>() -> ITPluggableTerminalEventSinkRegistration_Vtbl {
         unsafe extern "system" fn RegisterSink<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalEventSinkRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventsink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6962,6 +7141,8 @@ pub trait ITPluggableTerminalSuperclassInfo_Impl: Sized + super::super::System::
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn CLSID(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITPluggableTerminalSuperclassInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITPluggableTerminalSuperclassInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPluggableTerminalSuperclassInfo_Impl, const OFFSET: isize>() -> ITPluggableTerminalSuperclassInfo_Vtbl {
@@ -7005,6 +7186,8 @@ pub trait ITPrivateEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn EventCode(&self) -> ::windows::core::Result<i32>;
     fn EventInterface(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITPrivateEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITPrivateEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITPrivateEvent_Impl, const OFFSET: isize>() -> ITPrivateEvent_Vtbl {
@@ -7083,6 +7266,8 @@ pub trait ITQOSEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MediaType(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITQOSEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITQOSEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITQOSEvent_Impl, const OFFSET: isize>() -> ITQOSEvent_Vtbl {
         unsafe extern "system" fn Call<Identity: ::windows::core::IUnknownImpl, Impl: ITQOSEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcall: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7144,6 +7329,8 @@ pub trait ITQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FinalDisposition(&self) -> ::windows::core::Result<i32>;
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITQueue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITQueue_Impl, const OFFSET: isize>() -> ITQueue_Vtbl {
@@ -7299,6 +7486,8 @@ pub trait ITQueueEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Event(&self) -> ::windows::core::Result<ACDQUEUE_EVENT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITQueueEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITQueueEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITQueueEvent_Impl, const OFFSET: isize>() -> ITQueueEvent_Vtbl {
         unsafe extern "system" fn Queue<Identity: ::windows::core::IUnknownImpl, Impl: ITQueueEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppqueue: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7340,6 +7529,8 @@ pub trait ITRendezvous_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateDirectory(&self, directorytype: DIRECTORY_TYPE, pname: &super::super::Foundation::BSTR) -> ::windows::core::Result<ITDirectory>;
     fn CreateDirectoryObject(&self, directoryobjecttype: DIRECTORY_OBJECT_TYPE, pname: &super::super::Foundation::BSTR) -> ::windows::core::Result<ITDirectoryObject>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITRendezvous {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITRendezvous_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITRendezvous_Impl, const OFFSET: isize>() -> ITRendezvous_Vtbl {
@@ -7404,6 +7595,8 @@ pub trait ITRequest_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MakeCall(&self, pdestaddress: &super::super::Foundation::BSTR, pappname: &super::super::Foundation::BSTR, pcalledparty: &super::super::Foundation::BSTR, pcomment: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITRequest {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITRequest_Impl, const OFFSET: isize>() -> ITRequest_Vtbl {
         unsafe extern "system" fn MakeCall<Identity: ::windows::core::IUnknownImpl, Impl: ITRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdestaddress: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pappname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pcalledparty: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pcomment: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -7426,6 +7619,8 @@ pub trait ITRequestEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn CalledParty(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Comment(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITRequestEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITRequestEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITRequestEvent_Impl, const OFFSET: isize>() -> ITRequestEvent_Vtbl {
@@ -7524,6 +7719,8 @@ pub trait ITScriptableAudioFormat_Impl: Sized + super::super::System::Com::IDisp
     fn FormatTag(&self) -> ::windows::core::Result<i32>;
     fn SetFormatTag(&self, nnewval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITScriptableAudioFormat {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITScriptableAudioFormat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITScriptableAudioFormat_Impl, const OFFSET: isize>() -> ITScriptableAudioFormat_Vtbl {
@@ -7648,6 +7845,8 @@ pub trait ITStaticAudioTerminal_Impl: Sized + super::super::System::Com::IDispat
     fn WaveId(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITStaticAudioTerminal {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITStaticAudioTerminal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITStaticAudioTerminal_Impl, const OFFSET: isize>() -> ITStaticAudioTerminal_Vtbl {
         unsafe extern "system" fn WaveId<Identity: ::windows::core::IUnknownImpl, Impl: ITStaticAudioTerminal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plwaveid: *mut i32) -> ::windows::core::HRESULT {
@@ -7680,6 +7879,8 @@ pub trait ITStream_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnumerateTerminals(&self) -> ::windows::core::Result<IEnumTerminal>;
     fn Terminals(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITStream_Impl, const OFFSET: isize>() -> ITStream_Vtbl {
@@ -7789,6 +7990,8 @@ pub trait ITStreamControl_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Streams(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITStreamControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITStreamControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITStreamControl_Impl, const OFFSET: isize>() -> ITStreamControl_Vtbl {
         unsafe extern "system" fn CreateStream<Identity: ::windows::core::IUnknownImpl, Impl: ITStreamControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lmediatype: i32, td: TERMINAL_DIRECTION, ppstream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7852,6 +8055,8 @@ pub trait ITSubStream_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Terminals(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn Stream(&self) -> ::windows::core::Result<ITStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITSubStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITSubStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSubStream_Impl, const OFFSET: isize>() -> ITSubStream_Vtbl {
@@ -7937,6 +8142,8 @@ pub trait ITSubStreamControl_Impl: Sized + super::super::System::Com::IDispatch_
     fn SubStreams(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITSubStreamControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITSubStreamControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSubStreamControl_Impl, const OFFSET: isize>() -> ITSubStreamControl_Vtbl {
         unsafe extern "system" fn CreateSubStream<Identity: ::windows::core::IUnknownImpl, Impl: ITSubStreamControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsubstream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8008,6 +8215,8 @@ pub trait ITTAPI_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetEventFilter(&self, lfiltermask: i32) -> ::windows::core::Result<()>;
     fn EventFilter(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTAPI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTAPI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPI_Impl, const OFFSET: isize>() -> ITTAPI_Vtbl {
@@ -8170,6 +8379,8 @@ pub trait ITTAPI2_Impl: Sized + super::super::System::Com::IDispatch_Impl + ITTA
     fn CreateEmptyCollectionObject(&self) -> ::windows::core::Result<ITCollection2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTAPI2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTAPI2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPI2_Impl, const OFFSET: isize>() -> ITTAPI2_Vtbl {
         unsafe extern "system" fn Phones<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPI2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pphones: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -8222,6 +8433,8 @@ pub trait ITTAPICallCenter_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn AgentHandlers(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTAPICallCenter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTAPICallCenter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPICallCenter_Impl, const OFFSET: isize>() -> ITTAPICallCenter_Vtbl {
         unsafe extern "system" fn EnumerateAgentHandlers<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPICallCenter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenumhandler: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8259,6 +8472,8 @@ impl ITTAPICallCenter_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPIDispatchEventNotification_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTAPIDispatchEventNotification {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTAPIDispatchEventNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPIDispatchEventNotification_Impl, const OFFSET: isize>() -> ITTAPIDispatchEventNotification_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -8271,6 +8486,8 @@ impl ITTAPIDispatchEventNotification_Vtbl {
 pub trait ITTAPIEventNotification_Impl: Sized {
     fn Event(&self, tapievent: TAPI_EVENT, pevent: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITTAPIEventNotification {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITTAPIEventNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPIEventNotification_Impl, const OFFSET: isize>() -> ITTAPIEventNotification_Vtbl {
@@ -8292,6 +8509,8 @@ pub trait ITTAPIObjectEvent_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Address(&self) -> ::windows::core::Result<ITAddress>;
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTAPIObjectEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTAPIObjectEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPIObjectEvent_Impl, const OFFSET: isize>() -> ITTAPIObjectEvent_Vtbl {
@@ -8356,6 +8575,8 @@ pub trait ITTAPIObjectEvent2_Impl: Sized + super::super::System::Com::IDispatch_
     fn Phone(&self) -> ::windows::core::Result<ITPhone>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTAPIObjectEvent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTAPIObjectEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPIObjectEvent2_Impl, const OFFSET: isize>() -> ITTAPIObjectEvent2_Vtbl {
         unsafe extern "system" fn Phone<Identity: ::windows::core::IUnknownImpl, Impl: ITTAPIObjectEvent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppphone: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8381,6 +8602,8 @@ pub trait ITTTSTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch_
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
     fn Error(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTTSTerminalEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTTSTerminalEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTTSTerminalEvent_Impl, const OFFSET: isize>() -> ITTTSTerminalEvent_Vtbl {
@@ -8437,6 +8660,8 @@ pub trait ITTerminal_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MediaType(&self) -> ::windows::core::Result<i32>;
     fn Direction(&self) -> ::windows::core::Result<TERMINAL_DIRECTION>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTerminal {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTerminal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTerminal_Impl, const OFFSET: isize>() -> ITTerminal_Vtbl {
@@ -8530,6 +8755,8 @@ pub trait ITTerminalSupport_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetDefaultStaticTerminal(&self, lmediatype: i32, direction: TERMINAL_DIRECTION) -> ::windows::core::Result<ITTerminal>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTerminalSupport {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTerminalSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTerminalSupport_Impl, const OFFSET: isize>() -> ITTerminalSupport_Vtbl {
         unsafe extern "system" fn StaticTerminals<Identity: ::windows::core::IUnknownImpl, Impl: ITTerminalSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvariant: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -8620,6 +8847,8 @@ pub trait ITTerminalSupport2_Impl: Sized + super::super::System::Com::IDispatch_
     fn EnumeratePluggableTerminalClasses(&self, iidterminalsuperclass: &::windows::core::GUID, lmediatype: i32) -> ::windows::core::Result<IEnumPluggableTerminalClassInfo>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITTerminalSupport2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITTerminalSupport2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITTerminalSupport2_Impl, const OFFSET: isize>() -> ITTerminalSupport2_Vtbl {
         unsafe extern "system" fn PluggableSuperclasses<Identity: ::windows::core::IUnknownImpl, Impl: ITTerminalSupport2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvariant: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -8686,6 +8915,8 @@ pub trait ITToneDetectionEvent_Impl: Sized + super::super::System::Com::IDispatc
     fn CallbackInstance(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITToneDetectionEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITToneDetectionEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITToneDetectionEvent_Impl, const OFFSET: isize>() -> ITToneDetectionEvent_Vtbl {
         unsafe extern "system" fn Call<Identity: ::windows::core::IUnknownImpl, Impl: ITToneDetectionEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcallinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8751,6 +8982,8 @@ pub trait ITToneTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch
     fn Error(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITToneTerminalEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITToneTerminalEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITToneTerminalEvent_Impl, const OFFSET: isize>() -> ITToneTerminalEvent_Vtbl {
         unsafe extern "system" fn Terminal<Identity: ::windows::core::IUnknownImpl, Impl: ITToneTerminalEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppterminal: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8807,6 +9040,8 @@ pub trait ITnef_Impl: Sized {
     fn EncodeRecips(&self, ulflags: u32, lprecipienttable: &::core::option::Option<super::super::System::AddressBook::IMAPITable>) -> ::windows::core::Result<()>;
     fn FinishComponent(&self, ulflags: u32, ulcomponentid: u32, lpcustomproplist: *mut super::super::System::AddressBook::SPropTagArray, lpcustomprops: *mut super::super::System::AddressBook::SPropValue, lpproplist: *mut super::super::System::AddressBook::SPropTagArray, lpproblems: *mut *mut STnefProblemArray) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_AddressBook", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITnef {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_AddressBook", feature = "Win32_System_Com"))]
 impl ITnef_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITnef_Impl, const OFFSET: isize>() -> ITnef_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
@@ -4,6 +4,8 @@ pub trait IWSDAddress_Impl: Sized {
     fn Deserialize(&self, pszbuffer: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDAddress {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWSDAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDAddress_Impl, const OFFSET: isize>() -> IWSDAddress_Vtbl {
         unsafe extern "system" fn Serialize<Identity: ::windows::core::IUnknownImpl, Impl: IWSDAddress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszbuffer: ::windows::core::PWSTR, cchlength: u32, fsafe: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -29,6 +31,7 @@ impl IWSDAddress_Vtbl {
 pub trait IWSDAsyncCallback_Impl: Sized {
     fn AsyncOperationComplete(&self, pasyncresult: &::core::option::Option<IWSDAsyncResult>, pasyncstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDAsyncCallback {}
 impl IWSDAsyncCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDAsyncCallback_Impl, const OFFSET: isize>() -> IWSDAsyncCallback_Vtbl {
         unsafe extern "system" fn AsyncOperationComplete<Identity: ::windows::core::IUnknownImpl, Impl: IWSDAsyncCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pasyncresult: ::windows::core::RawPtr, pasyncstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -52,6 +55,8 @@ pub trait IWSDAsyncResult_Impl: Sized {
     fn GetEvent(&self) -> ::windows::core::Result<WSD_EVENT>;
     fn GetEndpointProxy(&self) -> ::windows::core::Result<IWSDEndpointProxy>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDAsyncResult {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWSDAsyncResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDAsyncResult_Impl, const OFFSET: isize>() -> IWSDAsyncResult_Vtbl {
@@ -124,6 +129,7 @@ impl IWSDAsyncResult_Vtbl {
     }
 }
 pub trait IWSDAttachment_Impl: Sized {}
+impl ::windows::core::RuntimeName for IWSDAttachment {}
 impl IWSDAttachment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDAttachment_Impl, const OFFSET: isize>() -> IWSDAttachment_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -147,6 +153,8 @@ pub trait IWSDDeviceHost_Impl: Sized {
     fn SetServiceDiscoverable(&self, pszserviceid: &::windows::core::PCWSTR, fdiscoverable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SignalEvent(&self, pszserviceid: &::windows::core::PCWSTR, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDDeviceHost {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWSDDeviceHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDDeviceHost_Impl, const OFFSET: isize>() -> IWSDDeviceHost_Vtbl {
@@ -233,6 +241,7 @@ impl IWSDDeviceHost_Vtbl {
 pub trait IWSDDeviceHostNotify_Impl: Sized {
     fn GetService(&self, pszserviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IWSDDeviceHostNotify {}
 impl IWSDDeviceHostNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDDeviceHostNotify_Impl, const OFFSET: isize>() -> IWSDDeviceHostNotify_Vtbl {
         unsafe extern "system" fn GetService<Identity: ::windows::core::IUnknownImpl, Impl: IWSDDeviceHostNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszserviceid: ::windows::core::PCWSTR, ppservice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -264,6 +273,7 @@ pub trait IWSDDeviceProxy_Impl: Sized {
     fn GetServiceProxyByType(&self, ptype: *const WSDXML_NAME) -> ::windows::core::Result<IWSDServiceProxy>;
     fn GetEndpointProxy(&self) -> ::windows::core::Result<IWSDEndpointProxy>;
 }
+impl ::windows::core::RuntimeName for IWSDDeviceProxy {}
 impl IWSDDeviceProxy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDDeviceProxy_Impl, const OFFSET: isize>() -> IWSDDeviceProxy_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IWSDDeviceProxy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdeviceid: ::windows::core::PCWSTR, pdeviceaddress: ::windows::core::RawPtr, pszlocalid: ::windows::core::PCWSTR, pcontext: ::windows::core::RawPtr, psponsor: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -393,6 +403,8 @@ pub trait IWSDEndpointProxy_Impl: Sized {
     fn GetFaultInfo(&self) -> ::windows::core::Result<*mut WSD_SOAP_FAULT>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDEndpointProxy {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWSDEndpointProxy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDEndpointProxy_Impl, const OFFSET: isize>() -> IWSDEndpointProxy_Vtbl {
         unsafe extern "system" fn SendOneWayRequest<Identity: ::windows::core::IUnknownImpl, Impl: IWSDEndpointProxy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION) -> ::windows::core::HRESULT {
@@ -468,6 +480,7 @@ pub trait IWSDEventingStatus_Impl: Sized {
     fn SubscriptionRenewalFailed(&self, pszsubscriptionaction: &::windows::core::PCWSTR, hr: ::windows::core::HRESULT);
     fn SubscriptionEnded(&self, pszsubscriptionaction: &::windows::core::PCWSTR);
 }
+impl ::windows::core::RuntimeName for IWSDEventingStatus {}
 impl IWSDEventingStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDEventingStatus_Impl, const OFFSET: isize>() -> IWSDEventingStatus_Vtbl {
         unsafe extern "system" fn SubscriptionRenewed<Identity: ::windows::core::IUnknownImpl, Impl: IWSDEventingStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsubscriptionaction: ::windows::core::PCWSTR) {
@@ -503,6 +516,8 @@ pub trait IWSDHttpAddress_Impl: Sized + IWSDAddress_Impl + IWSDTransportAddress_
     fn GetPath(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn SetPath(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDHttpAddress {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWSDHttpAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDHttpAddress_Impl, const OFFSET: isize>() -> IWSDHttpAddress_Vtbl {
@@ -550,6 +565,8 @@ pub trait IWSDHttpAuthParameters_Impl: Sized {
     fn GetAuthType(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDHttpAuthParameters {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWSDHttpAuthParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDHttpAuthParameters_Impl, const OFFSET: isize>() -> IWSDHttpAuthParameters_Vtbl {
         unsafe extern "system" fn GetClientAccessToken<Identity: ::windows::core::IUnknownImpl, Impl: IWSDHttpAuthParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phtoken: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -595,6 +612,7 @@ pub trait IWSDHttpMessageParameters_Impl: Sized + IWSDMessageParameters_Impl {
     fn GetContext(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDHttpMessageParameters {}
 impl IWSDHttpMessageParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDHttpMessageParameters_Impl, const OFFSET: isize>() -> IWSDHttpMessageParameters_Vtbl {
         unsafe extern "system" fn SetInboundHttpHeaders<Identity: ::windows::core::IUnknownImpl, Impl: IWSDHttpMessageParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszheaders: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -687,6 +705,7 @@ pub trait IWSDInboundAttachment_Impl: Sized + IWSDAttachment_Impl {
     fn Read(&self, pbuffer: *mut u8, dwbytestoread: u32, pdwnumberofbytesread: *mut u32) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDInboundAttachment {}
 impl IWSDInboundAttachment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDInboundAttachment_Impl, const OFFSET: isize>() -> IWSDInboundAttachment_Vtbl {
         unsafe extern "system" fn Read<Identity: ::windows::core::IUnknownImpl, Impl: IWSDInboundAttachment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffer: *mut u8, dwbytestoread: u32, pdwnumberofbytesread: *mut u32) -> ::windows::core::HRESULT {
@@ -712,6 +731,7 @@ pub trait IWSDMessageParameters_Impl: Sized {
     fn SetRemoteAddress(&self, paddress: &::core::option::Option<IWSDAddress>) -> ::windows::core::Result<()>;
     fn GetLowerParameters(&self) -> ::windows::core::Result<IWSDMessageParameters>;
 }
+impl ::windows::core::RuntimeName for IWSDMessageParameters {}
 impl IWSDMessageParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDMessageParameters_Impl, const OFFSET: isize>() -> IWSDMessageParameters_Vtbl {
         unsafe extern "system" fn GetLocalAddress<Identity: ::windows::core::IUnknownImpl, Impl: IWSDMessageParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppaddress: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -773,6 +793,7 @@ impl IWSDMessageParameters_Vtbl {
 pub trait IWSDMetadataExchange_Impl: Sized {
     fn GetMetadata(&self) -> ::windows::core::Result<*mut WSD_METADATA_SECTION_LIST>;
 }
+impl ::windows::core::RuntimeName for IWSDMetadataExchange {}
 impl IWSDMetadataExchange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDMetadataExchange_Impl, const OFFSET: isize>() -> IWSDMetadataExchange_Vtbl {
         unsafe extern "system" fn GetMetadata<Identity: ::windows::core::IUnknownImpl, Impl: IWSDMetadataExchange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, metadataout: *mut *mut WSD_METADATA_SECTION_LIST) -> ::windows::core::HRESULT {
@@ -797,6 +818,7 @@ pub trait IWSDOutboundAttachment_Impl: Sized + IWSDAttachment_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn Abort(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDOutboundAttachment {}
 impl IWSDOutboundAttachment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDOutboundAttachment_Impl, const OFFSET: isize>() -> IWSDOutboundAttachment_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows::core::IUnknownImpl, Impl: IWSDOutboundAttachment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffer: *const u8, dwbytestowrite: u32, pdwnumberofbyteswritten: *mut u32) -> ::windows::core::HRESULT {
@@ -836,6 +858,8 @@ pub trait IWSDSSLClientCertificate_Impl: Sized {
     fn GetClientCertificate(&self) -> ::windows::core::Result<*mut super::super::Security::Cryptography::CERT_CONTEXT>;
     fn GetMappedAccessToken(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
+impl ::windows::core::RuntimeName for IWSDSSLClientCertificate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl IWSDSSLClientCertificate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDSSLClientCertificate_Impl, const OFFSET: isize>() -> IWSDSSLClientCertificate_Vtbl {
@@ -877,6 +901,8 @@ pub trait IWSDScopeMatchingRule_Impl: Sized {
     fn MatchScopes(&self, pszscope1: &::windows::core::PCWSTR, pszscope2: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDScopeMatchingRule {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWSDScopeMatchingRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDScopeMatchingRule_Impl, const OFFSET: isize>() -> IWSDScopeMatchingRule_Vtbl {
         unsafe extern "system" fn GetScopeRule<Identity: ::windows::core::IUnknownImpl, Impl: IWSDScopeMatchingRule_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszscopematchingrule: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -915,6 +941,7 @@ pub trait IWSDServiceMessaging_Impl: Sized {
     fn SendResponse(&self, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION, pmessageparameters: &::core::option::Option<IWSDMessageParameters>) -> ::windows::core::Result<()>;
     fn FaultRequest(&self, prequestheader: *const WSD_SOAP_HEADER, pmessageparameters: &::core::option::Option<IWSDMessageParameters>, pfault: *const WSD_SOAP_FAULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDServiceMessaging {}
 impl IWSDServiceMessaging_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDServiceMessaging_Impl, const OFFSET: isize>() -> IWSDServiceMessaging_Vtbl {
         unsafe extern "system" fn SendResponse<Identity: ::windows::core::IUnknownImpl, Impl: IWSDServiceMessaging_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION, pmessageparameters: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -946,6 +973,7 @@ pub trait IWSDServiceProxy_Impl: Sized + IWSDMetadataExchange_Impl {
     fn SetEventingStatusCallback(&self, pstatus: &::core::option::Option<IWSDEventingStatus>) -> ::windows::core::Result<()>;
     fn GetEndpointProxy(&self) -> ::windows::core::Result<IWSDEndpointProxy>;
 }
+impl ::windows::core::RuntimeName for IWSDServiceProxy {}
 impl IWSDServiceProxy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDServiceProxy_Impl, const OFFSET: isize>() -> IWSDServiceProxy_Vtbl {
         unsafe extern "system" fn BeginGetMetadata<Identity: ::windows::core::IUnknownImpl, Impl: IWSDServiceProxy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1043,6 +1071,8 @@ pub trait IWSDServiceProxyEventing_Impl: Sized + IWSDMetadataExchange_Impl + IWS
     fn BeginGetStatusForMultipleOperations(&self, poperations: *const WSD_OPERATION, dwoperationcount: u32, pany: *const WSDXML_ELEMENT, pasyncstate: &::core::option::Option<::windows::core::IUnknown>, pasynccallback: &::core::option::Option<IWSDAsyncCallback>) -> ::windows::core::Result<IWSDAsyncResult>;
     fn EndGetStatusForMultipleOperations(&self, poperations: *const WSD_OPERATION, dwoperationcount: u32, presult: &::core::option::Option<IWSDAsyncResult>, ppexpires: *mut *mut WSD_EVENTING_EXPIRES, ppany: *mut *mut WSDXML_ELEMENT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDServiceProxyEventing {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWSDServiceProxyEventing_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDServiceProxyEventing_Impl, const OFFSET: isize>() -> IWSDServiceProxyEventing_Vtbl {
@@ -1159,6 +1189,8 @@ pub trait IWSDSignatureProperty_Impl: Sized {
     fn GetSignedInfoHash(&self, pbsignedinfohash: *mut u8, pdwhashsize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDSignatureProperty {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWSDSignatureProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDSignatureProperty_Impl, const OFFSET: isize>() -> IWSDSignatureProperty_Vtbl {
         unsafe extern "system" fn IsMessageSigned<Identity: ::windows::core::IUnknownImpl, Impl: IWSDSignatureProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbsigned: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1219,6 +1251,8 @@ pub trait IWSDTransportAddress_Impl: Sized + IWSDAddress_Impl {
     fn GetTransportAddressEx(&self, fsafe: super::super::Foundation::BOOL) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn SetTransportAddress(&self, pszaddress: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWSDTransportAddress {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWSDTransportAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDTransportAddress_Impl, const OFFSET: isize>() -> IWSDTransportAddress_Vtbl {
@@ -1291,6 +1325,8 @@ pub trait IWSDUdpAddress_Impl: Sized + IWSDAddress_Impl + IWSDTransportAddress_I
     fn SetAlias(&self, palias: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetAlias(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
+impl ::windows::core::RuntimeName for IWSDUdpAddress {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 impl IWSDUdpAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDUdpAddress_Impl, const OFFSET: isize>() -> IWSDUdpAddress_Vtbl {
@@ -1390,6 +1426,7 @@ pub trait IWSDUdpMessageParameters_Impl: Sized + IWSDMessageParameters_Impl {
     fn SetRetransmitParams(&self, pparams: *const WSDUdpRetransmitParams) -> ::windows::core::Result<()>;
     fn GetRetransmitParams(&self) -> ::windows::core::Result<WSDUdpRetransmitParams>;
 }
+impl ::windows::core::RuntimeName for IWSDUdpMessageParameters {}
 impl IWSDUdpMessageParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDUdpMessageParameters_Impl, const OFFSET: isize>() -> IWSDUdpMessageParameters_Vtbl {
         unsafe extern "system" fn SetRetransmitParams<Identity: ::windows::core::IUnknownImpl, Impl: IWSDUdpMessageParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparams: *const WSDUdpRetransmitParams) -> ::windows::core::HRESULT {
@@ -1424,6 +1461,7 @@ pub trait IWSDXMLContext_Impl: Sized {
     fn SetNamespaces(&self, pnamespaces: *const *const WSDXML_NAMESPACE, wnamespacescount: u16, blayernumber: u8) -> ::windows::core::Result<()>;
     fn SetTypes(&self, ptypes: *const *const WSDXML_TYPE, dwtypescount: u32, blayernumber: u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDXMLContext {}
 impl IWSDXMLContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDXMLContext_Impl, const OFFSET: isize>() -> IWSDXMLContext_Vtbl {
         unsafe extern "system" fn AddNamespace<Identity: ::windows::core::IUnknownImpl, Impl: IWSDXMLContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszuri: ::windows::core::PCWSTR, pszsuggestedprefix: ::windows::core::PCWSTR, ppnamespace: *mut *mut WSDXML_NAMESPACE) -> ::windows::core::HRESULT {
@@ -1483,6 +1521,7 @@ pub trait IWSDiscoveredService_Impl: Sized {
     fn GetLocalInterfaceGUID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetInstanceId(&self) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IWSDiscoveredService {}
 impl IWSDiscoveredService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveredService_Impl, const OFFSET: isize>() -> IWSDiscoveredService_Vtbl {
         unsafe extern "system" fn GetEndpointReference<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveredService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppendpointreference: *mut *mut WSD_ENDPOINT_REFERENCE) -> ::windows::core::HRESULT {
@@ -1628,6 +1667,7 @@ pub trait IWSDiscoveryProvider_Impl: Sized {
     fn SearchByType(&self, ptypeslist: *const WSD_NAME_LIST, pscopeslist: *const WSD_URI_LIST, pszmatchby: &::windows::core::PCWSTR, psztag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetXMLContext(&self) -> ::windows::core::Result<IWSDXMLContext>;
 }
+impl ::windows::core::RuntimeName for IWSDiscoveryProvider {}
 impl IWSDiscoveryProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryProvider_Impl, const OFFSET: isize>() -> IWSDiscoveryProvider_Vtbl {
         unsafe extern "system" fn SetAddressFamily<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwaddressfamily: u32) -> ::windows::core::HRESULT {
@@ -1692,6 +1732,7 @@ pub trait IWSDiscoveryProviderNotify_Impl: Sized {
     fn SearchFailed(&self, hr: ::windows::core::HRESULT, psztag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SearchComplete(&self, psztag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDiscoveryProviderNotify {}
 impl IWSDiscoveryProviderNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryProviderNotify_Impl, const OFFSET: isize>() -> IWSDiscoveryProviderNotify_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryProviderNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pservice: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1741,6 +1782,7 @@ pub trait IWSDiscoveryPublisher_Impl: Sized {
     fn UnRegisterScopeMatchingRule(&self, pscopematchingrule: &::core::option::Option<IWSDScopeMatchingRule>) -> ::windows::core::Result<()>;
     fn GetXMLContext(&self) -> ::windows::core::Result<IWSDXMLContext>;
 }
+impl ::windows::core::RuntimeName for IWSDiscoveryPublisher {}
 impl IWSDiscoveryPublisher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryPublisher_Impl, const OFFSET: isize>() -> IWSDiscoveryPublisher_Vtbl {
         unsafe extern "system" fn SetAddressFamily<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryPublisher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwaddressfamily: u32) -> ::windows::core::HRESULT {
@@ -1891,6 +1933,7 @@ pub trait IWSDiscoveryPublisherNotify_Impl: Sized {
     fn ProbeHandler(&self, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: &::core::option::Option<IWSDMessageParameters>) -> ::windows::core::Result<()>;
     fn ResolveHandler(&self, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: &::core::option::Option<IWSDMessageParameters>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWSDiscoveryPublisherNotify {}
 impl IWSDiscoveryPublisherNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryPublisherNotify_Impl, const OFFSET: isize>() -> IWSDiscoveryPublisherNotify_Vtbl {
         unsafe extern "system" fn ProbeHandler<Identity: ::windows::core::IUnknownImpl, Impl: IWSDiscoveryPublisherNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
@@ -6,6 +6,8 @@ pub trait IGameExplorer_Impl: Sized {
     fn VerifyAccess(&self, bstrgdfbinarypath: &super::Foundation::BSTR) -> ::windows::core::Result<super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGameExplorer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IGameExplorer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGameExplorer_Impl, const OFFSET: isize>() -> IGameExplorer_Vtbl {
         unsafe extern "system" fn AddGame<Identity: ::windows::core::IUnknownImpl, Impl: IGameExplorer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrgdfbinarypath: ::core::mem::ManuallyDrop<super::Foundation::BSTR>, bstrgameinstalldirectory: ::core::mem::ManuallyDrop<super::Foundation::BSTR>, installscope: GAME_INSTALL_SCOPE, pguidinstanceid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -52,6 +54,8 @@ pub trait IGameExplorer2_Impl: Sized {
     fn UninstallGame(&self, binarygdfpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn CheckAccess(&self, binarygdfpath: &::windows::core::PCWSTR) -> ::windows::core::Result<super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGameExplorer2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGameExplorer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGameExplorer2_Impl, const OFFSET: isize>() -> IGameExplorer2_Vtbl {
@@ -102,6 +106,8 @@ pub trait IGameStatistics_Impl: Sized {
     fn SetLastPlayedCategory(&self, categoryindex: u32) -> ::windows::core::Result<()>;
     fn GetLastPlayedCategory(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGameStatistics {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGameStatistics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGameStatistics_Impl, const OFFSET: isize>() -> IGameStatistics_Vtbl {
@@ -231,6 +237,7 @@ pub trait IGameStatisticsMgr_Impl: Sized {
     fn GetGameStatistics(&self, gdfbinarypath: &::windows::core::PCWSTR, opentype: GAMESTATS_OPEN_TYPE, popenresult: *mut GAMESTATS_OPEN_RESULT, ppistats: *mut ::core::option::Option<IGameStatistics>) -> ::windows::core::Result<()>;
     fn RemoveGameStatistics(&self, gdfbinarypath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGameStatisticsMgr {}
 impl IGameStatisticsMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGameStatisticsMgr_Impl, const OFFSET: isize>() -> IGameStatisticsMgr_Vtbl {
         unsafe extern "system" fn GetGameStatistics<Identity: ::windows::core::IUnknownImpl, Impl: IGameStatisticsMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gdfbinarypath: ::windows::core::PCWSTR, opentype: GAMESTATS_OPEN_TYPE, popenresult: *mut GAMESTATS_OPEN_RESULT, ppistats: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -262,6 +269,8 @@ pub trait IXblIdpAuthManager_Impl: Sized {
     fn GetSandbox(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetTokenAndSignatureWithTokenResult(&self, msaaccountid: &::windows::core::PCWSTR, appsid: &::windows::core::PCWSTR, msatarget: &::windows::core::PCWSTR, msapolicy: &::windows::core::PCWSTR, httpmethod: &::windows::core::PCWSTR, uri: &::windows::core::PCWSTR, headers: &::windows::core::PCWSTR, body: *const u8, bodysize: u32, forcerefresh: super::Foundation::BOOL) -> ::windows::core::Result<IXblIdpAuthTokenResult>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXblIdpAuthManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXblIdpAuthManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXblIdpAuthManager_Impl, const OFFSET: isize>() -> IXblIdpAuthManager_Vtbl {
@@ -349,6 +358,7 @@ pub trait IXblIdpAuthTokenResult_Impl: Sized {
     fn GetRestrictions(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetTitleRestrictions(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IXblIdpAuthTokenResult {}
 impl IXblIdpAuthTokenResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXblIdpAuthTokenResult_Impl, const OFFSET: isize>() -> IXblIdpAuthTokenResult_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IXblIdpAuthTokenResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, status: *mut XBL_IDP_AUTH_TOKEN_STATUS) -> ::windows::core::HRESULT {
@@ -604,6 +614,7 @@ pub trait IXblIdpAuthTokenResult2_Impl: Sized {
     fn GetModernGamertagSuffix(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetUniqueModernGamertag(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IXblIdpAuthTokenResult2 {}
 impl IXblIdpAuthTokenResult2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXblIdpAuthTokenResult2_Impl, const OFFSET: isize>() -> IXblIdpAuthTokenResult2_Vtbl {
         unsafe extern "system" fn GetModernGamertag<Identity: ::windows::core::IUnknownImpl, Impl: IXblIdpAuthTokenResult2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
@@ -1,6 +1,7 @@
 pub trait IComprehensiveSpellCheckProvider_Impl: Sized {
     fn ComprehensiveCheck(&self, text: &::windows::core::PCWSTR) -> ::windows::core::Result<IEnumSpellingError>;
 }
+impl ::windows::core::RuntimeName for IComprehensiveSpellCheckProvider {}
 impl IComprehensiveSpellCheckProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComprehensiveSpellCheckProvider_Impl, const OFFSET: isize>() -> IComprehensiveSpellCheckProvider_Vtbl {
         unsafe extern "system" fn ComprehensiveCheck<Identity: ::windows::core::IUnknownImpl, Impl: IComprehensiveSpellCheckProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, text: ::windows::core::PCWSTR, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -26,6 +27,7 @@ pub trait IEnumCodePage_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumCodePage {}
 impl IEnumCodePage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCodePage_Impl, const OFFSET: isize>() -> IEnumCodePage_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCodePage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -72,6 +74,7 @@ pub trait IEnumRfc1766_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumRfc1766 {}
 impl IEnumRfc1766_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRfc1766_Impl, const OFFSET: isize>() -> IEnumRfc1766_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRfc1766_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -118,6 +121,7 @@ pub trait IEnumScript_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumScript {}
 impl IEnumScript_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumScript_Impl, const OFFSET: isize>() -> IEnumScript_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumScript_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -161,6 +165,7 @@ impl IEnumScript_Vtbl {
 pub trait IEnumSpellingError_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<ISpellingError>;
 }
+impl ::windows::core::RuntimeName for IEnumSpellingError {}
 impl IEnumSpellingError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSpellingError_Impl, const OFFSET: isize>() -> IEnumSpellingError_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSpellingError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -186,6 +191,7 @@ pub trait IMLangCodePages_Impl: Sized {
     fn CodePageToCodePages(&self, ucodepage: u32) -> ::windows::core::Result<u32>;
     fn CodePagesToCodePage(&self, dwcodepages: u32, udefaultcodepage: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMLangCodePages {}
 impl IMLangCodePages_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangCodePages_Impl, const OFFSET: isize>() -> IMLangCodePages_Vtbl {
         unsafe extern "system" fn GetCharCodePages<Identity: ::windows::core::IUnknownImpl, Impl: IMLangCodePages_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, chsrc: u16, pdwcodepages: *mut u32) -> ::windows::core::HRESULT {
@@ -247,6 +253,7 @@ pub trait IMLangConvertCharset_Impl: Sized {
     fn DoConversionToUnicode(&self, psrcstr: &::windows::core::PCSTR, pcsrcsize: *mut u32, pdststr: ::windows::core::PWSTR, pcdstsize: *mut u32) -> ::windows::core::Result<()>;
     fn DoConversionFromUnicode(&self, psrcstr: &::windows::core::PCWSTR, pcsrcsize: *mut u32, pdststr: ::windows::core::PSTR, pcdstsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLangConvertCharset {}
 impl IMLangConvertCharset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangConvertCharset_Impl, const OFFSET: isize>() -> IMLangConvertCharset_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IMLangConvertCharset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uisrccodepage: u32, uidstcodepage: u32, dwproperty: u32) -> ::windows::core::HRESULT {
@@ -325,6 +332,8 @@ pub trait IMLangFontLink_Impl: Sized + IMLangCodePages_Impl {
     fn ResetFontMapping(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IMLangFontLink {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IMLangFontLink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangFontLink_Impl, const OFFSET: isize>() -> IMLangFontLink_Vtbl {
         unsafe extern "system" fn GetFontCodePages<Identity: ::windows::core::IUnknownImpl, Impl: IMLangFontLink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hdc: super::Graphics::Gdi::HDC, hfont: super::Graphics::Gdi::HFONT, pdwcodepages: *mut u32) -> ::windows::core::HRESULT {
@@ -381,6 +390,8 @@ pub trait IMLangFontLink2_Impl: Sized + IMLangCodePages_Impl {
     fn GetScriptFontInfo(&self, sid: u8, dwflags: u32, puifonts: *mut u32, pscriptfont: *mut tagSCRIPFONTINFO) -> ::windows::core::Result<()>;
     fn CodePageToScriptID(&self, uicodepage: u32) -> ::windows::core::Result<u8>;
 }
+#[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IMLangFontLink2 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl IMLangFontLink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangFontLink2_Impl, const OFFSET: isize>() -> IMLangFontLink2_Vtbl {
@@ -463,6 +474,7 @@ pub trait IMLangLineBreakConsole_Impl: Sized {
     fn BreakLineW(&self, locale: u32, pszsrc: &::windows::core::PCWSTR, cchsrc: i32, cmaxcolumns: i32, pcchline: *mut i32, pcchskip: *mut i32) -> ::windows::core::Result<()>;
     fn BreakLineA(&self, locale: u32, ucodepage: u32, pszsrc: &::windows::core::PCSTR, cchsrc: i32, cmaxcolumns: i32, pcchline: *mut i32, pcchskip: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLangLineBreakConsole {}
 impl IMLangLineBreakConsole_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangLineBreakConsole_Impl, const OFFSET: isize>() -> IMLangLineBreakConsole_Vtbl {
         unsafe extern "system" fn BreakLineML<Identity: ::windows::core::IUnknownImpl, Impl: IMLangLineBreakConsole_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psrcmlstr: ::windows::core::RawPtr, lsrcpos: i32, lsrclen: i32, cmincolumns: i32, cmaxcolumns: i32, pllinelen: *mut i32, plskiplen: *mut i32) -> ::windows::core::HRESULT {
@@ -498,6 +510,8 @@ pub trait IMLangString_Impl: Sized {
     fn SetMLStr(&self, ldestpos: i32, ldestlen: i32, psrcmlstr: &::core::option::Option<::windows::core::IUnknown>, lsrcpos: i32, lsrclen: i32) -> ::windows::core::Result<()>;
     fn GetMLStr(&self, lsrcpos: i32, lsrclen: i32, punkouter: &::core::option::Option<::windows::core::IUnknown>, dwclscontext: u32, piid: *const ::windows::core::GUID, ppdestmlstr: *mut ::core::option::Option<::windows::core::IUnknown>, pldestpos: *mut i32, pldestlen: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMLangString {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMLangString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangString_Impl, const OFFSET: isize>() -> IMLangString_Vtbl {
@@ -550,6 +564,8 @@ pub trait IMLangStringAStr_Impl: Sized + IMLangString_Impl {
     fn SetLocale(&self, ldestpos: i32, ldestlen: i32, locale: u32) -> ::windows::core::Result<()>;
     fn GetLocale(&self, lsrcpos: i32, lsrcmaxlen: i32, plocale: *mut u32, pllocalepos: *mut i32, pllocalelen: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMLangStringAStr {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMLangStringAStr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangStringAStr_Impl, const OFFSET: isize>() -> IMLangStringAStr_Vtbl {
@@ -618,6 +634,8 @@ pub trait IMLangStringBufA_Impl: Sized {
     fn Delete(&self, cchoffset: i32, cchdelete: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMLangStringBufA {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMLangStringBufA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangStringBufA_Impl, const OFFSET: isize>() -> IMLangStringBufA_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IMLangStringBufA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plflags: *mut i32, pcchbuf: *mut i32) -> ::windows::core::HRESULT {
@@ -671,6 +689,7 @@ pub trait IMLangStringBufW_Impl: Sized {
     fn Insert(&self, cchoffset: i32, cchmaxinsert: i32) -> ::windows::core::Result<i32>;
     fn Delete(&self, cchoffset: i32, cchdelete: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMLangStringBufW {}
 impl IMLangStringBufW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangStringBufW_Impl, const OFFSET: isize>() -> IMLangStringBufW_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IMLangStringBufW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plflags: *mut i32, pcchbuf: *mut i32) -> ::windows::core::HRESULT {
@@ -728,6 +747,8 @@ pub trait IMLangStringWStr_Impl: Sized + IMLangString_Impl {
     fn SetLocale(&self, ldestpos: i32, ldestlen: i32, locale: u32) -> ::windows::core::Result<()>;
     fn GetLocale(&self, lsrcpos: i32, lsrcmaxlen: i32, plocale: *mut u32, pllocalepos: *mut i32, pllocalelen: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMLangStringWStr {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMLangStringWStr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMLangStringWStr_Impl, const OFFSET: isize>() -> IMLangStringWStr_Vtbl {
@@ -805,6 +826,8 @@ pub trait IMultiLanguage_Impl: Sized {
     fn GetRfc1766Info(&self, locale: u32) -> ::windows::core::Result<RFC1766INFO>;
     fn CreateConvertCharset(&self, uisrccodepage: u32, uidstcodepage: u32, dwproperty: u32) -> ::windows::core::Result<IMLangConvertCharset>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMultiLanguage {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMultiLanguage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiLanguage_Impl, const OFFSET: isize>() -> IMultiLanguage_Vtbl {
@@ -990,6 +1013,8 @@ pub trait IMultiLanguage2_Impl: Sized {
     fn EnumScripts(&self, dwflags: u32, langid: u16) -> ::windows::core::Result<IEnumScript>;
     fn ValidateCodePageEx(&self, uicodepage: u32, hwnd: super::Foundation::HWND, dwfiodcontrol: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMultiLanguage2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMultiLanguage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiLanguage2_Impl, const OFFSET: isize>() -> IMultiLanguage2_Vtbl {
@@ -1235,6 +1260,8 @@ pub trait IMultiLanguage3_Impl: Sized + IMultiLanguage2_Impl {
     fn DetectOutboundCodePageInIStream(&self, dwflags: u32, pstrin: &::core::option::Option<super::System::Com::IStream>, puipreferredcodepages: *const u32, npreferredcodepages: u32, puidetectedcodepages: *mut u32, pndetectedcodepages: *mut u32, lpspecialchar: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMultiLanguage3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMultiLanguage3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiLanguage3_Impl, const OFFSET: isize>() -> IMultiLanguage3_Vtbl {
         unsafe extern "system" fn DetectOutboundCodePage<Identity: ::windows::core::IUnknownImpl, Impl: IMultiLanguage3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, lpwidecharstr: ::windows::core::PCWSTR, cchwidechar: u32, puipreferredcodepages: *const u32, npreferredcodepages: u32, puidetectedcodepages: *mut u32, pndetectedcodepages: *mut u32, lpspecialchar: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1264,6 +1291,8 @@ pub trait IOptionDescription_Impl: Sized {
     fn Description(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn Labels(&self) -> ::windows::core::Result<super::System::Com::IEnumString>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOptionDescription {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOptionDescription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOptionDescription_Impl, const OFFSET: isize>() -> IOptionDescription_Vtbl {
@@ -1336,6 +1365,8 @@ pub trait ISpellCheckProvider_Impl: Sized {
     fn GetOptionDescription(&self, optionid: &::windows::core::PCWSTR) -> ::windows::core::Result<IOptionDescription>;
     fn InitializeWordlist(&self, wordlisttype: WORDLIST_TYPE, words: &::core::option::Option<super::System::Com::IEnumString>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISpellCheckProvider {}
 #[cfg(feature = "Win32_System_Com")]
 impl ISpellCheckProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellCheckProvider_Impl, const OFFSET: isize>() -> ISpellCheckProvider_Vtbl {
@@ -1462,6 +1493,8 @@ pub trait ISpellCheckProviderFactory_Impl: Sized {
     fn CreateSpellCheckProvider(&self, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<ISpellCheckProvider>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISpellCheckProviderFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISpellCheckProviderFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellCheckProviderFactory_Impl, const OFFSET: isize>() -> ISpellCheckProviderFactory_Vtbl {
         unsafe extern "system" fn SupportedLanguages<Identity: ::windows::core::IUnknownImpl, Impl: ISpellCheckProviderFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1525,6 +1558,8 @@ pub trait ISpellChecker_Impl: Sized {
     fn GetOptionDescription(&self, optionid: &::windows::core::PCWSTR) -> ::windows::core::Result<IOptionDescription>;
     fn ComprehensiveCheck(&self, text: &::windows::core::PCWSTR) -> ::windows::core::Result<IEnumSpellingError>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISpellChecker {}
 #[cfg(feature = "Win32_System_Com")]
 impl ISpellChecker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellChecker_Impl, const OFFSET: isize>() -> ISpellChecker_Vtbl {
@@ -1685,6 +1720,8 @@ pub trait ISpellChecker2_Impl: Sized + ISpellChecker_Impl {
     fn Remove(&self, word: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISpellChecker2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl ISpellChecker2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellChecker2_Impl, const OFFSET: isize>() -> ISpellChecker2_Vtbl {
         unsafe extern "system" fn Remove<Identity: ::windows::core::IUnknownImpl, Impl: ISpellChecker2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, word: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1701,6 +1738,7 @@ impl ISpellChecker2_Vtbl {
 pub trait ISpellCheckerChangedEventHandler_Impl: Sized {
     fn Invoke(&self, sender: &::core::option::Option<ISpellChecker>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpellCheckerChangedEventHandler {}
 impl ISpellCheckerChangedEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellCheckerChangedEventHandler_Impl, const OFFSET: isize>() -> ISpellCheckerChangedEventHandler_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: ISpellCheckerChangedEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1720,6 +1758,8 @@ pub trait ISpellCheckerFactory_Impl: Sized {
     fn IsSupported(&self, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<super::Foundation::BOOL>;
     fn CreateSpellChecker(&self, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<ISpellChecker>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISpellCheckerFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISpellCheckerFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellCheckerFactory_Impl, const OFFSET: isize>() -> ISpellCheckerFactory_Vtbl {
@@ -1773,6 +1813,7 @@ pub trait ISpellingError_Impl: Sized {
     fn CorrectiveAction(&self) -> ::windows::core::Result<CORRECTIVE_ACTION>;
     fn Replacement(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISpellingError {}
 impl ISpellingError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpellingError_Impl, const OFFSET: isize>() -> ISpellingError_Vtbl {
         unsafe extern "system" fn StartIndex<Identity: ::windows::core::IUnknownImpl, Impl: ISpellingError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut u32) -> ::windows::core::HRESULT {
@@ -1835,6 +1876,7 @@ pub trait IUserDictionariesRegistrar_Impl: Sized {
     fn RegisterUserDictionary(&self, dictionarypath: &::windows::core::PCWSTR, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn UnregisterUserDictionary(&self, dictionarypath: &::windows::core::PCWSTR, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUserDictionariesRegistrar {}
 impl IUserDictionariesRegistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserDictionariesRegistrar_Impl, const OFFSET: isize>() -> IUserDictionariesRegistrar_Vtbl {
         unsafe extern "system" fn RegisterUserDictionary<Identity: ::windows::core::IUnknownImpl, Impl: IUserDictionariesRegistrar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dictionarypath: ::windows::core::PCWSTR, languagetag: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
@@ -5,6 +5,8 @@ pub trait ICompositionFramePresentStatistics_Impl: Sized + IPresentStatistics_Im
     fn GetDisplayInstanceArray(&self, displayinstancearraycount: *mut u32, displayinstancearray: *mut *mut CompositionFrameDisplayInstance);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ICompositionFramePresentStatistics {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ICompositionFramePresentStatistics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionFramePresentStatistics_Impl, const OFFSET: isize>() -> ICompositionFramePresentStatistics_Vtbl {
         unsafe extern "system" fn GetContentTag<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionFramePresentStatistics_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> usize {
@@ -41,6 +43,8 @@ pub trait IIndependentFlipFramePresentStatistics_Impl: Sized + IPresentStatistic
     fn GetDisplayedTime(&self) -> SystemInterruptTime;
     fn GetPresentDuration(&self) -> SystemInterruptTime;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIndependentFlipFramePresentStatistics {}
 #[cfg(feature = "Win32_Foundation")]
 impl IIndependentFlipFramePresentStatistics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIndependentFlipFramePresentStatistics_Impl, const OFFSET: isize>() -> IIndependentFlipFramePresentStatistics_Vtbl {
@@ -86,6 +90,7 @@ pub trait IPresentStatistics_Impl: Sized {
     fn GetPresentId(&self) -> u64;
     fn GetKind(&self) -> PresentStatisticsKind;
 }
+impl ::windows::core::RuntimeName for IPresentStatistics {}
 impl IPresentStatistics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentStatistics_Impl, const OFFSET: isize>() -> IPresentStatistics_Vtbl {
         unsafe extern "system" fn GetPresentId<Identity: ::windows::core::IUnknownImpl, Impl: IPresentStatistics_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u64 {
@@ -112,6 +117,7 @@ pub trait IPresentStatusPresentStatistics_Impl: Sized + IPresentStatistics_Impl 
     fn GetCompositionFrameId(&self) -> u64;
     fn GetPresentStatus(&self) -> PresentStatus;
 }
+impl ::windows::core::RuntimeName for IPresentStatusPresentStatistics {}
 impl IPresentStatusPresentStatistics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentStatusPresentStatistics_Impl, const OFFSET: isize>() -> IPresentStatusPresentStatistics_Vtbl {
         unsafe extern "system" fn GetCompositionFrameId<Identity: ::windows::core::IUnknownImpl, Impl: IPresentStatusPresentStatistics_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u64 {
@@ -139,6 +145,8 @@ pub trait IPresentationBuffer_Impl: Sized {
     fn GetAvailableEvent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
     fn IsAvailable(&self) -> ::windows::core::Result<u8>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPresentationBuffer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPresentationBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationBuffer_Impl, const OFFSET: isize>() -> IPresentationBuffer_Vtbl {
@@ -177,6 +185,7 @@ impl IPresentationBuffer_Vtbl {
 pub trait IPresentationContent_Impl: Sized {
     fn SetTag(&self, tag: usize);
 }
+impl ::windows::core::RuntimeName for IPresentationContent {}
 impl IPresentationContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationContent_Impl, const OFFSET: isize>() -> IPresentationContent_Vtbl {
         unsafe extern "system" fn SetTag<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationContent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tag: usize) {
@@ -195,6 +204,7 @@ pub trait IPresentationFactory_Impl: Sized {
     fn IsPresentationSupportedWithIndependentFlip(&self) -> u8;
     fn CreatePresentationManager(&self) -> ::windows::core::Result<IPresentationManager>;
 }
+impl ::windows::core::RuntimeName for IPresentationFactory {}
 impl IPresentationFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationFactory_Impl, const OFFSET: isize>() -> IPresentationFactory_Vtbl {
         unsafe extern "system" fn IsPresentationSupported<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u8 {
@@ -245,6 +255,8 @@ pub trait IPresentationManager_Impl: Sized {
     fn EnablePresentStatisticsKind(&self, presentstatisticskind: PresentStatisticsKind, enabled: u8) -> ::windows::core::Result<()>;
     fn GetNextPresentStatistics(&self) -> ::windows::core::Result<IPresentStatistics>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPresentationManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPresentationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationManager_Impl, const OFFSET: isize>() -> IPresentationManager_Vtbl {
@@ -381,6 +393,8 @@ pub trait IPresentationSurface_Impl: Sized + IPresentationContent_Impl {
     fn SetDisableReadback(&self, value: u8) -> ::windows::core::Result<()>;
     fn SetLetterboxingMargins(&self, leftletterboxsize: f32, topletterboxsize: f32, rightletterboxsize: f32, bottomletterboxsize: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IPresentationSurface {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IPresentationSurface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationSurface_Impl, const OFFSET: isize>() -> IPresentationSurface_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
@@ -10,6 +10,7 @@ pub trait IDXCoreAdapter_Impl: Sized {
     fn SetState(&self, state: DXCoreAdapterState, inputstatedetailssize: usize, inputstatedetails: *const ::core::ffi::c_void, inputdatasize: usize, inputdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetFactory(&self, riid: *const ::windows::core::GUID, ppvfactory: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDXCoreAdapter {}
 impl IDXCoreAdapter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXCoreAdapter_Impl, const OFFSET: isize>() -> IDXCoreAdapter_Vtbl {
         unsafe extern "system" fn IsValid<Identity: ::windows::core::IUnknownImpl, Impl: IDXCoreAdapter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> bool {
@@ -95,6 +96,8 @@ pub trait IDXCoreAdapterFactory_Impl: Sized {
     fn UnregisterEventNotification(&self, eventcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXCoreAdapterFactory {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDXCoreAdapterFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXCoreAdapterFactory_Impl, const OFFSET: isize>() -> IDXCoreAdapterFactory_Vtbl {
         unsafe extern "system" fn CreateAdapterList<Identity: ::windows::core::IUnknownImpl, Impl: IDXCoreAdapterFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, numattributes: u32, filterattributes: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvadapterlist: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -149,6 +152,7 @@ pub trait IDXCoreAdapterList_Impl: Sized {
     fn Sort(&self, numpreferences: u32, preferences: *const DXCoreAdapterPreference) -> ::windows::core::Result<()>;
     fn IsAdapterPreferenceSupported(&self, preference: DXCoreAdapterPreference) -> bool;
 }
+impl ::windows::core::RuntimeName for IDXCoreAdapterList {}
 impl IDXCoreAdapterList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXCoreAdapterList_Impl, const OFFSET: isize>() -> IDXCoreAdapterList_Vtbl {
         unsafe extern "system" fn GetAdapter<Identity: ::windows::core::IUnknownImpl, Impl: IDXCoreAdapterList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/impl.rs
@@ -7,6 +7,7 @@ pub trait ID2D1SimplifiedGeometrySink_Impl: Sized {
     fn EndFigure(&self, figureend: D2D1_FIGURE_END);
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1SimplifiedGeometrySink {}
 impl ID2D1SimplifiedGeometrySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SimplifiedGeometrySink_Impl, const OFFSET: isize>() -> ID2D1SimplifiedGeometrySink_Vtbl {
         unsafe extern "system" fn SetFillMode<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SimplifiedGeometrySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fillmode: D2D1_FILL_MODE) {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
@@ -1,6 +1,7 @@
 pub trait ID2D1AnalysisTransform_Impl: Sized {
     fn ProcessAnalysisResults(&self, analysisdata: *const u8, analysisdatacount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1AnalysisTransform {}
 impl ID2D1AnalysisTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1AnalysisTransform_Impl, const OFFSET: isize>() -> ID2D1AnalysisTransform_Vtbl {
         unsafe extern "system" fn ProcessAnalysisResults<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1AnalysisTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, analysisdata: *const u8, analysisdatacount: u32) -> ::windows::core::HRESULT {
@@ -24,6 +25,8 @@ pub trait ID2D1Bitmap_Impl: Sized + ID2D1Resource_Impl + ID2D1Image_Impl {
     fn CopyFromRenderTarget(&self, destpoint: *const Common::D2D_POINT_2U, rendertarget: &::core::option::Option<ID2D1RenderTarget>, srcrect: *const Common::D2D_RECT_U) -> ::windows::core::Result<()>;
     fn CopyFromMemory(&self, dstrect: *const Common::D2D_RECT_U, srcdata: *const ::core::ffi::c_void, pitch: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID2D1Bitmap {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID2D1Bitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Bitmap_Impl, const OFFSET: isize>() -> ID2D1Bitmap_Vtbl {
@@ -85,6 +88,8 @@ pub trait ID2D1Bitmap1_Impl: Sized + ID2D1Resource_Impl + ID2D1Image_Impl + ID2D
     fn Map(&self, options: D2D1_MAP_OPTIONS) -> ::windows::core::Result<D2D1_MAPPED_RECT>;
     fn Unmap(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID2D1Bitmap1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID2D1Bitmap1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Bitmap1_Impl, const OFFSET: isize>() -> ID2D1Bitmap1_Vtbl {
@@ -150,6 +155,8 @@ pub trait ID2D1BitmapBrush_Impl: Sized + ID2D1Resource_Impl + ID2D1Brush_Impl {
     fn GetBitmap(&self, bitmap: *mut ::core::option::Option<ID2D1Bitmap>);
 }
 #[cfg(feature = "Foundation_Numerics")]
+impl ::windows::core::RuntimeName for ID2D1BitmapBrush {}
+#[cfg(feature = "Foundation_Numerics")]
 impl ID2D1BitmapBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BitmapBrush_Impl, const OFFSET: isize>() -> ID2D1BitmapBrush_Vtbl {
         unsafe extern "system" fn SetExtendModeX<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BitmapBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, extendmodex: D2D1_EXTEND_MODE) {
@@ -214,6 +221,8 @@ pub trait ID2D1BitmapBrush1_Impl: Sized + ID2D1Resource_Impl + ID2D1Brush_Impl +
     fn GetInterpolationMode1(&self) -> D2D1_INTERPOLATION_MODE;
 }
 #[cfg(feature = "Foundation_Numerics")]
+impl ::windows::core::RuntimeName for ID2D1BitmapBrush1 {}
+#[cfg(feature = "Foundation_Numerics")]
 impl ID2D1BitmapBrush1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BitmapBrush1_Impl, const OFFSET: isize>() -> ID2D1BitmapBrush1_Vtbl {
         unsafe extern "system" fn SetInterpolationMode1<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BitmapBrush1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interpolationmode: D2D1_INTERPOLATION_MODE) {
@@ -241,6 +250,8 @@ pub trait ID2D1BitmapRenderTarget_Impl: Sized + ID2D1Resource_Impl + ID2D1Render
     fn GetBitmap(&self) -> ::windows::core::Result<ID2D1Bitmap>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1BitmapRenderTarget {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1BitmapRenderTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BitmapRenderTarget_Impl, const OFFSET: isize>() -> ID2D1BitmapRenderTarget_Vtbl {
         unsafe extern "system" fn GetBitmap<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BitmapRenderTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bitmap: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -265,6 +276,8 @@ pub trait ID2D1BlendTransform_Impl: Sized + ID2D1TransformNode_Impl + ID2D1Concr
     fn SetDescription(&self, description: *const D2D1_BLEND_DESCRIPTION);
     fn GetDescription(&self, description: *mut D2D1_BLEND_DESCRIPTION);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1BlendTransform {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1BlendTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BlendTransform_Impl, const OFFSET: isize>() -> ID2D1BlendTransform_Vtbl {
@@ -295,6 +308,8 @@ pub trait ID2D1BorderTransform_Impl: Sized + ID2D1TransformNode_Impl + ID2D1Conc
     fn GetExtendModeX(&self) -> D2D1_EXTEND_MODE;
     fn GetExtendModeY(&self) -> D2D1_EXTEND_MODE;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1BorderTransform {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1BorderTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BorderTransform_Impl, const OFFSET: isize>() -> ID2D1BorderTransform_Vtbl {
@@ -336,6 +351,8 @@ pub trait ID2D1BoundsAdjustmentTransform_Impl: Sized + ID2D1TransformNode_Impl {
     fn GetOutputBounds(&self, outputbounds: *mut super::super::Foundation::RECT);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1BoundsAdjustmentTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID2D1BoundsAdjustmentTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BoundsAdjustmentTransform_Impl, const OFFSET: isize>() -> ID2D1BoundsAdjustmentTransform_Vtbl {
         unsafe extern "system" fn SetOutputBounds<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1BoundsAdjustmentTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, outputbounds: *const super::super::Foundation::RECT) {
@@ -365,6 +382,8 @@ pub trait ID2D1Brush_Impl: Sized + ID2D1Resource_Impl {
     fn GetOpacity(&self) -> f32;
     fn GetTransform(&self, transform: *mut super::super::super::Foundation::Numerics::Matrix3x2);
 }
+#[cfg(feature = "Foundation_Numerics")]
+impl ::windows::core::RuntimeName for ID2D1Brush {}
 #[cfg(feature = "Foundation_Numerics")]
 impl ID2D1Brush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Brush_Impl, const OFFSET: isize>() -> ID2D1Brush_Vtbl {
@@ -405,6 +424,7 @@ pub trait ID2D1ColorContext_Impl: Sized + ID2D1Resource_Impl {
     fn GetProfileSize(&self) -> u32;
     fn GetProfile(&self, profile: *mut u8, profilesize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1ColorContext {}
 impl ID2D1ColorContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ColorContext_Impl, const OFFSET: isize>() -> ID2D1ColorContext_Vtbl {
         unsafe extern "system" fn GetColorSpace<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ColorContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D2D1_COLOR_SPACE {
@@ -439,6 +459,8 @@ pub trait ID2D1ColorContext1_Impl: Sized + ID2D1Resource_Impl + ID2D1ColorContex
     fn GetDXGIColorSpace(&self) -> super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE;
     fn GetSimpleColorProfile(&self) -> ::windows::core::Result<D2D1_SIMPLE_COLOR_PROFILE>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID2D1ColorContext1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID2D1ColorContext1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ColorContext1_Impl, const OFFSET: isize>() -> ID2D1ColorContext1_Vtbl {
@@ -478,6 +500,7 @@ pub trait ID2D1CommandList_Impl: Sized + ID2D1Resource_Impl + ID2D1Image_Impl {
     fn Stream(&self, sink: &::core::option::Option<ID2D1CommandSink>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1CommandList {}
 impl ID2D1CommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandList_Impl, const OFFSET: isize>() -> ID2D1CommandList_Vtbl {
         unsafe extern "system" fn Stream<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -524,6 +547,8 @@ pub trait ID2D1CommandSink_Impl: Sized {
     fn PopAxisAlignedClip(&self) -> ::windows::core::Result<()>;
     fn PopLayer(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1CommandSink {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1CommandSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink_Impl, const OFFSET: isize>() -> ID2D1CommandSink_Vtbl {
@@ -690,6 +715,8 @@ pub trait ID2D1CommandSink1_Impl: Sized + ID2D1CommandSink_Impl {
     fn SetPrimitiveBlend1(&self, primitiveblend: D2D1_PRIMITIVE_BLEND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1CommandSink1 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1CommandSink1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink1_Impl, const OFFSET: isize>() -> ID2D1CommandSink1_Vtbl {
         unsafe extern "system" fn SetPrimitiveBlend1<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, primitiveblend: D2D1_PRIMITIVE_BLEND) -> ::windows::core::HRESULT {
@@ -709,6 +736,8 @@ pub trait ID2D1CommandSink2_Impl: Sized + ID2D1CommandSink_Impl + ID2D1CommandSi
     fn DrawGradientMesh(&self, gradientmesh: &::core::option::Option<ID2D1GradientMesh>) -> ::windows::core::Result<()>;
     fn DrawGdiMetafile2(&self, gdimetafile: &::core::option::Option<ID2D1GdiMetafile>, destinationrectangle: *const Common::D2D_RECT_F, sourcerectangle: *const Common::D2D_RECT_F) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1CommandSink2 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1CommandSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink2_Impl, const OFFSET: isize>() -> ID2D1CommandSink2_Vtbl {
@@ -743,6 +772,8 @@ pub trait ID2D1CommandSink3_Impl: Sized + ID2D1CommandSink_Impl + ID2D1CommandSi
     fn DrawSpriteBatch(&self, spritebatch: &::core::option::Option<ID2D1SpriteBatch>, startindex: u32, spritecount: u32, bitmap: &::core::option::Option<ID2D1Bitmap>, interpolationmode: D2D1_BITMAP_INTERPOLATION_MODE, spriteoptions: D2D1_SPRITE_OPTIONS) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1CommandSink3 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1CommandSink3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink3_Impl, const OFFSET: isize>() -> ID2D1CommandSink3_Vtbl {
         unsafe extern "system" fn DrawSpriteBatch<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, spritebatch: ::windows::core::RawPtr, startindex: u32, spritecount: u32, bitmap: ::windows::core::RawPtr, interpolationmode: D2D1_BITMAP_INTERPOLATION_MODE, spriteoptions: D2D1_SPRITE_OPTIONS) -> ::windows::core::HRESULT {
@@ -761,6 +792,8 @@ pub trait ID2D1CommandSink4_Impl: Sized + ID2D1CommandSink_Impl + ID2D1CommandSi
     fn SetPrimitiveBlend2(&self, primitiveblend: D2D1_PRIMITIVE_BLEND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1CommandSink4 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1CommandSink4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink4_Impl, const OFFSET: isize>() -> ID2D1CommandSink4_Vtbl {
         unsafe extern "system" fn SetPrimitiveBlend2<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, primitiveblend: D2D1_PRIMITIVE_BLEND) -> ::windows::core::HRESULT {
@@ -778,6 +811,8 @@ impl ID2D1CommandSink4_Vtbl {
 pub trait ID2D1CommandSink5_Impl: Sized + ID2D1CommandSink_Impl + ID2D1CommandSink1_Impl + ID2D1CommandSink2_Impl + ID2D1CommandSink3_Impl + ID2D1CommandSink4_Impl {
     fn BlendImage(&self, image: &::core::option::Option<ID2D1Image>, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1CommandSink5 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1CommandSink5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1CommandSink5_Impl, const OFFSET: isize>() -> ID2D1CommandSink5_Vtbl {
@@ -798,6 +833,8 @@ pub trait ID2D1ComputeInfo_Impl: Sized + ID2D1RenderInfo_Impl {
     fn SetComputeShader(&self, shaderid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetResourceTexture(&self, textureindex: u32, resourcetexture: &::core::option::Option<ID2D1ResourceTexture>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1ComputeInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1ComputeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ComputeInfo_Impl, const OFFSET: isize>() -> ID2D1ComputeInfo_Vtbl {
@@ -833,6 +870,8 @@ pub trait ID2D1ComputeTransform_Impl: Sized + ID2D1TransformNode_Impl + ID2D1Tra
     fn CalculateThreadgroups(&self, outputrect: *const super::super::Foundation::RECT, dimensionx: *mut u32, dimensiony: *mut u32, dimensionz: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1ComputeTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID2D1ComputeTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ComputeTransform_Impl, const OFFSET: isize>() -> ID2D1ComputeTransform_Vtbl {
         unsafe extern "system" fn SetComputeInfo<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ComputeTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, computeinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -861,6 +900,8 @@ pub trait ID2D1ConcreteTransform_Impl: Sized + ID2D1TransformNode_Impl {
     fn SetCached(&self, iscached: super::super::Foundation::BOOL);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1ConcreteTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID2D1ConcreteTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ConcreteTransform_Impl, const OFFSET: isize>() -> ID2D1ConcreteTransform_Vtbl {
         unsafe extern "system" fn SetOutputBuffer<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ConcreteTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bufferprecision: D2D1_BUFFER_PRECISION, channeldepth: D2D1_CHANNEL_DEPTH) -> ::windows::core::HRESULT {
@@ -888,6 +929,8 @@ pub trait ID2D1DCRenderTarget_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn BindDC(&self, hdc: super::Gdi::HDC, psubrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1DCRenderTarget {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1DCRenderTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DCRenderTarget_Impl, const OFFSET: isize>() -> ID2D1DCRenderTarget_Vtbl {
         unsafe extern "system" fn BindDC<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DCRenderTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hdc: super::Gdi::HDC, psubrect: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -909,6 +952,8 @@ pub trait ID2D1Device_Impl: Sized + ID2D1Resource_Impl {
     fn GetMaximumTextureMemory(&self) -> u64;
     fn ClearResources(&self, millisecondssinceuse: u32);
 }
+#[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device {}
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device_Impl, const OFFSET: isize>() -> ID2D1Device_Vtbl {
@@ -969,6 +1014,8 @@ pub trait ID2D1Device1_Impl: Sized + ID2D1Resource_Impl + ID2D1Device_Impl {
     fn CreateDeviceContext2(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext1>;
 }
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device1 {}
+#[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device1_Impl, const OFFSET: isize>() -> ID2D1Device1_Vtbl {
         unsafe extern "system" fn GetRenderingPriority<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D2D1_RENDERING_PRIORITY {
@@ -1009,6 +1056,8 @@ pub trait ID2D1Device2_Impl: Sized + ID2D1Resource_Impl + ID2D1Device_Impl + ID2
     fn FlushDeviceContexts(&self, bitmap: &::core::option::Option<ID2D1Bitmap>);
     fn GetDxgiDevice(&self) -> ::windows::core::Result<super::Dxgi::IDXGIDevice>;
 }
+#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device2_Impl, const OFFSET: isize>() -> ID2D1Device2_Vtbl {
@@ -1055,6 +1104,8 @@ pub trait ID2D1Device3_Impl: Sized + ID2D1Resource_Impl + ID2D1Device_Impl + ID2
     fn CreateDeviceContext4(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext3>;
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device3 {}
+#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device3_Impl, const OFFSET: isize>() -> ID2D1Device3_Vtbl {
         unsafe extern "system" fn CreateDeviceContext4<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: D2D1_DEVICE_CONTEXT_OPTIONS, devicecontext3: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1080,6 +1131,8 @@ pub trait ID2D1Device4_Impl: Sized + ID2D1Resource_Impl + ID2D1Device_Impl + ID2
     fn SetMaximumColorGlyphCacheMemory(&self, maximuminbytes: u64);
     fn GetMaximumColorGlyphCacheMemory(&self) -> u64;
 }
+#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device4 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device4_Impl, const OFFSET: isize>() -> ID2D1Device4_Vtbl {
@@ -1120,6 +1173,8 @@ pub trait ID2D1Device5_Impl: Sized + ID2D1Resource_Impl + ID2D1Device_Impl + ID2
     fn CreateDeviceContext6(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext5>;
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device5 {}
+#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device5_Impl, const OFFSET: isize>() -> ID2D1Device5_Vtbl {
         unsafe extern "system" fn CreateDeviceContext6<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: D2D1_DEVICE_CONTEXT_OPTIONS, devicecontext5: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1143,6 +1198,8 @@ impl ID2D1Device5_Vtbl {
 pub trait ID2D1Device6_Impl: Sized + ID2D1Resource_Impl + ID2D1Device_Impl + ID2D1Device1_Impl + ID2D1Device2_Impl + ID2D1Device3_Impl + ID2D1Device4_Impl + ID2D1Device5_Impl {
     fn CreateDeviceContext7(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext6>;
 }
+#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
+impl ::windows::core::RuntimeName for ID2D1Device6 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl ID2D1Device6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Device6_Impl, const OFFSET: isize>() -> ID2D1Device6_Vtbl {
@@ -1201,6 +1258,8 @@ pub trait ID2D1DeviceContext_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarge
     fn GetEffectRequiredInputRectangles(&self, rendereffect: &::core::option::Option<ID2D1Effect>, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()>;
     fn FillOpacityMask2(&self, opacitymask: &::core::option::Option<ID2D1Bitmap>, brush: &::core::option::Option<ID2D1Brush>, destinationrectangle: *const Common::D2D_RECT_F, sourcerectangle: *const Common::D2D_RECT_F);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1DeviceContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext_Impl, const OFFSET: isize>() -> ID2D1DeviceContext_Vtbl {
@@ -1519,6 +1578,8 @@ pub trait ID2D1DeviceContext1_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn DrawGeometryRealization(&self, geometryrealization: &::core::option::Option<ID2D1GeometryRealization>, brush: &::core::option::Option<ID2D1Brush>);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext1 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1DeviceContext1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext1_Impl, const OFFSET: isize>() -> ID2D1DeviceContext1_Vtbl {
         unsafe extern "system" fn CreateFilledGeometryRealization<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, geometry: ::windows::core::RawPtr, flatteningtolerance: f32, geometryrealization: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1573,6 +1634,8 @@ pub trait ID2D1DeviceContext2_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn DrawGdiMetafile2(&self, gdimetafile: &::core::option::Option<ID2D1GdiMetafile>, destinationrectangle: *const Common::D2D_RECT_F, sourcerectangle: *const Common::D2D_RECT_F);
     fn CreateTransformedImageSource(&self, imagesource: &::core::option::Option<ID2D1ImageSource>, properties: *const D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES) -> ::windows::core::Result<ID2D1TransformedImageSource>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext2 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1DeviceContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext2_Impl, const OFFSET: isize>() -> ID2D1DeviceContext2_Vtbl {
@@ -1704,6 +1767,8 @@ pub trait ID2D1DeviceContext3_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn DrawSpriteBatch(&self, spritebatch: &::core::option::Option<ID2D1SpriteBatch>, startindex: u32, spritecount: u32, bitmap: &::core::option::Option<ID2D1Bitmap>, interpolationmode: D2D1_BITMAP_INTERPOLATION_MODE, spriteoptions: D2D1_SPRITE_OPTIONS);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext3 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1DeviceContext3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext3_Impl, const OFFSET: isize>() -> ID2D1DeviceContext3_Vtbl {
         unsafe extern "system" fn CreateSpriteBatch<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, spritebatch: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1742,6 +1807,8 @@ pub trait ID2D1DeviceContext4_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn GetColorBitmapGlyphImage(&self, glyphimageformat: super::DirectWrite::DWRITE_GLYPH_IMAGE_FORMATS, glyphorigin: &Common::D2D_POINT_2F, fontface: &::core::option::Option<super::DirectWrite::IDWriteFontFace>, fontemsize: f32, glyphindex: u16, issideways: super::super::Foundation::BOOL, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, dpix: f32, dpiy: f32, glyphtransform: *mut super::super::super::Foundation::Numerics::Matrix3x2, glyphimage: *mut ::core::option::Option<ID2D1Image>) -> ::windows::core::Result<()>;
     fn GetSvgGlyphImage(&self, glyphorigin: &Common::D2D_POINT_2F, fontface: &::core::option::Option<super::DirectWrite::IDWriteFontFace>, fontemsize: f32, glyphindex: u16, issideways: super::super::Foundation::BOOL, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, defaultfillbrush: &::core::option::Option<ID2D1Brush>, svgglyphstyle: &::core::option::Option<ID2D1SvgGlyphStyle>, colorpaletteindex: u32, glyphtransform: *mut super::super::super::Foundation::Numerics::Matrix3x2, glyphimage: *mut ::core::option::Option<ID2D1CommandList>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext4 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1DeviceContext4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext4_Impl, const OFFSET: isize>() -> ID2D1DeviceContext4_Vtbl {
@@ -1813,6 +1880,8 @@ pub trait ID2D1DeviceContext5_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn CreateColorContextFromSimpleColorProfile(&self, simpleprofile: *const D2D1_SIMPLE_COLOR_PROFILE) -> ::windows::core::Result<ID2D1ColorContext1>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext5 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1DeviceContext5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext5_Impl, const OFFSET: isize>() -> ID2D1DeviceContext5_Vtbl {
         unsafe extern "system" fn CreateSvgDocument<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputxmlstream: ::windows::core::RawPtr, viewportsize: Common::D2D_SIZE_F, svgdocument: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1870,6 +1939,8 @@ pub trait ID2D1DeviceContext6_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTarg
     fn BlendImage(&self, image: &::core::option::Option<ID2D1Image>, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1DeviceContext6 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1DeviceContext6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext6_Impl, const OFFSET: isize>() -> ID2D1DeviceContext6_Vtbl {
         unsafe extern "system" fn BlendImage<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DeviceContext6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, image: ::windows::core::RawPtr, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE) {
@@ -1891,6 +1962,8 @@ pub trait ID2D1DrawInfo_Impl: Sized + ID2D1RenderInfo_Impl {
     fn SetPixelShader(&self, shaderid: *const ::windows::core::GUID, pixeloptions: D2D1_PIXEL_OPTIONS) -> ::windows::core::Result<()>;
     fn SetVertexProcessing(&self, vertexbuffer: &::core::option::Option<ID2D1VertexBuffer>, vertexoptions: D2D1_VERTEX_OPTIONS, blenddescription: *const D2D1_BLEND_DESCRIPTION, vertexrange: *const D2D1_VERTEX_RANGE, vertexshader: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1DrawInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1DrawInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DrawInfo_Impl, const OFFSET: isize>() -> ID2D1DrawInfo_Vtbl {
@@ -1937,6 +2010,8 @@ pub trait ID2D1DrawTransform_Impl: Sized + ID2D1TransformNode_Impl + ID2D1Transf
     fn SetDrawInfo(&self, drawinfo: &::core::option::Option<ID2D1DrawInfo>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1DrawTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID2D1DrawTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DrawTransform_Impl, const OFFSET: isize>() -> ID2D1DrawTransform_Vtbl {
         unsafe extern "system" fn SetDrawInfo<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DrawTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, drawinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1957,6 +2032,8 @@ pub trait ID2D1DrawingStateBlock_Impl: Sized + ID2D1Resource_Impl {
     fn SetTextRenderingParams(&self, textrenderingparams: &::core::option::Option<super::DirectWrite::IDWriteRenderingParams>);
     fn GetTextRenderingParams(&self, textrenderingparams: *mut ::core::option::Option<super::DirectWrite::IDWriteRenderingParams>);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1DrawingStateBlock {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1DrawingStateBlock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DrawingStateBlock_Impl, const OFFSET: isize>() -> ID2D1DrawingStateBlock_Vtbl {
@@ -1998,6 +2075,8 @@ pub trait ID2D1DrawingStateBlock1_Impl: Sized + ID2D1Resource_Impl + ID2D1Drawin
     fn SetDescription2(&self, statedescription: *const D2D1_DRAWING_STATE_DESCRIPTION1);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
+impl ::windows::core::RuntimeName for ID2D1DrawingStateBlock1 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 impl ID2D1DrawingStateBlock1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DrawingStateBlock1_Impl, const OFFSET: isize>() -> ID2D1DrawingStateBlock1_Vtbl {
         unsafe extern "system" fn GetDescription2<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1DrawingStateBlock1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, statedescription: *mut D2D1_DRAWING_STATE_DESCRIPTION1) {
@@ -2028,6 +2107,8 @@ pub trait ID2D1Effect_Impl: Sized + ID2D1Properties_Impl {
     fn GetInputCount(&self) -> u32;
     fn GetOutput(&self, outputimage: *mut ::core::option::Option<ID2D1Image>);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1Effect {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1Effect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Effect_Impl, const OFFSET: isize>() -> ID2D1Effect_Vtbl {
@@ -2093,6 +2174,8 @@ pub trait ID2D1EffectContext_Impl: Sized {
     fn CheckFeatureSupport(&self, feature: D2D1_FEATURE, featuresupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::Result<()>;
     fn IsBufferPrecisionSupported(&self, bufferprecision: D2D1_BUFFER_PRECISION) -> super::super::Foundation::BOOL;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1EffectContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1EffectContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EffectContext_Impl, const OFFSET: isize>() -> ID2D1EffectContext_Vtbl {
@@ -2319,6 +2402,8 @@ pub trait ID2D1EffectContext1_Impl: Sized + ID2D1EffectContext_Impl {
     fn CreateLookupTable3D(&self, precision: D2D1_BUFFER_PRECISION, extents: *const u32, data: *const u8, datacount: u32, strides: *const u32) -> ::windows::core::Result<ID2D1LookupTable3D>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1EffectContext1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1EffectContext1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EffectContext1_Impl, const OFFSET: isize>() -> ID2D1EffectContext1_Vtbl {
         unsafe extern "system" fn CreateLookupTable3D<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EffectContext1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, precision: D2D1_BUFFER_PRECISION, extents: *const u32, data: *const u8, datacount: u32, strides: *const u32, lookuptable: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2343,6 +2428,8 @@ pub trait ID2D1EffectContext2_Impl: Sized + ID2D1EffectContext_Impl + ID2D1Effec
     fn CreateColorContextFromDxgiColorSpace(&self, colorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE) -> ::windows::core::Result<ID2D1ColorContext1>;
     fn CreateColorContextFromSimpleColorProfile(&self, simpleprofile: *const D2D1_SIMPLE_COLOR_PROFILE) -> ::windows::core::Result<ID2D1ColorContext1>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1EffectContext2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1EffectContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EffectContext2_Impl, const OFFSET: isize>() -> ID2D1EffectContext2_Vtbl {
@@ -2383,6 +2470,7 @@ pub trait ID2D1EffectImpl_Impl: Sized {
     fn PrepareForRender(&self, changetype: D2D1_CHANGE_TYPE) -> ::windows::core::Result<()>;
     fn SetGraph(&self, transformgraph: &::core::option::Option<ID2D1TransformGraph>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1EffectImpl {}
 impl ID2D1EffectImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EffectImpl_Impl, const OFFSET: isize>() -> ID2D1EffectImpl_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EffectImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectcontext: ::windows::core::RawPtr, transformgraph: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2416,6 +2504,8 @@ pub trait ID2D1EllipseGeometry_Impl: Sized + ID2D1Resource_Impl + ID2D1Geometry_
     fn GetEllipse(&self, ellipse: *mut D2D1_ELLIPSE);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1EllipseGeometry {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1EllipseGeometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EllipseGeometry_Impl, const OFFSET: isize>() -> ID2D1EllipseGeometry_Vtbl {
         unsafe extern "system" fn GetEllipse<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1EllipseGeometry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ellipse: *mut D2D1_ELLIPSE) {
@@ -2446,6 +2536,8 @@ pub trait ID2D1Factory_Impl: Sized {
     fn CreateDxgiSurfaceRenderTarget(&self, dxgisurface: &::core::option::Option<super::Dxgi::IDXGISurface>, rendertargetproperties: *const D2D1_RENDER_TARGET_PROPERTIES) -> ::windows::core::Result<ID2D1RenderTarget>;
     fn CreateDCRenderTarget(&self, rendertargetproperties: *const D2D1_RENDER_TARGET_PROPERTIES) -> ::windows::core::Result<ID2D1DCRenderTarget>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1Factory {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1Factory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory_Impl, const OFFSET: isize>() -> ID2D1Factory_Vtbl {
@@ -2627,6 +2719,8 @@ pub trait ID2D1Factory1_Impl: Sized + ID2D1Factory_Impl {
     fn GetEffectProperties(&self, effectid: *const ::windows::core::GUID) -> ::windows::core::Result<ID2D1Properties>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory1 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory1_Impl, const OFFSET: isize>() -> ID2D1Factory1_Vtbl {
         unsafe extern "system" fn CreateDevice<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dxgidevice: ::windows::core::RawPtr, d2ddevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2738,6 +2832,8 @@ pub trait ID2D1Factory2_Impl: Sized + ID2D1Factory_Impl + ID2D1Factory1_Impl {
     fn CreateDevice2(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device1>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory2 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory2_Impl, const OFFSET: isize>() -> ID2D1Factory2_Vtbl {
         unsafe extern "system" fn CreateDevice2<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dxgidevice: ::windows::core::RawPtr, d2ddevice1: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2761,6 +2857,8 @@ impl ID2D1Factory2_Vtbl {
 pub trait ID2D1Factory3_Impl: Sized + ID2D1Factory_Impl + ID2D1Factory1_Impl + ID2D1Factory2_Impl {
     fn CreateDevice3(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device2>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory3 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory3_Impl, const OFFSET: isize>() -> ID2D1Factory3_Vtbl {
@@ -2786,6 +2884,8 @@ pub trait ID2D1Factory4_Impl: Sized + ID2D1Factory_Impl + ID2D1Factory1_Impl + I
     fn CreateDevice4(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device3>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory4 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory4_Impl, const OFFSET: isize>() -> ID2D1Factory4_Vtbl {
         unsafe extern "system" fn CreateDevice4<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dxgidevice: ::windows::core::RawPtr, d2ddevice3: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2809,6 +2909,8 @@ impl ID2D1Factory4_Vtbl {
 pub trait ID2D1Factory5_Impl: Sized + ID2D1Factory_Impl + ID2D1Factory1_Impl + ID2D1Factory2_Impl + ID2D1Factory3_Impl + ID2D1Factory4_Impl {
     fn CreateDevice5(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device4>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory5 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory5_Impl, const OFFSET: isize>() -> ID2D1Factory5_Vtbl {
@@ -2834,6 +2936,8 @@ pub trait ID2D1Factory6_Impl: Sized + ID2D1Factory_Impl + ID2D1Factory1_Impl + I
     fn CreateDevice6(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device5>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory6 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory6_Impl, const OFFSET: isize>() -> ID2D1Factory6_Vtbl {
         unsafe extern "system" fn CreateDevice6<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dxgidevice: ::windows::core::RawPtr, d2ddevice5: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2857,6 +2961,8 @@ impl ID2D1Factory6_Vtbl {
 pub trait ID2D1Factory7_Impl: Sized + ID2D1Factory_Impl + ID2D1Factory1_Impl + ID2D1Factory2_Impl + ID2D1Factory3_Impl + ID2D1Factory4_Impl + ID2D1Factory5_Impl + ID2D1Factory6_Impl {
     fn CreateDevice7(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device6>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1Factory7 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl ID2D1Factory7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Factory7_Impl, const OFFSET: isize>() -> ID2D1Factory7_Vtbl {
@@ -2882,6 +2988,8 @@ pub trait ID2D1GdiInteropRenderTarget_Impl: Sized {
     fn GetDC(&self, mode: D2D1_DC_INITIALIZE_MODE) -> ::windows::core::Result<super::Gdi::HDC>;
     fn ReleaseDC(&self, update: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ID2D1GdiInteropRenderTarget {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ID2D1GdiInteropRenderTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiInteropRenderTarget_Impl, const OFFSET: isize>() -> ID2D1GdiInteropRenderTarget_Vtbl {
@@ -2917,6 +3025,8 @@ pub trait ID2D1GdiMetafile_Impl: Sized + ID2D1Resource_Impl {
     fn GetBounds(&self) -> ::windows::core::Result<Common::D2D_RECT_F>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1GdiMetafile {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1GdiMetafile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafile_Impl, const OFFSET: isize>() -> ID2D1GdiMetafile_Vtbl {
         unsafe extern "system" fn Stream<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2951,6 +3061,8 @@ pub trait ID2D1GdiMetafile1_Impl: Sized + ID2D1Resource_Impl + ID2D1GdiMetafile_
     fn GetSourceBounds(&self) -> ::windows::core::Result<Common::D2D_RECT_F>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1GdiMetafile1 {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1GdiMetafile1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafile1_Impl, const OFFSET: isize>() -> ID2D1GdiMetafile1_Vtbl {
         unsafe extern "system" fn GetDpi<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafile1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dpix: *mut f32, dpiy: *mut f32) -> ::windows::core::HRESULT {
@@ -2982,6 +3094,7 @@ impl ID2D1GdiMetafile1_Vtbl {
 pub trait ID2D1GdiMetafileSink_Impl: Sized {
     fn ProcessRecord(&self, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1GdiMetafileSink {}
 impl ID2D1GdiMetafileSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafileSink_Impl, const OFFSET: isize>() -> ID2D1GdiMetafileSink_Vtbl {
         unsafe extern "system" fn ProcessRecord<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafileSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32) -> ::windows::core::HRESULT {
@@ -2998,6 +3111,7 @@ impl ID2D1GdiMetafileSink_Vtbl {
 pub trait ID2D1GdiMetafileSink1_Impl: Sized + ID2D1GdiMetafileSink_Impl {
     fn ProcessRecord2(&self, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32, flags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1GdiMetafileSink1 {}
 impl ID2D1GdiMetafileSink1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafileSink1_Impl, const OFFSET: isize>() -> ID2D1GdiMetafileSink1_Vtbl {
         unsafe extern "system" fn ProcessRecord2<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GdiMetafileSink1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32, flags: u32) -> ::windows::core::HRESULT {
@@ -3027,6 +3141,8 @@ pub trait ID2D1Geometry_Impl: Sized + ID2D1Resource_Impl {
     fn ComputePointAtLength(&self, length: f32, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32, point: *mut Common::D2D_POINT_2F, unittangentvector: *mut Common::D2D_POINT_2F) -> ::windows::core::Result<()>;
     fn Widen(&self, strokewidth: f32, strokestyle: &::core::option::Option<ID2D1StrokeStyle>, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32, geometrysink: &::core::option::Option<Common::ID2D1SimplifiedGeometrySink>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1Geometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1Geometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Geometry_Impl, const OFFSET: isize>() -> ID2D1Geometry_Vtbl {
@@ -3165,6 +3281,8 @@ pub trait ID2D1GeometryGroup_Impl: Sized + ID2D1Resource_Impl + ID2D1Geometry_Im
     fn GetSourceGeometries(&self, geometries: *mut ::core::option::Option<ID2D1Geometry>, geometriescount: u32);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1GeometryGroup {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1GeometryGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GeometryGroup_Impl, const OFFSET: isize>() -> ID2D1GeometryGroup_Vtbl {
         unsafe extern "system" fn GetFillMode<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GeometryGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> Common::D2D1_FILL_MODE {
@@ -3194,6 +3312,7 @@ impl ID2D1GeometryGroup_Vtbl {
     }
 }
 pub trait ID2D1GeometryRealization_Impl: Sized + ID2D1Resource_Impl {}
+impl ::windows::core::RuntimeName for ID2D1GeometryRealization {}
 impl ID2D1GeometryRealization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GeometryRealization_Impl, const OFFSET: isize>() -> ID2D1GeometryRealization_Vtbl {
         Self { base__: ID2D1Resource_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3210,6 +3329,8 @@ pub trait ID2D1GeometrySink_Impl: Sized + Common::ID2D1SimplifiedGeometrySink_Im
     fn AddQuadraticBeziers(&self, beziers: *const D2D1_QUADRATIC_BEZIER_SEGMENT, bezierscount: u32);
     fn AddArc(&self, arc: *const D2D1_ARC_SEGMENT);
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1GeometrySink {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1GeometrySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GeometrySink_Impl, const OFFSET: isize>() -> ID2D1GeometrySink_Vtbl {
@@ -3257,6 +3378,8 @@ pub trait ID2D1GradientMesh_Impl: Sized + ID2D1Resource_Impl {
     fn GetPatches(&self, startindex: u32, patches: *mut D2D1_GRADIENT_MESH_PATCH, patchescount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1GradientMesh {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1GradientMesh_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GradientMesh_Impl, const OFFSET: isize>() -> ID2D1GradientMesh_Vtbl {
         unsafe extern "system" fn GetPatchCount<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GradientMesh_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -3286,6 +3409,8 @@ pub trait ID2D1GradientStopCollection_Impl: Sized + ID2D1Resource_Impl {
     fn GetColorInterpolationGamma(&self) -> D2D1_GAMMA;
     fn GetExtendMode(&self) -> D2D1_EXTEND_MODE;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1GradientStopCollection {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1GradientStopCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GradientStopCollection_Impl, const OFFSET: isize>() -> ID2D1GradientStopCollection_Vtbl {
@@ -3329,6 +3454,8 @@ pub trait ID2D1GradientStopCollection1_Impl: Sized + ID2D1Resource_Impl + ID2D1G
     fn GetBufferPrecision(&self) -> D2D1_BUFFER_PRECISION;
     fn GetColorInterpolationMode(&self) -> D2D1_COLOR_INTERPOLATION_MODE;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1GradientStopCollection1 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1GradientStopCollection1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1GradientStopCollection1_Impl, const OFFSET: isize>() -> ID2D1GradientStopCollection1_Vtbl {
@@ -3377,6 +3504,8 @@ pub trait ID2D1HwndRenderTarget_Impl: Sized + ID2D1Resource_Impl + ID2D1RenderTa
     fn GetHwnd(&self) -> super::super::Foundation::HWND;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1HwndRenderTarget {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1HwndRenderTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1HwndRenderTarget_Impl, const OFFSET: isize>() -> ID2D1HwndRenderTarget_Vtbl {
         unsafe extern "system" fn CheckWindowState<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1HwndRenderTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D2D1_WINDOW_STATE {
@@ -3406,6 +3535,7 @@ impl ID2D1HwndRenderTarget_Vtbl {
     }
 }
 pub trait ID2D1Image_Impl: Sized + ID2D1Resource_Impl {}
+impl ::windows::core::RuntimeName for ID2D1Image {}
 impl ID2D1Image_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Image_Impl, const OFFSET: isize>() -> ID2D1Image_Vtbl {
         Self { base__: ID2D1Resource_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3427,6 +3557,8 @@ pub trait ID2D1ImageBrush_Impl: Sized + ID2D1Resource_Impl + ID2D1Brush_Impl {
     fn GetInterpolationMode(&self) -> D2D1_INTERPOLATION_MODE;
     fn GetSourceRectangle(&self, sourcerectangle: *mut Common::D2D_RECT_F);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1ImageBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1ImageBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ImageBrush_Impl, const OFFSET: isize>() -> ID2D1ImageBrush_Vtbl {
@@ -3504,6 +3636,8 @@ pub trait ID2D1ImageSource_Impl: Sized + ID2D1Resource_Impl + ID2D1Image_Impl {
     fn TryReclaimResources(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1ImageSource {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID2D1ImageSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ImageSource_Impl, const OFFSET: isize>() -> ID2D1ImageSource_Vtbl {
         unsafe extern "system" fn OfferResources<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ImageSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3538,6 +3672,8 @@ pub trait ID2D1ImageSourceFromWic_Impl: Sized + ID2D1Resource_Impl + ID2D1Image_
     fn TrimCache(&self, rectangletopreserve: *const Common::D2D_RECT_U) -> ::windows::core::Result<()>;
     fn GetSource(&self, wicbitmapsource: *mut ::core::option::Option<super::Imaging::IWICBitmapSource>);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1ImageSourceFromWic {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1ImageSourceFromWic_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ImageSourceFromWic_Impl, const OFFSET: isize>() -> ID2D1ImageSourceFromWic_Vtbl {
@@ -3580,6 +3716,8 @@ pub trait ID2D1Ink_Impl: Sized + ID2D1Resource_Impl {
     fn StreamAsGeometry(&self, inkstyle: &::core::option::Option<ID2D1InkStyle>, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32, geometrysink: &::core::option::Option<Common::ID2D1SimplifiedGeometrySink>) -> ::windows::core::Result<()>;
     fn GetBounds(&self, inkstyle: &::core::option::Option<ID2D1InkStyle>, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2) -> ::windows::core::Result<Common::D2D_RECT_F>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1Ink {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1Ink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Ink_Impl, const OFFSET: isize>() -> ID2D1Ink_Vtbl {
@@ -3665,6 +3803,8 @@ pub trait ID2D1InkStyle_Impl: Sized + ID2D1Resource_Impl {
     fn GetNibShape(&self) -> D2D1_INK_NIB_SHAPE;
 }
 #[cfg(feature = "Foundation_Numerics")]
+impl ::windows::core::RuntimeName for ID2D1InkStyle {}
+#[cfg(feature = "Foundation_Numerics")]
 impl ID2D1InkStyle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1InkStyle_Impl, const OFFSET: isize>() -> ID2D1InkStyle_Vtbl {
         unsafe extern "system" fn SetNibTransform<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1InkStyle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, transform: *const super::super::super::Foundation::Numerics::Matrix3x2) {
@@ -3704,6 +3844,8 @@ pub trait ID2D1Layer_Impl: Sized + ID2D1Resource_Impl {
     fn GetSize(&self) -> Common::D2D_SIZE_F;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1Layer {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1Layer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Layer_Impl, const OFFSET: isize>() -> ID2D1Layer_Vtbl {
         unsafe extern "system" fn GetSize<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Layer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut Common::D2D_SIZE_F) {
@@ -3725,6 +3867,8 @@ pub trait ID2D1LinearGradientBrush_Impl: Sized + ID2D1Resource_Impl + ID2D1Brush
     fn GetEndPoint(&self) -> Common::D2D_POINT_2F;
     fn GetGradientStopCollection(&self, gradientstopcollection: *mut ::core::option::Option<ID2D1GradientStopCollection>);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1LinearGradientBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1LinearGradientBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1LinearGradientBrush_Impl, const OFFSET: isize>() -> ID2D1LinearGradientBrush_Vtbl {
@@ -3767,6 +3911,7 @@ impl ID2D1LinearGradientBrush_Vtbl {
     }
 }
 pub trait ID2D1LookupTable3D_Impl: Sized + ID2D1Resource_Impl {}
+impl ::windows::core::RuntimeName for ID2D1LookupTable3D {}
 impl ID2D1LookupTable3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1LookupTable3D_Impl, const OFFSET: isize>() -> ID2D1LookupTable3D_Vtbl {
         Self { base__: ID2D1Resource_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3778,6 +3923,7 @@ impl ID2D1LookupTable3D_Vtbl {
 pub trait ID2D1Mesh_Impl: Sized + ID2D1Resource_Impl {
     fn Open(&self) -> ::windows::core::Result<ID2D1TessellationSink>;
 }
+impl ::windows::core::RuntimeName for ID2D1Mesh {}
 impl ID2D1Mesh_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Mesh_Impl, const OFFSET: isize>() -> ID2D1Mesh_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Mesh_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tessellationsink: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3803,6 +3949,8 @@ pub trait ID2D1Multithread_Impl: Sized {
     fn Enter(&self);
     fn Leave(&self);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1Multithread {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1Multithread_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Multithread_Impl, const OFFSET: isize>() -> ID2D1Multithread_Vtbl {
@@ -3838,6 +3986,8 @@ pub trait ID2D1OffsetTransform_Impl: Sized + ID2D1TransformNode_Impl {
     fn GetOffset(&self) -> super::super::Foundation::POINT;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1OffsetTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID2D1OffsetTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1OffsetTransform_Impl, const OFFSET: isize>() -> ID2D1OffsetTransform_Vtbl {
         unsafe extern "system" fn SetOffset<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1OffsetTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offset: super::super::Foundation::POINT) {
@@ -3867,6 +4017,8 @@ pub trait ID2D1PathGeometry_Impl: Sized + ID2D1Resource_Impl + ID2D1Geometry_Imp
     fn GetSegmentCount(&self) -> ::windows::core::Result<u32>;
     fn GetFigureCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1PathGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1PathGeometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1PathGeometry_Impl, const OFFSET: isize>() -> ID2D1PathGeometry_Vtbl {
@@ -3925,6 +4077,8 @@ pub trait ID2D1PathGeometry1_Impl: Sized + ID2D1Resource_Impl + ID2D1Geometry_Im
     fn ComputePointAndSegmentAtLength(&self, length: f32, startsegment: u32, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32) -> ::windows::core::Result<D2D1_POINT_DESCRIPTION>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1PathGeometry1 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1PathGeometry1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1PathGeometry1_Impl, const OFFSET: isize>() -> ID2D1PathGeometry1_Vtbl {
         unsafe extern "system" fn ComputePointAndSegmentAtLength<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1PathGeometry1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, length: f32, startsegment: u32, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32, pointdescription: *mut D2D1_POINT_DESCRIPTION) -> ::windows::core::HRESULT {
@@ -3952,6 +4106,8 @@ pub trait ID2D1PrintControl_Impl: Sized {
     fn AddPage(&self, commandlist: &::core::option::Option<ID2D1CommandList>, pagesize: &Common::D2D_SIZE_F, pageprintticketstream: &::core::option::Option<super::super::System::Com::IStream>, tag1: *mut u64, tag2: *mut u64) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1PrintControl {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 impl ID2D1PrintControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1PrintControl_Impl, const OFFSET: isize>() -> ID2D1PrintControl_Vtbl {
@@ -3988,6 +4144,7 @@ pub trait ID2D1Properties_Impl: Sized {
     fn GetValueSize(&self, index: u32) -> u32;
     fn GetSubProperties(&self, index: u32) -> ::windows::core::Result<ID2D1Properties>;
 }
+impl ::windows::core::RuntimeName for ID2D1Properties {}
 impl ID2D1Properties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Properties_Impl, const OFFSET: isize>() -> ID2D1Properties_Vtbl {
         unsafe extern "system" fn GetPropertyCount<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Properties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -4083,6 +4240,8 @@ pub trait ID2D1RadialGradientBrush_Impl: Sized + ID2D1Resource_Impl + ID2D1Brush
     fn GetGradientStopCollection(&self, gradientstopcollection: *mut ::core::option::Option<ID2D1GradientStopCollection>);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1RadialGradientBrush {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1RadialGradientBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RadialGradientBrush_Impl, const OFFSET: isize>() -> ID2D1RadialGradientBrush_Vtbl {
         unsafe extern "system" fn SetCenter<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RadialGradientBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, center: Common::D2D_POINT_2F) {
@@ -4152,6 +4311,8 @@ pub trait ID2D1RectangleGeometry_Impl: Sized + ID2D1Resource_Impl + ID2D1Geometr
     fn GetRect(&self, rect: *mut Common::D2D_RECT_F);
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1RectangleGeometry {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1RectangleGeometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RectangleGeometry_Impl, const OFFSET: isize>() -> ID2D1RectangleGeometry_Vtbl {
         unsafe extern "system" fn GetRect<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RectangleGeometry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rect: *mut Common::D2D_RECT_F) {
@@ -4172,6 +4333,8 @@ pub trait ID2D1RenderInfo_Impl: Sized {
     fn SetCached(&self, iscached: super::super::Foundation::BOOL);
     fn SetInstructionCountHint(&self, instructioncount: u32);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1RenderInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1RenderInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RenderInfo_Impl, const OFFSET: isize>() -> ID2D1RenderInfo_Vtbl {
@@ -4263,6 +4426,8 @@ pub trait ID2D1RenderTarget_Impl: Sized + ID2D1Resource_Impl {
     fn GetMaximumBitmapSize(&self) -> u32;
     fn IsSupported(&self, rendertargetproperties: *const D2D1_RENDER_TARGET_PROPERTIES) -> super::super::Foundation::BOOL;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for ID2D1RenderTarget {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl ID2D1RenderTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RenderTarget_Impl, const OFFSET: isize>() -> ID2D1RenderTarget_Vtbl {
@@ -4655,6 +4820,7 @@ impl ID2D1RenderTarget_Vtbl {
 pub trait ID2D1Resource_Impl: Sized {
     fn GetFactory(&self, factory: *mut ::core::option::Option<ID2D1Factory>);
 }
+impl ::windows::core::RuntimeName for ID2D1Resource {}
 impl ID2D1Resource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Resource_Impl, const OFFSET: isize>() -> ID2D1Resource_Vtbl {
         unsafe extern "system" fn GetFactory<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Resource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, factory: *mut ::windows::core::RawPtr) {
@@ -4671,6 +4837,7 @@ impl ID2D1Resource_Vtbl {
 pub trait ID2D1ResourceTexture_Impl: Sized {
     fn Update(&self, minimumextents: *const u32, maximimumextents: *const u32, strides: *const u32, dimensions: u32, data: *const u8, datacount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1ResourceTexture {}
 impl ID2D1ResourceTexture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ResourceTexture_Impl, const OFFSET: isize>() -> ID2D1ResourceTexture_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1ResourceTexture_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, minimumextents: *const u32, maximimumextents: *const u32, strides: *const u32, dimensions: u32, data: *const u8, datacount: u32) -> ::windows::core::HRESULT {
@@ -4688,6 +4855,8 @@ impl ID2D1ResourceTexture_Vtbl {
 pub trait ID2D1RoundedRectangleGeometry_Impl: Sized + ID2D1Resource_Impl + ID2D1Geometry_Impl {
     fn GetRoundedRect(&self, roundedrect: *mut D2D1_ROUNDED_RECT);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1RoundedRectangleGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1RoundedRectangleGeometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1RoundedRectangleGeometry_Impl, const OFFSET: isize>() -> ID2D1RoundedRectangleGeometry_Vtbl {
@@ -4707,6 +4876,8 @@ pub trait ID2D1SolidColorBrush_Impl: Sized + ID2D1Resource_Impl + ID2D1Brush_Imp
     fn SetColor(&self, color: *const Common::D2D1_COLOR_F);
     fn GetColor(&self) -> Common::D2D1_COLOR_F;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1SolidColorBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1SolidColorBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SolidColorBrush_Impl, const OFFSET: isize>() -> ID2D1SolidColorBrush_Vtbl {
@@ -4735,6 +4906,8 @@ pub trait ID2D1SourceTransform_Impl: Sized + ID2D1TransformNode_Impl + ID2D1Tran
     fn SetRenderInfo(&self, renderinfo: &::core::option::Option<ID2D1RenderInfo>) -> ::windows::core::Result<()>;
     fn Draw(&self, target: &::core::option::Option<ID2D1Bitmap1>, drawrect: *const super::super::Foundation::RECT, targetorigin: &Common::D2D_POINT_2U) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1SourceTransform {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1SourceTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SourceTransform_Impl, const OFFSET: isize>() -> ID2D1SourceTransform_Vtbl {
@@ -4766,6 +4939,8 @@ pub trait ID2D1SpriteBatch_Impl: Sized + ID2D1Resource_Impl {
     fn GetSpriteCount(&self) -> u32;
     fn Clear(&self);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1SpriteBatch {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1SpriteBatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SpriteBatch_Impl, const OFFSET: isize>() -> ID2D1SpriteBatch_Vtbl {
@@ -4820,6 +4995,7 @@ pub trait ID2D1StrokeStyle_Impl: Sized + ID2D1Resource_Impl {
     fn GetDashesCount(&self) -> u32;
     fn GetDashes(&self, dashes: *mut f32, dashescount: u32);
 }
+impl ::windows::core::RuntimeName for ID2D1StrokeStyle {}
 impl ID2D1StrokeStyle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1StrokeStyle_Impl, const OFFSET: isize>() -> ID2D1StrokeStyle_Vtbl {
         unsafe extern "system" fn GetStartCap<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1StrokeStyle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D2D1_CAP_STYLE {
@@ -4887,6 +5063,7 @@ impl ID2D1StrokeStyle_Vtbl {
 pub trait ID2D1StrokeStyle1_Impl: Sized + ID2D1Resource_Impl + ID2D1StrokeStyle_Impl {
     fn GetStrokeTransformType(&self) -> D2D1_STROKE_TRANSFORM_TYPE;
 }
+impl ::windows::core::RuntimeName for ID2D1StrokeStyle1 {}
 impl ID2D1StrokeStyle1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1StrokeStyle1_Impl, const OFFSET: isize>() -> ID2D1StrokeStyle1_Vtbl {
         unsafe extern "system" fn GetStrokeTransformType<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1StrokeStyle1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D2D1_STROKE_TRANSFORM_TYPE {
@@ -4904,6 +5081,7 @@ pub trait ID2D1SvgAttribute_Impl: Sized + ID2D1Resource_Impl {
     fn GetElement(&self, element: *mut ::core::option::Option<ID2D1SvgElement>);
     fn Clone(&self) -> ::windows::core::Result<ID2D1SvgAttribute>;
 }
+impl ::windows::core::RuntimeName for ID2D1SvgAttribute {}
 impl ID2D1SvgAttribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgAttribute_Impl, const OFFSET: isize>() -> ID2D1SvgAttribute_Vtbl {
         unsafe extern "system" fn GetElement<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgAttribute_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, element: *mut ::windows::core::RawPtr) {
@@ -4946,6 +5124,8 @@ pub trait ID2D1SvgDocument_Impl: Sized + ID2D1Resource_Impl {
     fn CreatePointCollection(&self, points: *const Common::D2D_POINT_2F, pointscount: u32) -> ::windows::core::Result<ID2D1SvgPointCollection>;
     fn CreatePathData(&self, segmentdata: *const f32, segmentdatacount: u32, commands: *const D2D1_SVG_PATH_COMMAND, commandscount: u32) -> ::windows::core::Result<ID2D1SvgPathData>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ID2D1SvgDocument {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 impl ID2D1SvgDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgDocument_Impl, const OFFSET: isize>() -> ID2D1SvgDocument_Vtbl {
@@ -5092,6 +5272,8 @@ pub trait ID2D1SvgElement_Impl: Sized + ID2D1Resource_Impl {
     fn GetAttributeValue3(&self, name: &::windows::core::PCWSTR, r#type: D2D1_SVG_ATTRIBUTE_STRING_TYPE, value: ::windows::core::PWSTR, valuecount: u32) -> ::windows::core::Result<()>;
     fn GetAttributeValueLength(&self, name: &::windows::core::PCWSTR, r#type: D2D1_SVG_ATTRIBUTE_STRING_TYPE) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1SvgElement {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1SvgElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgElement_Impl, const OFFSET: isize>() -> ID2D1SvgElement_Vtbl {
@@ -5314,6 +5496,7 @@ pub trait ID2D1SvgGlyphStyle_Impl: Sized + ID2D1Resource_Impl {
     fn GetStrokeDashesCount(&self) -> u32;
     fn GetStroke(&self, brush: *mut ::core::option::Option<ID2D1Brush>, strokewidth: *mut f32, dashes: *mut f32, dashescount: u32, dashoffset: *mut f32);
 }
+impl ::windows::core::RuntimeName for ID2D1SvgGlyphStyle {}
 impl ID2D1SvgGlyphStyle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgGlyphStyle_Impl, const OFFSET: isize>() -> ID2D1SvgGlyphStyle_Vtbl {
         unsafe extern "system" fn SetFill<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgGlyphStyle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, brush: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5364,6 +5547,8 @@ pub trait ID2D1SvgPaint_Impl: Sized + ID2D1Resource_Impl + ID2D1SvgAttribute_Imp
     fn GetId(&self, id: ::windows::core::PWSTR, idcount: u32) -> ::windows::core::Result<()>;
     fn GetIdLength(&self) -> u32;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1SvgPaint {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1SvgPaint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgPaint_Impl, const OFFSET: isize>() -> ID2D1SvgPaint_Vtbl {
@@ -5429,6 +5614,8 @@ pub trait ID2D1SvgPathData_Impl: Sized + ID2D1Resource_Impl + ID2D1SvgAttribute_
     fn GetCommandsCount(&self) -> u32;
     fn CreatePathGeometry(&self, fillmode: Common::D2D1_FILL_MODE) -> ::windows::core::Result<ID2D1PathGeometry1>;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1SvgPathData {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1SvgPathData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgPathData_Impl, const OFFSET: isize>() -> ID2D1SvgPathData_Vtbl {
@@ -5508,6 +5695,8 @@ pub trait ID2D1SvgPointCollection_Impl: Sized + ID2D1Resource_Impl + ID2D1SvgAtt
     fn GetPointsCount(&self) -> u32;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1SvgPointCollection {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1SvgPointCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgPointCollection_Impl, const OFFSET: isize>() -> ID2D1SvgPointCollection_Vtbl {
         unsafe extern "system" fn RemovePointsAtEnd<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgPointCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pointscount: u32) -> ::windows::core::HRESULT {
@@ -5550,6 +5739,7 @@ pub trait ID2D1SvgStrokeDashArray_Impl: Sized + ID2D1Resource_Impl + ID2D1SvgAtt
     fn GetDashes2(&self, dashes: *mut f32, dashescount: u32, startindex: u32) -> ::windows::core::Result<()>;
     fn GetDashesCount(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID2D1SvgStrokeDashArray {}
 impl ID2D1SvgStrokeDashArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgStrokeDashArray_Impl, const OFFSET: isize>() -> ID2D1SvgStrokeDashArray_Vtbl {
         unsafe extern "system" fn RemoveDashesAtEnd<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1SvgStrokeDashArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dashescount: u32) -> ::windows::core::HRESULT {
@@ -5602,6 +5792,8 @@ pub trait ID2D1TessellationSink_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for ID2D1TessellationSink {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl ID2D1TessellationSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TessellationSink_Impl, const OFFSET: isize>() -> ID2D1TessellationSink_Vtbl {
         unsafe extern "system" fn AddTriangles<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TessellationSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, triangles: *const D2D1_TRIANGLE, trianglescount: u32) {
@@ -5630,6 +5822,8 @@ pub trait ID2D1Transform_Impl: Sized + ID2D1TransformNode_Impl {
     fn MapInputRectsToOutputRect(&self, inputrects: *const super::super::Foundation::RECT, inputopaquesubrects: *const super::super::Foundation::RECT, inputrectcount: u32, outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
     fn MapInvalidRect(&self, inputindex: u32, invalidinputrect: &super::super::Foundation::RECT) -> ::windows::core::Result<super::super::Foundation::RECT>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID2D1Transform {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID2D1Transform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1Transform_Impl, const OFFSET: isize>() -> ID2D1Transform_Vtbl {
@@ -5676,6 +5870,7 @@ pub trait ID2D1TransformGraph_Impl: Sized {
     fn Clear(&self);
     fn SetPassthroughGraph(&self, effectinputindex: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1TransformGraph {}
 impl ID2D1TransformGraph_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformGraph_Impl, const OFFSET: isize>() -> ID2D1TransformGraph_Vtbl {
         unsafe extern "system" fn GetInputCount<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformGraph_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -5743,6 +5938,7 @@ impl ID2D1TransformGraph_Vtbl {
 pub trait ID2D1TransformNode_Impl: Sized {
     fn GetInputCount(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID2D1TransformNode {}
 impl ID2D1TransformNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformNode_Impl, const OFFSET: isize>() -> ID2D1TransformNode_Vtbl {
         unsafe extern "system" fn GetInputCount<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformNode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -5761,6 +5957,8 @@ pub trait ID2D1TransformedGeometry_Impl: Sized + ID2D1Resource_Impl + ID2D1Geome
     fn GetSourceGeometry(&self, sourcegeometry: *mut ::core::option::Option<ID2D1Geometry>);
     fn GetTransform(&self, transform: *mut super::super::super::Foundation::Numerics::Matrix3x2);
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for ID2D1TransformedGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl ID2D1TransformedGeometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformedGeometry_Impl, const OFFSET: isize>() -> ID2D1TransformedGeometry_Vtbl {
@@ -5788,6 +5986,7 @@ pub trait ID2D1TransformedImageSource_Impl: Sized + ID2D1Resource_Impl + ID2D1Im
     fn GetSource(&self, imagesource: *mut ::core::option::Option<ID2D1ImageSource>);
     fn GetProperties(&self, properties: *mut D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES);
 }
+impl ::windows::core::RuntimeName for ID2D1TransformedImageSource {}
 impl ID2D1TransformedImageSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformedImageSource_Impl, const OFFSET: isize>() -> ID2D1TransformedImageSource_Vtbl {
         unsafe extern "system" fn GetSource<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1TransformedImageSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, imagesource: *mut ::windows::core::RawPtr) {
@@ -5814,6 +6013,7 @@ pub trait ID2D1VertexBuffer_Impl: Sized {
     fn Map(&self, data: *mut *mut u8, buffersize: u32) -> ::windows::core::Result<()>;
     fn Unmap(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID2D1VertexBuffer {}
 impl ID2D1VertexBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1VertexBuffer_Impl, const OFFSET: isize>() -> ID2D1VertexBuffer_Vtbl {
         unsafe extern "system" fn Map<Identity: ::windows::core::IUnknownImpl, Impl: ID2D1VertexBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, data: *mut *mut u8, buffersize: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
@@ -1,6 +1,7 @@
 pub trait IDxcAssembler_Impl: Sized {
     fn AssembleToContainer(&self, pshader: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<IDxcOperationResult>;
 }
+impl ::windows::core::RuntimeName for IDxcAssembler {}
 impl IDxcAssembler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcAssembler_Impl, const OFFSET: isize>() -> IDxcAssembler_Vtbl {
         unsafe extern "system" fn AssembleToContainer<Identity: ::windows::core::IUnknownImpl, Impl: IDxcAssembler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshader: ::windows::core::RawPtr, ppresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -24,6 +25,7 @@ pub trait IDxcBlob_Impl: Sized {
     fn GetBufferPointer(&self) -> *mut ::core::ffi::c_void;
     fn GetBufferSize(&self) -> usize;
 }
+impl ::windows::core::RuntimeName for IDxcBlob {}
 impl IDxcBlob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlob_Impl, const OFFSET: isize>() -> IDxcBlob_Vtbl {
         unsafe extern "system" fn GetBufferPointer<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlob_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut ::core::ffi::c_void {
@@ -51,6 +53,8 @@ pub trait IDxcBlobEncoding_Impl: Sized + IDxcBlob_Impl {
     fn GetEncoding(&self, pknown: *mut super::super::super::Foundation::BOOL, pcodepage: *mut DXC_CP) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDxcBlobEncoding {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDxcBlobEncoding_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlobEncoding_Impl, const OFFSET: isize>() -> IDxcBlobEncoding_Vtbl {
         unsafe extern "system" fn GetEncoding<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlobEncoding_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pknown: *mut super::super::super::Foundation::BOOL, pcodepage: *mut DXC_CP) -> ::windows::core::HRESULT {
@@ -69,6 +73,8 @@ pub trait IDxcBlobUtf16_Impl: Sized + IDxcBlob_Impl + IDxcBlobEncoding_Impl {
     fn GetStringPointer(&self) -> ::windows::core::PWSTR;
     fn GetStringLength(&self) -> usize;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDxcBlobUtf16 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDxcBlobUtf16_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlobUtf16_Impl, const OFFSET: isize>() -> IDxcBlobUtf16_Vtbl {
@@ -98,6 +104,8 @@ pub trait IDxcBlobUtf8_Impl: Sized + IDxcBlob_Impl + IDxcBlobEncoding_Impl {
     fn GetStringLength(&self) -> usize;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDxcBlobUtf8 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDxcBlobUtf8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlobUtf8_Impl, const OFFSET: isize>() -> IDxcBlobUtf8_Vtbl {
         unsafe extern "system" fn GetStringPointer<Identity: ::windows::core::IUnknownImpl, Impl: IDxcBlobUtf8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::PSTR {
@@ -125,6 +133,7 @@ pub trait IDxcCompiler_Impl: Sized {
     fn Preprocess(&self, psource: &::core::option::Option<IDxcBlob>, psourcename: &::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>) -> ::windows::core::Result<IDxcOperationResult>;
     fn Disassemble(&self, psource: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<IDxcBlobEncoding>;
 }
+impl ::windows::core::RuntimeName for IDxcCompiler {}
 impl IDxcCompiler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompiler_Impl, const OFFSET: isize>() -> IDxcCompiler_Vtbl {
         unsafe extern "system" fn Compile<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompiler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psource: ::windows::core::RawPtr, psourcename: ::windows::core::PCWSTR, pentrypoint: ::windows::core::PCWSTR, ptargetprofile: ::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: ::windows::core::RawPtr, ppresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -174,6 +183,7 @@ impl IDxcCompiler_Vtbl {
 pub trait IDxcCompiler2_Impl: Sized + IDxcCompiler_Impl {
     fn CompileWithDebug(&self, psource: &::core::option::Option<IDxcBlob>, psourcename: &::windows::core::PCWSTR, pentrypoint: &::windows::core::PCWSTR, ptargetprofile: &::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>, ppresult: *mut ::core::option::Option<IDxcOperationResult>, ppdebugblobname: *mut ::windows::core::PWSTR, ppdebugblob: *mut ::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcCompiler2 {}
 impl IDxcCompiler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompiler2_Impl, const OFFSET: isize>() -> IDxcCompiler2_Vtbl {
         unsafe extern "system" fn CompileWithDebug<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompiler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psource: ::windows::core::RawPtr, psourcename: ::windows::core::PCWSTR, pentrypoint: ::windows::core::PCWSTR, ptargetprofile: ::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: ::windows::core::RawPtr, ppresult: *mut ::windows::core::RawPtr, ppdebugblobname: *mut ::windows::core::PWSTR, ppdebugblob: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -206,6 +216,7 @@ pub trait IDxcCompiler3_Impl: Sized {
     fn Compile(&self, psource: *const DxcBuffer, parguments: *const ::windows::core::PWSTR, argcount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Disassemble(&self, pobject: *const DxcBuffer, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcCompiler3 {}
 impl IDxcCompiler3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompiler3_Impl, const OFFSET: isize>() -> IDxcCompiler3_Vtbl {
         unsafe extern "system" fn Compile<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompiler3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psource: *const DxcBuffer, parguments: *const ::windows::core::PWSTR, argcount: u32, pincludehandler: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -235,6 +246,7 @@ pub trait IDxcCompilerArgs_Impl: Sized {
     fn AddArgumentsUTF8(&self, parguments: *const ::windows::core::PSTR, argcount: u32) -> ::windows::core::Result<()>;
     fn AddDefines(&self, pdefines: *const DxcDefine, definecount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcCompilerArgs {}
 impl IDxcCompilerArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompilerArgs_Impl, const OFFSET: isize>() -> IDxcCompilerArgs_Vtbl {
         unsafe extern "system" fn GetArguments<Identity: ::windows::core::IUnknownImpl, Impl: IDxcCompilerArgs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut ::windows::core::PWSTR {
@@ -281,6 +293,7 @@ pub trait IDxcContainerBuilder_Impl: Sized {
     fn RemovePart(&self, fourcc: u32) -> ::windows::core::Result<()>;
     fn SerializeContainer(&self) -> ::windows::core::Result<IDxcOperationResult>;
 }
+impl ::windows::core::RuntimeName for IDxcContainerBuilder {}
 impl IDxcContainerBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcContainerBuilder_Impl, const OFFSET: isize>() -> IDxcContainerBuilder_Vtbl {
         unsafe extern "system" fn Load<Identity: ::windows::core::IUnknownImpl, Impl: IDxcContainerBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdxilcontainerheader: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -329,6 +342,7 @@ pub trait IDxcContainerReflection_Impl: Sized {
     fn FindFirstPartKind(&self, kind: u32) -> ::windows::core::Result<u32>;
     fn GetPartReflection(&self, idx: u32, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcContainerReflection {}
 impl IDxcContainerReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcContainerReflection_Impl, const OFFSET: isize>() -> IDxcContainerReflection_Vtbl {
         unsafe extern "system" fn Load<Identity: ::windows::core::IUnknownImpl, Impl: IDxcContainerReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontainer: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -403,6 +417,7 @@ pub trait IDxcExtraOutputs_Impl: Sized {
     fn GetOutputCount(&self) -> u32;
     fn GetOutput(&self, uindex: u32, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void, ppoutputtype: *mut ::core::option::Option<IDxcBlobUtf16>, ppoutputname: *mut ::core::option::Option<IDxcBlobUtf16>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcExtraOutputs {}
 impl IDxcExtraOutputs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcExtraOutputs_Impl, const OFFSET: isize>() -> IDxcExtraOutputs_Vtbl {
         unsafe extern "system" fn GetOutputCount<Identity: ::windows::core::IUnknownImpl, Impl: IDxcExtraOutputs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -428,6 +443,7 @@ impl IDxcExtraOutputs_Vtbl {
 pub trait IDxcIncludeHandler_Impl: Sized {
     fn LoadSource(&self, pfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<IDxcBlob>;
 }
+impl ::windows::core::RuntimeName for IDxcIncludeHandler {}
 impl IDxcIncludeHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcIncludeHandler_Impl, const OFFSET: isize>() -> IDxcIncludeHandler_Vtbl {
         unsafe extern "system" fn LoadSource<Identity: ::windows::core::IUnknownImpl, Impl: IDxcIncludeHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfilename: ::windows::core::PCWSTR, ppincludesource: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -460,6 +476,8 @@ pub trait IDxcLibrary_Impl: Sized {
     fn GetBlobAsUtf8(&self, pblob: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<IDxcBlobEncoding>;
     fn GetBlobAsUtf16(&self, pblob: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<IDxcBlobEncoding>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDxcLibrary {}
 #[cfg(feature = "Win32_System_Com")]
 impl IDxcLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcLibrary_Impl, const OFFSET: isize>() -> IDxcLibrary_Vtbl {
@@ -589,6 +607,7 @@ pub trait IDxcLinker_Impl: Sized {
     fn RegisterLibrary(&self, plibname: &::windows::core::PCWSTR, plib: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
     fn Link(&self, pentryname: &::windows::core::PCWSTR, ptargetprofile: &::windows::core::PCWSTR, plibnames: *const ::windows::core::PWSTR, libcount: u32, parguments: *const ::windows::core::PWSTR, argcount: u32) -> ::windows::core::Result<IDxcOperationResult>;
 }
+impl ::windows::core::RuntimeName for IDxcLinker {}
 impl IDxcLinker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcLinker_Impl, const OFFSET: isize>() -> IDxcLinker_Vtbl {
         unsafe extern "system" fn RegisterLibrary<Identity: ::windows::core::IUnknownImpl, Impl: IDxcLinker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plibname: ::windows::core::PCWSTR, plib: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -622,6 +641,7 @@ pub trait IDxcOperationResult_Impl: Sized {
     fn GetResult(&self) -> ::windows::core::Result<IDxcBlob>;
     fn GetErrorBuffer(&self) -> ::windows::core::Result<IDxcBlobEncoding>;
 }
+impl ::windows::core::RuntimeName for IDxcOperationResult {}
 impl IDxcOperationResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcOperationResult_Impl, const OFFSET: isize>() -> IDxcOperationResult_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IDxcOperationResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstatus: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -673,6 +693,7 @@ pub trait IDxcOptimizer_Impl: Sized {
     fn GetAvailablePass(&self, index: u32) -> ::windows::core::Result<IDxcOptimizerPass>;
     fn RunOptimizer(&self, pblob: &::core::option::Option<IDxcBlob>, ppoptions: *const ::windows::core::PWSTR, optioncount: u32, poutputmodule: *mut ::core::option::Option<IDxcBlob>, ppoutputtext: *mut ::core::option::Option<IDxcBlobEncoding>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcOptimizer {}
 impl IDxcOptimizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcOptimizer_Impl, const OFFSET: isize>() -> IDxcOptimizer_Vtbl {
         unsafe extern "system" fn GetAvailablePassCount<Identity: ::windows::core::IUnknownImpl, Impl: IDxcOptimizer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT {
@@ -720,6 +741,7 @@ pub trait IDxcOptimizerPass_Impl: Sized {
     fn GetOptionArgName(&self, argindex: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetOptionArgDescription(&self, argindex: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IDxcOptimizerPass {}
 impl IDxcOptimizerPass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcOptimizerPass_Impl, const OFFSET: isize>() -> IDxcOptimizerPass_Vtbl {
         unsafe extern "system" fn GetOptionName<Identity: ::windows::core::IUnknownImpl, Impl: IDxcOptimizerPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresult: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -817,6 +839,8 @@ pub trait IDxcPdbUtils_Impl: Sized {
     fn OverrideArgs(&self, pargpairs: *const DxcArgPair, unumargpairs: u32) -> ::windows::core::Result<()>;
     fn OverrideRootSignature(&self, prootsignature: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDxcPdbUtils {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDxcPdbUtils_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcPdbUtils_Impl, const OFFSET: isize>() -> IDxcPdbUtils_Vtbl {
@@ -1089,6 +1113,8 @@ pub trait IDxcResult_Impl: Sized + IDxcOperationResult_Impl {
     fn PrimaryOutput(&self) -> DXC_OUT_KIND;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDxcResult {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDxcResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcResult_Impl, const OFFSET: isize>() -> IDxcResult_Vtbl {
         unsafe extern "system" fn HasOutput<Identity: ::windows::core::IUnknownImpl, Impl: IDxcResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dxcoutkind: DXC_OUT_KIND) -> super::super::super::Foundation::BOOL {
@@ -1145,6 +1171,8 @@ pub trait IDxcUtils_Impl: Sized {
     fn BuildArguments(&self, psourcename: &::windows::core::PCWSTR, pentrypoint: &::windows::core::PCWSTR, ptargetprofile: &::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32) -> ::windows::core::Result<IDxcCompilerArgs>;
     fn GetPDBContents(&self, ppdbblob: &::core::option::Option<IDxcBlob>, pphash: *mut ::core::option::Option<IDxcBlob>, ppcontainer: *mut ::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDxcUtils {}
 #[cfg(feature = "Win32_System_Com")]
 impl IDxcUtils_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcUtils_Impl, const OFFSET: isize>() -> IDxcUtils_Vtbl {
@@ -1297,6 +1325,7 @@ impl IDxcUtils_Vtbl {
 pub trait IDxcValidator_Impl: Sized {
     fn Validate(&self, pshader: &::core::option::Option<IDxcBlob>, flags: u32) -> ::windows::core::Result<IDxcOperationResult>;
 }
+impl ::windows::core::RuntimeName for IDxcValidator {}
 impl IDxcValidator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcValidator_Impl, const OFFSET: isize>() -> IDxcValidator_Vtbl {
         unsafe extern "system" fn Validate<Identity: ::windows::core::IUnknownImpl, Impl: IDxcValidator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshader: ::windows::core::RawPtr, flags: u32, ppresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1319,6 +1348,7 @@ impl IDxcValidator_Vtbl {
 pub trait IDxcValidator2_Impl: Sized + IDxcValidator_Impl {
     fn ValidateWithDebug(&self, pshader: &::core::option::Option<IDxcBlob>, flags: u32, poptdebugbitcode: *const DxcBuffer) -> ::windows::core::Result<IDxcOperationResult>;
 }
+impl ::windows::core::RuntimeName for IDxcValidator2 {}
 impl IDxcValidator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcValidator2_Impl, const OFFSET: isize>() -> IDxcValidator2_Vtbl {
         unsafe extern "system" fn ValidateWithDebug<Identity: ::windows::core::IUnknownImpl, Impl: IDxcValidator2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshader: ::windows::core::RawPtr, flags: u32, poptdebugbitcode: *const DxcBuffer, ppresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1342,6 +1372,7 @@ pub trait IDxcVersionInfo_Impl: Sized {
     fn GetVersion(&self, pmajor: *mut u32, pminor: *mut u32) -> ::windows::core::Result<()>;
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IDxcVersionInfo {}
 impl IDxcVersionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcVersionInfo_Impl, const OFFSET: isize>() -> IDxcVersionInfo_Vtbl {
         unsafe extern "system" fn GetVersion<Identity: ::windows::core::IUnknownImpl, Impl: IDxcVersionInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmajor: *mut u32, pminor: *mut u32) -> ::windows::core::HRESULT {
@@ -1373,6 +1404,7 @@ impl IDxcVersionInfo_Vtbl {
 pub trait IDxcVersionInfo2_Impl: Sized + IDxcVersionInfo_Impl {
     fn GetCommitInfo(&self, pcommitcount: *mut u32, pcommithash: *mut *mut i8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDxcVersionInfo2 {}
 impl IDxcVersionInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcVersionInfo2_Impl, const OFFSET: isize>() -> IDxcVersionInfo2_Vtbl {
         unsafe extern "system" fn GetCommitInfo<Identity: ::windows::core::IUnknownImpl, Impl: IDxcVersionInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcommitcount: *mut u32, pcommithash: *mut *mut i8) -> ::windows::core::HRESULT {
@@ -1389,6 +1421,7 @@ impl IDxcVersionInfo2_Vtbl {
 pub trait IDxcVersionInfo3_Impl: Sized {
     fn GetCustomVersionString(&self) -> ::windows::core::Result<*mut i8>;
 }
+impl ::windows::core::RuntimeName for IDxcVersionInfo3 {}
 impl IDxcVersionInfo3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDxcVersionInfo3_Impl, const OFFSET: isize>() -> IDxcVersionInfo3_Vtbl {
         unsafe extern "system" fn GetCustomVersionString<Identity: ::windows::core::IUnknownImpl, Impl: IDxcVersionInfo3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pversionstring: *mut *mut i8) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
@@ -2,6 +2,7 @@ pub trait ID3DBlob_Impl: Sized {
     fn GetBufferPointer(&self) -> *mut ::core::ffi::c_void;
     fn GetBufferSize(&self) -> usize;
 }
+impl ::windows::core::RuntimeName for ID3DBlob {}
 impl ID3DBlob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DBlob_Impl, const OFFSET: isize>() -> ID3DBlob_Vtbl {
         unsafe extern "system" fn GetBufferPointer<Identity: ::windows::core::IUnknownImpl, Impl: ID3DBlob_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut ::core::ffi::c_void {
@@ -28,6 +29,7 @@ pub trait ID3DDestructionNotifier_Impl: Sized {
     fn RegisterDestructionCallback(&self, callbackfn: &PFN_DESTRUCTION_CALLBACK, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<u32>;
     fn UnregisterDestructionCallback(&self, callbackid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3DDestructionNotifier {}
 impl ID3DDestructionNotifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DDestructionNotifier_Impl, const OFFSET: isize>() -> ID3DDestructionNotifier_Vtbl {
         unsafe extern "system" fn RegisterDestructionCallback<Identity: ::windows::core::IUnknownImpl, Impl: ID3DDestructionNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, callbackfn: ::windows::core::RawPtr, pdata: *const ::core::ffi::c_void, pcallbackid: *mut u32) -> ::windows::core::HRESULT {
@@ -60,6 +62,7 @@ pub trait ID3DInclude_Impl: Sized {
     fn Open(&self, includetype: D3D_INCLUDE_TYPE, pfilename: &::windows::core::PCSTR, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::Result<()>;
     fn Close(&self, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3DInclude {}
 impl ID3DInclude_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DInclude_Impl, const OFFSET: isize>() -> ID3DInclude_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: ID3DInclude_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, includetype: D3D_INCLUDE_TYPE, pfilename: ::windows::core::PCSTR, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
@@ -4,6 +4,7 @@ pub trait ID3D10Asynchronous_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetData(&self, pdata: *mut ::core::ffi::c_void, datasize: u32, getdataflags: u32) -> ::windows::core::Result<()>;
     fn GetDataSize(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D10Asynchronous {}
 impl ID3D10Asynchronous_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Asynchronous_Impl, const OFFSET: isize>() -> ID3D10Asynchronous_Vtbl {
         unsafe extern "system" fn Begin<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Asynchronous_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -43,6 +44,8 @@ pub trait ID3D10BlendState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_BLEND_DESC);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10BlendState {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10BlendState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10BlendState_Impl, const OFFSET: isize>() -> ID3D10BlendState_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10BlendState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_BLEND_DESC) {
@@ -60,6 +63,8 @@ impl ID3D10BlendState_Vtbl {
 pub trait ID3D10BlendState1_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10BlendState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D10_BLEND_DESC1);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10BlendState1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10BlendState1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10BlendState1_Impl, const OFFSET: isize>() -> ID3D10BlendState1_Vtbl {
@@ -79,6 +84,7 @@ pub trait ID3D10Buffer_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Resource_Imp
     fn Unmap(&self);
     fn GetDesc(&self, pdesc: *mut D3D10_BUFFER_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D10Buffer {}
 impl ID3D10Buffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Buffer_Impl, const OFFSET: isize>() -> ID3D10Buffer_Vtbl {
         unsafe extern "system" fn Map<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Buffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maptype: D3D10_MAP, mapflags: u32, ppdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -110,6 +116,7 @@ impl ID3D10Buffer_Vtbl {
 pub trait ID3D10Counter_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_COUNTER_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D10Counter {}
 impl ID3D10Counter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Counter_Impl, const OFFSET: isize>() -> ID3D10Counter_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Counter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_COUNTER_DESC) {
@@ -133,6 +140,8 @@ pub trait ID3D10Debug_Impl: Sized {
     fn GetSwapChain(&self) -> ::windows::core::Result<super::Dxgi::IDXGISwapChain>;
     fn Validate(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Dxgi")]
+impl ::windows::core::RuntimeName for ID3D10Debug {}
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 impl ID3D10Debug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Debug_Impl, const OFFSET: isize>() -> ID3D10Debug_Vtbl {
@@ -197,6 +206,8 @@ pub trait ID3D10DepthStencilState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_DEPTH_STENCIL_DESC);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10DepthStencilState {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10DepthStencilState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10DepthStencilState_Impl, const OFFSET: isize>() -> ID3D10DepthStencilState_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10DepthStencilState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_DEPTH_STENCIL_DESC) {
@@ -214,6 +225,8 @@ impl ID3D10DepthStencilState_Vtbl {
 pub trait ID3D10DepthStencilView_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_DEPTH_STENCIL_VIEW_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D10DepthStencilView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D10DepthStencilView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10DepthStencilView_Impl, const OFFSET: isize>() -> ID3D10DepthStencilView_Vtbl {
@@ -326,6 +339,8 @@ pub trait ID3D10Device_Impl: Sized {
     fn SetTextFilterSize(&self, width: u32, height: u32);
     fn GetTextFilterSize(&self, pwidth: *mut u32, pheight: *mut u32);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D10Device {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D10Device_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Device_Impl, const OFFSET: isize>() -> ID3D10Device_Vtbl {
@@ -1040,6 +1055,8 @@ pub trait ID3D10Device1_Impl: Sized + ID3D10Device_Impl {
     fn GetFeatureLevel(&self) -> D3D10_FEATURE_LEVEL1;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D10Device1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D10Device1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Device1_Impl, const OFFSET: isize>() -> ID3D10Device1_Vtbl {
         unsafe extern "system" fn CreateShaderResourceView1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Device1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: ::windows::core::RawPtr, pdesc: *const D3D10_SHADER_RESOURCE_VIEW_DESC1, ppsrview: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1086,6 +1103,7 @@ pub trait ID3D10DeviceChild_Impl: Sized {
     fn SetPrivateData(&self, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetPrivateDataInterface(&self, guid: *const ::windows::core::GUID, pdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D10DeviceChild {}
 impl ID3D10DeviceChild_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10DeviceChild_Impl, const OFFSET: isize>() -> ID3D10DeviceChild_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10DeviceChild_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) {
@@ -1136,6 +1154,8 @@ pub trait ID3D10Effect_Impl: Sized {
     fn Optimize(&self) -> ::windows::core::Result<()>;
     fn IsOptimized(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10Effect {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10Effect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Effect_Impl, const OFFSET: isize>() -> ID3D10Effect_Vtbl {
@@ -1243,6 +1263,8 @@ pub trait ID3D10EffectBlendVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetBackingStore(&self, index: u32, pblenddesc: *mut D3D10_BLEND_DESC) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectBlendVariable {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectBlendVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectBlendVariable_Impl, const OFFSET: isize>() -> ID3D10EffectBlendVariable_Vtbl {
         unsafe extern "system" fn GetBlendState<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectBlendVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, ppblendstate: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1278,6 +1300,8 @@ pub trait ID3D10EffectConstantBuffer_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetTextureBuffer(&self, ptexturebuffer: &::core::option::Option<ID3D10ShaderResourceView>) -> ::windows::core::Result<()>;
     fn GetTextureBuffer(&self) -> ::windows::core::Result<ID3D10ShaderResourceView>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectConstantBuffer {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectConstantBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectConstantBuffer_Impl, const OFFSET: isize>() -> ID3D10EffectConstantBuffer_Vtbl {
@@ -1331,6 +1355,8 @@ pub trait ID3D10EffectDepthStencilVariable_Impl: Sized + ID3D10EffectVariable_Im
     fn GetBackingStore(&self, index: u32) -> ::windows::core::Result<D3D10_DEPTH_STENCIL_DESC>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectDepthStencilVariable {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectDepthStencilVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectDepthStencilVariable_Impl, const OFFSET: isize>() -> ID3D10EffectDepthStencilVariable_Vtbl {
         unsafe extern "system" fn GetDepthStencilState<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectDepthStencilVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, ppdepthstencilstate: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1372,6 +1398,8 @@ pub trait ID3D10EffectDepthStencilViewVariable_Impl: Sized + ID3D10EffectVariabl
     fn SetDepthStencilArray(&self, ppresources: *const ::core::option::Option<ID3D10DepthStencilView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
     fn GetDepthStencilArray(&self, ppresources: *mut ::core::option::Option<ID3D10DepthStencilView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectDepthStencilViewVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectDepthStencilViewVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectDepthStencilViewVariable_Impl, const OFFSET: isize>() -> ID3D10EffectDepthStencilViewVariable_Vtbl {
@@ -1424,6 +1452,8 @@ pub trait ID3D10EffectMatrixVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetMatrixTransposeArray(&self, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::Result<()>;
     fn GetMatrixTransposeArray(&self, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectMatrixVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectMatrixVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>() -> ID3D10EffectMatrixVariable_Vtbl {
@@ -1495,6 +1525,8 @@ pub trait ID3D10EffectPass_Impl: Sized {
     fn Apply(&self, flags: u32) -> ::windows::core::Result<()>;
     fn ComputeStateBlockMask(&self) -> ::windows::core::Result<D3D10_STATE_BLOCK_MASK>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectPass {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectPass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>() -> ID3D10EffectPass_Vtbl {
@@ -1568,6 +1600,7 @@ impl ID3D10EffectPass_Vtbl {
 pub trait ID3D10EffectPool_Impl: Sized {
     fn AsEffect(&self) -> ::core::option::Option<ID3D10Effect>;
 }
+impl ::windows::core::RuntimeName for ID3D10EffectPool {}
 impl ID3D10EffectPool_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectPool_Impl, const OFFSET: isize>() -> ID3D10EffectPool_Vtbl {
         unsafe extern "system" fn AsEffect<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectPool_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10Effect> {
@@ -1586,6 +1619,8 @@ pub trait ID3D10EffectRasterizerVariable_Impl: Sized + ID3D10EffectVariable_Impl
     fn GetRasterizerState(&self, index: u32) -> ::windows::core::Result<ID3D10RasterizerState>;
     fn GetBackingStore(&self, index: u32) -> ::windows::core::Result<D3D10_RASTERIZER_DESC>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectRasterizerVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectRasterizerVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectRasterizerVariable_Impl, const OFFSET: isize>() -> ID3D10EffectRasterizerVariable_Vtbl {
@@ -1628,6 +1663,8 @@ pub trait ID3D10EffectRenderTargetViewVariable_Impl: Sized + ID3D10EffectVariabl
     fn SetRenderTargetArray(&self, ppresources: *const ::core::option::Option<ID3D10RenderTargetView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
     fn GetRenderTargetArray(&self, ppresources: *mut ::core::option::Option<ID3D10RenderTargetView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectRenderTargetViewVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectRenderTargetViewVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectRenderTargetViewVariable_Impl, const OFFSET: isize>() -> ID3D10EffectRenderTargetViewVariable_Vtbl {
@@ -1674,6 +1711,8 @@ pub trait ID3D10EffectSamplerVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetSampler(&self, index: u32) -> ::windows::core::Result<ID3D10SamplerState>;
     fn GetBackingStore(&self, index: u32) -> ::windows::core::Result<D3D10_SAMPLER_DESC>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectSamplerVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectSamplerVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectSamplerVariable_Impl, const OFFSET: isize>() -> ID3D10EffectSamplerVariable_Vtbl {
@@ -1724,6 +1763,8 @@ pub trait ID3D10EffectScalarVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetBoolArray(&self, pdata: *const super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::Result<()>;
     fn GetBoolArray(&self, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectScalarVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectScalarVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>() -> ID3D10EffectScalarVariable_Vtbl {
@@ -1833,6 +1874,8 @@ pub trait ID3D10EffectShaderResourceVariable_Impl: Sized + ID3D10EffectVariable_
     fn GetResourceArray(&self, ppresources: *mut ::core::option::Option<ID3D10ShaderResourceView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectShaderResourceVariable {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectShaderResourceVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>() -> ID3D10EffectShaderResourceVariable_Vtbl {
         unsafe extern "system" fn SetResource<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1882,6 +1925,8 @@ pub trait ID3D10EffectShaderVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetInputSignatureElementDesc(&self, shaderindex: u32, element: u32) -> ::windows::core::Result<D3D10_SIGNATURE_PARAMETER_DESC>;
     fn GetOutputSignatureElementDesc(&self, shaderindex: u32, element: u32) -> ::windows::core::Result<D3D10_SIGNATURE_PARAMETER_DESC>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D10EffectShaderVariable {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D10EffectShaderVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>() -> ID3D10EffectShaderVariable_Vtbl {
@@ -1971,6 +2016,8 @@ pub trait ID3D10EffectStringVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetStringArray(&self, ppstrings: *mut ::windows::core::PSTR, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectStringVariable {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectStringVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectStringVariable_Impl, const OFFSET: isize>() -> ID3D10EffectStringVariable_Vtbl {
         unsafe extern "system" fn GetString<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectStringVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppstring: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT {
@@ -2009,6 +2056,8 @@ pub trait ID3D10EffectTechnique_Impl: Sized {
     fn GetPassByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectPass>;
     fn ComputeStateBlockMask(&self) -> ::windows::core::Result<D3D10_STATE_BLOCK_MASK>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectTechnique {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectTechnique_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>() -> ID3D10EffectTechnique_Vtbl {
@@ -2077,6 +2126,8 @@ pub trait ID3D10EffectType_Impl: Sized {
     fn GetMemberName(&self, index: u32) -> ::windows::core::PSTR;
     fn GetMemberSemantic(&self, index: u32) -> ::windows::core::PSTR;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D10EffectType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D10EffectType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectType_Impl, const OFFSET: isize>() -> ID3D10EffectType_Vtbl {
@@ -2157,6 +2208,8 @@ pub trait ID3D10EffectVariable_Impl: Sized {
     fn SetRawValue(&self, pdata: *const ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::Result<()>;
     fn GetRawValue(&self, pdata: *mut ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectVariable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>() -> ID3D10EffectVariable_Vtbl {
@@ -2339,6 +2392,8 @@ pub trait ID3D10EffectVectorVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetFloatVectorArray(&self, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10EffectVectorVariable {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectVectorVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>() -> ID3D10EffectVectorVariable_Vtbl {
         unsafe extern "system" fn SetBoolVector<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2422,6 +2477,7 @@ impl ID3D10EffectVectorVariable_Vtbl {
     }
 }
 pub trait ID3D10GeometryShader_Impl: Sized + ID3D10DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D10GeometryShader {}
 impl ID3D10GeometryShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10GeometryShader_Impl, const OFFSET: isize>() -> ID3D10GeometryShader_Vtbl {
         Self { base__: ID3D10DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2468,6 +2524,8 @@ pub trait ID3D10InfoQueue_Impl: Sized {
     fn SetMuteDebugOutput(&self, bmute: super::super::Foundation::BOOL);
     fn GetMuteDebugOutput(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10InfoQueue {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10InfoQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10InfoQueue_Impl, const OFFSET: isize>() -> ID3D10InfoQueue_Vtbl {
@@ -2690,6 +2748,7 @@ impl ID3D10InfoQueue_Vtbl {
     }
 }
 pub trait ID3D10InputLayout_Impl: Sized + ID3D10DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D10InputLayout {}
 impl ID3D10InputLayout_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10InputLayout_Impl, const OFFSET: isize>() -> ID3D10InputLayout_Vtbl {
         Self { base__: ID3D10DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2705,6 +2764,8 @@ pub trait ID3D10Multithread_Impl: Sized {
     fn SetMultithreadProtected(&self, bmtprotect: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL;
     fn GetMultithreadProtected(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10Multithread {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10Multithread_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Multithread_Impl, const OFFSET: isize>() -> ID3D10Multithread_Vtbl {
@@ -2741,6 +2802,7 @@ impl ID3D10Multithread_Vtbl {
     }
 }
 pub trait ID3D10PixelShader_Impl: Sized + ID3D10DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D10PixelShader {}
 impl ID3D10PixelShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10PixelShader_Impl, const OFFSET: isize>() -> ID3D10PixelShader_Vtbl {
         Self { base__: ID3D10DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2750,6 +2812,7 @@ impl ID3D10PixelShader_Vtbl {
     }
 }
 pub trait ID3D10Predicate_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Asynchronous_Impl + ID3D10Query_Impl {}
+impl ::windows::core::RuntimeName for ID3D10Predicate {}
 impl ID3D10Predicate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Predicate_Impl, const OFFSET: isize>() -> ID3D10Predicate_Vtbl {
         Self { base__: ID3D10Query_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2761,6 +2824,7 @@ impl ID3D10Predicate_Vtbl {
 pub trait ID3D10Query_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_QUERY_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D10Query {}
 impl ID3D10Query_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Query_Impl, const OFFSET: isize>() -> ID3D10Query_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Query_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_QUERY_DESC) {
@@ -2778,6 +2842,8 @@ impl ID3D10Query_Vtbl {
 pub trait ID3D10RasterizerState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_RASTERIZER_DESC);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10RasterizerState {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D10RasterizerState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10RasterizerState_Impl, const OFFSET: isize>() -> ID3D10RasterizerState_Vtbl {
@@ -2797,6 +2863,8 @@ pub trait ID3D10RenderTargetView_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Vi
     fn GetDesc(&self, pdesc: *mut D3D10_RENDER_TARGET_VIEW_DESC);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D10RenderTargetView {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D10RenderTargetView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10RenderTargetView_Impl, const OFFSET: isize>() -> ID3D10RenderTargetView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10RenderTargetView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_RENDER_TARGET_VIEW_DESC) {
@@ -2815,6 +2883,7 @@ pub trait ID3D10Resource_Impl: Sized + ID3D10DeviceChild_Impl {
     fn SetEvictionPriority(&self, evictionpriority: u32);
     fn GetEvictionPriority(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D10Resource {}
 impl ID3D10Resource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Resource_Impl, const OFFSET: isize>() -> ID3D10Resource_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Resource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rtype: *mut D3D10_RESOURCE_DIMENSION) {
@@ -2846,6 +2915,7 @@ impl ID3D10Resource_Vtbl {
 pub trait ID3D10SamplerState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SAMPLER_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D10SamplerState {}
 impl ID3D10SamplerState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10SamplerState_Impl, const OFFSET: isize>() -> ID3D10SamplerState_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10SamplerState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SAMPLER_DESC) {
@@ -2868,6 +2938,8 @@ pub trait ID3D10ShaderReflection_Impl: Sized {
     fn GetInputParameterDesc(&self, parameterindex: u32) -> ::windows::core::Result<D3D10_SIGNATURE_PARAMETER_DESC>;
     fn GetOutputParameterDesc(&self, parameterindex: u32) -> ::windows::core::Result<D3D10_SIGNATURE_PARAMETER_DESC>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D10ShaderReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D10ShaderReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflection_Impl, const OFFSET: isize>() -> ID3D10ShaderReflection_Vtbl {
@@ -2957,6 +3029,8 @@ pub trait ID3D10ShaderReflection1_Impl: Sized {
     fn IsLevel9Shader(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn IsSampleFrequencyShader(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D10ShaderReflection1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D10ShaderReflection1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflection1_Impl, const OFFSET: isize>() -> ID3D10ShaderReflection1_Vtbl {
@@ -3137,6 +3211,8 @@ pub trait ID3D10ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetVariableByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10ShaderReflectionVariable>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D10ShaderReflectionConstantBuffer {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D10ShaderReflectionConstantBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>() -> ID3D10ShaderReflectionConstantBuffer_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
@@ -3178,6 +3254,8 @@ pub trait ID3D10ShaderReflectionType_Impl: Sized {
     fn GetMemberTypeName(&self, index: u32) -> ::windows::core::PSTR;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D10ShaderReflectionType {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D10ShaderReflectionType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>() -> ID3D10ShaderReflectionType_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
@@ -3215,6 +3293,7 @@ pub trait ID3D10ShaderReflectionVariable_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_VARIABLE_DESC>;
     fn GetType(&self) -> ::core::option::Option<ID3D10ShaderReflectionType>;
 }
+impl ::windows::core::RuntimeName for ID3D10ShaderReflectionVariable {}
 impl ID3D10ShaderReflectionVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflectionVariable_Impl, const OFFSET: isize>() -> ID3D10ShaderReflectionVariable_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
@@ -3244,6 +3323,8 @@ pub trait ID3D10ShaderResourceView_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC);
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D10ShaderResourceView {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D10ShaderResourceView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderResourceView_Impl, const OFFSET: isize>() -> ID3D10ShaderResourceView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderResourceView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC) {
@@ -3261,6 +3342,8 @@ impl ID3D10ShaderResourceView_Vtbl {
 pub trait ID3D10ShaderResourceView1_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10View_Impl + ID3D10ShaderResourceView_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC1);
 }
+#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D10ShaderResourceView1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D10ShaderResourceView1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10ShaderResourceView1_Impl, const OFFSET: isize>() -> ID3D10ShaderResourceView1_Vtbl {
@@ -3281,6 +3364,7 @@ pub trait ID3D10StateBlock_Impl: Sized {
     fn ReleaseAllDeviceObjects(&self) -> ::windows::core::Result<()>;
     fn GetDevice(&self) -> ::windows::core::Result<ID3D10Device>;
 }
+impl ::windows::core::RuntimeName for ID3D10StateBlock {}
 impl ID3D10StateBlock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10StateBlock_Impl, const OFFSET: isize>() -> ID3D10StateBlock_Vtbl {
         unsafe extern "system" fn Capture<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10StateBlock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3327,6 +3411,8 @@ pub trait ID3D10SwitchToRef_Impl: Sized {
     fn GetUseRef(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D10SwitchToRef {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D10SwitchToRef_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10SwitchToRef_Impl, const OFFSET: isize>() -> ID3D10SwitchToRef_Vtbl {
         unsafe extern "system" fn SetUseRef<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10SwitchToRef_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL {
@@ -3355,6 +3441,8 @@ pub trait ID3D10Texture1D_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Resource_
     fn Unmap(&self, subresource: u32);
     fn GetDesc(&self, pdesc: *mut D3D10_TEXTURE1D_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D10Texture1D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D10Texture1D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Texture1D_Impl, const OFFSET: isize>() -> ID3D10Texture1D_Vtbl {
@@ -3390,6 +3478,8 @@ pub trait ID3D10Texture2D_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Resource_
     fn Unmap(&self, subresource: u32);
     fn GetDesc(&self, pdesc: *mut D3D10_TEXTURE2D_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D10Texture2D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D10Texture2D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Texture2D_Impl, const OFFSET: isize>() -> ID3D10Texture2D_Vtbl {
@@ -3432,6 +3522,8 @@ pub trait ID3D10Texture3D_Impl: Sized + ID3D10DeviceChild_Impl + ID3D10Resource_
     fn GetDesc(&self, pdesc: *mut D3D10_TEXTURE3D_DESC);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D10Texture3D {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D10Texture3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Texture3D_Impl, const OFFSET: isize>() -> ID3D10Texture3D_Vtbl {
         unsafe extern "system" fn Map<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10Texture3D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, subresource: u32, maptype: D3D10_MAP, mapflags: u32, pmappedtex3d: *mut D3D10_MAPPED_TEXTURE3D) -> ::windows::core::HRESULT {
@@ -3467,6 +3559,7 @@ impl ID3D10Texture3D_Vtbl {
     }
 }
 pub trait ID3D10VertexShader_Impl: Sized + ID3D10DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D10VertexShader {}
 impl ID3D10VertexShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10VertexShader_Impl, const OFFSET: isize>() -> ID3D10VertexShader_Vtbl {
         Self { base__: ID3D10DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3478,6 +3571,7 @@ impl ID3D10VertexShader_Vtbl {
 pub trait ID3D10View_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetResource(&self, ppresource: *mut ::core::option::Option<ID3D10Resource>);
 }
+impl ::windows::core::RuntimeName for ID3D10View {}
 impl ID3D10View_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10View_Impl, const OFFSET: isize>() -> ID3D10View_Vtbl {
         unsafe extern "system" fn GetResource<Identity: ::windows::core::IUnknownImpl, Impl: ID3D10View_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresource: *mut ::windows::core::RawPtr) {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
@@ -1,6 +1,7 @@
 pub trait ID3D11Asynchronous_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDataSize(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D11Asynchronous {}
 impl ID3D11Asynchronous_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Asynchronous_Impl, const OFFSET: isize>() -> ID3D11Asynchronous_Vtbl {
         unsafe extern "system" fn GetDataSize<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Asynchronous_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -20,6 +21,8 @@ pub trait ID3D11AuthenticatedChannel_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCertificate(&self, certificatesize: u32) -> ::windows::core::Result<u8>;
     fn GetChannelHandle(&self, pchannelhandle: *mut super::super::Foundation::HANDLE);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11AuthenticatedChannel {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11AuthenticatedChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11AuthenticatedChannel_Impl, const OFFSET: isize>() -> ID3D11AuthenticatedChannel_Vtbl {
@@ -66,6 +69,8 @@ pub trait ID3D11BlendState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_BLEND_DESC);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11BlendState {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D11BlendState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11BlendState_Impl, const OFFSET: isize>() -> ID3D11BlendState_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11BlendState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_BLEND_DESC) {
@@ -84,6 +89,8 @@ pub trait ID3D11BlendState1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11BlendSt
     fn GetDesc1(&self, pdesc: *mut D3D11_BLEND_DESC1);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11BlendState1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D11BlendState1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11BlendState1_Impl, const OFFSET: isize>() -> ID3D11BlendState1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11BlendState1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_BLEND_DESC1) {
@@ -100,6 +107,7 @@ impl ID3D11BlendState1_Vtbl {
 pub trait ID3D11Buffer_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_BUFFER_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11Buffer {}
 impl ID3D11Buffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Buffer_Impl, const OFFSET: isize>() -> ID3D11Buffer_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Buffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_BUFFER_DESC) {
@@ -120,6 +128,8 @@ pub trait ID3D11ClassInstance_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetInstanceName(&self, pinstancename: ::windows::core::PSTR, pbufferlength: *mut usize);
     fn GetTypeName(&self, ptypename: ::windows::core::PSTR, pbufferlength: *mut usize);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11ClassInstance {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11ClassInstance_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ClassInstance_Impl, const OFFSET: isize>() -> ID3D11ClassInstance_Vtbl {
@@ -159,6 +169,7 @@ pub trait ID3D11ClassLinkage_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetClassInstance(&self, pclassinstancename: &::windows::core::PCSTR, instanceindex: u32) -> ::windows::core::Result<ID3D11ClassInstance>;
     fn CreateClassInstance(&self, pclasstypename: &::windows::core::PCSTR, constantbufferoffset: u32, constantvectoroffset: u32, textureoffset: u32, sampleroffset: u32) -> ::windows::core::Result<ID3D11ClassInstance>;
 }
+impl ::windows::core::RuntimeName for ID3D11ClassLinkage {}
 impl ID3D11ClassLinkage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ClassLinkage_Impl, const OFFSET: isize>() -> ID3D11ClassLinkage_Vtbl {
         unsafe extern "system" fn GetClassInstance<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ClassLinkage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclassinstancename: ::windows::core::PCSTR, instanceindex: u32, ppinstance: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -196,6 +207,7 @@ impl ID3D11ClassLinkage_Vtbl {
 pub trait ID3D11CommandList_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetContextFlags(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D11CommandList {}
 impl ID3D11CommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11CommandList_Impl, const OFFSET: isize>() -> ID3D11CommandList_Vtbl {
         unsafe extern "system" fn GetContextFlags<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11CommandList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -210,6 +222,7 @@ impl ID3D11CommandList_Vtbl {
     }
 }
 pub trait ID3D11ComputeShader_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11ComputeShader {}
 impl ID3D11ComputeShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ComputeShader_Impl, const OFFSET: isize>() -> ID3D11ComputeShader_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -221,6 +234,7 @@ impl ID3D11ComputeShader_Vtbl {
 pub trait ID3D11Counter_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_COUNTER_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11Counter {}
 impl ID3D11Counter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Counter_Impl, const OFFSET: isize>() -> ID3D11Counter_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Counter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_COUNTER_DESC) {
@@ -242,6 +256,8 @@ pub trait ID3D11CryptoSession_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCertificate(&self, certificatesize: u32) -> ::windows::core::Result<u8>;
     fn GetCryptoSessionHandle(&self, pcryptosessionhandle: *mut super::super::Foundation::HANDLE);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11CryptoSession {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11CryptoSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11CryptoSession_Impl, const OFFSET: isize>() -> ID3D11CryptoSession_Vtbl {
@@ -307,6 +323,8 @@ pub trait ID3D11Debug_Impl: Sized {
     fn ReportLiveDeviceObjects(&self, flags: D3D11_RLDO_FLAGS) -> ::windows::core::Result<()>;
     fn ValidateContextForDispatch(&self, pcontext: &::core::option::Option<ID3D11DeviceContext>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Dxgi")]
+impl ::windows::core::RuntimeName for ID3D11Debug {}
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 impl ID3D11Debug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Debug_Impl, const OFFSET: isize>() -> ID3D11Debug_Vtbl {
@@ -383,6 +401,8 @@ pub trait ID3D11DepthStencilState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_DEPTH_STENCIL_DESC);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11DepthStencilState {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D11DepthStencilState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DepthStencilState_Impl, const OFFSET: isize>() -> ID3D11DepthStencilState_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DepthStencilState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_DEPTH_STENCIL_DESC) {
@@ -400,6 +420,8 @@ impl ID3D11DepthStencilState_Vtbl {
 pub trait ID3D11DepthStencilView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_DEPTH_STENCIL_VIEW_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11DepthStencilView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11DepthStencilView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DepthStencilView_Impl, const OFFSET: isize>() -> ID3D11DepthStencilView_Vtbl {
@@ -457,6 +479,8 @@ pub trait ID3D11Device_Impl: Sized {
     fn SetExceptionMode(&self, raiseflags: u32) -> ::windows::core::Result<()>;
     fn GetExceptionMode(&self) -> u32;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11Device {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11Device_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device_Impl, const OFFSET: isize>() -> ID3D11Device_Vtbl {
@@ -881,6 +905,8 @@ pub trait ID3D11Device1_Impl: Sized + ID3D11Device_Impl {
     fn OpenSharedResourceByName(&self, lpname: &::windows::core::PCWSTR, dwdesiredaccess: u32, returnedinterface: *const ::windows::core::GUID, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11Device1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11Device1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device1_Impl, const OFFSET: isize>() -> ID3D11Device1_Vtbl {
         unsafe extern "system" fn GetImmediateContext1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppimmediatecontext: *mut ::windows::core::RawPtr) {
@@ -959,6 +985,8 @@ pub trait ID3D11Device2_Impl: Sized + ID3D11Device_Impl + ID3D11Device1_Impl {
     fn CheckMultisampleQualityLevels1(&self, format: super::Dxgi::Common::DXGI_FORMAT, samplecount: u32, flags: u32) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11Device2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11Device2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device2_Impl, const OFFSET: isize>() -> ID3D11Device2_Vtbl {
         unsafe extern "system" fn GetImmediateContext2<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppimmediatecontext: *mut ::windows::core::RawPtr) {
@@ -1019,6 +1047,8 @@ pub trait ID3D11Device3_Impl: Sized + ID3D11Device_Impl + ID3D11Device1_Impl + I
     fn WriteToSubresource(&self, pdstresource: &::core::option::Option<ID3D11Resource>, dstsubresource: u32, pdstbox: *const D3D11_BOX, psrcdata: *const ::core::ffi::c_void, srcrowpitch: u32, srcdepthpitch: u32);
     fn ReadFromSubresource(&self, pdstdata: *mut ::core::ffi::c_void, dstrowpitch: u32, dstdepthpitch: u32, psrcresource: &::core::option::Option<ID3D11Resource>, srcsubresource: u32, psrcbox: *const D3D11_BOX);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11Device3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11Device3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device3_Impl, const OFFSET: isize>() -> ID3D11Device3_Vtbl {
@@ -1150,6 +1180,8 @@ pub trait ID3D11Device4_Impl: Sized + ID3D11Device_Impl + ID3D11Device1_Impl + I
     fn UnregisterDeviceRemoved(&self, dwcookie: u32);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11Device4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11Device4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device4_Impl, const OFFSET: isize>() -> ID3D11Device4_Vtbl {
         unsafe extern "system" fn RegisterDeviceRemovedEvent<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hevent: super::super::Foundation::HANDLE, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -1184,6 +1216,8 @@ pub trait ID3D11Device5_Impl: Sized + ID3D11Device_Impl + ID3D11Device1_Impl + I
     fn CreateFence(&self, initialvalue: u64, flags: D3D11_FENCE_FLAG, returnedinterface: *const ::windows::core::GUID, ppfence: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11Device5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11Device5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device5_Impl, const OFFSET: isize>() -> ID3D11Device5_Vtbl {
         unsafe extern "system" fn OpenSharedFence<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Device5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hfence: super::super::Foundation::HANDLE, returnedinterface: *const ::windows::core::GUID, ppfence: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1212,6 +1246,7 @@ pub trait ID3D11DeviceChild_Impl: Sized {
     fn SetPrivateData(&self, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetPrivateDataInterface(&self, guid: *const ::windows::core::GUID, pdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D11DeviceChild {}
 impl ID3D11DeviceChild_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceChild_Impl, const OFFSET: isize>() -> ID3D11DeviceChild_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceChild_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) {
@@ -1357,6 +1392,8 @@ pub trait ID3D11DeviceContext_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetContextFlags(&self) -> u32;
     fn FinishCommandList(&self, restoredeferredcontextstate: super::super::Foundation::BOOL) -> ::windows::core::Result<ID3D11CommandList>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11DeviceContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11DeviceContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext_Impl, const OFFSET: isize>() -> ID3D11DeviceContext_Vtbl {
@@ -2051,6 +2088,8 @@ pub trait ID3D11DeviceContext1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Devi
     fn DiscardView1(&self, presourceview: &::core::option::Option<ID3D11View>, prects: *const super::super::Foundation::RECT, numrects: u32);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11DeviceContext1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11DeviceContext1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext1_Impl, const OFFSET: isize>() -> ID3D11DeviceContext1_Vtbl {
         unsafe extern "system" fn CopySubresourceRegion1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdstresource: ::windows::core::RawPtr, dstsubresource: u32, dstx: u32, dsty: u32, dstz: u32, psrcresource: ::windows::core::RawPtr, srcsubresource: u32, psrcbox: *const D3D11_BOX, copyflags: u32) {
@@ -2189,6 +2228,8 @@ pub trait ID3D11DeviceContext2_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Devi
     fn EndEvent(&self);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11DeviceContext2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11DeviceContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext2_Impl, const OFFSET: isize>() -> ID3D11DeviceContext2_Vtbl {
         unsafe extern "system" fn UpdateTileMappings<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptiledresource: ::windows::core::RawPtr, numtiledresourceregions: u32, ptiledresourceregionstartcoordinates: *const D3D11_TILED_RESOURCE_COORDINATE, ptiledresourceregionsizes: *const D3D11_TILE_REGION_SIZE, ptilepool: ::windows::core::RawPtr, numranges: u32, prangeflags: *const u32, ptilepoolstartoffsets: *const u32, prangetilecounts: *const u32, flags: u32) -> ::windows::core::HRESULT {
@@ -2268,6 +2309,8 @@ pub trait ID3D11DeviceContext3_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Devi
     fn GetHardwareProtectionState(&self, phwprotectionenable: *mut super::super::Foundation::BOOL);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11DeviceContext3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11DeviceContext3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext3_Impl, const OFFSET: isize>() -> ID3D11DeviceContext3_Vtbl {
         unsafe extern "system" fn Flush1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contexttype: D3D11_CONTEXT_TYPE, hevent: super::super::Foundation::HANDLE) {
@@ -2302,6 +2345,8 @@ pub trait ID3D11DeviceContext4_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Devi
     fn Wait(&self, pfence: &::core::option::Option<ID3D11Fence>, value: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11DeviceContext4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11DeviceContext4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext4_Impl, const OFFSET: isize>() -> ID3D11DeviceContext4_Vtbl {
         unsafe extern "system" fn Signal<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DeviceContext4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfence: ::windows::core::RawPtr, value: u64) -> ::windows::core::HRESULT {
@@ -2325,6 +2370,7 @@ impl ID3D11DeviceContext4_Vtbl {
     }
 }
 pub trait ID3D11DomainShader_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11DomainShader {}
 impl ID3D11DomainShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11DomainShader_Impl, const OFFSET: isize>() -> ID3D11DomainShader_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2339,6 +2385,8 @@ pub trait ID3D11Fence_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCompletedValue(&self) -> u64;
     fn SetEventOnCompletion(&self, value: u64, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D11Fence {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl ID3D11Fence_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Fence_Impl, const OFFSET: isize>() -> ID3D11Fence_Vtbl {
@@ -2385,6 +2433,8 @@ pub trait ID3D11FunctionLinkingGraph_Impl: Sized {
     fn GetLastError(&self) -> ::windows::core::Result<super::Direct3D::ID3DBlob>;
     fn GenerateHlsl(&self, uflags: u32) -> ::windows::core::Result<super::Direct3D::ID3DBlob>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D11FunctionLinkingGraph {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11FunctionLinkingGraph_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11FunctionLinkingGraph_Impl, const OFFSET: isize>() -> ID3D11FunctionLinkingGraph_Vtbl {
@@ -2479,6 +2529,8 @@ pub trait ID3D11FunctionParameterReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_PARAMETER_DESC>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D11FunctionParameterReflection {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11FunctionParameterReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11FunctionParameterReflection_Impl, const OFFSET: isize>() -> ID3D11FunctionParameterReflection_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11FunctionParameterReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_PARAMETER_DESC) -> ::windows::core::HRESULT {
@@ -2508,6 +2560,8 @@ pub trait ID3D11FunctionReflection_Impl: Sized {
     fn GetResourceBindingDescByName(&self, name: &::windows::core::PCSTR) -> ::windows::core::Result<D3D11_SHADER_INPUT_BIND_DESC>;
     fn GetFunctionParameter(&self, parameterindex: i32) -> ::core::option::Option<ID3D11FunctionParameterReflection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D11FunctionReflection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D11FunctionReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>() -> ID3D11FunctionReflection_Vtbl {
@@ -2579,6 +2633,7 @@ impl ID3D11FunctionReflection_Vtbl {
     }
 }
 pub trait ID3D11GeometryShader_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11GeometryShader {}
 impl ID3D11GeometryShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11GeometryShader_Impl, const OFFSET: isize>() -> ID3D11GeometryShader_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2588,6 +2643,7 @@ impl ID3D11GeometryShader_Vtbl {
     }
 }
 pub trait ID3D11HullShader_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11HullShader {}
 impl ID3D11HullShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11HullShader_Impl, const OFFSET: isize>() -> ID3D11HullShader_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2634,6 +2690,8 @@ pub trait ID3D11InfoQueue_Impl: Sized {
     fn SetMuteDebugOutput(&self, bmute: super::super::Foundation::BOOL);
     fn GetMuteDebugOutput(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11InfoQueue {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11InfoQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11InfoQueue_Impl, const OFFSET: isize>() -> ID3D11InfoQueue_Vtbl {
@@ -2856,6 +2914,7 @@ impl ID3D11InfoQueue_Vtbl {
     }
 }
 pub trait ID3D11InputLayout_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11InputLayout {}
 impl ID3D11InputLayout_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11InputLayout_Impl, const OFFSET: isize>() -> ID3D11InputLayout_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2868,6 +2927,7 @@ pub trait ID3D11LibraryReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_LIBRARY_DESC>;
     fn GetFunctionByIndex(&self, functionindex: i32) -> ::core::option::Option<ID3D11FunctionReflection>;
 }
+impl ::windows::core::RuntimeName for ID3D11LibraryReflection {}
 impl ID3D11LibraryReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11LibraryReflection_Impl, const OFFSET: isize>() -> ID3D11LibraryReflection_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11LibraryReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_LIBRARY_DESC) -> ::windows::core::HRESULT {
@@ -2903,6 +2963,8 @@ pub trait ID3D11Linker_Impl: Sized {
     fn AddClipPlaneFromCBuffer(&self, ucbufferslot: u32, ucbufferentry: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D11Linker {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11Linker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Linker_Impl, const OFFSET: isize>() -> ID3D11Linker_Vtbl {
         unsafe extern "system" fn Link<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Linker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pentry: ::windows::core::RawPtr, pentryname: ::windows::core::PCSTR, ptargetname: ::windows::core::PCSTR, uflags: u32, ppshaderblob: *mut ::windows::core::RawPtr, pperrorbuffer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2932,6 +2994,7 @@ impl ID3D11Linker_Vtbl {
     }
 }
 pub trait ID3D11LinkingNode_Impl: Sized {}
+impl ::windows::core::RuntimeName for ID3D11LinkingNode {}
 impl ID3D11LinkingNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11LinkingNode_Impl, const OFFSET: isize>() -> ID3D11LinkingNode_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -2943,6 +3006,7 @@ impl ID3D11LinkingNode_Vtbl {
 pub trait ID3D11Module_Impl: Sized {
     fn CreateInstance(&self, pnamespace: &::windows::core::PCSTR) -> ::windows::core::Result<ID3D11ModuleInstance>;
 }
+impl ::windows::core::RuntimeName for ID3D11Module {}
 impl ID3D11Module_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Module_Impl, const OFFSET: isize>() -> ID3D11Module_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Module_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnamespace: ::windows::core::PCSTR, ppmoduleinstance: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2974,6 +3038,7 @@ pub trait ID3D11ModuleInstance_Impl: Sized {
     fn BindResourceAsUnorderedAccessView(&self, usrcsrvslot: u32, udstuavslot: u32, ucount: u32) -> ::windows::core::Result<()>;
     fn BindResourceAsUnorderedAccessViewByName(&self, psrvname: &::windows::core::PCSTR, udstuavslot: u32, ucount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D11ModuleInstance {}
 impl ID3D11ModuleInstance_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ModuleInstance_Impl, const OFFSET: isize>() -> ID3D11ModuleInstance_Vtbl {
         unsafe extern "system" fn BindConstantBuffer<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ModuleInstance_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, usrcslot: u32, udstslot: u32, cbdstoffset: u32) -> ::windows::core::HRESULT {
@@ -3052,6 +3117,8 @@ pub trait ID3D11Multithread_Impl: Sized {
     fn GetMultithreadProtected(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11Multithread {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D11Multithread_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Multithread_Impl, const OFFSET: isize>() -> ID3D11Multithread_Vtbl {
         unsafe extern "system" fn Enter<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Multithread_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -3087,6 +3154,7 @@ impl ID3D11Multithread_Vtbl {
     }
 }
 pub trait ID3D11PixelShader_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11PixelShader {}
 impl ID3D11PixelShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11PixelShader_Impl, const OFFSET: isize>() -> ID3D11PixelShader_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3096,6 +3164,7 @@ impl ID3D11PixelShader_Vtbl {
     }
 }
 pub trait ID3D11Predicate_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Asynchronous_Impl + ID3D11Query_Impl {}
+impl ::windows::core::RuntimeName for ID3D11Predicate {}
 impl ID3D11Predicate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Predicate_Impl, const OFFSET: isize>() -> ID3D11Predicate_Vtbl {
         Self { base__: ID3D11Query_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3107,6 +3176,7 @@ impl ID3D11Predicate_Vtbl {
 pub trait ID3D11Query_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_QUERY_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11Query {}
 impl ID3D11Query_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Query_Impl, const OFFSET: isize>() -> ID3D11Query_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Query_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_QUERY_DESC) {
@@ -3123,6 +3193,7 @@ impl ID3D11Query_Vtbl {
 pub trait ID3D11Query1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Asynchronous_Impl + ID3D11Query_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_QUERY_DESC1);
 }
+impl ::windows::core::RuntimeName for ID3D11Query1 {}
 impl ID3D11Query1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Query1_Impl, const OFFSET: isize>() -> ID3D11Query1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Query1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc1: *mut D3D11_QUERY_DESC1) {
@@ -3140,6 +3211,8 @@ impl ID3D11Query1_Vtbl {
 pub trait ID3D11RasterizerState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_RASTERIZER_DESC);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11RasterizerState {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11RasterizerState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RasterizerState_Impl, const OFFSET: isize>() -> ID3D11RasterizerState_Vtbl {
@@ -3159,6 +3232,8 @@ pub trait ID3D11RasterizerState1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Ra
     fn GetDesc1(&self, pdesc: *mut D3D11_RASTERIZER_DESC1);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11RasterizerState1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D11RasterizerState1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RasterizerState1_Impl, const OFFSET: isize>() -> ID3D11RasterizerState1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RasterizerState1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_RASTERIZER_DESC1) {
@@ -3177,6 +3252,8 @@ pub trait ID3D11RasterizerState2_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Ra
     fn GetDesc2(&self, pdesc: *mut D3D11_RASTERIZER_DESC2);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11RasterizerState2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D11RasterizerState2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RasterizerState2_Impl, const OFFSET: isize>() -> ID3D11RasterizerState2_Vtbl {
         unsafe extern "system" fn GetDesc2<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RasterizerState2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_RASTERIZER_DESC2) {
@@ -3193,6 +3270,7 @@ impl ID3D11RasterizerState2_Vtbl {
 pub trait ID3D11RefDefaultTrackingOptions_Impl: Sized {
     fn SetTrackingOptions(&self, resourcetypeflags: u32, options: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D11RefDefaultTrackingOptions {}
 impl ID3D11RefDefaultTrackingOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RefDefaultTrackingOptions_Impl, const OFFSET: isize>() -> ID3D11RefDefaultTrackingOptions_Vtbl {
         unsafe extern "system" fn SetTrackingOptions<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RefDefaultTrackingOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resourcetypeflags: u32, options: u32) -> ::windows::core::HRESULT {
@@ -3209,6 +3287,7 @@ impl ID3D11RefDefaultTrackingOptions_Vtbl {
 pub trait ID3D11RefTrackingOptions_Impl: Sized {
     fn SetTrackingOptions(&self, uoptions: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D11RefTrackingOptions {}
 impl ID3D11RefTrackingOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RefTrackingOptions_Impl, const OFFSET: isize>() -> ID3D11RefTrackingOptions_Vtbl {
         unsafe extern "system" fn SetTrackingOptions<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RefTrackingOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uoptions: u32) -> ::windows::core::HRESULT {
@@ -3226,6 +3305,8 @@ impl ID3D11RefTrackingOptions_Vtbl {
 pub trait ID3D11RenderTargetView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_RENDER_TARGET_VIEW_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11RenderTargetView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11RenderTargetView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RenderTargetView_Impl, const OFFSET: isize>() -> ID3D11RenderTargetView_Vtbl {
@@ -3245,6 +3326,8 @@ pub trait ID3D11RenderTargetView1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11V
     fn GetDesc1(&self, pdesc1: *mut D3D11_RENDER_TARGET_VIEW_DESC1);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11RenderTargetView1 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11RenderTargetView1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RenderTargetView1_Impl, const OFFSET: isize>() -> ID3D11RenderTargetView1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11RenderTargetView1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc1: *mut D3D11_RENDER_TARGET_VIEW_DESC1) {
@@ -3263,6 +3346,7 @@ pub trait ID3D11Resource_Impl: Sized + ID3D11DeviceChild_Impl {
     fn SetEvictionPriority(&self, evictionpriority: u32);
     fn GetEvictionPriority(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D11Resource {}
 impl ID3D11Resource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Resource_Impl, const OFFSET: isize>() -> ID3D11Resource_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Resource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presourcedimension: *mut D3D11_RESOURCE_DIMENSION) {
@@ -3294,6 +3378,7 @@ impl ID3D11Resource_Vtbl {
 pub trait ID3D11SamplerState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SAMPLER_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11SamplerState {}
 impl ID3D11SamplerState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11SamplerState_Impl, const OFFSET: isize>() -> ID3D11SamplerState_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11SamplerState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SAMPLER_DESC) {
@@ -3329,6 +3414,8 @@ pub trait ID3D11ShaderReflection_Impl: Sized {
     fn GetThreadGroupSize(&self, psizex: *mut u32, psizey: *mut u32, psizez: *mut u32) -> u32;
     fn GetRequiresFlags(&self) -> u64;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D11ShaderReflection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D11ShaderReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderReflection_Impl, const OFFSET: isize>() -> ID3D11ShaderReflection_Vtbl {
@@ -3503,6 +3590,8 @@ pub trait ID3D11ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetVariableByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionVariable>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D11ShaderReflectionConstantBuffer {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11ShaderReflectionConstantBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>() -> ID3D11ShaderReflectionConstantBuffer_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
@@ -3544,6 +3633,8 @@ pub trait ID3D11ShaderReflectionType_Impl: Sized {
     fn IsOfType(&self, ptype: &::core::option::Option<ID3D11ShaderReflectionType>) -> ::windows::core::Result<()>;
     fn ImplementsInterface(&self, pbase: &::core::option::Option<ID3D11ShaderReflectionType>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D11ShaderReflectionType {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11ShaderReflectionType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>() -> ID3D11ShaderReflectionType_Vtbl {
@@ -3632,6 +3723,7 @@ pub trait ID3D11ShaderReflectionVariable_Impl: Sized {
     fn GetBuffer(&self) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer>;
     fn GetInterfaceSlot(&self, uarrayindex: u32) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D11ShaderReflectionVariable {}
 impl ID3D11ShaderReflectionVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>() -> ID3D11ShaderReflectionVariable_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
@@ -3676,6 +3768,8 @@ pub trait ID3D11ShaderResourceView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_RESOURCE_VIEW_DESC);
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11ShaderResourceView {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11ShaderResourceView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderResourceView_Impl, const OFFSET: isize>() -> ID3D11ShaderResourceView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderResourceView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_RESOURCE_VIEW_DESC) {
@@ -3693,6 +3787,8 @@ impl ID3D11ShaderResourceView_Vtbl {
 pub trait ID3D11ShaderResourceView1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11View_Impl + ID3D11ShaderResourceView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_SHADER_RESOURCE_VIEW_DESC1);
 }
+#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11ShaderResourceView1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11ShaderResourceView1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderResourceView1_Impl, const OFFSET: isize>() -> ID3D11ShaderResourceView1_Vtbl {
@@ -3718,6 +3814,8 @@ pub trait ID3D11ShaderTrace_Impl: Sized {
     fn GetWrittenRegister(&self, stepindex: u32, writtenregisterindex: u32, pregister: *mut D3D11_TRACE_REGISTER, pvalue: *mut D3D11_TRACE_VALUE) -> ::windows::core::Result<()>;
     fn GetReadRegister(&self, stepindex: u32, readregisterindex: u32, pregister: *mut D3D11_TRACE_REGISTER, pvalue: *mut D3D11_TRACE_VALUE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11ShaderTrace {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11ShaderTrace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderTrace_Impl, const OFFSET: isize>() -> ID3D11ShaderTrace_Vtbl {
@@ -3804,6 +3902,7 @@ impl ID3D11ShaderTrace_Vtbl {
 pub trait ID3D11ShaderTraceFactory_Impl: Sized {
     fn CreateShaderTrace(&self, pshader: &::core::option::Option<::windows::core::IUnknown>, ptracedesc: *const D3D11_SHADER_TRACE_DESC) -> ::windows::core::Result<ID3D11ShaderTrace>;
 }
+impl ::windows::core::RuntimeName for ID3D11ShaderTraceFactory {}
 impl ID3D11ShaderTraceFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderTraceFactory_Impl, const OFFSET: isize>() -> ID3D11ShaderTraceFactory_Vtbl {
         unsafe extern "system" fn CreateShaderTrace<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11ShaderTraceFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshader: *mut ::core::ffi::c_void, ptracedesc: *const D3D11_SHADER_TRACE_DESC, ppshadertrace: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3828,6 +3927,8 @@ pub trait ID3D11SwitchToRef_Impl: Sized {
     fn SetUseRef(&self, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL;
     fn GetUseRef(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D11SwitchToRef {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D11SwitchToRef_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11SwitchToRef_Impl, const OFFSET: isize>() -> ID3D11SwitchToRef_Vtbl {
@@ -3856,6 +3957,8 @@ pub trait ID3D11Texture1D_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Resource_
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE1D_DESC);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11Texture1D {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11Texture1D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture1D_Impl, const OFFSET: isize>() -> ID3D11Texture1D_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture1D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_TEXTURE1D_DESC) {
@@ -3873,6 +3976,8 @@ impl ID3D11Texture1D_Vtbl {
 pub trait ID3D11Texture2D_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE2D_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11Texture2D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11Texture2D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture2D_Impl, const OFFSET: isize>() -> ID3D11Texture2D_Vtbl {
@@ -3892,6 +3997,8 @@ pub trait ID3D11Texture2D1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Resource
     fn GetDesc1(&self, pdesc: *mut D3D11_TEXTURE2D_DESC1);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11Texture2D1 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11Texture2D1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture2D1_Impl, const OFFSET: isize>() -> ID3D11Texture2D1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture2D1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_TEXTURE2D_DESC1) {
@@ -3909,6 +4016,8 @@ impl ID3D11Texture2D1_Vtbl {
 pub trait ID3D11Texture3D_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE3D_DESC);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11Texture3D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11Texture3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture3D_Impl, const OFFSET: isize>() -> ID3D11Texture3D_Vtbl {
@@ -3928,6 +4037,8 @@ pub trait ID3D11Texture3D1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Resource
     fn GetDesc1(&self, pdesc: *mut D3D11_TEXTURE3D_DESC1);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11Texture3D1 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11Texture3D1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture3D1_Impl, const OFFSET: isize>() -> ID3D11Texture3D1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11Texture3D1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_TEXTURE3D_DESC1) {
@@ -3945,6 +4056,7 @@ pub trait ID3D11TracingDevice_Impl: Sized {
     fn SetShaderTrackingOptionsByType(&self, resourcetypeflags: u32, options: u32) -> ::windows::core::Result<()>;
     fn SetShaderTrackingOptions(&self, pshader: &::core::option::Option<::windows::core::IUnknown>, options: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D11TracingDevice {}
 impl ID3D11TracingDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11TracingDevice_Impl, const OFFSET: isize>() -> ID3D11TracingDevice_Vtbl {
         unsafe extern "system" fn SetShaderTrackingOptionsByType<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11TracingDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resourcetypeflags: u32, options: u32) -> ::windows::core::HRESULT {
@@ -3972,6 +4084,8 @@ pub trait ID3D11UnorderedAccessView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D1
     fn GetDesc(&self, pdesc: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11UnorderedAccessView {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11UnorderedAccessView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11UnorderedAccessView_Impl, const OFFSET: isize>() -> ID3D11UnorderedAccessView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11UnorderedAccessView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC) {
@@ -3990,6 +4104,8 @@ pub trait ID3D11UnorderedAccessView1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D
     fn GetDesc1(&self, pdesc1: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC1);
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11UnorderedAccessView1 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11UnorderedAccessView1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11UnorderedAccessView1_Impl, const OFFSET: isize>() -> ID3D11UnorderedAccessView1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11UnorderedAccessView1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc1: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC1) {
@@ -4004,6 +4120,7 @@ impl ID3D11UnorderedAccessView1_Vtbl {
     }
 }
 pub trait ID3D11VertexShader_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D11VertexShader {}
 impl ID3D11VertexShader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VertexShader_Impl, const OFFSET: isize>() -> ID3D11VertexShader_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -4073,6 +4190,8 @@ pub trait ID3D11VideoContext_Impl: Sized + ID3D11DeviceChild_Impl {
     fn VideoProcessorSetStreamRotation(&self, pvideoprocessor: &::core::option::Option<ID3D11VideoProcessor>, streamindex: u32, enable: super::super::Foundation::BOOL, rotation: D3D11_VIDEO_PROCESSOR_ROTATION);
     fn VideoProcessorGetStreamRotation(&self, pvideoprocessor: &::core::option::Option<ID3D11VideoProcessor>, streamindex: u32, penable: *mut super::super::Foundation::BOOL, protation: *mut D3D11_VIDEO_PROCESSOR_ROTATION);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext_Impl, const OFFSET: isize>() -> ID3D11VideoContext_Vtbl {
@@ -4456,6 +4575,8 @@ pub trait ID3D11VideoContext1_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Video
     fn VideoProcessorGetBehaviorHints(&self, pvideoprocessor: &::core::option::Option<ID3D11VideoProcessor>, outputwidth: u32, outputheight: u32, outputformat: super::Dxgi::Common::DXGI_FORMAT, streamcount: u32, pstreams: *const D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINT) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoContext1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoContext1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext1_Impl, const OFFSET: isize>() -> ID3D11VideoContext1_Vtbl {
         unsafe extern "system" fn SubmitDecoderBuffers1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdecoder: ::windows::core::RawPtr, numbuffers: u32, pbufferdesc: *const D3D11_VIDEO_DECODER_BUFFER_DESC1) -> ::windows::core::HRESULT {
@@ -4576,6 +4697,8 @@ pub trait ID3D11VideoContext2_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Video
     fn VideoProcessorGetStreamHDRMetaData(&self, pvideoprocessor: &::core::option::Option<ID3D11VideoProcessor>, streamindex: u32, ptype: *mut super::Dxgi::DXGI_HDR_METADATA_TYPE, size: u32, pmetadata: *mut ::core::ffi::c_void);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoContext2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext2_Impl, const OFFSET: isize>() -> ID3D11VideoContext2_Vtbl {
         unsafe extern "system" fn VideoProcessorSetOutputHDRMetaData<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvideoprocessor: ::windows::core::RawPtr, r#type: super::Dxgi::DXGI_HDR_METADATA_TYPE, size: u32, phdrmetadata: *const ::core::ffi::c_void) {
@@ -4616,6 +4739,8 @@ pub trait ID3D11VideoContext3_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11Video
     fn SubmitDecoderBuffers2(&self, pdecoder: &::core::option::Option<ID3D11VideoDecoder>, numbuffers: u32, pbufferdesc: *const D3D11_VIDEO_DECODER_BUFFER_DESC2) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoContext3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoContext3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext3_Impl, const OFFSET: isize>() -> ID3D11VideoContext3_Vtbl {
         unsafe extern "system" fn DecoderBeginFrame1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoContext3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdecoder: ::windows::core::RawPtr, pview: ::windows::core::RawPtr, contentkeysize: u32, pcontentkey: *const ::core::ffi::c_void, numcomponenthistograms: u32, phistogramoffsets: *const u32, pphistogrambuffers: *const ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4643,6 +4768,8 @@ pub trait ID3D11VideoDecoder_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCreationParameters(&self, pvideodesc: *mut D3D11_VIDEO_DECODER_DESC, pconfig: *mut D3D11_VIDEO_DECODER_CONFIG) -> ::windows::core::Result<()>;
     fn GetDriverHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoDecoder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDecoder_Impl, const OFFSET: isize>() -> ID3D11VideoDecoder_Vtbl {
@@ -4675,6 +4802,7 @@ impl ID3D11VideoDecoder_Vtbl {
 pub trait ID3D11VideoDecoderOutputView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11VideoDecoderOutputView {}
 impl ID3D11VideoDecoderOutputView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDecoderOutputView_Impl, const OFFSET: isize>() -> ID3D11VideoDecoderOutputView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDecoderOutputView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC) {
@@ -4708,6 +4836,8 @@ pub trait ID3D11VideoDevice_Impl: Sized {
     fn SetPrivateData(&self, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetPrivateDataInterface(&self, guid: *const ::windows::core::GUID, pdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDevice_Impl, const OFFSET: isize>() -> ID3D11VideoDevice_Vtbl {
@@ -4913,6 +5043,8 @@ pub trait ID3D11VideoDevice1_Impl: Sized + ID3D11VideoDevice_Impl {
     fn RecommendVideoDecoderDownsampleParameters(&self, pinputdesc: *const D3D11_VIDEO_DECODER_DESC, inputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE, pinputconfig: *const D3D11_VIDEO_DECODER_CONFIG, pframerate: *const super::Dxgi::Common::DXGI_RATIONAL) -> ::windows::core::Result<D3D11_VIDEO_SAMPLE_DESC>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoDevice1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoDevice1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDevice1_Impl, const OFFSET: isize>() -> ID3D11VideoDevice1_Vtbl {
         unsafe extern "system" fn GetCryptoSessionPrivateDataSize<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDevice1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcryptotype: *const ::windows::core::GUID, pdecoderprofile: *const ::windows::core::GUID, pkeyexchangetype: *const ::windows::core::GUID, pprivateinputsize: *mut u32, pprivateoutputsize: *mut u32) -> ::windows::core::HRESULT {
@@ -4965,6 +5097,8 @@ pub trait ID3D11VideoDevice2_Impl: Sized + ID3D11VideoDevice_Impl + ID3D11VideoD
     fn NegotiateCryptoSessionKeyExchangeMT(&self, pcryptosession: &::core::option::Option<ID3D11CryptoSession>, flags: D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS, datasize: u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoDevice2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDevice2_Impl, const OFFSET: isize>() -> ID3D11VideoDevice2_Vtbl {
         unsafe extern "system" fn CheckFeatureSupport<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, feature: D3D11_FEATURE_VIDEO, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::HRESULT {
@@ -4992,6 +5126,8 @@ pub trait ID3D11VideoProcessor_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetContentDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_CONTENT_DESC);
     fn GetRateConversionCaps(&self, pcaps: *mut D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS);
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D11VideoProcessor {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D11VideoProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessor_Impl, const OFFSET: isize>() -> ID3D11VideoProcessor_Vtbl {
@@ -5024,6 +5160,8 @@ pub trait ID3D11VideoProcessorEnumerator_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetVideoProcessorCustomRate(&self, typeindex: u32, customrateindex: u32) -> ::windows::core::Result<D3D11_VIDEO_PROCESSOR_CUSTOM_RATE>;
     fn GetVideoProcessorFilterRange(&self, filter: D3D11_VIDEO_PROCESSOR_FILTER) -> ::windows::core::Result<D3D11_VIDEO_PROCESSOR_FILTER_RANGE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoProcessorEnumerator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoProcessorEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorEnumerator_Impl, const OFFSET: isize>() -> ID3D11VideoProcessorEnumerator_Vtbl {
@@ -5112,6 +5250,8 @@ pub trait ID3D11VideoProcessorEnumerator1_Impl: Sized + ID3D11DeviceChild_Impl +
     fn CheckVideoProcessorFormatConversion(&self, inputformat: super::Dxgi::Common::DXGI_FORMAT, inputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE, outputformat: super::Dxgi::Common::DXGI_FORMAT, outputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D11VideoProcessorEnumerator1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D11VideoProcessorEnumerator1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorEnumerator1_Impl, const OFFSET: isize>() -> ID3D11VideoProcessorEnumerator1_Vtbl {
         unsafe extern "system" fn CheckVideoProcessorFormatConversion<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorEnumerator1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputformat: super::Dxgi::Common::DXGI_FORMAT, inputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE, outputformat: super::Dxgi::Common::DXGI_FORMAT, outputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE, psupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5137,6 +5277,7 @@ impl ID3D11VideoProcessorEnumerator1_Vtbl {
 pub trait ID3D11VideoProcessorInputView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11VideoProcessorInputView {}
 impl ID3D11VideoProcessorInputView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorInputView_Impl, const OFFSET: isize>() -> ID3D11VideoProcessorInputView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorInputView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC) {
@@ -5153,6 +5294,7 @@ impl ID3D11VideoProcessorInputView_Vtbl {
 pub trait ID3D11VideoProcessorOutputView_Impl: Sized + ID3D11DeviceChild_Impl + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC);
 }
+impl ::windows::core::RuntimeName for ID3D11VideoProcessorOutputView {}
 impl ID3D11VideoProcessorOutputView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorOutputView_Impl, const OFFSET: isize>() -> ID3D11VideoProcessorOutputView_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11VideoProcessorOutputView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC) {
@@ -5169,6 +5311,7 @@ impl ID3D11VideoProcessorOutputView_Vtbl {
 pub trait ID3D11View_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetResource(&self, ppresource: *mut ::core::option::Option<ID3D11Resource>);
 }
+impl ::windows::core::RuntimeName for ID3D11View {}
 impl ID3D11View_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11View_Impl, const OFFSET: isize>() -> ID3D11View_Vtbl {
         unsafe extern "system" fn GetResource<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11View_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresource: *mut ::windows::core::RawPtr) {
@@ -5183,6 +5326,7 @@ impl ID3D11View_Vtbl {
     }
 }
 pub trait ID3DDeviceContextState_Impl: Sized + ID3D11DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3DDeviceContextState {}
 impl ID3DDeviceContextState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DDeviceContextState_Impl, const OFFSET: isize>() -> ID3DDeviceContextState_Vtbl {
         Self { base__: ID3D11DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -5198,6 +5342,8 @@ pub trait ID3DUserDefinedAnnotation_Impl: Sized {
     fn SetMarker(&self, name: &::windows::core::PCWSTR);
     fn GetStatus(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3DUserDefinedAnnotation {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3DUserDefinedAnnotation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DUserDefinedAnnotation_Impl, const OFFSET: isize>() -> ID3DUserDefinedAnnotation_Vtbl {
@@ -5242,6 +5388,7 @@ pub trait ID3DX11FFT_Impl: Sized {
     fn ForwardTransform(&self, pinputbuffer: &::core::option::Option<ID3D11UnorderedAccessView>, ppoutputbuffer: *mut ::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;
     fn InverseTransform(&self, pinputbuffer: &::core::option::Option<ID3D11UnorderedAccessView>, ppoutputbuffer: *mut ::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3DX11FFT {}
 impl ID3DX11FFT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DX11FFT_Impl, const OFFSET: isize>() -> ID3DX11FFT_Vtbl {
         unsafe extern "system" fn SetForwardScale<Identity: ::windows::core::IUnknownImpl, Impl: ID3DX11FFT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, forwardscale: f32) -> ::windows::core::HRESULT {
@@ -5299,6 +5446,7 @@ pub trait ID3DX11Scan_Impl: Sized {
     fn Scan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: &::core::option::Option<ID3D11UnorderedAccessView>, pdst: &::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;
     fn Multiscan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, elementscanpitch: u32, scancount: u32, psrc: &::core::option::Option<ID3D11UnorderedAccessView>, pdst: &::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3DX11Scan {}
 impl ID3DX11Scan_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DX11Scan_Impl, const OFFSET: isize>() -> ID3DX11Scan_Vtbl {
         unsafe extern "system" fn SetScanDirection<Identity: ::windows::core::IUnknownImpl, Impl: ID3DX11Scan_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::HRESULT {
@@ -5331,6 +5479,7 @@ pub trait ID3DX11SegmentedScan_Impl: Sized {
     fn SetScanDirection(&self, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::Result<()>;
     fn SegScan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: &::core::option::Option<ID3D11UnorderedAccessView>, psrcelementflags: &::core::option::Option<ID3D11UnorderedAccessView>, pdst: &::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3DX11SegmentedScan {}
 impl ID3DX11SegmentedScan_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3DX11SegmentedScan_Impl, const OFFSET: isize>() -> ID3DX11SegmentedScan_Vtbl {
         unsafe extern "system" fn SetScanDirection<Identity: ::windows::core::IUnknownImpl, Impl: ID3DX11SegmentedScan_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/impl.rs
@@ -5,6 +5,8 @@ pub trait ID3D11On12Device_Impl: Sized {
     fn AcquireWrappedResources(&self, ppresources: *const ::core::option::Option<super::Direct3D11::ID3D11Resource>, numresources: u32);
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D11On12Device {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D11On12Device_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11On12Device_Impl, const OFFSET: isize>() -> ID3D11On12Device_Vtbl {
         unsafe extern "system" fn CreateWrappedResource<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11On12Device_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource12: *mut ::core::ffi::c_void, pflags11: *const D3D11_RESOURCE_FLAGS, instate: super::Direct3D12::D3D12_RESOURCE_STATES, outstate: super::Direct3D12::D3D12_RESOURCE_STATES, riid: *const ::windows::core::GUID, ppresource11: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -38,6 +40,8 @@ pub trait ID3D11On12Device1_Impl: Sized + ID3D11On12Device_Impl {
     fn GetD3D12Device(&self, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D11On12Device1 {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D11On12Device1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11On12Device1_Impl, const OFFSET: isize>() -> ID3D11On12Device1_Vtbl {
         unsafe extern "system" fn GetD3D12Device<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11On12Device1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -56,6 +60,8 @@ pub trait ID3D11On12Device2_Impl: Sized + ID3D11On12Device_Impl + ID3D11On12Devi
     fn UnwrapUnderlyingResource(&self, presource11: &::core::option::Option<super::Direct3D11::ID3D11Resource>, pcommandqueue: &::core::option::Option<super::Direct3D12::ID3D12CommandQueue>, riid: *const ::windows::core::GUID, ppvresource12: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn ReturnUnderlyingResource(&self, presource11: &::core::option::Option<super::Direct3D11::ID3D11Resource>, numsync: u32, psignalvalues: *const u64, ppfences: *const ::core::option::Option<super::Direct3D12::ID3D12Fence>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D11On12Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D11On12Device2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D11On12Device2_Impl, const OFFSET: isize>() -> ID3D11On12Device2_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
@@ -1,6 +1,7 @@
 pub trait ID3D12CommandAllocator_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12CommandAllocator {}
 impl ID3D12CommandAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12CommandAllocator_Impl, const OFFSET: isize>() -> ID3D12CommandAllocator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12CommandAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17,6 +18,7 @@ impl ID3D12CommandAllocator_Vtbl {
 pub trait ID3D12CommandList_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl {
     fn GetType(&self) -> D3D12_COMMAND_LIST_TYPE;
 }
+impl ::windows::core::RuntimeName for ID3D12CommandList {}
 impl ID3D12CommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12CommandList_Impl, const OFFSET: isize>() -> ID3D12CommandList_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12CommandList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D3D12_COMMAND_LIST_TYPE {
@@ -44,6 +46,8 @@ pub trait ID3D12CommandQueue_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild
     fn GetClockCalibration(&self, pgputimestamp: *mut u64, pcputimestamp: *mut u64) -> ::windows::core::Result<()>;
     fn GetDesc(&self) -> D3D12_COMMAND_QUEUE_DESC;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12CommandQueue {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12CommandQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12CommandQueue_Impl, const OFFSET: isize>() -> ID3D12CommandQueue_Vtbl {
@@ -128,6 +132,7 @@ impl ID3D12CommandQueue_Vtbl {
     }
 }
 pub trait ID3D12CommandSignature_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {}
+impl ::windows::core::RuntimeName for ID3D12CommandSignature {}
 impl ID3D12CommandSignature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12CommandSignature_Impl, const OFFSET: isize>() -> ID3D12CommandSignature_Vtbl {
         Self { base__: ID3D12Pageable_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -139,6 +144,7 @@ impl ID3D12CommandSignature_Vtbl {
 pub trait ID3D12Debug_Impl: Sized {
     fn EnableDebugLayer(&self);
 }
+impl ::windows::core::RuntimeName for ID3D12Debug {}
 impl ID3D12Debug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug_Impl, const OFFSET: isize>() -> ID3D12Debug_Vtbl {
         unsafe extern "system" fn EnableDebugLayer<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -158,6 +164,8 @@ pub trait ID3D12Debug1_Impl: Sized {
     fn SetEnableGPUBasedValidation(&self, enable: super::super::Foundation::BOOL);
     fn SetEnableSynchronizedCommandQueueValidation(&self, enable: super::super::Foundation::BOOL);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Debug1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12Debug1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug1_Impl, const OFFSET: isize>() -> ID3D12Debug1_Vtbl {
@@ -190,6 +198,7 @@ impl ID3D12Debug1_Vtbl {
 pub trait ID3D12Debug2_Impl: Sized {
     fn SetGPUBasedValidationFlags(&self, flags: D3D12_GPU_BASED_VALIDATION_FLAGS);
 }
+impl ::windows::core::RuntimeName for ID3D12Debug2 {}
 impl ID3D12Debug2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug2_Impl, const OFFSET: isize>() -> ID3D12Debug2_Vtbl {
         unsafe extern "system" fn SetGPUBasedValidationFlags<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: D3D12_GPU_BASED_VALIDATION_FLAGS) {
@@ -212,6 +221,8 @@ pub trait ID3D12Debug3_Impl: Sized + ID3D12Debug_Impl {
     fn SetEnableSynchronizedCommandQueueValidation(&self, enable: super::super::Foundation::BOOL);
     fn SetGPUBasedValidationFlags(&self, flags: D3D12_GPU_BASED_VALIDATION_FLAGS);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Debug3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12Debug3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug3_Impl, const OFFSET: isize>() -> ID3D12Debug3_Vtbl {
@@ -246,6 +257,8 @@ pub trait ID3D12Debug4_Impl: Sized + ID3D12Debug_Impl + ID3D12Debug3_Impl {
     fn DisableDebugLayer(&self);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Debug4 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12Debug4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug4_Impl, const OFFSET: isize>() -> ID3D12Debug4_Vtbl {
         unsafe extern "system" fn DisableDebugLayer<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -263,6 +276,8 @@ impl ID3D12Debug4_Vtbl {
 pub trait ID3D12Debug5_Impl: Sized + ID3D12Debug_Impl + ID3D12Debug3_Impl + ID3D12Debug4_Impl {
     fn SetEnableAutoName(&self, enable: super::super::Foundation::BOOL);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Debug5 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12Debug5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Debug5_Impl, const OFFSET: isize>() -> ID3D12Debug5_Vtbl {
@@ -283,6 +298,8 @@ pub trait ID3D12DebugCommandList_Impl: Sized {
     fn SetFeatureMask(&self, mask: D3D12_DEBUG_FEATURE) -> ::windows::core::Result<()>;
     fn GetFeatureMask(&self) -> D3D12_DEBUG_FEATURE;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12DebugCommandList {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12DebugCommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandList_Impl, const OFFSET: isize>() -> ID3D12DebugCommandList_Vtbl {
@@ -319,6 +336,8 @@ pub trait ID3D12DebugCommandList1_Impl: Sized {
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12DebugCommandList1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12DebugCommandList1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandList1_Impl, const OFFSET: isize>() -> ID3D12DebugCommandList1_Vtbl {
         unsafe extern "system" fn AssertResourceState<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandList1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: ::windows::core::RawPtr, subresource: u32, state: u32) -> super::super::Foundation::BOOL {
@@ -353,6 +372,8 @@ pub trait ID3D12DebugCommandList2_Impl: Sized + ID3D12DebugCommandList_Impl {
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12DebugCommandList2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12DebugCommandList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandList2_Impl, const OFFSET: isize>() -> ID3D12DebugCommandList2_Vtbl {
         unsafe extern "system" fn SetDebugParameter<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandList2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::HRESULT {
@@ -380,6 +401,8 @@ pub trait ID3D12DebugCommandQueue_Impl: Sized {
     fn AssertResourceState(&self, presource: &::core::option::Option<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12DebugCommandQueue {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12DebugCommandQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandQueue_Impl, const OFFSET: isize>() -> ID3D12DebugCommandQueue_Vtbl {
         unsafe extern "system" fn AssertResourceState<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugCommandQueue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: ::windows::core::RawPtr, subresource: u32, state: u32) -> super::super::Foundation::BOOL {
@@ -398,6 +421,7 @@ pub trait ID3D12DebugDevice_Impl: Sized {
     fn GetFeatureMask(&self) -> D3D12_DEBUG_FEATURE;
     fn ReportLiveDeviceObjects(&self, flags: D3D12_RLDO_FLAGS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12DebugDevice {}
 impl ID3D12DebugDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugDevice_Impl, const OFFSET: isize>() -> ID3D12DebugDevice_Vtbl {
         unsafe extern "system" fn SetFeatureMask<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mask: D3D12_DEBUG_FEATURE) -> ::windows::core::HRESULT {
@@ -431,6 +455,7 @@ pub trait ID3D12DebugDevice1_Impl: Sized {
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
     fn ReportLiveDeviceObjects(&self, flags: D3D12_RLDO_FLAGS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12DebugDevice1 {}
 impl ID3D12DebugDevice1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugDevice1_Impl, const OFFSET: isize>() -> ID3D12DebugDevice1_Vtbl {
         unsafe extern "system" fn SetDebugParameter<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugDevice1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::HRESULT {
@@ -463,6 +488,7 @@ pub trait ID3D12DebugDevice2_Impl: Sized + ID3D12DebugDevice_Impl {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12DebugDevice2 {}
 impl ID3D12DebugDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugDevice2_Impl, const OFFSET: isize>() -> ID3D12DebugDevice2_Vtbl {
         unsafe extern "system" fn SetDebugParameter<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DebugDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::HRESULT {
@@ -490,6 +516,7 @@ pub trait ID3D12DescriptorHeap_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChi
     fn GetCPUDescriptorHandleForHeapStart(&self) -> D3D12_CPU_DESCRIPTOR_HANDLE;
     fn GetGPUDescriptorHandleForHeapStart(&self) -> D3D12_GPU_DESCRIPTOR_HANDLE;
 }
+impl ::windows::core::RuntimeName for ID3D12DescriptorHeap {}
 impl ID3D12DescriptorHeap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DescriptorHeap_Impl, const OFFSET: isize>() -> ID3D12DescriptorHeap_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DescriptorHeap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_DESCRIPTOR_HEAP_DESC) {
@@ -558,6 +585,8 @@ pub trait ID3D12Device_Impl: Sized + ID3D12Object_Impl {
     fn GetResourceTiling(&self, ptiledresource: &::core::option::Option<ID3D12Resource>, pnumtilesforentireresource: *mut u32, ppackedmipdesc: *mut D3D12_PACKED_MIP_INFO, pstandardtileshapefornonpackedmips: *mut D3D12_TILE_SHAPE, pnumsubresourcetilings: *mut u32, firstsubresourcetilingtoget: u32, psubresourcetilingsfornonpackedmips: *mut D3D12_SUBRESOURCE_TILING);
     fn GetAdapterLuid(&self) -> super::super::Foundation::LUID;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device_Impl, const OFFSET: isize>() -> ID3D12Device_Vtbl {
@@ -810,6 +839,8 @@ pub trait ID3D12Device1_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl {
     fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device1_Impl, const OFFSET: isize>() -> ID3D12Device1_Vtbl {
         unsafe extern "system" fn CreatePipelineLibrary<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plibraryblob: *const ::core::ffi::c_void, bloblength: usize, riid: *const ::windows::core::GUID, pppipelinelibrary: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -843,6 +874,8 @@ pub trait ID3D12Device2_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn CreatePipelineState(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const ::windows::core::GUID, pppipelinestate: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device2_Impl, const OFFSET: isize>() -> ID3D12Device2_Vtbl {
         unsafe extern "system" fn CreatePipelineState<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const ::windows::core::GUID, pppipelinestate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -862,6 +895,8 @@ pub trait ID3D12Device3_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn OpenExistingHeapFromFileMapping(&self, hfilemapping: super::super::Foundation::HANDLE, riid: *const ::windows::core::GUID, ppvheap: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn EnqueueMakeResident(&self, flags: D3D12_RESIDENCY_FLAGS, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, pfencetosignal: &::core::option::Option<ID3D12Fence>, fencevaluetosignal: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device3_Impl, const OFFSET: isize>() -> ID3D12Device3_Vtbl {
@@ -900,6 +935,8 @@ pub trait ID3D12Device4_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn CreateReservedResource1(&self, pdesc: *const D3D12_RESOURCE_DESC, initialstate: D3D12_RESOURCE_STATES, poptimizedclearvalue: *const D3D12_CLEAR_VALUE, pprotectedsession: &::core::option::Option<ID3D12ProtectedResourceSession>, riid: *const ::windows::core::GUID, ppvresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetResourceAllocationInfo1(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC, presourceallocationinfo1: *mut D3D12_RESOURCE_ALLOCATION_INFO1) -> D3D12_RESOURCE_ALLOCATION_INFO;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device4_Impl, const OFFSET: isize>() -> ID3D12Device4_Vtbl {
@@ -958,6 +995,8 @@ pub trait ID3D12Device5_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn GetRaytracingAccelerationStructurePrebuildInfo(&self, pdesc: *const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS, pinfo: *mut D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO);
     fn CheckDriverMatchingIdentifier(&self, serializeddatatype: D3D12_SERIALIZED_DATA_TYPE, pidentifiertocheck: *const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER) -> D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device5_Impl, const OFFSET: isize>() -> ID3D12Device5_Vtbl {
@@ -1022,6 +1061,8 @@ pub trait ID3D12Device6_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn SetBackgroundProcessingMode(&self, mode: D3D12_BACKGROUND_PROCESSING_MODE, measurementsaction: D3D12_MEASUREMENTS_ACTION, heventtosignaluponcompletion: super::super::Foundation::HANDLE) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device6 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device6_Impl, const OFFSET: isize>() -> ID3D12Device6_Vtbl {
         unsafe extern "system" fn SetBackgroundProcessingMode<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: D3D12_BACKGROUND_PROCESSING_MODE, measurementsaction: D3D12_MEASUREMENTS_ACTION, heventtosignaluponcompletion: super::super::Foundation::HANDLE, pbfurthermeasurementsdesired: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1046,6 +1087,8 @@ pub trait ID3D12Device7_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn AddToStateObject(&self, paddition: *const D3D12_STATE_OBJECT_DESC, pstateobjecttogrowfrom: &::core::option::Option<ID3D12StateObject>, riid: *const ::windows::core::GUID, ppnewstateobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateProtectedResourceSession1(&self, pdesc: *const D3D12_PROTECTED_RESOURCE_SESSION_DESC1, riid: *const ::windows::core::GUID, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device7 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device7_Impl, const OFFSET: isize>() -> ID3D12Device7_Vtbl {
@@ -1077,6 +1120,8 @@ pub trait ID3D12Device8_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn CreateSamplerFeedbackUnorderedAccessView(&self, ptargetedresource: &::core::option::Option<ID3D12Resource>, pfeedbackresource: &::core::option::Option<ID3D12Resource>, destdescriptor: &D3D12_CPU_DESCRIPTOR_HANDLE);
     fn GetCopyableFootprints1(&self, presourcedesc: *const D3D12_RESOURCE_DESC1, firstsubresource: u32, numsubresources: u32, baseoffset: u64, playouts: *mut D3D12_PLACED_SUBRESOURCE_FOOTPRINT, pnumrows: *mut u32, prowsizeinbytes: *mut u64, ptotalbytes: *mut u64);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device8 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device8_Impl, const OFFSET: isize>() -> ID3D12Device8_Vtbl {
@@ -1125,6 +1170,8 @@ pub trait ID3D12Device9_Impl: Sized + ID3D12Object_Impl + ID3D12Device_Impl + ID
     fn CreateCommandQueue1(&self, pdesc: *const D3D12_COMMAND_QUEUE_DESC, creatorid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppcommandqueue: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for ID3D12Device9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl ID3D12Device9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device9_Impl, const OFFSET: isize>() -> ID3D12Device9_Vtbl {
         unsafe extern "system" fn CreateShaderCacheSession<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Device9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *const D3D12_SHADER_CACHE_SESSION_DESC, riid: *const ::windows::core::GUID, ppvsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1156,6 +1203,7 @@ impl ID3D12Device9_Vtbl {
 pub trait ID3D12DeviceChild_Impl: Sized + ID3D12Object_Impl {
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12DeviceChild {}
 impl ID3D12DeviceChild_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceChild_Impl, const OFFSET: isize>() -> ID3D12DeviceChild_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceChild_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1173,6 +1221,7 @@ pub trait ID3D12DeviceRemovedExtendedData_Impl: Sized {
     fn GetAutoBreadcrumbsOutput(&self) -> ::windows::core::Result<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>;
     fn GetPageFaultAllocationOutput(&self) -> ::windows::core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT>;
 }
+impl ::windows::core::RuntimeName for ID3D12DeviceRemovedExtendedData {}
 impl ID3D12DeviceRemovedExtendedData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedData_Impl, const OFFSET: isize>() -> ID3D12DeviceRemovedExtendedData_Vtbl {
         unsafe extern "system" fn GetAutoBreadcrumbsOutput<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poutput: *mut D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT) -> ::windows::core::HRESULT {
@@ -1211,6 +1260,7 @@ pub trait ID3D12DeviceRemovedExtendedData1_Impl: Sized + ID3D12DeviceRemovedExte
     fn GetAutoBreadcrumbsOutput1(&self) -> ::windows::core::Result<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>;
     fn GetPageFaultAllocationOutput1(&self) -> ::windows::core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT1>;
 }
+impl ::windows::core::RuntimeName for ID3D12DeviceRemovedExtendedData1 {}
 impl ID3D12DeviceRemovedExtendedData1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedData1_Impl, const OFFSET: isize>() -> ID3D12DeviceRemovedExtendedData1_Vtbl {
         unsafe extern "system" fn GetAutoBreadcrumbsOutput1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedData1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poutput: *mut D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1) -> ::windows::core::HRESULT {
@@ -1249,6 +1299,7 @@ pub trait ID3D12DeviceRemovedExtendedData2_Impl: Sized + ID3D12DeviceRemovedExte
     fn GetPageFaultAllocationOutput2(&self) -> ::windows::core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT2>;
     fn GetDeviceState(&self) -> D3D12_DRED_DEVICE_STATE;
 }
+impl ::windows::core::RuntimeName for ID3D12DeviceRemovedExtendedData2 {}
 impl ID3D12DeviceRemovedExtendedData2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedData2_Impl, const OFFSET: isize>() -> ID3D12DeviceRemovedExtendedData2_Vtbl {
         unsafe extern "system" fn GetPageFaultAllocationOutput2<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedData2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poutput: *mut D3D12_DRED_PAGE_FAULT_OUTPUT2) -> ::windows::core::HRESULT {
@@ -1282,6 +1333,7 @@ pub trait ID3D12DeviceRemovedExtendedDataSettings_Impl: Sized {
     fn SetPageFaultEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
     fn SetWatsonDumpEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
 }
+impl ::windows::core::RuntimeName for ID3D12DeviceRemovedExtendedDataSettings {}
 impl ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedDataSettings_Impl, const OFFSET: isize>() -> ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
         unsafe extern "system" fn SetAutoBreadcrumbsEnablement<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedDataSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enablement: D3D12_DRED_ENABLEMENT) {
@@ -1313,6 +1365,7 @@ impl ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
 pub trait ID3D12DeviceRemovedExtendedDataSettings1_Impl: Sized + ID3D12DeviceRemovedExtendedDataSettings_Impl {
     fn SetBreadcrumbContextEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
 }
+impl ::windows::core::RuntimeName for ID3D12DeviceRemovedExtendedDataSettings1 {}
 impl ID3D12DeviceRemovedExtendedDataSettings1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedDataSettings1_Impl, const OFFSET: isize>() -> ID3D12DeviceRemovedExtendedDataSettings1_Vtbl {
         unsafe extern "system" fn SetBreadcrumbContextEnablement<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12DeviceRemovedExtendedDataSettings1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enablement: D3D12_DRED_ENABLEMENT) {
@@ -1335,6 +1388,8 @@ pub trait ID3D12Fence_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl +
     fn SetEventOnCompletion(&self, value: u64, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn Signal(&self, value: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Fence {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12Fence_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Fence_Impl, const OFFSET: isize>() -> ID3D12Fence_Vtbl {
@@ -1369,6 +1424,8 @@ pub trait ID3D12Fence1_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl 
     fn GetCreationFlags(&self) -> D3D12_FENCE_FLAGS;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Fence1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12Fence1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Fence1_Impl, const OFFSET: isize>() -> ID3D12Fence1_Vtbl {
         unsafe extern "system" fn GetCreationFlags<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Fence1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> D3D12_FENCE_FLAGS {
@@ -1386,6 +1443,8 @@ impl ID3D12Fence1_Vtbl {
 pub trait ID3D12FunctionParameterReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_PARAMETER_DESC>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D12FunctionParameterReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12FunctionParameterReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12FunctionParameterReflection_Impl, const OFFSET: isize>() -> ID3D12FunctionParameterReflection_Vtbl {
@@ -1416,6 +1475,8 @@ pub trait ID3D12FunctionReflection_Impl: Sized {
     fn GetResourceBindingDescByName(&self, name: &::windows::core::PCSTR) -> ::windows::core::Result<D3D12_SHADER_INPUT_BIND_DESC>;
     fn GetFunctionParameter(&self, parameterindex: i32) -> ::core::option::Option<ID3D12FunctionParameterReflection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D12FunctionReflection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D12FunctionReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>() -> ID3D12FunctionReflection_Vtbl {
@@ -1540,6 +1601,8 @@ pub trait ID3D12GraphicsCommandList_Impl: Sized + ID3D12Object_Impl + ID3D12Devi
     fn EndEvent(&self);
     fn ExecuteIndirect(&self, pcommandsignature: &::core::option::Option<ID3D12CommandSignature>, maxcommandcount: u32, pargumentbuffer: &::core::option::Option<ID3D12Resource>, argumentbufferoffset: u64, pcountbuffer: &::core::option::Option<ID3D12Resource>, countbufferoffset: u64);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList_Vtbl {
@@ -1867,6 +1930,8 @@ pub trait ID3D12GraphicsCommandList1_Impl: Sized + ID3D12Object_Impl + ID3D12Dev
     fn SetViewInstanceMask(&self, mask: u32);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList1_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList1_Vtbl {
         unsafe extern "system" fn AtomicCopyBufferUINT<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdstbuffer: ::windows::core::RawPtr, dstoffset: u64, psrcbuffer: ::windows::core::RawPtr, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::windows::core::RawPtr, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
@@ -1918,6 +1983,8 @@ pub trait ID3D12GraphicsCommandList2_Impl: Sized + ID3D12Object_Impl + ID3D12Dev
     fn WriteBufferImmediate(&self, count: u32, pparams: *const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const D3D12_WRITEBUFFERIMMEDIATE_MODE);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList2_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList2_Vtbl {
         unsafe extern "system" fn WriteBufferImmediate<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: u32, pparams: *const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const D3D12_WRITEBUFFERIMMEDIATE_MODE) {
@@ -1935,6 +2002,8 @@ impl ID3D12GraphicsCommandList2_Vtbl {
 pub trait ID3D12GraphicsCommandList3_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12CommandList_Impl + ID3D12GraphicsCommandList_Impl + ID3D12GraphicsCommandList1_Impl + ID3D12GraphicsCommandList2_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: &::core::option::Option<ID3D12ProtectedResourceSession>);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList3_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList3_Vtbl {
@@ -1964,6 +2033,8 @@ pub trait ID3D12GraphicsCommandList4_Impl: Sized + ID3D12Object_Impl + ID3D12Dev
     fn SetPipelineState1(&self, pstateobject: &::core::option::Option<ID3D12StateObject>);
     fn DispatchRays(&self, pdesc: *const D3D12_DISPATCH_RAYS_DESC);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList4_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList4_Vtbl {
@@ -2035,6 +2106,8 @@ pub trait ID3D12GraphicsCommandList5_Impl: Sized + ID3D12Object_Impl + ID3D12Dev
     fn RSSetShadingRateImage(&self, shadingrateimage: &::core::option::Option<ID3D12Resource>);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList5_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList5_Vtbl {
         unsafe extern "system" fn RSSetShadingRate<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, baseshadingrate: D3D12_SHADING_RATE, combiners: *const D3D12_SHADING_RATE_COMBINER) {
@@ -2062,6 +2135,8 @@ pub trait ID3D12GraphicsCommandList6_Impl: Sized + ID3D12Object_Impl + ID3D12Dev
     fn DispatchMesh(&self, threadgroupcountx: u32, threadgroupcounty: u32, threadgroupcountz: u32);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12GraphicsCommandList6 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12GraphicsCommandList6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList6_Impl, const OFFSET: isize>() -> ID3D12GraphicsCommandList6_Vtbl {
         unsafe extern "system" fn DispatchMesh<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12GraphicsCommandList6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, threadgroupcountx: u32, threadgroupcounty: u32, threadgroupcountz: u32) {
@@ -2078,6 +2153,7 @@ impl ID3D12GraphicsCommandList6_Vtbl {
 pub trait ID3D12Heap_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_HEAP_DESC;
 }
+impl ::windows::core::RuntimeName for ID3D12Heap {}
 impl ID3D12Heap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Heap_Impl, const OFFSET: isize>() -> ID3D12Heap_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Heap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_HEAP_DESC) {
@@ -2094,6 +2170,7 @@ impl ID3D12Heap_Vtbl {
 pub trait ID3D12Heap1_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl + ID3D12Heap_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12Heap1 {}
 impl ID3D12Heap1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Heap1_Impl, const OFFSET: isize>() -> ID3D12Heap1_Vtbl {
         unsafe extern "system" fn GetProtectedResourceSession<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Heap1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2145,6 +2222,8 @@ pub trait ID3D12InfoQueue_Impl: Sized {
     fn SetMuteDebugOutput(&self, bmute: super::super::Foundation::BOOL);
     fn GetMuteDebugOutput(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12InfoQueue {}
 #[cfg(feature = "Win32_Foundation")]
 impl ID3D12InfoQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12InfoQueue_Impl, const OFFSET: isize>() -> ID3D12InfoQueue_Vtbl {
@@ -2372,6 +2451,8 @@ pub trait ID3D12InfoQueue1_Impl: Sized + ID3D12InfoQueue_Impl {
     fn UnregisterMessageCallback(&self, callbackcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12InfoQueue1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12InfoQueue1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12InfoQueue1_Impl, const OFFSET: isize>() -> ID3D12InfoQueue1_Vtbl {
         unsafe extern "system" fn RegisterMessageCallback<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12InfoQueue1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, callbackfunc: ::windows::core::RawPtr, callbackfilterflags: D3D12_MESSAGE_CALLBACK_FLAGS, pcontext: *const ::core::ffi::c_void, pcallbackcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -2398,6 +2479,7 @@ pub trait ID3D12LibraryReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_LIBRARY_DESC>;
     fn GetFunctionByIndex(&self, functionindex: i32) -> ::core::option::Option<ID3D12FunctionReflection>;
 }
+impl ::windows::core::RuntimeName for ID3D12LibraryReflection {}
 impl ID3D12LibraryReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12LibraryReflection_Impl, const OFFSET: isize>() -> ID3D12LibraryReflection_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12LibraryReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_LIBRARY_DESC) -> ::windows::core::HRESULT {
@@ -2429,6 +2511,7 @@ impl ID3D12LibraryReflection_Vtbl {
 pub trait ID3D12LifetimeOwner_Impl: Sized {
     fn LifetimeStateUpdated(&self, newstate: D3D12_LIFETIME_STATE);
 }
+impl ::windows::core::RuntimeName for ID3D12LifetimeOwner {}
 impl ID3D12LifetimeOwner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12LifetimeOwner_Impl, const OFFSET: isize>() -> ID3D12LifetimeOwner_Vtbl {
         unsafe extern "system" fn LifetimeStateUpdated<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12LifetimeOwner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newstate: D3D12_LIFETIME_STATE) {
@@ -2445,6 +2528,7 @@ impl ID3D12LifetimeOwner_Vtbl {
 pub trait ID3D12LifetimeTracker_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl {
     fn DestroyOwnedObject(&self, pobject: &::core::option::Option<ID3D12DeviceChild>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12LifetimeTracker {}
 impl ID3D12LifetimeTracker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12LifetimeTracker_Impl, const OFFSET: isize>() -> ID3D12LifetimeTracker_Vtbl {
         unsafe extern "system" fn DestroyOwnedObject<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12LifetimeTracker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobject: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2461,6 +2545,7 @@ impl ID3D12LifetimeTracker_Vtbl {
 pub trait ID3D12MetaCommand_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {
     fn GetRequiredParameterResourceSize(&self, stage: D3D12_META_COMMAND_PARAMETER_STAGE, parameterindex: u32) -> u64;
 }
+impl ::windows::core::RuntimeName for ID3D12MetaCommand {}
 impl ID3D12MetaCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12MetaCommand_Impl, const OFFSET: isize>() -> ID3D12MetaCommand_Vtbl {
         unsafe extern "system" fn GetRequiredParameterResourceSize<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12MetaCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stage: D3D12_META_COMMAND_PARAMETER_STAGE, parameterindex: u32) -> u64 {
@@ -2483,6 +2568,7 @@ pub trait ID3D12Object_Impl: Sized {
     fn SetPrivateDataInterface(&self, guid: *const ::windows::core::GUID, pdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetName(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12Object {}
 impl ID3D12Object_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Object_Impl, const OFFSET: isize>() -> ID3D12Object_Vtbl {
         unsafe extern "system" fn GetPrivateData<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Object_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2518,6 +2604,7 @@ impl ID3D12Object_Vtbl {
     }
 }
 pub trait ID3D12Pageable_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D12Pageable {}
 impl ID3D12Pageable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Pageable_Impl, const OFFSET: isize>() -> ID3D12Pageable_Vtbl {
         Self { base__: ID3D12DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2534,6 +2621,8 @@ pub trait ID3D12PipelineLibrary_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceCh
     fn GetSerializedSize(&self) -> usize;
     fn Serialize(&self, pdata: *mut ::core::ffi::c_void, datasizeinbytes: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12PipelineLibrary {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12PipelineLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12PipelineLibrary_Impl, const OFFSET: isize>() -> ID3D12PipelineLibrary_Vtbl {
@@ -2580,6 +2669,8 @@ pub trait ID3D12PipelineLibrary1_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceC
     fn LoadPipeline(&self, pname: &::windows::core::PCWSTR, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const ::windows::core::GUID, pppipelinestate: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12PipelineLibrary1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12PipelineLibrary1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12PipelineLibrary1_Impl, const OFFSET: isize>() -> ID3D12PipelineLibrary1_Vtbl {
         unsafe extern "system" fn LoadPipeline<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12PipelineLibrary1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pname: ::windows::core::PCWSTR, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const ::windows::core::GUID, pppipelinestate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2597,6 +2688,8 @@ impl ID3D12PipelineLibrary1_Vtbl {
 pub trait ID3D12PipelineState_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {
     fn GetCachedBlob(&self) -> ::windows::core::Result<super::Direct3D::ID3DBlob>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D12PipelineState {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12PipelineState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12PipelineState_Impl, const OFFSET: isize>() -> ID3D12PipelineState_Vtbl {
@@ -2620,6 +2713,7 @@ impl ID3D12PipelineState_Vtbl {
 pub trait ID3D12ProtectedResourceSession_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12ProtectedSession_Impl {
     fn GetDesc(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC;
 }
+impl ::windows::core::RuntimeName for ID3D12ProtectedResourceSession {}
 impl ID3D12ProtectedResourceSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ProtectedResourceSession_Impl, const OFFSET: isize>() -> ID3D12ProtectedResourceSession_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ProtectedResourceSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_PROTECTED_RESOURCE_SESSION_DESC) {
@@ -2636,6 +2730,7 @@ impl ID3D12ProtectedResourceSession_Vtbl {
 pub trait ID3D12ProtectedResourceSession1_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12ProtectedSession_Impl + ID3D12ProtectedResourceSession_Impl {
     fn GetDesc1(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC1;
 }
+impl ::windows::core::RuntimeName for ID3D12ProtectedResourceSession1 {}
 impl ID3D12ProtectedResourceSession1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ProtectedResourceSession1_Impl, const OFFSET: isize>() -> ID3D12ProtectedResourceSession1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ProtectedResourceSession1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_PROTECTED_RESOURCE_SESSION_DESC1) {
@@ -2653,6 +2748,7 @@ pub trait ID3D12ProtectedSession_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceC
     fn GetStatusFence(&self, riid: *const ::windows::core::GUID, ppfence: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetSessionStatus(&self) -> D3D12_PROTECTED_SESSION_STATUS;
 }
+impl ::windows::core::RuntimeName for ID3D12ProtectedSession {}
 impl ID3D12ProtectedSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ProtectedSession_Impl, const OFFSET: isize>() -> ID3D12ProtectedSession_Vtbl {
         unsafe extern "system" fn GetStatusFence<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ProtectedSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppfence: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2676,6 +2772,7 @@ impl ID3D12ProtectedSession_Vtbl {
     }
 }
 pub trait ID3D12QueryHeap_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {}
+impl ::windows::core::RuntimeName for ID3D12QueryHeap {}
 impl ID3D12QueryHeap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12QueryHeap_Impl, const OFFSET: isize>() -> ID3D12QueryHeap_Vtbl {
         Self { base__: ID3D12Pageable_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2694,6 +2791,8 @@ pub trait ID3D12Resource_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Imp
     fn ReadFromSubresource(&self, pdstdata: *mut ::core::ffi::c_void, dstrowpitch: u32, dstdepthpitch: u32, srcsubresource: u32, psrcbox: *const D3D12_BOX) -> ::windows::core::Result<()>;
     fn GetHeapProperties(&self, pheapproperties: *mut D3D12_HEAP_PROPERTIES, pheapflags: *mut D3D12_HEAP_FLAGS) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D12Resource {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D12Resource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Resource_Impl, const OFFSET: isize>() -> ID3D12Resource_Vtbl {
@@ -2752,6 +2851,8 @@ pub trait ID3D12Resource1_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Im
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D12Resource1 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D12Resource1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Resource1_Impl, const OFFSET: isize>() -> ID3D12Resource1_Vtbl {
         unsafe extern "system" fn GetProtectedResourceSession<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Resource1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2770,6 +2871,8 @@ pub trait ID3D12Resource2_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Im
     fn GetDesc1(&self) -> D3D12_RESOURCE_DESC1;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for ID3D12Resource2 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl ID3D12Resource2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Resource2_Impl, const OFFSET: isize>() -> ID3D12Resource2_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Resource2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_RESOURCE_DESC1) {
@@ -2784,6 +2887,7 @@ impl ID3D12Resource2_Vtbl {
     }
 }
 pub trait ID3D12RootSignature_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl {}
+impl ::windows::core::RuntimeName for ID3D12RootSignature {}
 impl ID3D12RootSignature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12RootSignature_Impl, const OFFSET: isize>() -> ID3D12RootSignature_Vtbl {
         Self { base__: ID3D12DeviceChild_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2795,6 +2899,7 @@ impl ID3D12RootSignature_Vtbl {
 pub trait ID3D12RootSignatureDeserializer_Impl: Sized {
     fn GetRootSignatureDesc(&self) -> *mut D3D12_ROOT_SIGNATURE_DESC;
 }
+impl ::windows::core::RuntimeName for ID3D12RootSignatureDeserializer {}
 impl ID3D12RootSignatureDeserializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12RootSignatureDeserializer_Impl, const OFFSET: isize>() -> ID3D12RootSignatureDeserializer_Vtbl {
         unsafe extern "system" fn GetRootSignatureDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12RootSignatureDeserializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut D3D12_ROOT_SIGNATURE_DESC {
@@ -2811,6 +2916,7 @@ impl ID3D12RootSignatureDeserializer_Vtbl {
 pub trait ID3D12SDKConfiguration_Impl: Sized {
     fn SetSDKVersion(&self, sdkversion: u32, sdkpath: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ID3D12SDKConfiguration {}
 impl ID3D12SDKConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12SDKConfiguration_Impl, const OFFSET: isize>() -> ID3D12SDKConfiguration_Vtbl {
         unsafe extern "system" fn SetSDKVersion<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12SDKConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sdkversion: u32, sdkpath: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -2830,6 +2936,7 @@ pub trait ID3D12ShaderCacheSession_Impl: Sized + ID3D12Object_Impl + ID3D12Devic
     fn SetDeleteOnDestroy(&self);
     fn GetDesc(&self) -> D3D12_SHADER_CACHE_SESSION_DESC;
 }
+impl ::windows::core::RuntimeName for ID3D12ShaderCacheSession {}
 impl ID3D12ShaderCacheSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderCacheSession_Impl, const OFFSET: isize>() -> ID3D12ShaderCacheSession_Vtbl {
         unsafe extern "system" fn FindValue<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderCacheSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pkey: *const ::core::ffi::c_void, keysize: u32, pvalue: *mut ::core::ffi::c_void, pvaluesize: *mut u32) -> ::windows::core::HRESULT {
@@ -2886,6 +2993,8 @@ pub trait ID3D12ShaderReflection_Impl: Sized {
     fn GetThreadGroupSize(&self, psizex: *mut u32, psizey: *mut u32, psizez: *mut u32) -> u32;
     fn GetRequiresFlags(&self) -> u64;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ::windows::core::RuntimeName for ID3D12ShaderReflection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D12ShaderReflection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderReflection_Impl, const OFFSET: isize>() -> ID3D12ShaderReflection_Vtbl {
@@ -3060,6 +3169,8 @@ pub trait ID3D12ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetVariableByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionVariable>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D12ShaderReflectionConstantBuffer {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12ShaderReflectionConstantBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>() -> ID3D12ShaderReflectionConstantBuffer_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
@@ -3101,6 +3212,8 @@ pub trait ID3D12ShaderReflectionType_Impl: Sized {
     fn IsOfType(&self, ptype: &::core::option::Option<ID3D12ShaderReflectionType>) -> ::windows::core::Result<()>;
     fn ImplementsInterface(&self, pbase: &::core::option::Option<ID3D12ShaderReflectionType>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for ID3D12ShaderReflectionType {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12ShaderReflectionType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>() -> ID3D12ShaderReflectionType_Vtbl {
@@ -3189,6 +3302,7 @@ pub trait ID3D12ShaderReflectionVariable_Impl: Sized {
     fn GetBuffer(&self) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer>;
     fn GetInterfaceSlot(&self, uarrayindex: u32) -> u32;
 }
+impl ::windows::core::RuntimeName for ID3D12ShaderReflectionVariable {}
 impl ID3D12ShaderReflectionVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>() -> ID3D12ShaderReflectionVariable_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
@@ -3236,6 +3350,8 @@ pub trait ID3D12SharingContract_Impl: Sized {
     fn EndCapturableWork(&self, guid: *const ::windows::core::GUID);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12SharingContract {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12SharingContract_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12SharingContract_Impl, const OFFSET: isize>() -> ID3D12SharingContract_Vtbl {
         unsafe extern "system" fn Present<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12SharingContract_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: ::windows::core::RawPtr, subresource: u32, window: super::super::Foundation::HWND) {
@@ -3271,6 +3387,7 @@ impl ID3D12SharingContract_Vtbl {
     }
 }
 pub trait ID3D12StateObject_Impl: Sized + ID3D12Object_Impl + ID3D12DeviceChild_Impl + ID3D12Pageable_Impl {}
+impl ::windows::core::RuntimeName for ID3D12StateObject {}
 impl ID3D12StateObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12StateObject_Impl, const OFFSET: isize>() -> ID3D12StateObject_Vtbl {
         Self { base__: ID3D12Pageable_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3285,6 +3402,7 @@ pub trait ID3D12StateObjectProperties_Impl: Sized {
     fn GetPipelineStackSize(&self) -> u64;
     fn SetPipelineStackSize(&self, pipelinestacksizeinbytes: u64);
 }
+impl ::windows::core::RuntimeName for ID3D12StateObjectProperties {}
 impl ID3D12StateObjectProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12StateObjectProperties_Impl, const OFFSET: isize>() -> ID3D12StateObjectProperties_Vtbl {
         unsafe extern "system" fn GetShaderIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12StateObjectProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pexportname: ::windows::core::PCWSTR) -> *mut ::core::ffi::c_void {
@@ -3327,6 +3445,8 @@ pub trait ID3D12SwapChainAssistant_Impl: Sized {
     fn InsertImplicitSync(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12SwapChainAssistant {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12SwapChainAssistant_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12SwapChainAssistant_Impl, const OFFSET: isize>() -> ID3D12SwapChainAssistant_Vtbl {
         unsafe extern "system" fn GetLUID<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12SwapChainAssistant_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut super::super::Foundation::LUID) {
@@ -3367,6 +3487,8 @@ pub trait ID3D12Tools_Impl: Sized {
     fn ShaderInstrumentationEnabled(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ID3D12Tools {}
+#[cfg(feature = "Win32_Foundation")]
 impl ID3D12Tools_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Tools_Impl, const OFFSET: isize>() -> ID3D12Tools_Vtbl {
         unsafe extern "system" fn EnableShaderInstrumentation<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12Tools_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, benable: super::super::Foundation::BOOL) {
@@ -3393,6 +3515,7 @@ pub trait ID3D12VersionedRootSignatureDeserializer_Impl: Sized {
     fn GetRootSignatureDescAtVersion(&self, converttoversion: D3D_ROOT_SIGNATURE_VERSION) -> ::windows::core::Result<*mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC>;
     fn GetUnconvertedRootSignatureDesc(&self) -> *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC;
 }
+impl ::windows::core::RuntimeName for ID3D12VersionedRootSignatureDeserializer {}
 impl ID3D12VersionedRootSignatureDeserializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VersionedRootSignatureDeserializer_Impl, const OFFSET: isize>() -> ID3D12VersionedRootSignatureDeserializer_Vtbl {
         unsafe extern "system" fn GetRootSignatureDescAtVersion<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VersionedRootSignatureDeserializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, converttoversion: D3D_ROOT_SIGNATURE_VERSION, ppdesc: *mut *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
@@ -16,6 +16,8 @@ pub trait IDirect3D9_Impl: Sized {
     fn CreateDevice(&self, adapter: u32, devicetype: D3DDEVTYPE, hfocuswindow: super::super::Foundation::HWND, behaviorflags: u32, ppresentationparameters: *mut D3DPRESENT_PARAMETERS, ppreturneddeviceinterface: *mut ::core::option::Option<IDirect3DDevice9>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3D9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3D9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3D9_Impl, const OFFSET: isize>() -> IDirect3D9_Vtbl {
         unsafe extern "system" fn RegisterSoftwareDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3D9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinitializefunction: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -119,6 +121,8 @@ pub trait IDirect3D9Ex_Impl: Sized + IDirect3D9_Impl {
     fn GetAdapterLUID(&self, adapter: u32, pluid: *mut super::super::Foundation::LUID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3D9Ex {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3D9Ex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3D9Ex_Impl, const OFFSET: isize>() -> IDirect3D9Ex_Vtbl {
         unsafe extern "system" fn GetAdapterModeCountEx<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3D9Ex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, adapter: u32, pfilter: *const D3DDISPLAYMODEFILTER) -> u32 {
@@ -167,6 +171,7 @@ pub trait IDirect3DBaseTexture9_Impl: Sized + IDirect3DResource9_Impl {
     fn GetAutoGenFilterType(&self) -> D3DTEXTUREFILTERTYPE;
     fn GenerateMipSubLevels(&self);
 }
+impl ::windows::core::RuntimeName for IDirect3DBaseTexture9 {}
 impl IDirect3DBaseTexture9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DBaseTexture9_Impl, const OFFSET: isize>() -> IDirect3DBaseTexture9_Vtbl {
         unsafe extern "system" fn SetLOD<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DBaseTexture9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lodnew: u32) -> u32 {
@@ -221,6 +226,8 @@ pub trait IDirect3DCubeTexture9_Impl: Sized + IDirect3DResource9_Impl + IDirect3
     fn UnlockRect(&self, facetype: D3DCUBEMAP_FACES, level: u32) -> ::windows::core::Result<()>;
     fn AddDirtyRect(&self, facetype: D3DCUBEMAP_FACES, pdirtyrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirect3DCubeTexture9 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirect3DCubeTexture9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DCubeTexture9_Impl, const OFFSET: isize>() -> IDirect3DCubeTexture9_Vtbl {
@@ -387,6 +394,8 @@ pub trait IDirect3DDevice9_Impl: Sized {
     fn DeletePatch(&self, handle: u32) -> ::windows::core::Result<()>;
     fn CreateQuery(&self, r#type: D3DQUERYTYPE) -> ::windows::core::Result<IDirect3DQuery9>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3DDevice9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3DDevice9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9_Impl, const OFFSET: isize>() -> IDirect3DDevice9_Vtbl {
@@ -1209,6 +1218,8 @@ pub trait IDirect3DDevice9Ex_Impl: Sized + IDirect3DDevice9_Impl {
     fn GetDisplayModeEx(&self, iswapchain: u32, pmode: *mut D3DDISPLAYMODEEX, protation: *mut D3DDISPLAYROTATION) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3DDevice9Ex {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3DDevice9Ex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9Ex_Impl, const OFFSET: isize>() -> IDirect3DDevice9Ex_Vtbl {
         unsafe extern "system" fn SetConvolutionMonoKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9Ex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, width: u32, height: u32, rows: *mut f32, columns: *mut f32) -> ::windows::core::HRESULT {
@@ -1314,6 +1325,7 @@ pub trait IDirect3DIndexBuffer9_Impl: Sized + IDirect3DResource9_Impl {
     fn Unlock(&self) -> ::windows::core::Result<()>;
     fn GetDesc(&self, pdesc: *mut D3DINDEXBUFFER_DESC) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DIndexBuffer9 {}
 impl IDirect3DIndexBuffer9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DIndexBuffer9_Impl, const OFFSET: isize>() -> IDirect3DIndexBuffer9_Vtbl {
         unsafe extern "system" fn Lock<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DIndexBuffer9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offsettolock: u32, sizetolock: u32, ppbdata: *mut *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT {
@@ -1346,6 +1358,7 @@ pub trait IDirect3DPixelShader9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetFunction(&self, param0: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DPixelShader9 {}
 impl IDirect3DPixelShader9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DPixelShader9_Impl, const OFFSET: isize>() -> IDirect3DPixelShader9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DPixelShader9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1381,6 +1394,7 @@ pub trait IDirect3DQuery9_Impl: Sized {
     fn Issue(&self, dwissueflags: u32) -> ::windows::core::Result<()>;
     fn GetData(&self, pdata: *mut ::core::ffi::c_void, dwsize: u32, dwgetdataflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DQuery9 {}
 impl IDirect3DQuery9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DQuery9_Impl, const OFFSET: isize>() -> IDirect3DQuery9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DQuery9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1437,6 +1451,7 @@ pub trait IDirect3DResource9_Impl: Sized {
     fn PreLoad(&self);
     fn GetType(&self) -> D3DRESOURCETYPE;
 }
+impl ::windows::core::RuntimeName for IDirect3DResource9 {}
 impl IDirect3DResource9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DResource9_Impl, const OFFSET: isize>() -> IDirect3DResource9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DResource9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1506,6 +1521,7 @@ pub trait IDirect3DStateBlock9_Impl: Sized {
     fn Capture(&self) -> ::windows::core::Result<()>;
     fn Apply(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DStateBlock9 {}
 impl IDirect3DStateBlock9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DStateBlock9_Impl, const OFFSET: isize>() -> IDirect3DStateBlock9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DStateBlock9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1549,6 +1565,8 @@ pub trait IDirect3DSurface9_Impl: Sized + IDirect3DResource9_Impl {
     fn GetDC(&self, phdc: *mut super::Gdi::HDC) -> ::windows::core::Result<()>;
     fn ReleaseDC(&self, hdc: super::Gdi::HDC) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3DSurface9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3DSurface9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DSurface9_Impl, const OFFSET: isize>() -> IDirect3DSurface9_Vtbl {
@@ -1606,6 +1624,8 @@ pub trait IDirect3DSwapChain9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetPresentParameters(&self, ppresentationparameters: *mut D3DPRESENT_PARAMETERS) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3DSwapChain9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3DSwapChain9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DSwapChain9_Impl, const OFFSET: isize>() -> IDirect3DSwapChain9_Vtbl {
@@ -1678,6 +1698,8 @@ pub trait IDirect3DSwapChain9Ex_Impl: Sized + IDirect3DSwapChain9_Impl {
     fn GetDisplayModeEx(&self, pmode: *mut D3DDISPLAYMODEEX, protation: *mut D3DDISPLAYROTATION) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirect3DSwapChain9Ex {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirect3DSwapChain9Ex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DSwapChain9Ex_Impl, const OFFSET: isize>() -> IDirect3DSwapChain9Ex_Vtbl {
         unsafe extern "system" fn GetLastPresentCount<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DSwapChain9Ex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plastpresentcount: *mut u32) -> ::windows::core::HRESULT {
@@ -1714,6 +1736,8 @@ pub trait IDirect3DTexture9_Impl: Sized + IDirect3DResource9_Impl + IDirect3DBas
     fn UnlockRect(&self, level: u32) -> ::windows::core::Result<()>;
     fn AddDirtyRect(&self, pdirtyrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirect3DTexture9 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirect3DTexture9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DTexture9_Impl, const OFFSET: isize>() -> IDirect3DTexture9_Vtbl {
@@ -1766,6 +1790,7 @@ pub trait IDirect3DVertexBuffer9_Impl: Sized + IDirect3DResource9_Impl {
     fn Unlock(&self) -> ::windows::core::Result<()>;
     fn GetDesc(&self, pdesc: *mut D3DVERTEXBUFFER_DESC) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DVertexBuffer9 {}
 impl IDirect3DVertexBuffer9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVertexBuffer9_Impl, const OFFSET: isize>() -> IDirect3DVertexBuffer9_Vtbl {
         unsafe extern "system" fn Lock<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVertexBuffer9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offsettolock: u32, sizetolock: u32, ppbdata: *mut *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT {
@@ -1798,6 +1823,7 @@ pub trait IDirect3DVertexDeclaration9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetDeclaration(&self, pelement: *mut D3DVERTEXELEMENT9, pnumelements: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DVertexDeclaration9 {}
 impl IDirect3DVertexDeclaration9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVertexDeclaration9_Impl, const OFFSET: isize>() -> IDirect3DVertexDeclaration9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVertexDeclaration9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1830,6 +1856,7 @@ pub trait IDirect3DVertexShader9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetFunction(&self, param0: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DVertexShader9 {}
 impl IDirect3DVertexShader9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVertexShader9_Impl, const OFFSET: isize>() -> IDirect3DVertexShader9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVertexShader9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1868,6 +1895,7 @@ pub trait IDirect3DVolume9_Impl: Sized {
     fn LockBox(&self, plockedvolume: *mut D3DLOCKED_BOX, pbox: *const D3DBOX, flags: u32) -> ::windows::core::Result<()>;
     fn UnlockBox(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DVolume9 {}
 impl IDirect3DVolume9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVolume9_Impl, const OFFSET: isize>() -> IDirect3DVolume9_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVolume9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1939,6 +1967,7 @@ pub trait IDirect3DVolumeTexture9_Impl: Sized + IDirect3DResource9_Impl + IDirec
     fn UnlockBox(&self, level: u32) -> ::windows::core::Result<()>;
     fn AddDirtyBox(&self, pdirtybox: *const D3DBOX) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DVolumeTexture9 {}
 impl IDirect3DVolumeTexture9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVolumeTexture9_Impl, const OFFSET: isize>() -> IDirect3DVolumeTexture9_Vtbl {
         unsafe extern "system" fn GetLevelDesc<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DVolumeTexture9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, level: u32, pdesc: *mut D3DVOLUME_DESC) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/impl.rs
@@ -5,6 +5,8 @@ pub trait IDirect3DDevice9On12_Impl: Sized {
     fn ReturnUnderlyingResource(&self, presource: &::core::option::Option<super::Direct3D9::IDirect3DResource9>, numsync: u32, psignalvalues: *mut u64, ppfences: *mut ::core::option::Option<super::Direct3D12::ID3D12Fence>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirect3DDevice9On12 {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirect3DDevice9On12_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9On12_Impl, const OFFSET: isize>() -> IDirect3DDevice9On12_Vtbl {
         unsafe extern "system" fn GetD3D12Device<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9On12_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
@@ -9,6 +9,8 @@ pub trait IDCompositionAffineTransform2DEffect_Impl: Sized + IDCompositionEffect
     fn SetSharpness2(&self, sharpness: f32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionAffineTransform2DEffect {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionAffineTransform2DEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionAffineTransform2DEffect_Impl, const OFFSET: isize>() -> IDCompositionAffineTransform2DEffect_Vtbl {
         unsafe extern "system" fn SetInterpolationMode<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionAffineTransform2DEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interpolationmode: super::Direct2D::Common::D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE) -> ::windows::core::HRESULT {
@@ -69,6 +71,7 @@ pub trait IDCompositionAnimation_Impl: Sized {
     fn AddRepeat(&self, beginoffset: f64, durationtorepeat: f64) -> ::windows::core::Result<()>;
     fn End(&self, endoffset: f64, endvalue: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionAnimation {}
 impl IDCompositionAnimation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionAnimation_Impl, const OFFSET: isize>() -> IDCompositionAnimation_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionAnimation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -128,6 +131,8 @@ pub trait IDCompositionArithmeticCompositeEffect_Impl: Sized + IDCompositionEffe
     fn SetCoefficient4(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetCoefficient42(&self, coefficient4: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionArithmeticCompositeEffect {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionArithmeticCompositeEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionArithmeticCompositeEffect_Impl, const OFFSET: isize>() -> IDCompositionArithmeticCompositeEffect_Vtbl {
@@ -204,6 +209,8 @@ pub trait IDCompositionBlendEffect_Impl: Sized + IDCompositionEffect_Impl + IDCo
     fn SetMode(&self, mode: super::Direct2D::Common::D2D1_BLEND_MODE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for IDCompositionBlendEffect {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl IDCompositionBlendEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionBlendEffect_Impl, const OFFSET: isize>() -> IDCompositionBlendEffect_Vtbl {
         unsafe extern "system" fn SetMode<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionBlendEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: super::Direct2D::Common::D2D1_BLEND_MODE) -> ::windows::core::HRESULT {
@@ -230,6 +237,8 @@ pub trait IDCompositionBrightnessEffect_Impl: Sized + IDCompositionEffect_Impl +
     fn SetBlackPointY(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetBlackPointY2(&self, blackpointy: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for IDCompositionBrightnessEffect {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl IDCompositionBrightnessEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionBrightnessEffect_Impl, const OFFSET: isize>() -> IDCompositionBrightnessEffect_Vtbl {
@@ -302,6 +311,7 @@ impl IDCompositionBrightnessEffect_Vtbl {
     }
 }
 pub trait IDCompositionClip_Impl: Sized {}
+impl ::windows::core::RuntimeName for IDCompositionClip {}
 impl IDCompositionClip_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionClip_Impl, const OFFSET: isize>() -> IDCompositionClip_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -318,6 +328,8 @@ pub trait IDCompositionColorMatrixEffect_Impl: Sized + IDCompositionEffect_Impl 
     fn SetAlphaMode(&self, mode: super::Direct2D::Common::D2D1_COLORMATRIX_ALPHA_MODE) -> ::windows::core::Result<()>;
     fn SetClampOutput(&self, clamp: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionColorMatrixEffect {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionColorMatrixEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionColorMatrixEffect_Impl, const OFFSET: isize>() -> IDCompositionColorMatrixEffect_Vtbl {
@@ -364,6 +376,8 @@ pub trait IDCompositionCompositeEffect_Impl: Sized + IDCompositionEffect_Impl + 
     fn SetMode(&self, mode: super::Direct2D::Common::D2D1_COMPOSITE_MODE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for IDCompositionCompositeEffect {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl IDCompositionCompositeEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionCompositeEffect_Impl, const OFFSET: isize>() -> IDCompositionCompositeEffect_Vtbl {
         unsafe extern "system" fn SetMode<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionCompositeEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: super::Direct2D::Common::D2D1_COMPOSITE_MODE) -> ::windows::core::HRESULT {
@@ -384,6 +398,8 @@ pub trait IDCompositionDelegatedInkTrail_Impl: Sized {
     fn RemoveTrailPoints(&self, generationid: u32) -> ::windows::core::Result<()>;
     fn StartNewTrail(&self, color: *const super::Direct2D::Common::D2D1_COLOR_F) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for IDCompositionDelegatedInkTrail {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl IDCompositionDelegatedInkTrail_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDelegatedInkTrail_Impl, const OFFSET: isize>() -> IDCompositionDelegatedInkTrail_Vtbl {
@@ -437,6 +453,8 @@ pub trait IDCompositionDesktopDevice_Impl: Sized + IDCompositionDevice2_Impl {
     fn CreateSurfaceFromHandle(&self, handle: super::super::Foundation::HANDLE) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn CreateSurfaceFromHwnd(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionDesktopDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDCompositionDesktopDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDesktopDevice_Impl, const OFFSET: isize>() -> IDCompositionDesktopDevice_Vtbl {
@@ -511,6 +529,8 @@ pub trait IDCompositionDevice_Impl: Sized {
     fn CreateAnimation(&self) -> ::windows::core::Result<IDCompositionAnimation>;
     fn CheckDeviceState(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDCompositionDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDevice_Impl, const OFFSET: isize>() -> IDCompositionDevice_Vtbl {
@@ -823,6 +843,8 @@ pub trait IDCompositionDevice2_Impl: Sized {
     fn CreateAnimation(&self) -> ::windows::core::Result<IDCompositionAnimation>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IDCompositionDevice2 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IDCompositionDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDevice2_Impl, const OFFSET: isize>() -> IDCompositionDevice2_Vtbl {
         unsafe extern "system" fn Commit<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1090,6 +1112,8 @@ pub trait IDCompositionDevice3_Impl: Sized + IDCompositionDevice2_Impl {
     fn CreateAffineTransform2DEffect(&self) -> ::windows::core::Result<IDCompositionAffineTransform2DEffect>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IDCompositionDevice3 {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IDCompositionDevice3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDevice3_Impl, const OFFSET: isize>() -> IDCompositionDevice3_Vtbl {
         unsafe extern "system" fn CreateGaussianBlurEffect<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDevice3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gaussianblureffect: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1260,6 +1284,7 @@ pub trait IDCompositionDeviceDebug_Impl: Sized {
     fn EnableDebugCounters(&self) -> ::windows::core::Result<()>;
     fn DisableDebugCounters(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionDeviceDebug {}
 impl IDCompositionDeviceDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDeviceDebug_Impl, const OFFSET: isize>() -> IDCompositionDeviceDebug_Vtbl {
         unsafe extern "system" fn EnableDebugCounters<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionDeviceDebug_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1283,6 +1308,7 @@ impl IDCompositionDeviceDebug_Vtbl {
     }
 }
 pub trait IDCompositionEffect_Impl: Sized {}
+impl ::windows::core::RuntimeName for IDCompositionEffect {}
 impl IDCompositionEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionEffect_Impl, const OFFSET: isize>() -> IDCompositionEffect_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -1296,6 +1322,7 @@ pub trait IDCompositionEffectGroup_Impl: Sized + IDCompositionEffect_Impl {
     fn SetOpacity2(&self, opacity: f32) -> ::windows::core::Result<()>;
     fn SetTransform3D(&self, transform3d: &::core::option::Option<IDCompositionTransform3D>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionEffectGroup {}
 impl IDCompositionEffectGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionEffectGroup_Impl, const OFFSET: isize>() -> IDCompositionEffectGroup_Vtbl {
         unsafe extern "system" fn SetOpacity<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionEffectGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1327,6 +1354,7 @@ impl IDCompositionEffectGroup_Vtbl {
 pub trait IDCompositionFilterEffect_Impl: Sized + IDCompositionEffect_Impl {
     fn SetInput(&self, index: u32, input: &::core::option::Option<::windows::core::IUnknown>, flags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionFilterEffect {}
 impl IDCompositionFilterEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionFilterEffect_Impl, const OFFSET: isize>() -> IDCompositionFilterEffect_Vtbl {
         unsafe extern "system" fn SetInput<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionFilterEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, input: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT {
@@ -1346,6 +1374,8 @@ pub trait IDCompositionGaussianBlurEffect_Impl: Sized + IDCompositionEffect_Impl
     fn SetStandardDeviation2(&self, amount: f32) -> ::windows::core::Result<()>;
     fn SetBorderMode(&self, mode: super::Direct2D::Common::D2D1_BORDER_MODE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for IDCompositionGaussianBlurEffect {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl IDCompositionGaussianBlurEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionGaussianBlurEffect_Impl, const OFFSET: isize>() -> IDCompositionGaussianBlurEffect_Vtbl {
@@ -1379,6 +1409,7 @@ pub trait IDCompositionHueRotationEffect_Impl: Sized + IDCompositionEffect_Impl 
     fn SetAngle(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetAngle2(&self, amountdegrees: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionHueRotationEffect {}
 impl IDCompositionHueRotationEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionHueRotationEffect_Impl, const OFFSET: isize>() -> IDCompositionHueRotationEffect_Vtbl {
         unsafe extern "system" fn SetAngle<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionHueRotationEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1405,6 +1436,7 @@ pub trait IDCompositionInkTrailDevice_Impl: Sized {
     fn CreateDelegatedInkTrail(&self) -> ::windows::core::Result<IDCompositionDelegatedInkTrail>;
     fn CreateDelegatedInkTrailForSwapChain(&self, swapchain: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDCompositionDelegatedInkTrail>;
 }
+impl ::windows::core::RuntimeName for IDCompositionInkTrailDevice {}
 impl IDCompositionInkTrailDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionInkTrailDevice_Impl, const OFFSET: isize>() -> IDCompositionInkTrailDevice_Vtbl {
         unsafe extern "system" fn CreateDelegatedInkTrail<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionInkTrailDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inktrail: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1463,6 +1495,8 @@ pub trait IDCompositionLinearTransferEffect_Impl: Sized + IDCompositionEffect_Im
     fn SetAlphaDisable(&self, alphadisable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SetClampOutput(&self, clampoutput: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDCompositionLinearTransferEffect {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDCompositionLinearTransferEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionLinearTransferEffect_Impl, const OFFSET: isize>() -> IDCompositionLinearTransferEffect_Vtbl {
@@ -1607,6 +1641,8 @@ pub trait IDCompositionMatrixTransform_Impl: Sized + IDCompositionEffect_Impl + 
     fn SetMatrixElement2(&self, row: i32, column: i32, value: f32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Foundation_Numerics")]
+impl ::windows::core::RuntimeName for IDCompositionMatrixTransform {}
+#[cfg(feature = "Foundation_Numerics")]
 impl IDCompositionMatrixTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionMatrixTransform_Impl, const OFFSET: isize>() -> IDCompositionMatrixTransform_Vtbl {
         unsafe extern "system" fn SetMatrix<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionMatrixTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, matrix: *const super::super::super::Foundation::Numerics::Matrix3x2) -> ::windows::core::HRESULT {
@@ -1641,6 +1677,8 @@ pub trait IDCompositionMatrixTransform3D_Impl: Sized + IDCompositionEffect_Impl 
     fn SetMatrixElement(&self, row: i32, column: i32, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetMatrixElement2(&self, row: i32, column: i32, value: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for IDCompositionMatrixTransform3D {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl IDCompositionMatrixTransform3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionMatrixTransform3D_Impl, const OFFSET: isize>() -> IDCompositionMatrixTransform3D_Vtbl {
@@ -1696,6 +1734,7 @@ pub trait IDCompositionRectangleClip_Impl: Sized + IDCompositionClip_Impl {
     fn SetBottomRightRadiusY(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetBottomRightRadiusY2(&self, radius: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionRectangleClip {}
 impl IDCompositionRectangleClip_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionRectangleClip_Impl, const OFFSET: isize>() -> IDCompositionRectangleClip_Vtbl {
         unsafe extern "system" fn SetLeft<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionRectangleClip_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1858,6 +1897,7 @@ pub trait IDCompositionRotateTransform_Impl: Sized + IDCompositionEffect_Impl + 
     fn SetCenterY(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetCenterY2(&self, centery: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionRotateTransform {}
 impl IDCompositionRotateTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionRotateTransform_Impl, const OFFSET: isize>() -> IDCompositionRotateTransform_Vtbl {
         unsafe extern "system" fn SetAngle<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionRotateTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1920,6 +1960,7 @@ pub trait IDCompositionRotateTransform3D_Impl: Sized + IDCompositionEffect_Impl 
     fn SetCenterZ(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetCenterZ2(&self, centerz: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionRotateTransform3D {}
 impl IDCompositionRotateTransform3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionRotateTransform3D_Impl, const OFFSET: isize>() -> IDCompositionRotateTransform3D_Vtbl {
         unsafe extern "system" fn SetAngle<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionRotateTransform3D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2018,6 +2059,7 @@ pub trait IDCompositionSaturationEffect_Impl: Sized + IDCompositionEffect_Impl +
     fn SetSaturation(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetSaturation2(&self, ratio: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionSaturationEffect {}
 impl IDCompositionSaturationEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSaturationEffect_Impl, const OFFSET: isize>() -> IDCompositionSaturationEffect_Vtbl {
         unsafe extern "system" fn SetSaturation<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSaturationEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2050,6 +2092,7 @@ pub trait IDCompositionScaleTransform_Impl: Sized + IDCompositionEffect_Impl + I
     fn SetCenterY(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetCenterY2(&self, centery: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionScaleTransform {}
 impl IDCompositionScaleTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionScaleTransform_Impl, const OFFSET: isize>() -> IDCompositionScaleTransform_Vtbl {
         unsafe extern "system" fn SetScaleX<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionScaleTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2122,6 +2165,7 @@ pub trait IDCompositionScaleTransform3D_Impl: Sized + IDCompositionEffect_Impl +
     fn SetCenterZ(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetCenterZ2(&self, centerz: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionScaleTransform3D {}
 impl IDCompositionScaleTransform3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionScaleTransform3D_Impl, const OFFSET: isize>() -> IDCompositionScaleTransform3D_Vtbl {
         unsafe extern "system" fn SetScaleX<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionScaleTransform3D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2219,6 +2263,8 @@ pub trait IDCompositionShadowEffect_Impl: Sized + IDCompositionEffect_Impl + IDC
     fn SetAlpha2(&self, amount: f32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl ::windows::core::RuntimeName for IDCompositionShadowEffect {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl IDCompositionShadowEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionShadowEffect_Impl, const OFFSET: isize>() -> IDCompositionShadowEffect_Vtbl {
         unsafe extern "system" fn SetStandardDeviation<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionShadowEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2305,6 +2351,7 @@ pub trait IDCompositionSkewTransform_Impl: Sized + IDCompositionEffect_Impl + ID
     fn SetCenterY(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetCenterY2(&self, centery: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionSkewTransform {}
 impl IDCompositionSkewTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSkewTransform_Impl, const OFFSET: isize>() -> IDCompositionSkewTransform_Vtbl {
         unsafe extern "system" fn SetAngleX<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSkewTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2372,6 +2419,8 @@ pub trait IDCompositionSurface_Impl: Sized {
     fn Scroll(&self, scrollrect: *const super::super::Foundation::RECT, cliprect: *const super::super::Foundation::RECT, offsetx: i32, offsety: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDCompositionSurface {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDCompositionSurface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSurface_Impl, const OFFSET: isize>() -> IDCompositionSurface_Vtbl {
         unsafe extern "system" fn BeginDraw<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSurface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, updaterect: *const super::super::Foundation::RECT, iid: *const ::windows::core::GUID, updateobject: *mut *mut ::core::ffi::c_void, updateoffset: *mut super::super::Foundation::POINT) -> ::windows::core::HRESULT {
@@ -2417,6 +2466,8 @@ pub trait IDCompositionSurfaceFactory_Impl: Sized {
     fn CreateSurface(&self, width: u32, height: u32, pixelformat: super::Dxgi::Common::DXGI_FORMAT, alphamode: super::Dxgi::Common::DXGI_ALPHA_MODE) -> ::windows::core::Result<IDCompositionSurface>;
     fn CreateVirtualSurface(&self, initialwidth: u32, initialheight: u32, pixelformat: super::Dxgi::Common::DXGI_FORMAT, alphamode: super::Dxgi::Common::DXGI_ALPHA_MODE) -> ::windows::core::Result<IDCompositionVirtualSurface>;
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IDCompositionSurfaceFactory {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IDCompositionSurfaceFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionSurfaceFactory_Impl, const OFFSET: isize>() -> IDCompositionSurfaceFactory_Vtbl {
@@ -2472,6 +2523,8 @@ pub trait IDCompositionTableTransferEffect_Impl: Sized + IDCompositionEffect_Imp
     fn SetAlphaTableValue(&self, index: u32, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetAlphaTableValue2(&self, index: u32, value: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDCompositionTableTransferEffect {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDCompositionTableTransferEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTableTransferEffect_Impl, const OFFSET: isize>() -> IDCompositionTableTransferEffect_Vtbl {
@@ -2588,6 +2641,7 @@ impl IDCompositionTableTransferEffect_Vtbl {
 pub trait IDCompositionTarget_Impl: Sized {
     fn SetRoot(&self, visual: &::core::option::Option<IDCompositionVisual>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionTarget {}
 impl IDCompositionTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTarget_Impl, const OFFSET: isize>() -> IDCompositionTarget_Vtbl {
         unsafe extern "system" fn SetRoot<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, visual: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2602,6 +2656,7 @@ impl IDCompositionTarget_Vtbl {
     }
 }
 pub trait IDCompositionTransform_Impl: Sized + IDCompositionEffect_Impl + IDCompositionTransform3D_Impl {}
+impl ::windows::core::RuntimeName for IDCompositionTransform {}
 impl IDCompositionTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTransform_Impl, const OFFSET: isize>() -> IDCompositionTransform_Vtbl {
         Self { base__: IDCompositionTransform3D_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2611,6 +2666,7 @@ impl IDCompositionTransform_Vtbl {
     }
 }
 pub trait IDCompositionTransform3D_Impl: Sized + IDCompositionEffect_Impl {}
+impl ::windows::core::RuntimeName for IDCompositionTransform3D {}
 impl IDCompositionTransform3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTransform3D_Impl, const OFFSET: isize>() -> IDCompositionTransform3D_Vtbl {
         Self { base__: IDCompositionEffect_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2625,6 +2681,7 @@ pub trait IDCompositionTranslateTransform_Impl: Sized + IDCompositionEffect_Impl
     fn SetOffsetY(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetOffsetY2(&self, offsety: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionTranslateTransform {}
 impl IDCompositionTranslateTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTranslateTransform_Impl, const OFFSET: isize>() -> IDCompositionTranslateTransform_Vtbl {
         unsafe extern "system" fn SetOffsetX<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTranslateTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2667,6 +2724,7 @@ pub trait IDCompositionTranslateTransform3D_Impl: Sized + IDCompositionEffect_Im
     fn SetOffsetZ(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetOffsetZ2(&self, offsetz: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDCompositionTranslateTransform3D {}
 impl IDCompositionTranslateTransform3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTranslateTransform3D_Impl, const OFFSET: isize>() -> IDCompositionTranslateTransform3D_Vtbl {
         unsafe extern "system" fn SetOffsetX<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTranslateTransform3D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2723,6 +2781,8 @@ pub trait IDCompositionTurbulenceEffect_Impl: Sized + IDCompositionEffect_Impl +
     fn SetNoise(&self, noise: super::Direct2D::Common::D2D1_TURBULENCE_NOISE) -> ::windows::core::Result<()>;
     fn SetStitchable(&self, stitchable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionTurbulenceEffect {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionTurbulenceEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionTurbulenceEffect_Impl, const OFFSET: isize>() -> IDCompositionTurbulenceEffect_Vtbl {
@@ -2782,6 +2842,8 @@ pub trait IDCompositionVirtualSurface_Impl: Sized + IDCompositionSurface_Impl {
     fn Trim(&self, rectangles: *const super::super::Foundation::RECT, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDCompositionVirtualSurface {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDCompositionVirtualSurface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVirtualSurface_Impl, const OFFSET: isize>() -> IDCompositionVirtualSurface_Vtbl {
         unsafe extern "system" fn Resize<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVirtualSurface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, width: u32, height: u32) -> ::windows::core::HRESULT {
@@ -2824,6 +2886,8 @@ pub trait IDCompositionVisual_Impl: Sized {
     fn RemoveAllVisuals(&self) -> ::windows::core::Result<()>;
     fn SetCompositeMode(&self, compositemode: DCOMPOSITION_COMPOSITE_MODE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionVisual {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionVisual_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVisual_Impl, const OFFSET: isize>() -> IDCompositionVisual_Vtbl {
@@ -2943,6 +3007,8 @@ pub trait IDCompositionVisual2_Impl: Sized + IDCompositionVisual_Impl {
     fn SetBackFaceVisibility(&self, visibility: DCOMPOSITION_BACKFACE_VISIBILITY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionVisual2 {}
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionVisual2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVisual2_Impl, const OFFSET: isize>() -> IDCompositionVisual2_Vtbl {
         unsafe extern "system" fn SetOpacityMode<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVisual2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: DCOMPOSITION_OPACITY_MODE) -> ::windows::core::HRESULT {
@@ -2976,6 +3042,8 @@ pub trait IDCompositionVisual3_Impl: Sized + IDCompositionVisual_Impl + IDCompos
     fn SetTransform4(&self, matrix: *const super::Direct2D::Common::D2D_MATRIX_4X4_F) -> ::windows::core::Result<()>;
     fn SetVisible(&self, visible: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionVisual3 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionVisual3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVisual3_Impl, const OFFSET: isize>() -> IDCompositionVisual3_Vtbl {
@@ -3042,6 +3110,8 @@ pub trait IDCompositionVisualDebug_Impl: Sized + IDCompositionVisual_Impl + IDCo
     fn EnableRedrawRegions(&self) -> ::windows::core::Result<()>;
     fn DisableRedrawRegions(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDCompositionVisualDebug {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDCompositionVisualDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCompositionVisualDebug_Impl, const OFFSET: isize>() -> IDCompositionVisualDebug_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
@@ -6,6 +6,8 @@ pub trait IDDVideoPortContainer_Impl: Sized {
     fn QueryVideoPortStatus(&self, param0: u32, param1: *mut DDVIDEOPORTSTATUS) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDDVideoPortContainer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDDVideoPortContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDDVideoPortContainer_Impl, const OFFSET: isize>() -> IDDVideoPortContainer_Vtbl {
         unsafe extern "system" fn CreateVideoPort<Identity: ::windows::core::IUnknownImpl, Impl: IDDVideoPortContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut DDVIDEOPORTDESC, param2: *mut ::windows::core::RawPtr, param3: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -63,6 +65,8 @@ pub trait IDirectDraw_Impl: Sized {
     fn SetDisplayMode(&self, param0: u32, param1: u32, param2: u32) -> ::windows::core::Result<()>;
     fn WaitForVerticalBlank(&self, param0: u32, param1: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDraw {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDraw_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDraw_Impl, const OFFSET: isize>() -> IDirectDraw_Vtbl {
@@ -230,6 +234,8 @@ pub trait IDirectDraw2_Impl: Sized {
     fn WaitForVerticalBlank(&self, param0: u32, param1: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn GetAvailableVidMem(&self, param0: *mut DDSCAPS, param1: *mut u32, param2: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDraw2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDraw2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDraw2_Impl, const OFFSET: isize>() -> IDirectDraw2_Vtbl {
@@ -407,6 +413,8 @@ pub trait IDirectDraw4_Impl: Sized {
     fn TestCooperativeLevel(&self) -> ::windows::core::Result<()>;
     fn GetDeviceIdentifier(&self, param0: *mut DDDEVICEIDENTIFIER, param1: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDraw4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDraw4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDraw4_Impl, const OFFSET: isize>() -> IDirectDraw4_Vtbl {
@@ -617,6 +625,8 @@ pub trait IDirectDraw7_Impl: Sized {
     fn EvaluateMode(&self, param0: u32, param1: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDraw7 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDraw7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDraw7_Impl, const OFFSET: isize>() -> IDirectDraw7_Vtbl {
         unsafe extern "system" fn Compact<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDraw7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -817,6 +827,8 @@ pub trait IDirectDrawClipper_Impl: Sized {
     fn SetHWnd(&self, param0: u32, param1: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDrawClipper {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDrawClipper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawClipper_Impl, const OFFSET: isize>() -> IDirectDrawClipper_Vtbl {
         unsafe extern "system" fn GetClipList<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawClipper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT, param1: *mut super::Gdi::RGNDATA, param2: *mut u32) -> ::windows::core::HRESULT {
@@ -867,6 +879,7 @@ pub trait IDirectDrawColorControl_Impl: Sized {
     fn GetColorControls(&self, param0: *mut DDCOLORCONTROL) -> ::windows::core::Result<()>;
     fn SetColorControls(&self, param0: *mut DDCOLORCONTROL) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectDrawColorControl {}
 impl IDirectDrawColorControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawColorControl_Impl, const OFFSET: isize>() -> IDirectDrawColorControl_Vtbl {
         unsafe extern "system" fn GetColorControls<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawColorControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut DDCOLORCONTROL) -> ::windows::core::HRESULT {
@@ -893,6 +906,7 @@ pub trait IDirectDrawGammaControl_Impl: Sized {
     fn GetGammaRamp(&self, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::Result<()>;
     fn SetGammaRamp(&self, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectDrawGammaControl {}
 impl IDirectDrawGammaControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawGammaControl_Impl, const OFFSET: isize>() -> IDirectDrawGammaControl_Vtbl {
         unsafe extern "system" fn GetGammaRamp<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawGammaControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::HRESULT {
@@ -920,6 +934,7 @@ pub trait IDirectDrawKernel_Impl: Sized {
     fn GetKernelHandle(&self, param0: *mut usize) -> ::windows::core::Result<()>;
     fn ReleaseKernelHandle(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectDrawKernel {}
 impl IDirectDrawKernel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawKernel_Impl, const OFFSET: isize>() -> IDirectDrawKernel_Vtbl {
         unsafe extern "system" fn GetCaps<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawKernel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut DDKERNELCAPS) -> ::windows::core::HRESULT {
@@ -955,6 +970,8 @@ pub trait IDirectDrawPalette_Impl: Sized {
     fn Initialize(&self, param0: &::core::option::Option<IDirectDraw>, param1: u32, param2: *mut super::Gdi::PALETTEENTRY) -> ::windows::core::Result<()>;
     fn SetEntries(&self, param0: u32, param1: u32, param2: u32, param3: *mut super::Gdi::PALETTEENTRY) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IDirectDrawPalette {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl IDirectDrawPalette_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawPalette_Impl, const OFFSET: isize>() -> IDirectDrawPalette_Vtbl {
@@ -1026,6 +1043,8 @@ pub trait IDirectDrawSurface_Impl: Sized {
     fn UpdateOverlayDisplay(&self, param0: u32) -> ::windows::core::Result<()>;
     fn UpdateOverlayZOrder(&self, param0: u32, param1: &::core::option::Option<IDirectDrawSurface>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDrawSurface {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDrawSurface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurface_Impl, const OFFSET: isize>() -> IDirectDrawSurface_Vtbl {
@@ -1286,6 +1305,8 @@ pub trait IDirectDrawSurface2_Impl: Sized {
     fn PageLock(&self, param0: u32) -> ::windows::core::Result<()>;
     fn PageUnlock(&self, param0: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDrawSurface2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDrawSurface2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurface2_Impl, const OFFSET: isize>() -> IDirectDrawSurface2_Vtbl {
@@ -1565,6 +1586,8 @@ pub trait IDirectDrawSurface3_Impl: Sized {
     fn PageUnlock(&self, param0: u32) -> ::windows::core::Result<()>;
     fn SetSurfaceDesc(&self, param0: *mut DDSURFACEDESC, param1: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDrawSurface3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDrawSurface3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurface3_Impl, const OFFSET: isize>() -> IDirectDrawSurface3_Vtbl {
@@ -1855,6 +1878,8 @@ pub trait IDirectDrawSurface4_Impl: Sized {
     fn GetUniquenessValue(&self, param0: *mut u32) -> ::windows::core::Result<()>;
     fn ChangeUniquenessValue(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDrawSurface4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDrawSurface4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurface4_Impl, const OFFSET: isize>() -> IDirectDrawSurface4_Vtbl {
@@ -2180,6 +2205,8 @@ pub trait IDirectDrawSurface7_Impl: Sized {
     fn GetLOD(&self, param0: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDirectDrawSurface7 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDirectDrawSurface7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurface7_Impl, const OFFSET: isize>() -> IDirectDrawSurface7_Vtbl {
         unsafe extern "system" fn AddAttachedSurface<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurface7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2482,6 +2509,7 @@ pub trait IDirectDrawSurfaceKernel_Impl: Sized {
     fn GetKernelHandle(&self, param0: *mut usize) -> ::windows::core::Result<()>;
     fn ReleaseKernelHandle(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectDrawSurfaceKernel {}
 impl IDirectDrawSurfaceKernel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurfaceKernel_Impl, const OFFSET: isize>() -> IDirectDrawSurfaceKernel_Vtbl {
         unsafe extern "system" fn GetKernelHandle<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawSurfaceKernel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut usize) -> ::windows::core::HRESULT {
@@ -2521,6 +2549,8 @@ pub trait IDirectDrawVideoPort_Impl: Sized {
     fn UpdateVideo(&self, param0: *mut DDVIDEOPORTINFO) -> ::windows::core::Result<()>;
     fn WaitForSync(&self, param0: u32, param1: u32, param2: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectDrawVideoPort {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectDrawVideoPort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawVideoPort_Impl, const OFFSET: isize>() -> IDirectDrawVideoPort_Vtbl {
@@ -2621,6 +2651,8 @@ pub trait IDirectDrawVideoPortNotify_Impl: Sized {
     fn AcquireNotification(&self, param0: *mut super::super::Foundation::HANDLE, param1: *mut DDVIDEOPORTNOTIFY) -> ::windows::core::Result<()>;
     fn ReleaseNotification(&self, param0: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectDrawVideoPortNotify {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectDrawVideoPortNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawVideoPortNotify_Impl, const OFFSET: isize>() -> IDirectDrawVideoPortNotify_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
@@ -1,6 +1,7 @@
 pub trait IDirectManipulationAutoScrollBehavior_Impl: Sized {
     fn SetConfiguration(&self, motiontypes: DIRECTMANIPULATION_MOTION_TYPES, scrollmotion: DIRECTMANIPULATION_AUTOSCROLL_CONFIGURATION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationAutoScrollBehavior {}
 impl IDirectManipulationAutoScrollBehavior_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationAutoScrollBehavior_Impl, const OFFSET: isize>() -> IDirectManipulationAutoScrollBehavior_Vtbl {
         unsafe extern "system" fn SetConfiguration<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationAutoScrollBehavior_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, motiontypes: DIRECTMANIPULATION_MOTION_TYPES, scrollmotion: DIRECTMANIPULATION_AUTOSCROLL_CONFIGURATION) -> ::windows::core::HRESULT {
@@ -20,6 +21,7 @@ pub trait IDirectManipulationCompositor_Impl: Sized {
     fn SetUpdateManager(&self, updatemanager: &::core::option::Option<IDirectManipulationUpdateManager>) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationCompositor {}
 impl IDirectManipulationCompositor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationCompositor_Impl, const OFFSET: isize>() -> IDirectManipulationCompositor_Vtbl {
         unsafe extern "system" fn AddContent<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationCompositor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, content: ::windows::core::RawPtr, device: *mut ::core::ffi::c_void, parentvisual: *mut ::core::ffi::c_void, childvisual: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -57,6 +59,7 @@ impl IDirectManipulationCompositor_Vtbl {
 pub trait IDirectManipulationCompositor2_Impl: Sized + IDirectManipulationCompositor_Impl {
     fn AddContentWithCrossProcessChaining(&self, content: &::core::option::Option<IDirectManipulationPrimaryContent>, device: &::core::option::Option<::windows::core::IUnknown>, parentvisual: &::core::option::Option<::windows::core::IUnknown>, childvisual: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationCompositor2 {}
 impl IDirectManipulationCompositor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationCompositor2_Impl, const OFFSET: isize>() -> IDirectManipulationCompositor2_Vtbl {
         unsafe extern "system" fn AddContentWithCrossProcessChaining<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationCompositor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, content: ::windows::core::RawPtr, device: *mut ::core::ffi::c_void, parentvisual: *mut ::core::ffi::c_void, childvisual: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -84,6 +87,8 @@ pub trait IDirectManipulationContent_Impl: Sized {
     fn GetContentTransform(&self, matrix: *mut f32, pointcount: u32) -> ::windows::core::Result<()>;
     fn SyncContentTransform(&self, matrix: *const f32, pointcount: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectManipulationContent {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectManipulationContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationContent_Impl, const OFFSET: isize>() -> IDirectManipulationContent_Vtbl {
@@ -154,6 +159,7 @@ pub trait IDirectManipulationDeferContactService_Impl: Sized {
     fn CancelContact(&self, pointerid: u32) -> ::windows::core::Result<()>;
     fn CancelDeferral(&self, pointerid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationDeferContactService {}
 impl IDirectManipulationDeferContactService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationDeferContactService_Impl, const OFFSET: isize>() -> IDirectManipulationDeferContactService_Vtbl {
         unsafe extern "system" fn DeferContact<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationDeferContactService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pointerid: u32, timeout: u32) -> ::windows::core::HRESULT {
@@ -186,6 +192,7 @@ pub trait IDirectManipulationDragDropBehavior_Impl: Sized {
     fn SetConfiguration(&self, configuration: DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION) -> ::windows::core::Result<()>;
     fn GetStatus(&self) -> ::windows::core::Result<DIRECTMANIPULATION_DRAG_DROP_STATUS>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationDragDropBehavior {}
 impl IDirectManipulationDragDropBehavior_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationDragDropBehavior_Impl, const OFFSET: isize>() -> IDirectManipulationDragDropBehavior_Vtbl {
         unsafe extern "system" fn SetConfiguration<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationDragDropBehavior_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, configuration: DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION) -> ::windows::core::HRESULT {
@@ -217,6 +224,7 @@ impl IDirectManipulationDragDropBehavior_Vtbl {
 pub trait IDirectManipulationDragDropEventHandler_Impl: Sized {
     fn OnDragDropStatusChange(&self, viewport: &::core::option::Option<IDirectManipulationViewport2>, current: DIRECTMANIPULATION_DRAG_DROP_STATUS, previous: DIRECTMANIPULATION_DRAG_DROP_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationDragDropEventHandler {}
 impl IDirectManipulationDragDropEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationDragDropEventHandler_Impl, const OFFSET: isize>() -> IDirectManipulationDragDropEventHandler_Vtbl {
         unsafe extern "system" fn OnDragDropStatusChange<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationDragDropEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, viewport: ::windows::core::RawPtr, current: DIRECTMANIPULATION_DRAG_DROP_STATUS, previous: DIRECTMANIPULATION_DRAG_DROP_STATUS) -> ::windows::core::HRESULT {
@@ -233,6 +241,7 @@ impl IDirectManipulationDragDropEventHandler_Vtbl {
 pub trait IDirectManipulationFrameInfoProvider_Impl: Sized {
     fn GetNextFrameInfo(&self, time: *mut u64, processtime: *mut u64, compositiontime: *mut u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationFrameInfoProvider {}
 impl IDirectManipulationFrameInfoProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationFrameInfoProvider_Impl, const OFFSET: isize>() -> IDirectManipulationFrameInfoProvider_Vtbl {
         unsafe extern "system" fn GetNextFrameInfo<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationFrameInfoProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, time: *mut u64, processtime: *mut u64, compositiontime: *mut u64) -> ::windows::core::HRESULT {
@@ -249,6 +258,7 @@ impl IDirectManipulationFrameInfoProvider_Vtbl {
 pub trait IDirectManipulationInteractionEventHandler_Impl: Sized {
     fn OnInteraction(&self, viewport: &::core::option::Option<IDirectManipulationViewport2>, interaction: DIRECTMANIPULATION_INTERACTION_TYPE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationInteractionEventHandler {}
 impl IDirectManipulationInteractionEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationInteractionEventHandler_Impl, const OFFSET: isize>() -> IDirectManipulationInteractionEventHandler_Vtbl {
         unsafe extern "system" fn OnInteraction<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationInteractionEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, viewport: ::windows::core::RawPtr, interaction: DIRECTMANIPULATION_INTERACTION_TYPE) -> ::windows::core::HRESULT {
@@ -272,6 +282,8 @@ pub trait IDirectManipulationManager_Impl: Sized {
     fn CreateViewport(&self, frameinfo: &::core::option::Option<IDirectManipulationFrameInfoProvider>, window: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateContent(&self, frameinfo: &::core::option::Option<IDirectManipulationFrameInfoProvider>, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDirectManipulationManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDirectManipulationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationManager_Impl, const OFFSET: isize>() -> IDirectManipulationManager_Vtbl {
@@ -336,6 +348,8 @@ pub trait IDirectManipulationManager2_Impl: Sized + IDirectManipulationManager_I
     fn CreateBehavior(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDirectManipulationManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDirectManipulationManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationManager2_Impl, const OFFSET: isize>() -> IDirectManipulationManager2_Vtbl {
         unsafe extern "system" fn CreateBehavior<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -353,6 +367,8 @@ impl IDirectManipulationManager2_Vtbl {
 pub trait IDirectManipulationManager3_Impl: Sized + IDirectManipulationManager_Impl + IDirectManipulationManager2_Impl {
     fn GetService(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDirectManipulationManager3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDirectManipulationManager3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationManager3_Impl, const OFFSET: isize>() -> IDirectManipulationManager3_Vtbl {
@@ -378,6 +394,7 @@ pub trait IDirectManipulationPrimaryContent_Impl: Sized {
     fn GetInertiaEndTransform(&self, matrix: *mut f32, pointcount: u32) -> ::windows::core::Result<()>;
     fn GetCenterPoint(&self, centerx: *mut f32, centery: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationPrimaryContent {}
 impl IDirectManipulationPrimaryContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationPrimaryContent_Impl, const OFFSET: isize>() -> IDirectManipulationPrimaryContent_Vtbl {
         unsafe extern "system" fn SetSnapInterval<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationPrimaryContent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, motion: DIRECTMANIPULATION_MOTION_TYPES, interval: f32, offset: f32) -> ::windows::core::HRESULT {
@@ -445,6 +462,7 @@ impl IDirectManipulationPrimaryContent_Vtbl {
 pub trait IDirectManipulationUpdateHandler_Impl: Sized {
     fn Update(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationUpdateHandler {}
 impl IDirectManipulationUpdateHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationUpdateHandler_Impl, const OFFSET: isize>() -> IDirectManipulationUpdateHandler_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationUpdateHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -464,6 +482,8 @@ pub trait IDirectManipulationUpdateManager_Impl: Sized {
     fn UnregisterWaitHandleCallback(&self, cookie: u32) -> ::windows::core::Result<()>;
     fn Update(&self, frameinfo: &::core::option::Option<IDirectManipulationFrameInfoProvider>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectManipulationUpdateManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectManipulationUpdateManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationUpdateManager_Impl, const OFFSET: isize>() -> IDirectManipulationUpdateManager_Vtbl {
@@ -530,6 +550,8 @@ pub trait IDirectManipulationViewport_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn Abandon(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectManipulationViewport {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectManipulationViewport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationViewport_Impl, const OFFSET: isize>() -> IDirectManipulationViewport_Vtbl {
@@ -734,6 +756,8 @@ pub trait IDirectManipulationViewport2_Impl: Sized + IDirectManipulationViewport
     fn RemoveAllBehaviors(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectManipulationViewport2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectManipulationViewport2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationViewport2_Impl, const OFFSET: isize>() -> IDirectManipulationViewport2_Vtbl {
         unsafe extern "system" fn AddBehavior<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationViewport2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, behavior: *mut ::core::ffi::c_void, cookie: *mut u32) -> ::windows::core::HRESULT {
@@ -773,6 +797,7 @@ pub trait IDirectManipulationViewportEventHandler_Impl: Sized {
     fn OnViewportUpdated(&self, viewport: &::core::option::Option<IDirectManipulationViewport>) -> ::windows::core::Result<()>;
     fn OnContentUpdated(&self, viewport: &::core::option::Option<IDirectManipulationViewport>, content: &::core::option::Option<IDirectManipulationContent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectManipulationViewportEventHandler {}
 impl IDirectManipulationViewportEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationViewportEventHandler_Impl, const OFFSET: isize>() -> IDirectManipulationViewportEventHandler_Vtbl {
         unsafe extern "system" fn OnViewportStatusChanged<Identity: ::windows::core::IUnknownImpl, Impl: IDirectManipulationViewportEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, viewport: ::windows::core::RawPtr, current: DIRECTMANIPULATION_STATUS, previous: DIRECTMANIPULATION_STATUS) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
@@ -4,6 +4,8 @@ pub trait IDWriteAsyncResult_Impl: Sized {
     fn GetResult(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteAsyncResult {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteAsyncResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteAsyncResult_Impl, const OFFSET: isize>() -> IDWriteAsyncResult_Vtbl {
         unsafe extern "system" fn GetWaitHandle<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteAsyncResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::HANDLE {
@@ -37,6 +39,8 @@ pub trait IDWriteBitmapRenderTarget_Impl: Sized {
     fn GetSize(&self) -> ::windows::core::Result<super::super::Foundation::SIZE>;
     fn Resize(&self, width: u32, height: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteBitmapRenderTarget {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteBitmapRenderTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteBitmapRenderTarget_Impl, const OFFSET: isize>() -> IDWriteBitmapRenderTarget_Vtbl {
@@ -120,6 +124,8 @@ pub trait IDWriteBitmapRenderTarget1_Impl: Sized + IDWriteBitmapRenderTarget_Imp
     fn SetTextAntialiasMode(&self, antialiasmode: DWRITE_TEXT_ANTIALIAS_MODE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteBitmapRenderTarget1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteBitmapRenderTarget1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteBitmapRenderTarget1_Impl, const OFFSET: isize>() -> IDWriteBitmapRenderTarget1_Vtbl {
         unsafe extern "system" fn GetTextAntialiasMode<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteBitmapRenderTarget1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> DWRITE_TEXT_ANTIALIAS_MODE {
@@ -147,6 +153,8 @@ pub trait IDWriteColorGlyphRunEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetCurrentRun(&self) -> ::windows::core::Result<*mut DWRITE_COLOR_GLYPH_RUN>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteColorGlyphRunEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteColorGlyphRunEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteColorGlyphRunEnumerator_Impl, const OFFSET: isize>() -> IDWriteColorGlyphRunEnumerator_Vtbl {
@@ -186,6 +194,8 @@ impl IDWriteColorGlyphRunEnumerator_Vtbl {
 pub trait IDWriteColorGlyphRunEnumerator1_Impl: Sized + IDWriteColorGlyphRunEnumerator_Impl {
     fn GetCurrentRun2(&self) -> ::windows::core::Result<*mut DWRITE_COLOR_GLYPH_RUN1>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteColorGlyphRunEnumerator1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteColorGlyphRunEnumerator1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteColorGlyphRunEnumerator1_Impl, const OFFSET: isize>() -> IDWriteColorGlyphRunEnumerator1_Vtbl {
@@ -230,6 +240,8 @@ pub trait IDWriteFactory_Impl: Sized {
     fn CreateNumberSubstitution(&self, substitutionmethod: DWRITE_NUMBER_SUBSTITUTION_METHOD, localename: &::windows::core::PCWSTR, ignoreuseroverride: super::super::Foundation::BOOL) -> ::windows::core::Result<IDWriteNumberSubstitution>;
     fn CreateGlyphRunAnalysis(&self, glyphrun: *const DWRITE_GLYPH_RUN, pixelsperdip: f32, transform: *const DWRITE_MATRIX, renderingmode: DWRITE_RENDERING_MODE, measuringmode: DWRITE_MEASURING_MODE, baselineoriginx: f32, baselineoriginy: f32) -> ::windows::core::Result<IDWriteGlyphRunAnalysis>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory_Impl, const OFFSET: isize>() -> IDWriteFactory_Vtbl {
@@ -469,6 +481,8 @@ pub trait IDWriteFactory1_Impl: Sized + IDWriteFactory_Impl {
     fn CreateCustomRenderingParams2(&self, gamma: f32, enhancedcontrast: f32, enhancedcontrastgrayscale: f32, cleartypelevel: f32, pixelgeometry: DWRITE_PIXEL_GEOMETRY, renderingmode: DWRITE_RENDERING_MODE) -> ::windows::core::Result<IDWriteRenderingParams1>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory1_Impl, const OFFSET: isize>() -> IDWriteFactory1_Vtbl {
         unsafe extern "system" fn GetEudcFontCollection<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontcollection: *mut ::windows::core::RawPtr, checkforupdates: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -505,6 +519,8 @@ pub trait IDWriteFactory2_Impl: Sized + IDWriteFactory_Impl + IDWriteFactory1_Im
     fn CreateCustomRenderingParams3(&self, gamma: f32, enhancedcontrast: f32, grayscaleenhancedcontrast: f32, cleartypelevel: f32, pixelgeometry: DWRITE_PIXEL_GEOMETRY, renderingmode: DWRITE_RENDERING_MODE, gridfitmode: DWRITE_GRID_FIT_MODE) -> ::windows::core::Result<IDWriteRenderingParams2>;
     fn CreateGlyphRunAnalysis2(&self, glyphrun: *const DWRITE_GLYPH_RUN, transform: *const DWRITE_MATRIX, renderingmode: DWRITE_RENDERING_MODE, measuringmode: DWRITE_MEASURING_MODE, gridfitmode: DWRITE_GRID_FIT_MODE, antialiasmode: DWRITE_TEXT_ANTIALIAS_MODE, baselineoriginx: f32, baselineoriginy: f32) -> ::windows::core::Result<IDWriteGlyphRunAnalysis>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory2_Impl, const OFFSET: isize>() -> IDWriteFactory2_Vtbl {
@@ -588,6 +604,8 @@ pub trait IDWriteFactory3_Impl: Sized + IDWriteFactory_Impl + IDWriteFactory1_Im
     fn GetSystemFontCollection2(&self, includedownloadablefonts: super::super::Foundation::BOOL, fontcollection: *mut ::core::option::Option<IDWriteFontCollection1>, checkforupdates: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetFontDownloadQueue(&self) -> ::windows::core::Result<IDWriteFontDownloadQueue>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory3_Impl, const OFFSET: isize>() -> IDWriteFactory3_Vtbl {
@@ -708,6 +726,8 @@ pub trait IDWriteFactory4_Impl: Sized + IDWriteFactory_Impl + IDWriteFactory1_Im
     fn ComputeGlyphOrigins2(&self, glyphrun: *const DWRITE_GLYPH_RUN, measuringmode: DWRITE_MEASURING_MODE, baselineorigin: &super::Direct2D::Common::D2D_POINT_2F, worldanddpitransform: *const DWRITE_MATRIX) -> ::windows::core::Result<super::Direct2D::Common::D2D_POINT_2F>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory4_Impl, const OFFSET: isize>() -> IDWriteFactory4_Vtbl {
         unsafe extern "system" fn TranslateColorGlyphRun2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, baselineorigin: super::Direct2D::Common::D2D_POINT_2F, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, desiredglyphimageformats: DWRITE_GLYPH_IMAGE_FORMATS, measuringmode: DWRITE_MEASURING_MODE, worldanddpitransform: *const DWRITE_MATRIX, colorpaletteindex: u32, colorlayers: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -762,6 +782,8 @@ pub trait IDWriteFactory5_Impl: Sized + IDWriteFactory_Impl + IDWriteFactory1_Im
     fn AnalyzeContainerType(&self, filedata: *const ::core::ffi::c_void, filedatasize: u32) -> DWRITE_CONTAINER_TYPE;
     fn UnpackFontFile(&self, containertype: DWRITE_CONTAINER_TYPE, filedata: *const ::core::ffi::c_void, filedatasize: u32) -> ::windows::core::Result<IDWriteFontFileStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory5_Impl, const OFFSET: isize>() -> IDWriteFactory5_Vtbl {
@@ -837,6 +859,8 @@ pub trait IDWriteFactory6_Impl: Sized + IDWriteFactory_Impl + IDWriteFactory1_Im
     fn CreateFontSetBuilder3(&self) -> ::windows::core::Result<IDWriteFontSetBuilder2>;
     fn CreateTextFormat2(&self, fontfamilyname: &::windows::core::PCWSTR, fontcollection: &::core::option::Option<IDWriteFontCollection>, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, fontsize: f32, localename: &::windows::core::PCWSTR) -> ::windows::core::Result<IDWriteTextFormat3>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory6 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory6_Impl, const OFFSET: isize>() -> IDWriteFactory6_Vtbl {
@@ -938,6 +962,8 @@ pub trait IDWriteFactory7_Impl: Sized + IDWriteFactory_Impl + IDWriteFactory1_Im
     fn GetSystemFontCollection4(&self, includedownloadablefonts: super::super::Foundation::BOOL, fontfamilymodel: DWRITE_FONT_FAMILY_MODEL) -> ::windows::core::Result<IDWriteFontCollection3>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteFactory7 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteFactory7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory7_Impl, const OFFSET: isize>() -> IDWriteFactory7_Vtbl {
         unsafe extern "system" fn GetSystemFontSet3<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFactory7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, includedownloadablefonts: super::super::Foundation::BOOL, fontset: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -986,6 +1012,8 @@ pub trait IDWriteFont_Impl: Sized {
     fn HasCharacter(&self, unicodevalue: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn CreateFontFace(&self) -> ::windows::core::Result<IDWriteFontFace>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFont {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFont_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFont_Impl, const OFFSET: isize>() -> IDWriteFont_Vtbl {
@@ -1095,6 +1123,8 @@ pub trait IDWriteFont1_Impl: Sized + IDWriteFont_Impl {
     fn IsMonospacedFont(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFont1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFont1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFont1_Impl, const OFFSET: isize>() -> IDWriteFont1_Vtbl {
         unsafe extern "system" fn GetMetrics2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFont1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontmetrics: *mut DWRITE_FONT_METRICS1) {
@@ -1134,6 +1164,8 @@ pub trait IDWriteFont2_Impl: Sized + IDWriteFont_Impl + IDWriteFont1_Impl {
     fn IsColorFont(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFont2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFont2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFont2_Impl, const OFFSET: isize>() -> IDWriteFont2_Vtbl {
         unsafe extern "system" fn IsColorFont<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFont2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
@@ -1155,6 +1187,8 @@ pub trait IDWriteFont3_Impl: Sized + IDWriteFont_Impl + IDWriteFont1_Impl + IDWr
     fn HasCharacter2(&self, unicodevalue: u32) -> super::super::Foundation::BOOL;
     fn GetLocality(&self) -> DWRITE_LOCALITY;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFont3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFont3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFont3_Impl, const OFFSET: isize>() -> IDWriteFont3_Vtbl {
@@ -1216,6 +1250,8 @@ pub trait IDWriteFontCollection_Impl: Sized {
     fn GetFontFromFontFace(&self, fontface: &::core::option::Option<IDWriteFontFace>) -> ::windows::core::Result<IDWriteFont>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontCollection {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection_Impl, const OFFSET: isize>() -> IDWriteFontCollection_Vtbl {
         unsafe extern "system" fn GetFontFamilyCount<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -1268,6 +1304,8 @@ pub trait IDWriteFontCollection1_Impl: Sized + IDWriteFontCollection_Impl {
     fn GetFontFamily2(&self, index: u32) -> ::windows::core::Result<IDWriteFontFamily1>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontCollection1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontCollection1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection1_Impl, const OFFSET: isize>() -> IDWriteFontCollection1_Vtbl {
         unsafe extern "system" fn GetFontSet<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontset: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1309,6 +1347,8 @@ pub trait IDWriteFontCollection2_Impl: Sized + IDWriteFontCollection_Impl + IDWr
     fn GetFontFamilyModel(&self) -> DWRITE_FONT_FAMILY_MODEL;
     fn GetFontSet2(&self) -> ::windows::core::Result<IDWriteFontSet1>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontCollection2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontCollection2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection2_Impl, const OFFSET: isize>() -> IDWriteFontCollection2_Vtbl {
@@ -1367,6 +1407,8 @@ pub trait IDWriteFontCollection3_Impl: Sized + IDWriteFontCollection_Impl + IDWr
     fn GetExpirationEvent(&self) -> super::super::Foundation::HANDLE;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontCollection3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontCollection3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection3_Impl, const OFFSET: isize>() -> IDWriteFontCollection3_Vtbl {
         unsafe extern "system" fn GetExpirationEvent<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollection3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::HANDLE {
@@ -1383,6 +1425,7 @@ impl IDWriteFontCollection3_Vtbl {
 pub trait IDWriteFontCollectionLoader_Impl: Sized {
     fn CreateEnumeratorFromKey(&self, factory: &::core::option::Option<IDWriteFactory>, collectionkey: *const ::core::ffi::c_void, collectionkeysize: u32) -> ::windows::core::Result<IDWriteFontFileEnumerator>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontCollectionLoader {}
 impl IDWriteFontCollectionLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollectionLoader_Impl, const OFFSET: isize>() -> IDWriteFontCollectionLoader_Vtbl {
         unsafe extern "system" fn CreateEnumeratorFromKey<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontCollectionLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, factory: ::windows::core::RawPtr, collectionkey: *const ::core::ffi::c_void, collectionkeysize: u32, fontfileenumerator: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1405,6 +1448,7 @@ impl IDWriteFontCollectionLoader_Vtbl {
 pub trait IDWriteFontDownloadListener_Impl: Sized {
     fn DownloadCompleted(&self, downloadqueue: &::core::option::Option<IDWriteFontDownloadQueue>, context: &::core::option::Option<::windows::core::IUnknown>, downloadresult: ::windows::core::HRESULT);
 }
+impl ::windows::core::RuntimeName for IDWriteFontDownloadListener {}
 impl IDWriteFontDownloadListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontDownloadListener_Impl, const OFFSET: isize>() -> IDWriteFontDownloadListener_Vtbl {
         unsafe extern "system" fn DownloadCompleted<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontDownloadListener_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, downloadqueue: ::windows::core::RawPtr, context: *mut ::core::ffi::c_void, downloadresult: ::windows::core::HRESULT) {
@@ -1427,6 +1471,8 @@ pub trait IDWriteFontDownloadQueue_Impl: Sized {
     fn CancelDownload(&self) -> ::windows::core::Result<()>;
     fn GetGenerationCount(&self) -> u64;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontDownloadQueue {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontDownloadQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontDownloadQueue_Impl, const OFFSET: isize>() -> IDWriteFontDownloadQueue_Vtbl {
@@ -1498,6 +1544,8 @@ pub trait IDWriteFontFace_Impl: Sized {
     fn GetGdiCompatibleMetrics(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX) -> ::windows::core::Result<DWRITE_FONT_METRICS>;
     fn GetGdiCompatibleGlyphMetrics(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: super::super::Foundation::BOOL, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace_Impl, const OFFSET: isize>() -> IDWriteFontFace_Vtbl {
@@ -1627,6 +1675,8 @@ pub trait IDWriteFontFace1_Impl: Sized + IDWriteFontFace_Impl {
     fn HasVerticalGlyphVariants(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace1_Impl, const OFFSET: isize>() -> IDWriteFontFace1_Vtbl {
         unsafe extern "system" fn GetMetrics2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontmetrics: *mut DWRITE_FONT_METRICS1) {
@@ -1730,6 +1780,8 @@ pub trait IDWriteFontFace2_Impl: Sized + IDWriteFontFace_Impl + IDWriteFontFace1
     fn GetRecommendedRenderingMode3(&self, fontemsize: f32, dpix: f32, dpiy: f32, transform: *const DWRITE_MATRIX, issideways: super::super::Foundation::BOOL, outlinethreshold: DWRITE_OUTLINE_THRESHOLD, measuringmode: DWRITE_MEASURING_MODE, renderingparams: &::core::option::Option<IDWriteRenderingParams>, renderingmode: *mut DWRITE_RENDERING_MODE, gridfitmode: *mut DWRITE_GRID_FIT_MODE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace2_Impl, const OFFSET: isize>() -> IDWriteFontFace2_Vtbl {
         unsafe extern "system" fn IsColorFont<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
@@ -1787,6 +1839,8 @@ pub trait IDWriteFontFace3_Impl: Sized + IDWriteFontFace_Impl + IDWriteFontFace1
     fn AreCharactersLocal(&self, characters: &::windows::core::PCWSTR, charactercount: u32, enqueueifnotlocal: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn AreGlyphsLocal(&self, glyphindices: *const u16, glyphcount: u32, enqueueifnotlocal: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace3_Impl, const OFFSET: isize>() -> IDWriteFontFace3_Vtbl {
@@ -1920,6 +1974,8 @@ pub trait IDWriteFontFace4_Impl: Sized + IDWriteFontFace_Impl + IDWriteFontFace1
     fn ReleaseGlyphImageData(&self, glyphdatacontext: *mut ::core::ffi::c_void);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace4_Impl, const OFFSET: isize>() -> IDWriteFontFace4_Vtbl {
         unsafe extern "system" fn GetGlyphImageFormats<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, glyphid: u16, pixelsperemfirst: u32, pixelsperemlast: u32, glyphimageformats: *mut DWRITE_GLYPH_IMAGE_FORMATS) -> ::windows::core::HRESULT {
@@ -1968,6 +2024,8 @@ pub trait IDWriteFontFace5_Impl: Sized + IDWriteFontFace_Impl + IDWriteFontFace1
     fn GetFontResource(&self) -> ::windows::core::Result<IDWriteFontResource>;
     fn Equals(&self, fontface: &::core::option::Option<IDWriteFontFace>) -> super::super::Foundation::BOOL;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace5_Impl, const OFFSET: isize>() -> IDWriteFontFace5_Vtbl {
@@ -2021,6 +2079,8 @@ pub trait IDWriteFontFace6_Impl: Sized + IDWriteFontFace_Impl + IDWriteFontFace1
     fn GetFaceNames2(&self, fontfamilymodel: DWRITE_FONT_FAMILY_MODEL) -> ::windows::core::Result<IDWriteLocalizedStrings>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
+impl ::windows::core::RuntimeName for IDWriteFontFace6 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 impl IDWriteFontFace6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace6_Impl, const OFFSET: isize>() -> IDWriteFontFace6_Vtbl {
         unsafe extern "system" fn GetFamilyNames2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFace6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfamilymodel: DWRITE_FONT_FAMILY_MODEL, names: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2072,6 +2132,8 @@ pub trait IDWriteFontFaceReference_Impl: Sized {
     fn EnqueueGlyphDownloadRequest(&self, glyphindices: *const u16, glyphcount: u32) -> ::windows::core::Result<()>;
     fn EnqueueFileFragmentDownloadRequest(&self, fileoffset: u64, fragmentsize: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontFaceReference {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontFaceReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFaceReference_Impl, const OFFSET: isize>() -> IDWriteFontFaceReference_Vtbl {
@@ -2198,6 +2260,8 @@ pub trait IDWriteFontFaceReference1_Impl: Sized + IDWriteFontFaceReference_Impl 
     fn GetFontAxisValues(&self, fontaxisvalues: *mut DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontFaceReference1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontFaceReference1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFaceReference1_Impl, const OFFSET: isize>() -> IDWriteFontFaceReference1_Vtbl {
         unsafe extern "system" fn CreateFontFace2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFaceReference1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2235,6 +2299,7 @@ impl IDWriteFontFaceReference1_Vtbl {
 pub trait IDWriteFontFallback_Impl: Sized {
     fn MapCharacters(&self, analysissource: &::core::option::Option<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, basefontcollection: &::core::option::Option<IDWriteFontCollection>, basefamilyname: &::windows::core::PCWSTR, baseweight: DWRITE_FONT_WEIGHT, basestyle: DWRITE_FONT_STYLE, basestretch: DWRITE_FONT_STRETCH, mappedlength: *mut u32, mappedfont: *mut ::core::option::Option<IDWriteFont>, scale: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFallback {}
 impl IDWriteFontFallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFallback_Impl, const OFFSET: isize>() -> IDWriteFontFallback_Vtbl {
         unsafe extern "system" fn MapCharacters<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, analysissource: ::windows::core::RawPtr, textposition: u32, textlength: u32, basefontcollection: ::windows::core::RawPtr, basefamilyname: ::windows::core::PCWSTR, baseweight: DWRITE_FONT_WEIGHT, basestyle: DWRITE_FONT_STYLE, basestretch: DWRITE_FONT_STRETCH, mappedlength: *mut u32, mappedfont: *mut ::windows::core::RawPtr, scale: *mut f32) -> ::windows::core::HRESULT {
@@ -2253,6 +2318,7 @@ impl IDWriteFontFallback_Vtbl {
 pub trait IDWriteFontFallback1_Impl: Sized + IDWriteFontFallback_Impl {
     fn MapCharacters2(&self, analysissource: &::core::option::Option<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, basefontcollection: &::core::option::Option<IDWriteFontCollection>, basefamilyname: &::windows::core::PCWSTR, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, mappedlength: *mut u32, scale: *mut f32, mappedfontface: *mut ::core::option::Option<IDWriteFontFace5>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFallback1 {}
 impl IDWriteFontFallback1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFallback1_Impl, const OFFSET: isize>() -> IDWriteFontFallback1_Vtbl {
         unsafe extern "system" fn MapCharacters2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFallback1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, analysissource: ::windows::core::RawPtr, textposition: u32, textlength: u32, basefontcollection: ::windows::core::RawPtr, basefamilyname: ::windows::core::PCWSTR, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, mappedlength: *mut u32, scale: *mut f32, mappedfontface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2271,6 +2337,7 @@ pub trait IDWriteFontFallbackBuilder_Impl: Sized {
     fn AddMappings(&self, fontfallback: &::core::option::Option<IDWriteFontFallback>) -> ::windows::core::Result<()>;
     fn CreateFontFallback(&self) -> ::windows::core::Result<IDWriteFontFallback>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFallbackBuilder {}
 impl IDWriteFontFallbackBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFallbackBuilder_Impl, const OFFSET: isize>() -> IDWriteFontFallbackBuilder_Vtbl {
         unsafe extern "system" fn AddMapping<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFallbackBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ranges: *const DWRITE_UNICODE_RANGE, rangescount: u32, targetfamilynames: *const *const u16, targetfamilynamescount: u32, fontcollection: ::windows::core::RawPtr, localename: ::windows::core::PCWSTR, basefamilyname: ::windows::core::PCWSTR, scale: f32) -> ::windows::core::HRESULT {
@@ -2310,6 +2377,7 @@ pub trait IDWriteFontFamily_Impl: Sized + IDWriteFontList_Impl {
     fn GetFirstMatchingFont(&self, weight: DWRITE_FONT_WEIGHT, stretch: DWRITE_FONT_STRETCH, style: DWRITE_FONT_STYLE) -> ::windows::core::Result<IDWriteFont>;
     fn GetMatchingFonts(&self, weight: DWRITE_FONT_WEIGHT, stretch: DWRITE_FONT_STRETCH, style: DWRITE_FONT_STYLE) -> ::windows::core::Result<IDWriteFontList>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFamily {}
 impl IDWriteFontFamily_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFamily_Impl, const OFFSET: isize>() -> IDWriteFontFamily_Vtbl {
         unsafe extern "system" fn GetFamilyNames<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFamily_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, names: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2361,6 +2429,7 @@ pub trait IDWriteFontFamily1_Impl: Sized + IDWriteFontList_Impl + IDWriteFontFam
     fn GetFont2(&self, listindex: u32) -> ::windows::core::Result<IDWriteFont3>;
     fn GetFontFaceReference(&self, listindex: u32) -> ::windows::core::Result<IDWriteFontFaceReference>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFamily1 {}
 impl IDWriteFontFamily1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFamily1_Impl, const OFFSET: isize>() -> IDWriteFontFamily1_Vtbl {
         unsafe extern "system" fn GetFontLocality<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFamily1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, listindex: u32) -> DWRITE_LOCALITY {
@@ -2405,6 +2474,7 @@ pub trait IDWriteFontFamily2_Impl: Sized + IDWriteFontList_Impl + IDWriteFontFam
     fn GetMatchingFonts2(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<IDWriteFontList2>;
     fn GetFontSet(&self) -> ::windows::core::Result<IDWriteFontSet1>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFamily2 {}
 impl IDWriteFontFamily2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFamily2_Impl, const OFFSET: isize>() -> IDWriteFontFamily2_Vtbl {
         unsafe extern "system" fn GetMatchingFonts2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFamily2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, matchingfonts: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2446,6 +2516,8 @@ pub trait IDWriteFontFile_Impl: Sized {
     fn Analyze(&self, issupportedfonttype: *mut super::super::Foundation::BOOL, fontfiletype: *mut DWRITE_FONT_FILE_TYPE, fontfacetype: *mut DWRITE_FONT_FACE_TYPE, numberoffaces: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontFile {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFile_Impl, const OFFSET: isize>() -> IDWriteFontFile_Vtbl {
         unsafe extern "system" fn GetReferenceKey<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfilereferencekey: *mut *mut ::core::ffi::c_void, fontfilereferencekeysize: *mut u32) -> ::windows::core::HRESULT {
@@ -2486,6 +2558,8 @@ pub trait IDWriteFontFileEnumerator_Impl: Sized {
     fn GetCurrentFontFile(&self) -> ::windows::core::Result<IDWriteFontFile>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontFileEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontFileEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFileEnumerator_Impl, const OFFSET: isize>() -> IDWriteFontFileEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFileEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hascurrentfile: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2523,6 +2597,7 @@ impl IDWriteFontFileEnumerator_Vtbl {
 pub trait IDWriteFontFileLoader_Impl: Sized {
     fn CreateStreamFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<IDWriteFontFileStream>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFileLoader {}
 impl IDWriteFontFileLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFileLoader_Impl, const OFFSET: isize>() -> IDWriteFontFileLoader_Vtbl {
         unsafe extern "system" fn CreateStreamFromKey<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFileLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32, fontfilestream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2548,6 +2623,7 @@ pub trait IDWriteFontFileStream_Impl: Sized {
     fn GetFileSize(&self) -> ::windows::core::Result<u64>;
     fn GetLastWriteTime(&self) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontFileStream {}
 impl IDWriteFontFileStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFileStream_Impl, const OFFSET: isize>() -> IDWriteFontFileStream_Vtbl {
         unsafe extern "system" fn ReadFileFragment<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontFileStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fragmentstart: *mut *mut ::core::ffi::c_void, fileoffset: u64, fragmentsize: u64, fragmentcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2599,6 +2675,7 @@ pub trait IDWriteFontList_Impl: Sized {
     fn GetFontCount(&self) -> u32;
     fn GetFont(&self, index: u32) -> ::windows::core::Result<IDWriteFont>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontList {}
 impl IDWriteFontList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontList_Impl, const OFFSET: isize>() -> IDWriteFontList_Vtbl {
         unsafe extern "system" fn GetFontCollection<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontcollection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2644,6 +2721,7 @@ pub trait IDWriteFontList1_Impl: Sized + IDWriteFontList_Impl {
     fn GetFont2(&self, listindex: u32) -> ::windows::core::Result<IDWriteFont3>;
     fn GetFontFaceReference(&self, listindex: u32) -> ::windows::core::Result<IDWriteFontFaceReference>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontList1 {}
 impl IDWriteFontList1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontList1_Impl, const OFFSET: isize>() -> IDWriteFontList1_Vtbl {
         unsafe extern "system" fn GetFontLocality<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontList1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, listindex: u32) -> DWRITE_LOCALITY {
@@ -2687,6 +2765,7 @@ impl IDWriteFontList1_Vtbl {
 pub trait IDWriteFontList2_Impl: Sized + IDWriteFontList_Impl + IDWriteFontList1_Impl {
     fn GetFontSet(&self) -> ::windows::core::Result<IDWriteFontSet1>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontList2 {}
 impl IDWriteFontList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontList2_Impl, const OFFSET: isize>() -> IDWriteFontList2_Vtbl {
         unsafe extern "system" fn GetFontSet<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontList2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontset: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2721,6 +2800,8 @@ pub trait IDWriteFontResource_Impl: Sized {
     fn CreateFontFace(&self, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<IDWriteFontFace5>;
     fn CreateFontFaceReference(&self, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<IDWriteFontFaceReference1>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontResource {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontResource_Impl, const OFFSET: isize>() -> IDWriteFontResource_Vtbl {
@@ -2841,6 +2922,8 @@ pub trait IDWriteFontSet_Impl: Sized {
     fn GetMatchingFonts(&self, familyname: &::windows::core::PCWSTR, fontweight: DWRITE_FONT_WEIGHT, fontstretch: DWRITE_FONT_STRETCH, fontstyle: DWRITE_FONT_STYLE) -> ::windows::core::Result<IDWriteFontSet>;
     fn GetMatchingFonts2(&self, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::Result<IDWriteFontSet>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontSet {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSet_Impl, const OFFSET: isize>() -> IDWriteFontSet_Vtbl {
@@ -2964,6 +3047,8 @@ pub trait IDWriteFontSet1_Impl: Sized + IDWriteFontSet_Impl {
     fn CreateFontFace(&self, listindex: u32) -> ::windows::core::Result<IDWriteFontFace5>;
     fn GetFontLocality(&self, listindex: u32) -> DWRITE_LOCALITY;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontSet1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontSet1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSet1_Impl, const OFFSET: isize>() -> IDWriteFontSet1_Vtbl {
@@ -3106,6 +3191,8 @@ pub trait IDWriteFontSet2_Impl: Sized + IDWriteFontSet_Impl + IDWriteFontSet1_Im
     fn GetExpirationEvent(&self) -> super::super::Foundation::HANDLE;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontSet2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontSet2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSet2_Impl, const OFFSET: isize>() -> IDWriteFontSet2_Vtbl {
         unsafe extern "system" fn GetExpirationEvent<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSet2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::HANDLE {
@@ -3125,6 +3212,8 @@ pub trait IDWriteFontSet3_Impl: Sized + IDWriteFontSet_Impl + IDWriteFontSet1_Im
     fn GetFontSourceNameLength(&self, listindex: u32) -> u32;
     fn GetFontSourceName(&self, listindex: u32, stringbuffer: ::windows::core::PWSTR, stringbuffersize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteFontSet3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteFontSet3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSet3_Impl, const OFFSET: isize>() -> IDWriteFontSet3_Vtbl {
@@ -3160,6 +3249,7 @@ pub trait IDWriteFontSetBuilder_Impl: Sized {
     fn AddFontSet(&self, fontset: &::core::option::Option<IDWriteFontSet>) -> ::windows::core::Result<()>;
     fn CreateFontSet(&self) -> ::windows::core::Result<IDWriteFontSet>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontSetBuilder {}
 impl IDWriteFontSetBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSetBuilder_Impl, const OFFSET: isize>() -> IDWriteFontSetBuilder_Vtbl {
         unsafe extern "system" fn AddFontFaceReference<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSetBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfacereference: ::windows::core::RawPtr, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::HRESULT {
@@ -3203,6 +3293,7 @@ impl IDWriteFontSetBuilder_Vtbl {
 pub trait IDWriteFontSetBuilder1_Impl: Sized + IDWriteFontSetBuilder_Impl {
     fn AddFontFile(&self, fontfile: &::core::option::Option<IDWriteFontFile>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontSetBuilder1 {}
 impl IDWriteFontSetBuilder1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSetBuilder1_Impl, const OFFSET: isize>() -> IDWriteFontSetBuilder1_Vtbl {
         unsafe extern "system" fn AddFontFile<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSetBuilder1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfile: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3220,6 +3311,7 @@ pub trait IDWriteFontSetBuilder2_Impl: Sized + IDWriteFontSetBuilder_Impl + IDWr
     fn AddFont(&self, fontfile: &::core::option::Option<IDWriteFontFile>, fontfaceindex: u32, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, fontaxisranges: *const DWRITE_FONT_AXIS_RANGE, fontaxisrangecount: u32, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::Result<()>;
     fn AddFontFile2(&self, filepath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteFontSetBuilder2 {}
 impl IDWriteFontSetBuilder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSetBuilder2_Impl, const OFFSET: isize>() -> IDWriteFontSetBuilder2_Vtbl {
         unsafe extern "system" fn AddFont<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteFontSetBuilder2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfile: ::windows::core::RawPtr, fontfaceindex: u32, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, fontaxisranges: *const DWRITE_FONT_AXIS_RANGE, fontaxisrangecount: u32, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::HRESULT {
@@ -3250,6 +3342,8 @@ pub trait IDWriteGdiInterop_Impl: Sized {
     fn CreateFontFaceFromHdc(&self, hdc: super::Gdi::HDC) -> ::windows::core::Result<IDWriteFontFace>;
     fn CreateBitmapRenderTarget(&self, hdc: super::Gdi::HDC, width: u32, height: u32) -> ::windows::core::Result<IDWriteBitmapRenderTarget>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteGdiInterop {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteGdiInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteGdiInterop_Impl, const OFFSET: isize>() -> IDWriteGdiInterop_Vtbl {
@@ -3323,6 +3417,8 @@ pub trait IDWriteGdiInterop1_Impl: Sized + IDWriteGdiInterop_Impl {
     fn GetMatchingFontsByLOGFONT(&self, logfont: *const super::Gdi::LOGFONTA, fontset: &::core::option::Option<IDWriteFontSet>) -> ::windows::core::Result<IDWriteFontSet>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDWriteGdiInterop1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
 impl IDWriteGdiInterop1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteGdiInterop1_Impl, const OFFSET: isize>() -> IDWriteGdiInterop1_Vtbl {
         unsafe extern "system" fn CreateFontFromLOGFONT2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteGdiInterop1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, logfont: *const super::Gdi::LOGFONTW, fontcollection: ::windows::core::RawPtr, font: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3388,6 +3484,8 @@ pub trait IDWriteGlyphRunAnalysis_Impl: Sized {
     fn GetAlphaBlendParams(&self, renderingparams: &::core::option::Option<IDWriteRenderingParams>, blendgamma: *mut f32, blendenhancedcontrast: *mut f32, blendcleartypelevel: *mut f32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteGlyphRunAnalysis {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteGlyphRunAnalysis_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteGlyphRunAnalysis_Impl, const OFFSET: isize>() -> IDWriteGlyphRunAnalysis_Vtbl {
         unsafe extern "system" fn GetAlphaTextureBounds<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteGlyphRunAnalysis_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, texturetype: DWRITE_TEXTURE_TYPE, texturebounds: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -3426,6 +3524,7 @@ pub trait IDWriteInMemoryFontFileLoader_Impl: Sized + IDWriteFontFileLoader_Impl
     fn CreateInMemoryFontFileReference(&self, factory: &::core::option::Option<IDWriteFactory>, fontdata: *const ::core::ffi::c_void, fontdatasize: u32, ownerobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDWriteFontFile>;
     fn GetFileCount(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for IDWriteInMemoryFontFileLoader {}
 impl IDWriteInMemoryFontFileLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteInMemoryFontFileLoader_Impl, const OFFSET: isize>() -> IDWriteInMemoryFontFileLoader_Vtbl {
         unsafe extern "system" fn CreateInMemoryFontFileReference<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteInMemoryFontFileLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, factory: ::windows::core::RawPtr, fontdata: *const ::core::ffi::c_void, fontdatasize: u32, ownerobject: *mut ::core::ffi::c_void, fontfile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3461,6 +3560,8 @@ pub trait IDWriteInlineObject_Impl: Sized {
     fn GetOverhangMetrics(&self) -> ::windows::core::Result<DWRITE_OVERHANG_METRICS>;
     fn GetBreakConditions(&self, breakconditionbefore: *mut DWRITE_BREAK_CONDITION, breakconditionafter: *mut DWRITE_BREAK_CONDITION) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteInlineObject {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteInlineObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteInlineObject_Impl, const OFFSET: isize>() -> IDWriteInlineObject_Vtbl {
@@ -3515,6 +3616,8 @@ pub trait IDWriteLocalFontFileLoader_Impl: Sized + IDWriteFontFileLoader_Impl {
     fn GetLastWriteTimeFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteLocalFontFileLoader {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteLocalFontFileLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteLocalFontFileLoader_Impl, const OFFSET: isize>() -> IDWriteLocalFontFileLoader_Vtbl {
         unsafe extern "system" fn GetFilePathLengthFromKey<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteLocalFontFileLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32, filepathlength: *mut u32) -> ::windows::core::HRESULT {
@@ -3564,6 +3667,8 @@ pub trait IDWriteLocalizedStrings_Impl: Sized {
     fn GetStringLength(&self, index: u32) -> ::windows::core::Result<u32>;
     fn GetString(&self, index: u32, stringbuffer: ::windows::core::PWSTR, size: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteLocalizedStrings {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteLocalizedStrings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteLocalizedStrings_Impl, const OFFSET: isize>() -> IDWriteLocalizedStrings_Vtbl {
@@ -3624,6 +3729,7 @@ impl IDWriteLocalizedStrings_Vtbl {
     }
 }
 pub trait IDWriteNumberSubstitution_Impl: Sized {}
+impl ::windows::core::RuntimeName for IDWriteNumberSubstitution {}
 impl IDWriteNumberSubstitution_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteNumberSubstitution_Impl, const OFFSET: isize>() -> IDWriteNumberSubstitution_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -3638,6 +3744,8 @@ pub trait IDWritePixelSnapping_Impl: Sized {
     fn GetCurrentTransform(&self, clientdrawingcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<DWRITE_MATRIX>;
     fn GetPixelsPerDip(&self, clientdrawingcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<f32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWritePixelSnapping {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWritePixelSnapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWritePixelSnapping_Impl, const OFFSET: isize>() -> IDWritePixelSnapping_Vtbl {
@@ -3690,6 +3798,7 @@ pub trait IDWriteRemoteFontFileLoader_Impl: Sized + IDWriteFontFileLoader_Impl {
     fn GetLocalityFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<DWRITE_LOCALITY>;
     fn CreateFontFileReferenceFromUrl(&self, factory: &::core::option::Option<IDWriteFactory>, baseurl: &::windows::core::PCWSTR, fontfileurl: &::windows::core::PCWSTR) -> ::windows::core::Result<IDWriteFontFile>;
 }
+impl ::windows::core::RuntimeName for IDWriteRemoteFontFileLoader {}
 impl IDWriteRemoteFontFileLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRemoteFontFileLoader_Impl, const OFFSET: isize>() -> IDWriteRemoteFontFileLoader_Vtbl {
         unsafe extern "system" fn CreateRemoteStreamFromKey<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRemoteFontFileLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32, fontfilestream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3744,6 +3853,8 @@ pub trait IDWriteRemoteFontFileStream_Impl: Sized + IDWriteFontFileStream_Impl {
     fn BeginDownload(&self, downloadoperationid: *const ::windows::core::GUID, filefragments: *const DWRITE_FILE_FRAGMENT, fragmentcount: u32) -> ::windows::core::Result<IDWriteAsyncResult>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteRemoteFontFileStream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteRemoteFontFileStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRemoteFontFileStream_Impl, const OFFSET: isize>() -> IDWriteRemoteFontFileStream_Vtbl {
         unsafe extern "system" fn GetLocalFileSize<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRemoteFontFileStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, localfilesize: *mut u64) -> ::windows::core::HRESULT {
@@ -3797,6 +3908,7 @@ pub trait IDWriteRenderingParams_Impl: Sized {
     fn GetPixelGeometry(&self) -> DWRITE_PIXEL_GEOMETRY;
     fn GetRenderingMode(&self) -> DWRITE_RENDERING_MODE;
 }
+impl ::windows::core::RuntimeName for IDWriteRenderingParams {}
 impl IDWriteRenderingParams_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams_Impl, const OFFSET: isize>() -> IDWriteRenderingParams_Vtbl {
         unsafe extern "system" fn GetGamma<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> f32 {
@@ -3840,6 +3952,7 @@ impl IDWriteRenderingParams_Vtbl {
 pub trait IDWriteRenderingParams1_Impl: Sized + IDWriteRenderingParams_Impl {
     fn GetGrayscaleEnhancedContrast(&self) -> f32;
 }
+impl ::windows::core::RuntimeName for IDWriteRenderingParams1 {}
 impl IDWriteRenderingParams1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams1_Impl, const OFFSET: isize>() -> IDWriteRenderingParams1_Vtbl {
         unsafe extern "system" fn GetGrayscaleEnhancedContrast<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> f32 {
@@ -3859,6 +3972,7 @@ impl IDWriteRenderingParams1_Vtbl {
 pub trait IDWriteRenderingParams2_Impl: Sized + IDWriteRenderingParams_Impl + IDWriteRenderingParams1_Impl {
     fn GetGridFitMode(&self) -> DWRITE_GRID_FIT_MODE;
 }
+impl ::windows::core::RuntimeName for IDWriteRenderingParams2 {}
 impl IDWriteRenderingParams2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams2_Impl, const OFFSET: isize>() -> IDWriteRenderingParams2_Vtbl {
         unsafe extern "system" fn GetGridFitMode<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> DWRITE_GRID_FIT_MODE {
@@ -3875,6 +3989,7 @@ impl IDWriteRenderingParams2_Vtbl {
 pub trait IDWriteRenderingParams3_Impl: Sized + IDWriteRenderingParams_Impl + IDWriteRenderingParams1_Impl + IDWriteRenderingParams2_Impl {
     fn GetRenderingMode1(&self) -> DWRITE_RENDERING_MODE1;
 }
+impl ::windows::core::RuntimeName for IDWriteRenderingParams3 {}
 impl IDWriteRenderingParams3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams3_Impl, const OFFSET: isize>() -> IDWriteRenderingParams3_Vtbl {
         unsafe extern "system" fn GetRenderingMode1<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteRenderingParams3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> DWRITE_RENDERING_MODE1 {
@@ -3895,6 +4010,7 @@ pub trait IDWriteStringList_Impl: Sized {
     fn GetStringLength(&self, listindex: u32) -> ::windows::core::Result<u32>;
     fn GetString(&self, listindex: u32, stringbuffer: ::windows::core::PWSTR, stringbuffersize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteStringList {}
 impl IDWriteStringList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteStringList_Impl, const OFFSET: isize>() -> IDWriteStringList_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteStringList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -3953,6 +4069,7 @@ pub trait IDWriteTextAnalysisSink_Impl: Sized {
     fn SetBidiLevel(&self, textposition: u32, textlength: u32, explicitlevel: u8, resolvedlevel: u8) -> ::windows::core::Result<()>;
     fn SetNumberSubstitution(&self, textposition: u32, textlength: u32, numbersubstitution: &::core::option::Option<IDWriteNumberSubstitution>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteTextAnalysisSink {}
 impl IDWriteTextAnalysisSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSink_Impl, const OFFSET: isize>() -> IDWriteTextAnalysisSink_Vtbl {
         unsafe extern "system" fn SetScriptAnalysis<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, scriptanalysis: *const DWRITE_SCRIPT_ANALYSIS) -> ::windows::core::HRESULT {
@@ -3992,6 +4109,8 @@ pub trait IDWriteTextAnalysisSink1_Impl: Sized + IDWriteTextAnalysisSink_Impl {
     fn SetGlyphOrientation(&self, textposition: u32, textlength: u32, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, adjustedbidilevel: u8, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextAnalysisSink1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextAnalysisSink1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSink1_Impl, const OFFSET: isize>() -> IDWriteTextAnalysisSink1_Vtbl {
         unsafe extern "system" fn SetGlyphOrientation<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSink1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, adjustedbidilevel: u8, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -4012,6 +4131,7 @@ pub trait IDWriteTextAnalysisSource_Impl: Sized {
     fn GetLocaleName(&self, textposition: u32, textlength: *mut u32, localename: *mut *mut u16) -> ::windows::core::Result<()>;
     fn GetNumberSubstitution(&self, textposition: u32, textlength: *mut u32, numbersubstitution: *mut ::core::option::Option<IDWriteNumberSubstitution>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteTextAnalysisSource {}
 impl IDWriteTextAnalysisSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSource_Impl, const OFFSET: isize>() -> IDWriteTextAnalysisSource_Vtbl {
         unsafe extern "system" fn GetTextAtPosition<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> ::windows::core::HRESULT {
@@ -4055,6 +4175,7 @@ impl IDWriteTextAnalysisSource_Vtbl {
 pub trait IDWriteTextAnalysisSource1_Impl: Sized + IDWriteTextAnalysisSource_Impl {
     fn GetVerticalGlyphOrientation(&self, textposition: u32, textlength: *mut u32, glyphorientation: *mut DWRITE_VERTICAL_GLYPH_ORIENTATION, bidilevel: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteTextAnalysisSource1 {}
 impl IDWriteTextAnalysisSource1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSource1_Impl, const OFFSET: isize>() -> IDWriteTextAnalysisSource1_Vtbl {
         unsafe extern "system" fn GetVerticalGlyphOrientation<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalysisSource1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, textposition: u32, textlength: *mut u32, glyphorientation: *mut DWRITE_VERTICAL_GLYPH_ORIENTATION, bidilevel: *mut u8) -> ::windows::core::HRESULT {
@@ -4104,6 +4225,8 @@ pub trait IDWriteTextAnalyzer_Impl: Sized {
         glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextAnalyzer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextAnalyzer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalyzer_Impl, const OFFSET: isize>() -> IDWriteTextAnalyzer_Vtbl {
@@ -4297,6 +4420,8 @@ pub trait IDWriteTextAnalyzer1_Impl: Sized + IDWriteTextAnalyzer_Impl {
     fn GetJustifiedGlyphs(&self, fontface: &::core::option::Option<IDWriteFontFace>, fontemsize: f32, scriptanalysis: &DWRITE_SCRIPT_ANALYSIS, textlength: u32, glyphcount: u32, maxglyphcount: u32, clustermap: *const u16, glyphindices: *const u16, glyphadvances: *const f32, justifiedglyphadvances: *const f32, justifiedglyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, actualglyphcount: *mut u32, modifiedclustermap: *mut u16, modifiedglyphindices: *mut u16, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextAnalyzer1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextAnalyzer1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalyzer1_Impl, const OFFSET: isize>() -> IDWriteTextAnalyzer1_Vtbl {
         unsafe extern "system" fn ApplyCharacterSpacing<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalyzer1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, textlength: u32, glyphcount: u32, clustermap: *const u16, glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::HRESULT {
@@ -4414,6 +4539,8 @@ pub trait IDWriteTextAnalyzer2_Impl: Sized + IDWriteTextAnalyzer_Impl + IDWriteT
     fn CheckTypographicFeature(&self, fontface: &::core::option::Option<IDWriteFontFace>, scriptanalysis: &DWRITE_SCRIPT_ANALYSIS, localename: &::windows::core::PCWSTR, featuretag: DWRITE_FONT_FEATURE_TAG, glyphcount: u32, glyphindices: *const u16, featureapplies: *mut u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextAnalyzer2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextAnalyzer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalyzer2_Impl, const OFFSET: isize>() -> IDWriteTextAnalyzer2_Vtbl {
         unsafe extern "system" fn GetGlyphOrientationTransform2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextAnalyzer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, issideways: super::super::Foundation::BOOL, originx: f32, originy: f32, transform: *mut DWRITE_MATRIX) -> ::windows::core::HRESULT {
@@ -4475,6 +4602,7 @@ pub trait IDWriteTextFormat_Impl: Sized {
     fn GetLocaleNameLength(&self) -> u32;
     fn GetLocaleName(&self, localename: ::windows::core::PWSTR, namesize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDWriteTextFormat {}
 impl IDWriteTextFormat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat_Impl, const OFFSET: isize>() -> IDWriteTextFormat_Vtbl {
         unsafe extern "system" fn SetTextAlignment<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, textalignment: DWRITE_TEXT_ALIGNMENT) -> ::windows::core::HRESULT {
@@ -4653,6 +4781,8 @@ pub trait IDWriteTextFormat1_Impl: Sized + IDWriteTextFormat_Impl {
     fn GetFontFallback(&self) -> ::windows::core::Result<IDWriteFontFallback>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextFormat1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextFormat1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat1_Impl, const OFFSET: isize>() -> IDWriteTextFormat1_Vtbl {
         unsafe extern "system" fn SetVerticalGlyphOrientation<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, glyphorientation: DWRITE_VERTICAL_GLYPH_ORIENTATION) -> ::windows::core::HRESULT {
@@ -4723,6 +4853,8 @@ pub trait IDWriteTextFormat2_Impl: Sized + IDWriteTextFormat_Impl + IDWriteTextF
     fn GetLineSpacing2(&self) -> ::windows::core::Result<DWRITE_LINE_SPACING>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextFormat2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextFormat2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat2_Impl, const OFFSET: isize>() -> IDWriteTextFormat2_Vtbl {
         unsafe extern "system" fn SetLineSpacing2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, linespacingoptions: *const DWRITE_LINE_SPACING) -> ::windows::core::HRESULT {
@@ -4759,6 +4891,8 @@ pub trait IDWriteTextFormat3_Impl: Sized + IDWriteTextFormat_Impl + IDWriteTextF
     fn GetAutomaticFontAxes(&self) -> DWRITE_AUTOMATIC_FONT_AXES;
     fn SetAutomaticFontAxes(&self, automaticfontaxes: DWRITE_AUTOMATIC_FONT_AXES) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextFormat3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextFormat3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextFormat3_Impl, const OFFSET: isize>() -> IDWriteTextFormat3_Vtbl {
@@ -4842,6 +4976,8 @@ pub trait IDWriteTextLayout_Impl: Sized + IDWriteTextFormat_Impl {
     fn HitTestTextPosition(&self, textposition: u32, istrailinghit: super::super::Foundation::BOOL, pointx: *mut f32, pointy: *mut f32, hittestmetrics: *mut DWRITE_HIT_TEST_METRICS) -> ::windows::core::Result<()>;
     fn HitTestTextRange(&self, textposition: u32, textlength: u32, originx: f32, originy: f32, hittestmetrics: *mut DWRITE_HIT_TEST_METRICS, maxhittestmetricscount: u32, actualhittestmetricscount: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextLayout {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextLayout_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout_Impl, const OFFSET: isize>() -> IDWriteTextLayout_Vtbl {
@@ -5113,6 +5249,8 @@ pub trait IDWriteTextLayout1_Impl: Sized + IDWriteTextFormat_Impl + IDWriteTextL
     fn GetCharacterSpacing(&self, currentposition: u32, leadingspacing: *mut f32, trailingspacing: *mut f32, minimumadvancewidth: *mut f32, textrange: *mut DWRITE_TEXT_RANGE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextLayout1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextLayout1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout1_Impl, const OFFSET: isize>() -> IDWriteTextLayout1_Vtbl {
         unsafe extern "system" fn SetPairKerning<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ispairkerningenabled: super::super::Foundation::BOOL, textrange: DWRITE_TEXT_RANGE) -> ::windows::core::HRESULT {
@@ -5159,6 +5297,8 @@ pub trait IDWriteTextLayout2_Impl: Sized + IDWriteTextFormat_Impl + IDWriteTextL
     fn SetFontFallback(&self, fontfallback: &::core::option::Option<IDWriteFontFallback>) -> ::windows::core::Result<()>;
     fn GetFontFallback(&self) -> ::windows::core::Result<IDWriteFontFallback>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextLayout2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextLayout2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout2_Impl, const OFFSET: isize>() -> IDWriteTextLayout2_Vtbl {
@@ -5244,6 +5384,8 @@ pub trait IDWriteTextLayout3_Impl: Sized + IDWriteTextFormat_Impl + IDWriteTextL
     fn GetLineMetrics2(&self, linemetrics: *mut DWRITE_LINE_METRICS1, maxlinecount: u32, actuallinecount: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextLayout3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextLayout3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout3_Impl, const OFFSET: isize>() -> IDWriteTextLayout3_Vtbl {
         unsafe extern "system" fn InvalidateLayout<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5293,6 +5435,8 @@ pub trait IDWriteTextLayout4_Impl: Sized + IDWriteTextFormat_Impl + IDWriteTextL
     fn SetAutomaticFontAxes(&self, automaticfontaxes: DWRITE_AUTOMATIC_FONT_AXES) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextLayout4 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextLayout4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout4_Impl, const OFFSET: isize>() -> IDWriteTextLayout4_Vtbl {
         unsafe extern "system" fn SetFontAxisValues<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextLayout4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, textrange: DWRITE_TEXT_RANGE) -> ::windows::core::HRESULT {
@@ -5341,6 +5485,8 @@ pub trait IDWriteTextRenderer_Impl: Sized + IDWritePixelSnapping_Impl {
     fn DrawInlineObject(&self, clientdrawingcontext: *const ::core::ffi::c_void, originx: f32, originy: f32, inlineobject: &::core::option::Option<IDWriteInlineObject>, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL, clientdrawingeffect: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextRenderer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextRenderer_Impl, const OFFSET: isize>() -> IDWriteTextRenderer_Vtbl {
         unsafe extern "system" fn DrawGlyphRun<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextRenderer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clientdrawingcontext: *const ::core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, clientdrawingeffect: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5383,6 +5529,8 @@ pub trait IDWriteTextRenderer1_Impl: Sized + IDWritePixelSnapping_Impl + IDWrite
     fn DrawInlineObject2(&self, clientdrawingcontext: *const ::core::ffi::c_void, originx: f32, originy: f32, orientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, inlineobject: &::core::option::Option<IDWriteInlineObject>, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL, clientdrawingeffect: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDWriteTextRenderer1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDWriteTextRenderer1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextRenderer1_Impl, const OFFSET: isize>() -> IDWriteTextRenderer1_Vtbl {
         unsafe extern "system" fn DrawGlyphRun2<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTextRenderer1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clientdrawingcontext: *const ::core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, orientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, clientdrawingeffect: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5422,6 +5570,7 @@ pub trait IDWriteTypography_Impl: Sized {
     fn GetFontFeatureCount(&self) -> u32;
     fn GetFontFeature(&self, fontfeatureindex: u32) -> ::windows::core::Result<DWRITE_FONT_FEATURE>;
 }
+impl ::windows::core::RuntimeName for IDWriteTypography {}
 impl IDWriteTypography_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTypography_Impl, const OFFSET: isize>() -> IDWriteTypography_Vtbl {
         unsafe extern "system" fn AddFontFeature<Identity: ::windows::core::IUnknownImpl, Impl: IDWriteTypography_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontfeature: DWRITE_FONT_FEATURE) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
@@ -5,6 +5,8 @@ pub trait IDXGIAdapter_Impl: Sized + IDXGIObject_Impl {
     fn CheckInterfaceSupport(&self, interfacename: *const ::windows::core::GUID) -> ::windows::core::Result<i64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIAdapter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDXGIAdapter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter_Impl, const OFFSET: isize>() -> IDXGIAdapter_Vtbl {
         unsafe extern "system" fn EnumOutputs<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, output: u32, ppoutput: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -56,6 +58,8 @@ pub trait IDXGIAdapter1_Impl: Sized + IDXGIObject_Impl + IDXGIAdapter_Impl {
     fn GetDesc1(&self) -> ::windows::core::Result<DXGI_ADAPTER_DESC1>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIAdapter1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDXGIAdapter1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter1_Impl, const OFFSET: isize>() -> IDXGIAdapter1_Vtbl {
         unsafe extern "system" fn GetDesc1<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut DXGI_ADAPTER_DESC1) -> ::windows::core::HRESULT {
@@ -79,6 +83,8 @@ impl IDXGIAdapter1_Vtbl {
 pub trait IDXGIAdapter2_Impl: Sized + IDXGIObject_Impl + IDXGIAdapter_Impl + IDXGIAdapter1_Impl {
     fn GetDesc2(&self) -> ::windows::core::Result<DXGI_ADAPTER_DESC2>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIAdapter2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDXGIAdapter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter2_Impl, const OFFSET: isize>() -> IDXGIAdapter2_Vtbl {
@@ -108,6 +114,8 @@ pub trait IDXGIAdapter3_Impl: Sized + IDXGIObject_Impl + IDXGIAdapter_Impl + IDX
     fn RegisterVideoMemoryBudgetChangeNotificationEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
     fn UnregisterVideoMemoryBudgetChangeNotification(&self, dwcookie: u32);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIAdapter3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDXGIAdapter3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter3_Impl, const OFFSET: isize>() -> IDXGIAdapter3_Vtbl {
@@ -178,6 +186,8 @@ pub trait IDXGIAdapter4_Impl: Sized + IDXGIObject_Impl + IDXGIAdapter_Impl + IDX
     fn GetDesc3(&self) -> ::windows::core::Result<DXGI_ADAPTER_DESC3>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIAdapter4 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDXGIAdapter4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter4_Impl, const OFFSET: isize>() -> IDXGIAdapter4_Vtbl {
         unsafe extern "system" fn GetDesc3<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIAdapter4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut DXGI_ADAPTER_DESC3) -> ::windows::core::HRESULT {
@@ -200,6 +210,7 @@ impl IDXGIAdapter4_Vtbl {
 pub trait IDXGIDebug_Impl: Sized {
     fn ReportLiveObjects(&self, apiid: &::windows::core::GUID, flags: DXGI_DEBUG_RLO_FLAGS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDXGIDebug {}
 impl IDXGIDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDebug_Impl, const OFFSET: isize>() -> IDXGIDebug_Vtbl {
         unsafe extern "system" fn ReportLiveObjects<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDebug_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, apiid: ::windows::core::GUID, flags: DXGI_DEBUG_RLO_FLAGS) -> ::windows::core::HRESULT {
@@ -219,6 +230,8 @@ pub trait IDXGIDebug1_Impl: Sized + IDXGIDebug_Impl {
     fn DisableLeakTrackingForThread(&self);
     fn IsLeakTrackingEnabledForThread(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIDebug1 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDXGIDebug1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDebug1_Impl, const OFFSET: isize>() -> IDXGIDebug1_Vtbl {
@@ -260,6 +273,8 @@ pub trait IDXGIDecodeSwapChain_Impl: Sized {
     fn SetColorSpace(&self, colorspace: DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS) -> ::windows::core::Result<()>;
     fn GetColorSpace(&self) -> DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIDecodeSwapChain {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDXGIDecodeSwapChain_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDecodeSwapChain_Impl, const OFFSET: isize>() -> IDXGIDecodeSwapChain_Vtbl {
@@ -346,6 +361,8 @@ pub trait IDXGIDevice_Impl: Sized + IDXGIObject_Impl {
     fn GetGPUThreadPriority(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice_Impl, const OFFSET: isize>() -> IDXGIDevice_Vtbl {
         unsafe extern "system" fn GetAdapter<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, padapter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -404,6 +421,8 @@ pub trait IDXGIDevice1_Impl: Sized + IDXGIObject_Impl + IDXGIDevice_Impl {
     fn GetMaximumFrameLatency(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIDevice1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIDevice1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice1_Impl, const OFFSET: isize>() -> IDXGIDevice1_Vtbl {
         unsafe extern "system" fn SetMaximumFrameLatency<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxlatency: u32) -> ::windows::core::HRESULT {
@@ -438,6 +457,8 @@ pub trait IDXGIDevice2_Impl: Sized + IDXGIObject_Impl + IDXGIDevice_Impl + IDXGI
     fn ReclaimResources(&self, numresources: u32, ppresources: *const ::core::option::Option<IDXGIResource>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn EnqueueSetEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIDevice2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice2_Impl, const OFFSET: isize>() -> IDXGIDevice2_Vtbl {
@@ -478,6 +499,8 @@ pub trait IDXGIDevice3_Impl: Sized + IDXGIObject_Impl + IDXGIDevice_Impl + IDXGI
     fn Trim(&self);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIDevice3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIDevice3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice3_Impl, const OFFSET: isize>() -> IDXGIDevice3_Vtbl {
         unsafe extern "system" fn Trim<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -496,6 +519,8 @@ pub trait IDXGIDevice4_Impl: Sized + IDXGIObject_Impl + IDXGIDevice_Impl + IDXGI
     fn OfferResources1(&self, numresources: u32, ppresources: *const ::core::option::Option<IDXGIResource>, priority: DXGI_OFFER_RESOURCE_PRIORITY, flags: u32) -> ::windows::core::Result<()>;
     fn ReclaimResources1(&self, numresources: u32, ppresources: *const ::core::option::Option<IDXGIResource>) -> ::windows::core::Result<DXGI_RECLAIM_RESOURCE_RESULTS>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIDevice4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIDevice4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDevice4_Impl, const OFFSET: isize>() -> IDXGIDevice4_Vtbl {
@@ -528,6 +553,7 @@ impl IDXGIDevice4_Vtbl {
 pub trait IDXGIDeviceSubObject_Impl: Sized + IDXGIObject_Impl {
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDXGIDeviceSubObject {}
 impl IDXGIDeviceSubObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDeviceSubObject_Impl, const OFFSET: isize>() -> IDXGIDeviceSubObject_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDeviceSubObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -546,6 +572,8 @@ pub trait IDXGIDisplayControl_Impl: Sized {
     fn IsStereoEnabled(&self) -> super::super::Foundation::BOOL;
     fn SetStereoEnabled(&self, enabled: super::super::Foundation::BOOL);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIDisplayControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDXGIDisplayControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIDisplayControl_Impl, const OFFSET: isize>() -> IDXGIDisplayControl_Vtbl {
@@ -577,6 +605,8 @@ pub trait IDXGIFactory_Impl: Sized + IDXGIObject_Impl {
     fn CreateSwapChain(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, pdesc: *const DXGI_SWAP_CHAIN_DESC) -> ::windows::core::Result<IDXGISwapChain>;
     fn CreateSoftwareAdapter(&self, module: super::super::Foundation::HINSTANCE) -> ::windows::core::Result<IDXGIAdapter>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory_Impl, const OFFSET: isize>() -> IDXGIFactory_Vtbl {
@@ -648,6 +678,8 @@ pub trait IDXGIFactory1_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl {
     fn IsCurrent(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory1_Impl, const OFFSET: isize>() -> IDXGIFactory1_Vtbl {
         unsafe extern "system" fn EnumAdapters1<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, adapter: u32, ppadapter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -690,6 +722,8 @@ pub trait IDXGIFactory2_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl + IDX
     fn UnregisterOcclusionStatus(&self, dwcookie: u32);
     fn CreateSwapChainForComposition(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, pdesc: *const DXGI_SWAP_CHAIN_DESC1, prestricttooutput: &::core::option::Option<IDXGIOutput>) -> ::windows::core::Result<IDXGISwapChain1>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory2_Impl, const OFFSET: isize>() -> IDXGIFactory2_Vtbl {
@@ -820,6 +854,8 @@ pub trait IDXGIFactory3_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl + IDX
     fn GetCreationFlags(&self) -> u32;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory3_Impl, const OFFSET: isize>() -> IDXGIFactory3_Vtbl {
         unsafe extern "system" fn GetCreationFlags<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -838,6 +874,8 @@ pub trait IDXGIFactory4_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl + IDX
     fn EnumAdapterByLuid(&self, adapterluid: &super::super::Foundation::LUID, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn EnumWarpAdapter(&self, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory4_Impl, const OFFSET: isize>() -> IDXGIFactory4_Vtbl {
@@ -866,6 +904,8 @@ pub trait IDXGIFactory5_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl + IDX
     fn CheckFeatureSupport(&self, feature: DXGI_FEATURE, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory5_Impl, const OFFSET: isize>() -> IDXGIFactory5_Vtbl {
         unsafe extern "system" fn CheckFeatureSupport<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, feature: DXGI_FEATURE, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::HRESULT {
@@ -883,6 +923,8 @@ impl IDXGIFactory5_Vtbl {
 pub trait IDXGIFactory6_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl + IDXGIFactory1_Impl + IDXGIFactory2_Impl + IDXGIFactory3_Impl + IDXGIFactory4_Impl + IDXGIFactory5_Impl {
     fn EnumAdapterByGpuPreference(&self, adapter: u32, gpupreference: DXGI_GPU_PREFERENCE, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory6 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory6_Impl, const OFFSET: isize>() -> IDXGIFactory6_Vtbl {
@@ -902,6 +944,8 @@ pub trait IDXGIFactory7_Impl: Sized + IDXGIObject_Impl + IDXGIFactory_Impl + IDX
     fn RegisterAdaptersChangedEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
     fn UnregisterAdaptersChangedEvent(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactory7 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactory7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactory7_Impl, const OFFSET: isize>() -> IDXGIFactory7_Vtbl {
@@ -936,6 +980,8 @@ pub trait IDXGIFactoryMedia_Impl: Sized {
     fn CreateSwapChainForCompositionSurfaceHandle(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, hsurface: super::super::Foundation::HANDLE, pdesc: *const DXGI_SWAP_CHAIN_DESC1, prestricttooutput: &::core::option::Option<IDXGIOutput>) -> ::windows::core::Result<IDXGISwapChain1>;
     fn CreateDecodeSwapChainForCompositionSurfaceHandle(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, hsurface: super::super::Foundation::HANDLE, pdesc: *const DXGI_DECODE_SWAP_CHAIN_DESC, pyuvdecodebuffers: &::core::option::Option<IDXGIResource>, prestricttooutput: &::core::option::Option<IDXGIOutput>) -> ::windows::core::Result<IDXGIDecodeSwapChain>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIFactoryMedia {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIFactoryMedia_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIFactoryMedia_Impl, const OFFSET: isize>() -> IDXGIFactoryMedia_Vtbl {
@@ -1011,6 +1057,8 @@ pub trait IDXGIInfoQueue_Impl: Sized {
     fn SetMuteDebugOutput(&self, producer: &::windows::core::GUID, bmute: super::super::Foundation::BOOL);
     fn GetMuteDebugOutput(&self, producer: &::windows::core::GUID) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIInfoQueue {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDXGIInfoQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIInfoQueue_Impl, const OFFSET: isize>() -> IDXGIInfoQueue_Vtbl {
@@ -1248,6 +1296,7 @@ pub trait IDXGIKeyedMutex_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_
     fn AcquireSync(&self, key: u64, dwmilliseconds: u32) -> ::windows::core::Result<()>;
     fn ReleaseSync(&self, key: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDXGIKeyedMutex {}
 impl IDXGIKeyedMutex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIKeyedMutex_Impl, const OFFSET: isize>() -> IDXGIKeyedMutex_Vtbl {
         unsafe extern "system" fn AcquireSync<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIKeyedMutex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: u64, dwmilliseconds: u32) -> ::windows::core::HRESULT {
@@ -1276,6 +1325,7 @@ pub trait IDXGIObject_Impl: Sized {
     fn GetPrivateData(&self, name: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetParent(&self, riid: *const ::windows::core::GUID, ppparent: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDXGIObject {}
 impl IDXGIObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIObject_Impl, const OFFSET: isize>() -> IDXGIObject_Vtbl {
         unsafe extern "system" fn SetPrivateData<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1325,6 +1375,8 @@ pub trait IDXGIOutput_Impl: Sized + IDXGIObject_Impl {
     fn GetDisplaySurfaceData(&self, pdestination: &::core::option::Option<IDXGISurface>) -> ::windows::core::Result<()>;
     fn GetFrameStatistics(&self) -> ::windows::core::Result<DXGI_FRAME_STATISTICS>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput_Impl, const OFFSET: isize>() -> IDXGIOutput_Vtbl {
@@ -1440,6 +1492,8 @@ pub trait IDXGIOutput1_Impl: Sized + IDXGIObject_Impl + IDXGIOutput_Impl {
     fn DuplicateOutput(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDXGIOutputDuplication>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput1_Impl, const OFFSET: isize>() -> IDXGIOutput1_Vtbl {
         unsafe extern "system" fn GetDisplayModeList1<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumformat: Common::DXGI_FORMAT, flags: u32, pnummodes: *mut u32, pdesc: *mut DXGI_MODE_DESC1) -> ::windows::core::HRESULT {
@@ -1485,6 +1539,8 @@ pub trait IDXGIOutput2_Impl: Sized + IDXGIObject_Impl + IDXGIOutput_Impl + IDXGI
     fn SupportsOverlays(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput2_Impl, const OFFSET: isize>() -> IDXGIOutput2_Vtbl {
         unsafe extern "system" fn SupportsOverlays<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
@@ -1502,6 +1558,8 @@ impl IDXGIOutput2_Vtbl {
 pub trait IDXGIOutput3_Impl: Sized + IDXGIObject_Impl + IDXGIOutput_Impl + IDXGIOutput1_Impl + IDXGIOutput2_Impl {
     fn CheckOverlaySupport(&self, enumformat: Common::DXGI_FORMAT, pconcerneddevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput3_Impl, const OFFSET: isize>() -> IDXGIOutput3_Vtbl {
@@ -1526,6 +1584,8 @@ impl IDXGIOutput3_Vtbl {
 pub trait IDXGIOutput4_Impl: Sized + IDXGIObject_Impl + IDXGIOutput_Impl + IDXGIOutput1_Impl + IDXGIOutput2_Impl + IDXGIOutput3_Impl {
     fn CheckOverlayColorSpaceSupport(&self, format: Common::DXGI_FORMAT, colorspace: Common::DXGI_COLOR_SPACE_TYPE, pconcerneddevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput4_Impl, const OFFSET: isize>() -> IDXGIOutput4_Vtbl {
@@ -1554,6 +1614,8 @@ pub trait IDXGIOutput5_Impl: Sized + IDXGIObject_Impl + IDXGIOutput_Impl + IDXGI
     fn DuplicateOutput1(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, flags: u32, supportedformatscount: u32, psupportedformats: *const Common::DXGI_FORMAT) -> ::windows::core::Result<IDXGIOutputDuplication>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput5_Impl, const OFFSET: isize>() -> IDXGIOutput5_Vtbl {
         unsafe extern "system" fn DuplicateOutput1<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevice: *mut ::core::ffi::c_void, flags: u32, supportedformatscount: u32, psupportedformats: *const Common::DXGI_FORMAT, ppoutputduplication: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1578,6 +1640,8 @@ pub trait IDXGIOutput6_Impl: Sized + IDXGIObject_Impl + IDXGIOutput_Impl + IDXGI
     fn GetDesc1(&self) -> ::windows::core::Result<DXGI_OUTPUT_DESC1>;
     fn CheckHardwareCompositionSupport(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGIOutput6 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGIOutput6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutput6_Impl, const OFFSET: isize>() -> IDXGIOutput6_Vtbl {
@@ -1624,6 +1688,8 @@ pub trait IDXGIOutputDuplication_Impl: Sized + IDXGIObject_Impl {
     fn UnMapDesktopSurface(&self) -> ::windows::core::Result<()>;
     fn ReleaseFrame(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGIOutputDuplication {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGIOutputDuplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIOutputDuplication_Impl, const OFFSET: isize>() -> IDXGIOutputDuplication_Vtbl {
@@ -1697,6 +1763,8 @@ pub trait IDXGIResource_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_Im
     fn GetEvictionPriority(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDXGIResource {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDXGIResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIResource_Impl, const OFFSET: isize>() -> IDXGIResource_Vtbl {
         unsafe extern "system" fn GetSharedHandle<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -1755,6 +1823,8 @@ pub trait IDXGIResource1_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_I
     fn CreateSharedHandle(&self, pattributes: *const super::super::Security::SECURITY_ATTRIBUTES, dwaccess: u32, lpname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for IDXGIResource1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl IDXGIResource1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIResource1_Impl, const OFFSET: isize>() -> IDXGIResource1_Vtbl {
         unsafe extern "system" fn CreateSubresourceSurface<Identity: ::windows::core::IUnknownImpl, Impl: IDXGIResource1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, ppsurface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1796,6 +1866,8 @@ pub trait IDXGISurface_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_Imp
     fn Unmap(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IDXGISurface {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IDXGISurface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISurface_Impl, const OFFSET: isize>() -> IDXGISurface_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISurface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut DXGI_SURFACE_DESC) -> ::windows::core::HRESULT {
@@ -1836,6 +1908,8 @@ pub trait IDXGISurface1_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_Im
     fn ReleaseDC(&self, pdirtyrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGISurface1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGISurface1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISurface1_Impl, const OFFSET: isize>() -> IDXGISurface1_Vtbl {
         unsafe extern "system" fn GetDC<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISurface1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, discard: super::super::Foundation::BOOL, phdc: *mut super::Gdi::HDC) -> ::windows::core::HRESULT {
@@ -1869,6 +1943,8 @@ pub trait IDXGISurface2_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_Im
     fn GetResource(&self, riid: *const ::windows::core::GUID, ppparentresource: *mut *mut ::core::ffi::c_void, psubresourceindex: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDXGISurface2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl IDXGISurface2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISurface2_Impl, const OFFSET: isize>() -> IDXGISurface2_Vtbl {
         unsafe extern "system" fn GetResource<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISurface2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppparentresource: *mut *mut ::core::ffi::c_void, psubresourceindex: *mut u32) -> ::windows::core::HRESULT {
@@ -1895,6 +1971,8 @@ pub trait IDXGISwapChain_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_I
     fn GetFrameStatistics(&self) -> ::windows::core::Result<DXGI_FRAME_STATISTICS>;
     fn GetLastPresentCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGISwapChain {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGISwapChain_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain_Impl, const OFFSET: isize>() -> IDXGISwapChain_Vtbl {
@@ -2004,6 +2082,8 @@ pub trait IDXGISwapChain1_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_
     fn SetRotation(&self, rotation: Common::DXGI_MODE_ROTATION) -> ::windows::core::Result<()>;
     fn GetRotation(&self) -> ::windows::core::Result<Common::DXGI_MODE_ROTATION>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGISwapChain1 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGISwapChain1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain1_Impl, const OFFSET: isize>() -> IDXGISwapChain1_Vtbl {
@@ -2128,6 +2208,8 @@ pub trait IDXGISwapChain2_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_
     fn GetMatrixTransform(&self) -> ::windows::core::Result<DXGI_MATRIX_3X2_F>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGISwapChain2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGISwapChain2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain2_Impl, const OFFSET: isize>() -> IDXGISwapChain2_Vtbl {
         unsafe extern "system" fn SetSourceSize<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, width: u32, height: u32) -> ::windows::core::HRESULT {
@@ -2200,6 +2282,8 @@ pub trait IDXGISwapChain3_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_
     fn ResizeBuffers1(&self, buffercount: u32, width: u32, height: u32, format: Common::DXGI_FORMAT, swapchainflags: u32, pcreationnodemask: *const u32, pppresentqueue: *const ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGISwapChain3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGISwapChain3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain3_Impl, const OFFSET: isize>() -> IDXGISwapChain3_Vtbl {
         unsafe extern "system" fn GetCurrentBackBufferIndex<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -2245,6 +2329,8 @@ pub trait IDXGISwapChain4_Impl: Sized + IDXGIObject_Impl + IDXGIDeviceSubObject_
     fn SetHDRMetaData(&self, r#type: DXGI_HDR_METADATA_TYPE, size: u32, pmetadata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IDXGISwapChain4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IDXGISwapChain4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain4_Impl, const OFFSET: isize>() -> IDXGISwapChain4_Vtbl {
         unsafe extern "system" fn SetHDRMetaData<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChain4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: DXGI_HDR_METADATA_TYPE, size: u32, pmetadata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2263,6 +2349,7 @@ pub trait IDXGISwapChainMedia_Impl: Sized {
     fn SetPresentDuration(&self, duration: u32) -> ::windows::core::Result<()>;
     fn CheckPresentDurationSupport(&self, desiredpresentduration: u32, pclosestsmallerpresentduration: *mut u32, pclosestlargerpresentduration: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDXGISwapChainMedia {}
 impl IDXGISwapChainMedia_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChainMedia_Impl, const OFFSET: isize>() -> IDXGISwapChainMedia_Vtbl {
         unsafe extern "system" fn GetFrameStatisticsMedia<Identity: ::windows::core::IUnknownImpl, Impl: IDXGISwapChainMedia_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstats: *mut DXGI_FRAME_STATISTICS_MEDIA) -> ::windows::core::HRESULT {
@@ -2301,6 +2388,7 @@ pub trait IDXGraphicsAnalysis_Impl: Sized {
     fn BeginCapture(&self);
     fn EndCapture(&self);
 }
+impl ::windows::core::RuntimeName for IDXGraphicsAnalysis {}
 impl IDXGraphicsAnalysis_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXGraphicsAnalysis_Impl, const OFFSET: isize>() -> IDXGraphicsAnalysis_Vtbl {
         unsafe extern "system" fn BeginCapture<Identity: ::windows::core::IUnknownImpl, Impl: IDXGraphicsAnalysis_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
@@ -5,6 +5,8 @@ pub trait IWICImageEncoder_Impl: Sized {
     fn WriteThumbnail(&self, pimage: &::core::option::Option<super::super::Direct2D::ID2D1Image>, pencoder: &::core::option::Option<super::IWICBitmapEncoder>, pimageparameters: *const super::WICImageParameters) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IWICImageEncoder {}
+#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IWICImageEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICImageEncoder_Impl, const OFFSET: isize>() -> IWICImageEncoder_Vtbl {
         unsafe extern "system" fn WriteFrame<Identity: ::windows::core::IUnknownImpl, Impl: IWICImageEncoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pimage: ::windows::core::RawPtr, pframeencode: ::windows::core::RawPtr, pimageparameters: *const super::WICImageParameters) -> ::windows::core::HRESULT {
@@ -37,6 +39,8 @@ impl IWICImageEncoder_Vtbl {
 pub trait IWICImagingFactory2_Impl: Sized + super::IWICImagingFactory_Impl {
     fn CreateImageEncoder(&self, pd2ddevice: &::core::option::Option<super::super::Direct2D::ID2D1Device>) -> ::windows::core::Result<IWICImageEncoder>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct2D", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IWICImagingFactory2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IWICImagingFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICImagingFactory2_Impl, const OFFSET: isize>() -> IWICImagingFactory2_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
@@ -3,6 +3,7 @@ pub trait IWICBitmap_Impl: Sized + IWICBitmapSource_Impl {
     fn SetPalette(&self, pipalette: &::core::option::Option<IWICPalette>) -> ::windows::core::Result<()>;
     fn SetResolution(&self, dpix: f64, dpiy: f64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICBitmap {}
 impl IWICBitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmap_Impl, const OFFSET: isize>() -> IWICBitmap_Vtbl {
         unsafe extern "system" fn Lock<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prclock: *const WICRect, flags: u32, ppilock: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -40,6 +41,7 @@ impl IWICBitmap_Vtbl {
 pub trait IWICBitmapClipper_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, prc: *const WICRect) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapClipper {}
 impl IWICBitmapClipper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapClipper_Impl, const OFFSET: isize>() -> IWICBitmapClipper_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapClipper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisource: ::windows::core::RawPtr, prc: *const WICRect) -> ::windows::core::HRESULT {
@@ -68,6 +70,8 @@ pub trait IWICBitmapCodecInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn DoesSupportMultiframe(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn MatchesMimeType(&self, wzmimetype: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICBitmapCodecInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWICBitmapCodecInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapCodecInfo_Impl, const OFFSET: isize>() -> IWICBitmapCodecInfo_Vtbl {
@@ -190,6 +194,7 @@ impl IWICBitmapCodecInfo_Vtbl {
 pub trait IWICBitmapCodecProgressNotification_Impl: Sized {
     fn RegisterProgressNotification(&self, pfnprogressnotification: &PFNProgressNotification, pvdata: *const ::core::ffi::c_void, dwprogressflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapCodecProgressNotification {}
 impl IWICBitmapCodecProgressNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapCodecProgressNotification_Impl, const OFFSET: isize>() -> IWICBitmapCodecProgressNotification_Vtbl {
         unsafe extern "system" fn RegisterProgressNotification<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapCodecProgressNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfnprogressnotification: ::windows::core::RawPtr, pvdata: *const ::core::ffi::c_void, dwprogressflags: u32) -> ::windows::core::HRESULT {
@@ -220,6 +225,8 @@ pub trait IWICBitmapDecoder_Impl: Sized {
     fn GetFrameCount(&self) -> ::windows::core::Result<u32>;
     fn GetFrame(&self, index: u32) -> ::windows::core::Result<IWICBitmapFrameDecode>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IWICBitmapDecoder {}
 #[cfg(feature = "Win32_System_Com")]
 impl IWICBitmapDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapDecoder_Impl, const OFFSET: isize>() -> IWICBitmapDecoder_Vtbl {
@@ -352,6 +359,8 @@ pub trait IWICBitmapDecoderInfo_Impl: Sized + IWICComponentInfo_Impl + IWICBitma
     fn CreateInstance(&self) -> ::windows::core::Result<IWICBitmapDecoder>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWICBitmapDecoderInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWICBitmapDecoderInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapDecoderInfo_Impl, const OFFSET: isize>() -> IWICBitmapDecoderInfo_Vtbl {
         unsafe extern "system" fn GetPatterns<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapDecoderInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsizepatterns: u32, ppatterns: *mut WICBitmapPattern, pcpatterns: *mut u32, pcbpatternsactual: *mut u32) -> ::windows::core::HRESULT {
@@ -405,6 +414,8 @@ pub trait IWICBitmapEncoder_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
     fn GetMetadataQueryWriter(&self) -> ::windows::core::Result<IWICMetadataQueryWriter>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IWICBitmapEncoder {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IWICBitmapEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapEncoder_Impl, const OFFSET: isize>() -> IWICBitmapEncoder_Vtbl {
@@ -499,6 +510,8 @@ pub trait IWICBitmapEncoderInfo_Impl: Sized + IWICComponentInfo_Impl + IWICBitma
     fn CreateInstance(&self) -> ::windows::core::Result<IWICBitmapEncoder>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICBitmapEncoderInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWICBitmapEncoderInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapEncoderInfo_Impl, const OFFSET: isize>() -> IWICBitmapEncoderInfo_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapEncoderInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppibitmapencoder: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -521,6 +534,7 @@ impl IWICBitmapEncoderInfo_Vtbl {
 pub trait IWICBitmapFlipRotator_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, options: WICBitmapTransformOptions) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapFlipRotator {}
 impl IWICBitmapFlipRotator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapFlipRotator_Impl, const OFFSET: isize>() -> IWICBitmapFlipRotator_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapFlipRotator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisource: ::windows::core::RawPtr, options: WICBitmapTransformOptions) -> ::windows::core::HRESULT {
@@ -539,6 +553,7 @@ pub trait IWICBitmapFrameDecode_Impl: Sized + IWICBitmapSource_Impl {
     fn GetColorContexts(&self, ccount: u32, ppicolorcontexts: *mut ::core::option::Option<IWICColorContext>, pcactualcount: *mut u32) -> ::windows::core::Result<()>;
     fn GetThumbnail(&self) -> ::windows::core::Result<IWICBitmapSource>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapFrameDecode {}
 impl IWICBitmapFrameDecode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapFrameDecode_Impl, const OFFSET: isize>() -> IWICBitmapFrameDecode_Vtbl {
         unsafe extern "system" fn GetMetadataQueryReader<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapFrameDecode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppimetadataqueryreader: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -593,6 +608,8 @@ pub trait IWICBitmapFrameEncode_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
     fn GetMetadataQueryWriter(&self) -> ::windows::core::Result<IWICMetadataQueryWriter>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IWICBitmapFrameEncode {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IWICBitmapFrameEncode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapFrameEncode_Impl, const OFFSET: isize>() -> IWICBitmapFrameEncode_Vtbl {
@@ -682,6 +699,7 @@ pub trait IWICBitmapLock_Impl: Sized {
     fn GetDataPointer(&self, pcbbuffersize: *mut u32, ppbdata: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetPixelFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapLock {}
 impl IWICBitmapLock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapLock_Impl, const OFFSET: isize>() -> IWICBitmapLock_Vtbl {
         unsafe extern "system" fn GetSize<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapLock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT {
@@ -731,6 +749,7 @@ impl IWICBitmapLock_Vtbl {
 pub trait IWICBitmapScaler_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, uiwidth: u32, uiheight: u32, mode: WICBitmapInterpolationMode) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapScaler {}
 impl IWICBitmapScaler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapScaler_Impl, const OFFSET: isize>() -> IWICBitmapScaler_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapScaler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisource: ::windows::core::RawPtr, uiwidth: u32, uiheight: u32, mode: WICBitmapInterpolationMode) -> ::windows::core::HRESULT {
@@ -751,6 +770,7 @@ pub trait IWICBitmapSource_Impl: Sized {
     fn CopyPalette(&self, pipalette: &::core::option::Option<IWICPalette>) -> ::windows::core::Result<()>;
     fn CopyPixels(&self, prc: *const WICRect, cbstride: u32, cbbuffersize: u32, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICBitmapSource {}
 impl IWICBitmapSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapSource_Impl, const OFFSET: isize>() -> IWICBitmapSource_Vtbl {
         unsafe extern "system" fn GetSize<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT {
@@ -805,6 +825,8 @@ pub trait IWICBitmapSourceTransform_Impl: Sized {
     fn DoesSupportTransform(&self, dsttransform: WICBitmapTransformOptions) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICBitmapSourceTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWICBitmapSourceTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapSourceTransform_Impl, const OFFSET: isize>() -> IWICBitmapSourceTransform_Vtbl {
         unsafe extern "system" fn CopyPixels<Identity: ::windows::core::IUnknownImpl, Impl: IWICBitmapSourceTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prc: *const WICRect, uiwidth: u32, uiheight: u32, pguiddstformat: *const ::windows::core::GUID, dsttransform: WICBitmapTransformOptions, nstride: u32, cbbuffersize: u32, pbbuffer: *mut u8) -> ::windows::core::HRESULT {
@@ -853,6 +875,7 @@ pub trait IWICColorContext_Impl: Sized {
     fn GetProfileBytes(&self, cbbuffer: u32, pbbuffer: *mut u8, pcbactual: *mut u32) -> ::windows::core::Result<()>;
     fn GetExifColorSpace(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IWICColorContext {}
 impl IWICColorContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICColorContext_Impl, const OFFSET: isize>() -> IWICColorContext_Vtbl {
         unsafe extern "system" fn InitializeFromFilename<Identity: ::windows::core::IUnknownImpl, Impl: IWICColorContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wzfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -914,6 +937,7 @@ impl IWICColorContext_Vtbl {
 pub trait IWICColorTransform_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pibitmapsource: &::core::option::Option<IWICBitmapSource>, picontextsource: &::core::option::Option<IWICColorContext>, picontextdest: &::core::option::Option<IWICColorContext>, pixelfmtdest: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICColorTransform {}
 impl IWICColorTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICColorTransform_Impl, const OFFSET: isize>() -> IWICColorTransform_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWICColorTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pibitmapsource: ::windows::core::RawPtr, picontextsource: ::windows::core::RawPtr, picontextdest: ::windows::core::RawPtr, pixelfmtdest: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -937,6 +961,8 @@ pub trait IWICComponentFactory_Impl: Sized + IWICImagingFactory_Impl {
     fn CreateQueryWriterFromBlockWriter(&self, piblockwriter: &::core::option::Option<IWICMetadataBlockWriter>) -> ::windows::core::Result<IWICMetadataQueryWriter>;
     fn CreateEncoderPropertyBag(&self, ppropoptions: *const super::super::System::Com::StructuredStorage::PROPBAG2, ccount: u32) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::IPropertyBag2>;
 }
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IWICComponentFactory {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IWICComponentFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICComponentFactory_Impl, const OFFSET: isize>() -> IWICComponentFactory_Vtbl {
@@ -1042,6 +1068,7 @@ pub trait IWICComponentInfo_Impl: Sized {
     fn GetSpecVersion(&self, cchspecversion: u32, wzspecversion: &::windows::core::PWSTR, pcchactual: *mut u32) -> ::windows::core::Result<()>;
     fn GetFriendlyName(&self, cchfriendlyname: u32, wzfriendlyname: &::windows::core::PWSTR, pcchactual: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICComponentInfo {}
 impl IWICComponentInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICComponentInfo_Impl, const OFFSET: isize>() -> IWICComponentInfo_Vtbl {
         unsafe extern "system" fn GetComponentType<Identity: ::windows::core::IUnknownImpl, Impl: IWICComponentInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut WICComponentType) -> ::windows::core::HRESULT {
@@ -1130,6 +1157,8 @@ pub trait IWICDdsDecoder_Impl: Sized {
     fn GetFrame(&self, arrayindex: u32, miplevel: u32, sliceindex: u32) -> ::windows::core::Result<IWICBitmapFrameDecode>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IWICDdsDecoder {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IWICDdsDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICDdsDecoder_Impl, const OFFSET: isize>() -> IWICDdsDecoder_Vtbl {
         unsafe extern "system" fn GetParameters<Identity: ::windows::core::IUnknownImpl, Impl: IWICDdsDecoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparameters: *mut WICDdsParameters) -> ::windows::core::HRESULT {
@@ -1171,6 +1200,8 @@ pub trait IWICDdsEncoder_Impl: Sized {
     fn CreateNewFrame(&self, ppiframeencode: *mut ::core::option::Option<IWICBitmapFrameEncode>, parrayindex: *mut u32, pmiplevel: *mut u32, psliceindex: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IWICDdsEncoder {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IWICDdsEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICDdsEncoder_Impl, const OFFSET: isize>() -> IWICDdsEncoder_Vtbl {
         unsafe extern "system" fn SetParameters<Identity: ::windows::core::IUnknownImpl, Impl: IWICDdsEncoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparameters: *const WICDdsParameters) -> ::windows::core::HRESULT {
@@ -1211,6 +1242,8 @@ pub trait IWICDdsFrameDecode_Impl: Sized {
     fn GetFormatInfo(&self) -> ::windows::core::Result<WICDdsFormatInfo>;
     fn CopyBlocks(&self, prcboundsinblocks: *const WICRect, cbstride: u32, cbbuffersize: u32, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IWICDdsFrameDecode {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IWICDdsFrameDecode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICDdsFrameDecode_Impl, const OFFSET: isize>() -> IWICDdsFrameDecode_Vtbl {
@@ -1281,6 +1314,8 @@ pub trait IWICDevelopRaw_Impl: Sized + IWICBitmapSource_Impl + IWICBitmapFrameDe
     fn GetRenderMode(&self) -> ::windows::core::Result<WICRawRenderMode>;
     fn SetNotificationCallback(&self, pcallback: &::core::option::Option<IWICDevelopRawNotificationCallback>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IWICDevelopRaw {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IWICDevelopRaw_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICDevelopRaw_Impl, const OFFSET: isize>() -> IWICDevelopRaw_Vtbl {
@@ -1559,6 +1594,7 @@ impl IWICDevelopRaw_Vtbl {
 pub trait IWICDevelopRawNotificationCallback_Impl: Sized {
     fn Notify(&self, notificationmask: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICDevelopRawNotificationCallback {}
 impl IWICDevelopRawNotificationCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICDevelopRawNotificationCallback_Impl, const OFFSET: isize>() -> IWICDevelopRawNotificationCallback_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IWICDevelopRawNotificationCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, notificationmask: u32) -> ::windows::core::HRESULT {
@@ -1579,6 +1615,8 @@ pub trait IWICEnumMetadataItem_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IWICEnumMetadataItem>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWICEnumMetadataItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWICEnumMetadataItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICEnumMetadataItem_Impl, const OFFSET: isize>() -> IWICEnumMetadataItem_Vtbl {
@@ -1624,6 +1662,7 @@ pub trait IWICFastMetadataEncoder_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
     fn GetMetadataQueryWriter(&self) -> ::windows::core::Result<IWICMetadataQueryWriter>;
 }
+impl ::windows::core::RuntimeName for IWICFastMetadataEncoder {}
 impl IWICFastMetadataEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICFastMetadataEncoder_Impl, const OFFSET: isize>() -> IWICFastMetadataEncoder_Vtbl {
         unsafe extern "system" fn Commit<Identity: ::windows::core::IUnknownImpl, Impl: IWICFastMetadataEncoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1658,6 +1697,8 @@ pub trait IWICFormatConverter_Impl: Sized + IWICBitmapSource_Impl {
     fn CanConvert(&self, srcpixelformat: *const ::windows::core::GUID, dstpixelformat: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICFormatConverter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWICFormatConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICFormatConverter_Impl, const OFFSET: isize>() -> IWICFormatConverter_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWICFormatConverter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisource: ::windows::core::RawPtr, dstformat: *const ::windows::core::GUID, dither: WICBitmapDitherType, pipalette: ::windows::core::RawPtr, alphathresholdpercent: f64, palettetranslate: WICBitmapPaletteType) -> ::windows::core::HRESULT {
@@ -1690,6 +1731,7 @@ pub trait IWICFormatConverterInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn GetPixelFormats(&self, cformats: u32, ppixelformatguids: *mut ::windows::core::GUID, pcactual: *mut u32) -> ::windows::core::Result<()>;
     fn CreateInstance(&self) -> ::windows::core::Result<IWICFormatConverter>;
 }
+impl ::windows::core::RuntimeName for IWICFormatConverterInfo {}
 impl IWICFormatConverterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICFormatConverterInfo_Impl, const OFFSET: isize>() -> IWICFormatConverterInfo_Vtbl {
         unsafe extern "system" fn GetPixelFormats<Identity: ::windows::core::IUnknownImpl, Impl: IWICFormatConverterInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cformats: u32, ppixelformatguids: *mut ::windows::core::GUID, pcactual: *mut u32) -> ::windows::core::HRESULT {
@@ -1746,6 +1788,8 @@ pub trait IWICImagingFactory_Impl: Sized {
     fn CreateQueryWriter(&self, guidmetadataformat: *const ::windows::core::GUID, pguidvendor: *const ::windows::core::GUID) -> ::windows::core::Result<IWICMetadataQueryWriter>;
     fn CreateQueryWriterFromReader(&self, piqueryreader: &::core::option::Option<IWICMetadataQueryReader>, pguidvendor: *const ::windows::core::GUID) -> ::windows::core::Result<IWICMetadataQueryWriter>;
 }
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IWICImagingFactory {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IWICImagingFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICImagingFactory_Impl, const OFFSET: isize>() -> IWICImagingFactory_Vtbl {
@@ -2071,6 +2115,8 @@ pub trait IWICJpegFrameDecode_Impl: Sized {
     fn CopyMinimalStream(&self, streamoffset: u32, cbstreamdata: u32, pbstreamdata: *mut u8, pcbstreamdataactual: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for IWICJpegFrameDecode {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IWICJpegFrameDecode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICJpegFrameDecode_Impl, const OFFSET: isize>() -> IWICJpegFrameDecode_Vtbl {
         unsafe extern "system" fn DoesSupportIndexing<Identity: ::windows::core::IUnknownImpl, Impl: IWICJpegFrameDecode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfindexingsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2185,6 +2231,8 @@ pub trait IWICJpegFrameEncode_Impl: Sized {
     fn WriteScan(&self, cbscandata: u32, pbscandata: *const u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IWICJpegFrameEncode {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IWICJpegFrameEncode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICJpegFrameEncode_Impl, const OFFSET: isize>() -> IWICJpegFrameEncode_Vtbl {
         unsafe extern "system" fn GetAcHuffmanTable<Identity: ::windows::core::IUnknownImpl, Impl: IWICJpegFrameEncode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scanindex: u32, tableindex: u32, pachuffmantable: *mut super::Dxgi::Common::DXGI_JPEG_AC_HUFFMAN_TABLE) -> ::windows::core::HRESULT {
@@ -2244,6 +2292,8 @@ pub trait IWICMetadataBlockReader_Impl: Sized {
     fn GetReaderByIndex(&self, nindex: u32) -> ::windows::core::Result<IWICMetadataReader>;
     fn GetEnumerator(&self) -> ::windows::core::Result<super::super::System::Com::IEnumUnknown>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IWICMetadataBlockReader {}
 #[cfg(feature = "Win32_System_Com")]
 impl IWICMetadataBlockReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataBlockReader_Impl, const OFFSET: isize>() -> IWICMetadataBlockReader_Vtbl {
@@ -2312,6 +2362,8 @@ pub trait IWICMetadataBlockWriter_Impl: Sized + IWICMetadataBlockReader_Impl {
     fn RemoveWriterByIndex(&self, nindex: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IWICMetadataBlockWriter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IWICMetadataBlockWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataBlockWriter_Impl, const OFFSET: isize>() -> IWICMetadataBlockWriter_Vtbl {
         unsafe extern "system" fn InitializeFromBlockReader<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataBlockWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pimdblockreader: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2368,6 +2420,8 @@ pub trait IWICMetadataHandlerInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn DoesSupportPadding(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn DoesRequireFixedSize(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICMetadataHandlerInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWICMetadataHandlerInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataHandlerInfo_Impl, const OFFSET: isize>() -> IWICMetadataHandlerInfo_Vtbl {
@@ -2453,6 +2507,8 @@ pub trait IWICMetadataQueryReader_Impl: Sized {
     fn GetEnumerator(&self) -> ::windows::core::Result<super::super::System::Com::IEnumString>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWICMetadataQueryReader {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWICMetadataQueryReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataQueryReader_Impl, const OFFSET: isize>() -> IWICMetadataQueryReader_Vtbl {
         unsafe extern "system" fn GetContainerFormat<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataQueryReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidcontainerformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2505,6 +2561,8 @@ pub trait IWICMetadataQueryWriter_Impl: Sized + IWICMetadataQueryReader_Impl {
     fn RemoveMetadataByName(&self, wzname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWICMetadataQueryWriter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWICMetadataQueryWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataQueryWriter_Impl, const OFFSET: isize>() -> IWICMetadataQueryWriter_Vtbl {
         unsafe extern "system" fn SetMetadataByName<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataQueryWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wzname: ::windows::core::PCWSTR, pvarvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -2536,6 +2594,8 @@ pub trait IWICMetadataReader_Impl: Sized {
     fn GetValue(&self, pvarschema: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarid: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
     fn GetEnumerator(&self) -> ::windows::core::Result<IWICEnumMetadataItem>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWICMetadataReader {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWICMetadataReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataReader_Impl, const OFFSET: isize>() -> IWICMetadataReader_Vtbl {
@@ -2614,6 +2674,8 @@ pub trait IWICMetadataReaderInfo_Impl: Sized + IWICComponentInfo_Impl + IWICMeta
     fn CreateInstance(&self) -> ::windows::core::Result<IWICMetadataReader>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWICMetadataReaderInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWICMetadataReaderInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataReaderInfo_Impl, const OFFSET: isize>() -> IWICMetadataReaderInfo_Vtbl {
         unsafe extern "system" fn GetPatterns<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataReaderInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidcontainerformat: *const ::windows::core::GUID, cbsize: u32, ppattern: *mut WICMetadataPattern, pccount: *mut u32, pcbactual: *mut u32) -> ::windows::core::HRESULT {
@@ -2662,6 +2724,8 @@ pub trait IWICMetadataWriter_Impl: Sized + IWICMetadataReader_Impl {
     fn RemoveValueByIndex(&self, nindex: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWICMetadataWriter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWICMetadataWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataWriter_Impl, const OFFSET: isize>() -> IWICMetadataWriter_Vtbl {
         unsafe extern "system" fn SetValue<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvarschema: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarid: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -2701,6 +2765,8 @@ pub trait IWICMetadataWriterInfo_Impl: Sized + IWICComponentInfo_Impl + IWICMeta
     fn GetHeader(&self, guidcontainerformat: *const ::windows::core::GUID, cbsize: u32, pheader: *mut WICMetadataHeader, pcbactual: *mut u32) -> ::windows::core::Result<()>;
     fn CreateInstance(&self) -> ::windows::core::Result<IWICMetadataWriter>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICMetadataWriterInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWICMetadataWriterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICMetadataWriterInfo_Impl, const OFFSET: isize>() -> IWICMetadataWriterInfo_Vtbl {
@@ -2743,6 +2809,8 @@ pub trait IWICPalette_Impl: Sized {
     fn IsGrayscale(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn HasAlpha(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICPalette {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWICPalette_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPalette_Impl, const OFFSET: isize>() -> IWICPalette_Vtbl {
@@ -2850,6 +2918,8 @@ pub trait IWICPersistStream_Impl: Sized + super::super::System::Com::IPersist_Im
     fn SaveEx(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>, dwpersistoptions: u32, fcleardirty: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWICPersistStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWICPersistStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPersistStream_Impl, const OFFSET: isize>() -> IWICPersistStream_Vtbl {
         unsafe extern "system" fn LoadEx<Identity: ::windows::core::IUnknownImpl, Impl: IWICPersistStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pistream: ::windows::core::RawPtr, pguidpreferredvendor: *const ::windows::core::GUID, dwpersistoptions: u32) -> ::windows::core::HRESULT {
@@ -2879,6 +2949,7 @@ pub trait IWICPixelFormatInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn GetChannelMask(&self, uichannelindex: u32, cbmaskbuffer: u32, pbmaskbuffer: *mut u8, pcbactual: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICPixelFormatInfo {}
 impl IWICPixelFormatInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPixelFormatInfo_Impl, const OFFSET: isize>() -> IWICPixelFormatInfo_Vtbl {
         unsafe extern "system" fn GetFormatGUID<Identity: ::windows::core::IUnknownImpl, Impl: IWICPixelFormatInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2949,6 +3020,8 @@ pub trait IWICPixelFormatInfo2_Impl: Sized + IWICComponentInfo_Impl + IWICPixelF
     fn GetNumericRepresentation(&self) -> ::windows::core::Result<WICPixelFormatNumericRepresentation>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICPixelFormatInfo2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWICPixelFormatInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPixelFormatInfo2_Impl, const OFFSET: isize>() -> IWICPixelFormatInfo2_Vtbl {
         unsafe extern "system" fn SupportsTransparency<Identity: ::windows::core::IUnknownImpl, Impl: IWICPixelFormatInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfsupportstransparency: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2987,6 +3060,7 @@ pub trait IWICPlanarBitmapFrameEncode_Impl: Sized {
     fn WritePixels(&self, linecount: u32, pplanes: *const WICBitmapPlane, cplanes: u32) -> ::windows::core::Result<()>;
     fn WriteSource(&self, ppplanes: *const ::core::option::Option<IWICBitmapSource>, cplanes: u32, prcsource: *const WICRect) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICPlanarBitmapFrameEncode {}
 impl IWICPlanarBitmapFrameEncode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPlanarBitmapFrameEncode_Impl, const OFFSET: isize>() -> IWICPlanarBitmapFrameEncode_Vtbl {
         unsafe extern "system" fn WritePixels<Identity: ::windows::core::IUnknownImpl, Impl: IWICPlanarBitmapFrameEncode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, linecount: u32, pplanes: *const WICBitmapPlane, cplanes: u32) -> ::windows::core::HRESULT {
@@ -3015,6 +3089,8 @@ pub trait IWICPlanarBitmapSourceTransform_Impl: Sized {
     fn CopyPixels(&self, prcsource: *const WICRect, uiwidth: u32, uiheight: u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pdstplanes: *const WICBitmapPlane, cplanes: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICPlanarBitmapSourceTransform {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWICPlanarBitmapSourceTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPlanarBitmapSourceTransform_Impl, const OFFSET: isize>() -> IWICPlanarBitmapSourceTransform_Vtbl {
         unsafe extern "system" fn DoesSupportTransform<Identity: ::windows::core::IUnknownImpl, Impl: IWICPlanarBitmapSourceTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pguiddstformats: *const ::windows::core::GUID, pplanedescriptions: *mut WICBitmapPlaneDescription, cplanes: u32, pfissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3042,6 +3118,8 @@ pub trait IWICPlanarFormatConverter_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, ppplanes: *const ::core::option::Option<IWICBitmapSource>, cplanes: u32, dstformat: *const ::windows::core::GUID, dither: WICBitmapDitherType, pipalette: &::core::option::Option<IWICPalette>, alphathresholdpercent: f64, palettetranslate: WICBitmapPaletteType) -> ::windows::core::Result<()>;
     fn CanConvert(&self, psrcpixelformats: *const ::windows::core::GUID, csrcplanes: u32, dstpixelformat: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWICPlanarFormatConverter {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWICPlanarFormatConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICPlanarFormatConverter_Impl, const OFFSET: isize>() -> IWICPlanarFormatConverter_Vtbl {
@@ -3074,6 +3152,7 @@ impl IWICPlanarFormatConverter_Vtbl {
 pub trait IWICProgressCallback_Impl: Sized {
     fn Notify(&self, uframenum: u32, operation: WICProgressOperation, dblprogress: f64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICProgressCallback {}
 impl IWICProgressCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICProgressCallback_Impl, const OFFSET: isize>() -> IWICProgressCallback_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IWICProgressCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uframenum: u32, operation: WICProgressOperation, dblprogress: f64) -> ::windows::core::HRESULT {
@@ -3092,6 +3171,7 @@ pub trait IWICProgressiveLevelControl_Impl: Sized {
     fn GetCurrentLevel(&self) -> ::windows::core::Result<u32>;
     fn SetCurrentLevel(&self, nlevel: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWICProgressiveLevelControl {}
 impl IWICProgressiveLevelControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICProgressiveLevelControl_Impl, const OFFSET: isize>() -> IWICProgressiveLevelControl_Vtbl {
         unsafe extern "system" fn GetLevelCount<Identity: ::windows::core::IUnknownImpl, Impl: IWICProgressiveLevelControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclevels: *mut u32) -> ::windows::core::HRESULT {
@@ -3140,6 +3220,8 @@ pub trait IWICStream_Impl: Sized + super::super::System::Com::ISequentialStream_
     fn InitializeFromIStreamRegion(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>, uloffset: u64, ulmaxsize: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IWICStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IWICStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICStream_Impl, const OFFSET: isize>() -> IWICStream_Vtbl {
         unsafe extern "system" fn InitializeFromIStream<Identity: ::windows::core::IUnknownImpl, Impl: IWICStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pistream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3181,6 +3263,8 @@ pub trait IWICStreamProvider_Impl: Sized {
     fn GetPreferredVendorGUID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn RefreshStream(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IWICStreamProvider {}
 #[cfg(feature = "Win32_System_Com")]
 impl IWICStreamProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWICStreamProvider_Impl, const OFFSET: isize>() -> IWICStreamProvider_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
@@ -3,6 +3,8 @@ pub trait IAsyncGetSendNotificationCookie_Impl: Sized + IPrintAsyncCookie_Impl {
     fn FinishAsyncCallWithData(&self, param0: &::core::option::Option<IPrintAsyncNotifyDataObject>, param1: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAsyncGetSendNotificationCookie {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAsyncGetSendNotificationCookie_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncGetSendNotificationCookie_Impl, const OFFSET: isize>() -> IAsyncGetSendNotificationCookie_Vtbl {
         unsafe extern "system" fn FinishAsyncCallWithData<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncGetSendNotificationCookie_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::RawPtr, param1: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -21,6 +23,7 @@ pub trait IAsyncGetSrvReferralCookie_Impl: Sized {
     fn CancelAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn FinishAsyncCallWithData(&self, param0: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAsyncGetSrvReferralCookie {}
 impl IAsyncGetSrvReferralCookie_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncGetSrvReferralCookie_Impl, const OFFSET: isize>() -> IAsyncGetSrvReferralCookie_Vtbl {
         unsafe extern "system" fn FinishAsyncCall<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncGetSrvReferralCookie_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -56,6 +59,7 @@ pub trait IBidiAsyncNotifyChannel_Impl: Sized + IPrintAsyncNotifyChannel_Impl {
     fn AsyncGetNotificationSendResponse(&self, param0: &::core::option::Option<IPrintAsyncNotifyDataObject>, param1: &::core::option::Option<IAsyncGetSendNotificationCookie>) -> ::windows::core::Result<()>;
     fn AsyncCloseChannel(&self, param0: &::core::option::Option<IPrintAsyncNotifyDataObject>, param1: &::core::option::Option<IPrintAsyncCookie>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBidiAsyncNotifyChannel {}
 impl IBidiAsyncNotifyChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBidiAsyncNotifyChannel_Impl, const OFFSET: isize>() -> IBidiAsyncNotifyChannel_Vtbl {
         unsafe extern "system" fn CreateNotificationChannel<Identity: ::windows::core::IUnknownImpl, Impl: IBidiAsyncNotifyChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -103,6 +107,7 @@ pub trait IBidiRequest_Impl: Sized {
     fn GetOutputData(&self, dwindex: u32, ppszschema: *mut ::windows::core::PWSTR, pdwtype: *mut u32, ppdata: *mut *mut u8, usize: *mut u32) -> ::windows::core::Result<()>;
     fn GetEnumCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBidiRequest {}
 impl IBidiRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBidiRequest_Impl, const OFFSET: isize>() -> IBidiRequest_Vtbl {
         unsafe extern "system" fn SetSchema<Identity: ::windows::core::IUnknownImpl, Impl: IBidiRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszschema: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -162,6 +167,8 @@ pub trait IBidiRequestContainer_Impl: Sized {
     fn GetRequestCount(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBidiRequestContainer {}
+#[cfg(feature = "Win32_System_Com")]
 impl IBidiRequestContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBidiRequestContainer_Impl, const OFFSET: isize>() -> IBidiRequestContainer_Vtbl {
         unsafe extern "system" fn AddRequest<Identity: ::windows::core::IUnknownImpl, Impl: IBidiRequestContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prequest: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -208,6 +215,7 @@ pub trait IBidiSpl_Impl: Sized {
     fn SendRecv(&self, pszaction: &::windows::core::PCWSTR, prequest: &::core::option::Option<IBidiRequest>) -> ::windows::core::Result<()>;
     fn MultiSendRecv(&self, pszaction: &::windows::core::PCWSTR, prequestcontainer: &::core::option::Option<IBidiRequestContainer>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBidiSpl {}
 impl IBidiSpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBidiSpl_Impl, const OFFSET: isize>() -> IBidiSpl_Vtbl {
         unsafe extern "system" fn BindDevice<Identity: ::windows::core::IUnknownImpl, Impl: IBidiSpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdevicename: ::windows::core::PCWSTR, dwaccess: u32) -> ::windows::core::HRESULT {
@@ -249,6 +257,8 @@ pub trait IBidiSpl2_Impl: Sized {
     fn SendRecvXMLString(&self, bstrrequest: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SendRecvXMLStream(&self, psrequest: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IBidiSpl2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IBidiSpl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBidiSpl2_Impl, const OFFSET: isize>() -> IBidiSpl2_Vtbl {
@@ -303,6 +313,8 @@ pub trait IFixedDocument_Impl: Sized {
     fn SetPrintTicket(&self, pprintticket: &::core::option::Option<IPartPrintTicket>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFixedDocument {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFixedDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFixedDocument_Impl, const OFFSET: isize>() -> IFixedDocument_Vtbl {
         unsafe extern "system" fn GetUri<Identity: ::windows::core::IUnknownImpl, Impl: IFixedDocument_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uri: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -349,6 +361,8 @@ pub trait IFixedDocumentSequence_Impl: Sized {
     fn GetPrintTicket(&self) -> ::windows::core::Result<IPartPrintTicket>;
     fn SetPrintTicket(&self, pprintticket: &::core::option::Option<IPartPrintTicket>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFixedDocumentSequence {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFixedDocumentSequence_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFixedDocumentSequence_Impl, const OFFSET: isize>() -> IFixedDocumentSequence_Vtbl {
@@ -400,6 +414,8 @@ pub trait IFixedPage_Impl: Sized + IPartBase_Impl {
     fn DeleteResource(&self, uri: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetXpsPartIterator(&self) -> ::windows::core::Result<IXpsPartIterator>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFixedPage {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFixedPage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFixedPage_Impl, const OFFSET: isize>() -> IFixedPage_Vtbl {
@@ -482,6 +498,8 @@ pub trait IImgCreateErrorInfo_Impl: Sized + super::super::System::Ole::ICreateEr
     fn AttachToErrorInfo(&self, perrorinfo: *mut __MIDL___MIDL_itf_imgerror_0000_0000_0001) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IImgCreateErrorInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IImgCreateErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImgCreateErrorInfo_Impl, const OFFSET: isize>() -> IImgCreateErrorInfo_Vtbl {
         unsafe extern "system" fn AttachToErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: IImgCreateErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, perrorinfo: *mut __MIDL___MIDL_itf_imgerror_0000_0000_0001) -> ::windows::core::HRESULT {
@@ -508,6 +526,8 @@ pub trait IImgErrorInfo_Impl: Sized + super::super::System::Com::IErrorInfo_Impl
     fn GetExceptionId(&self) -> ::windows::core::Result<u32>;
     fn DetachErrorInfo(&self) -> ::windows::core::Result<__MIDL___MIDL_itf_imgerror_0000_0000_0001>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IImgErrorInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IImgErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImgErrorInfo_Impl, const OFFSET: isize>() -> IImgErrorInfo_Vtbl {
@@ -607,6 +627,7 @@ pub trait IInterFilterCommunicator_Impl: Sized {
     fn RequestReader(&self, ppireader: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn RequestWriter(&self, ppiwriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInterFilterCommunicator {}
 impl IInterFilterCommunicator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInterFilterCommunicator_Impl, const OFFSET: isize>() -> IInterFilterCommunicator_Vtbl {
         unsafe extern "system" fn RequestReader<Identity: ::windows::core::IUnknownImpl, Impl: IInterFilterCommunicator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppireader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -636,6 +657,8 @@ pub trait IPartBase_Impl: Sized {
     fn GetPartCompression(&self) -> ::windows::core::Result<EXpsCompressionOptions>;
     fn SetPartCompression(&self, compression: EXpsCompressionOptions) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartBase {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPartBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartBase_Impl, const OFFSET: isize>() -> IPartBase_Vtbl {
@@ -692,6 +715,8 @@ impl IPartBase_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPartColorProfile_Impl: Sized + IPartBase_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartColorProfile {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPartColorProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartColorProfile_Impl, const OFFSET: isize>() -> IPartColorProfile_Vtbl {
         Self { base__: IPartBase_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -704,6 +729,8 @@ impl IPartColorProfile_Vtbl {
 pub trait IPartDiscardControl_Impl: Sized {
     fn GetDiscardProperties(&self, urisentinelpage: *mut super::super::Foundation::BSTR, uriparttodiscard: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartDiscardControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPartDiscardControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartDiscardControl_Impl, const OFFSET: isize>() -> IPartDiscardControl_Vtbl {
@@ -724,6 +751,8 @@ pub trait IPartFont_Impl: Sized + IPartBase_Impl {
     fn SetFontContent(&self, pcontenttype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetFontOptions(&self, options: EXpsFontOptions) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartFont {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPartFont_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartFont_Impl, const OFFSET: isize>() -> IPartFont_Vtbl {
@@ -758,6 +787,8 @@ pub trait IPartFont2_Impl: Sized + IPartBase_Impl + IPartFont_Impl {
     fn GetFontRestriction(&self) -> ::windows::core::Result<EXpsFontRestriction>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartFont2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPartFont2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartFont2_Impl, const OFFSET: isize>() -> IPartFont2_Vtbl {
         unsafe extern "system" fn GetFontRestriction<Identity: ::windows::core::IUnknownImpl, Impl: IPartFont2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prestriction: *mut EXpsFontRestriction) -> ::windows::core::HRESULT {
@@ -782,6 +813,8 @@ pub trait IPartImage_Impl: Sized + IPartBase_Impl {
     fn GetImageProperties(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetImageContent(&self, pcontenttype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartImage {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPartImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartImage_Impl, const OFFSET: isize>() -> IPartImage_Vtbl {
@@ -814,6 +847,8 @@ impl IPartImage_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPartPrintTicket_Impl: Sized + IPartBase_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartPrintTicket {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPartPrintTicket_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartPrintTicket_Impl, const OFFSET: isize>() -> IPartPrintTicket_Vtbl {
         Self { base__: IPartBase_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -824,6 +859,8 @@ impl IPartPrintTicket_Vtbl {
 }
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPartResourceDictionary_Impl: Sized + IPartBase_Impl {}
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartResourceDictionary {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPartResourceDictionary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartResourceDictionary_Impl, const OFFSET: isize>() -> IPartResourceDictionary_Vtbl {
@@ -838,6 +875,8 @@ pub trait IPartThumbnail_Impl: Sized + IPartBase_Impl {
     fn GetThumbnailProperties(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetThumbnailContent(&self, pcontenttype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPartThumbnail {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPartThumbnail_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartThumbnail_Impl, const OFFSET: isize>() -> IPartThumbnail_Vtbl {
@@ -871,6 +910,7 @@ pub trait IPrintAsyncCookie_Impl: Sized {
     fn FinishAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn CancelAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncCookie {}
 impl IPrintAsyncCookie_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncCookie_Impl, const OFFSET: isize>() -> IPrintAsyncCookie_Vtbl {
         unsafe extern "system" fn FinishAsyncCall<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncCookie_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -896,6 +936,7 @@ impl IPrintAsyncCookie_Vtbl {
 pub trait IPrintAsyncNewChannelCookie_Impl: Sized + IPrintAsyncCookie_Impl {
     fn FinishAsyncCallWithData(&self, param0: *const ::core::option::Option<IPrintAsyncNotifyChannel>, param1: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNewChannelCookie {}
 impl IPrintAsyncNewChannelCookie_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNewChannelCookie_Impl, const OFFSET: isize>() -> IPrintAsyncNewChannelCookie_Vtbl {
         unsafe extern "system" fn FinishAsyncCallWithData<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNewChannelCookie_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::RawPtr, param1: u32) -> ::windows::core::HRESULT {
@@ -913,6 +954,7 @@ pub trait IPrintAsyncNotify_Impl: Sized {
     fn CreatePrintAsyncNotifyChannel(&self, param0: u32, param1: *const ::windows::core::GUID, param2: PrintAsyncNotifyUserFilter, param3: PrintAsyncNotifyConversationStyle, param4: &::core::option::Option<IPrintAsyncNotifyCallback>) -> ::windows::core::Result<IPrintAsyncNotifyChannel>;
     fn CreatePrintAsyncNotifyRegistration(&self, param0: *const ::windows::core::GUID, param1: PrintAsyncNotifyUserFilter, param2: PrintAsyncNotifyConversationStyle, param3: &::core::option::Option<IPrintAsyncNotifyCallback>) -> ::windows::core::Result<IPrintAsyncNotifyRegistration>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNotify {}
 impl IPrintAsyncNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotify_Impl, const OFFSET: isize>() -> IPrintAsyncNotify_Vtbl {
         unsafe extern "system" fn CreatePrintAsyncNotifyChannel<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: u32, param1: *const ::windows::core::GUID, param2: PrintAsyncNotifyUserFilter, param3: PrintAsyncNotifyConversationStyle, param4: ::windows::core::RawPtr, param5: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -951,6 +993,7 @@ pub trait IPrintAsyncNotifyCallback_Impl: Sized {
     fn OnEventNotify(&self, pchannel: &::core::option::Option<IPrintAsyncNotifyChannel>, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
     fn ChannelClosed(&self, pchannel: &::core::option::Option<IPrintAsyncNotifyChannel>, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNotifyCallback {}
 impl IPrintAsyncNotifyCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyCallback_Impl, const OFFSET: isize>() -> IPrintAsyncNotifyCallback_Vtbl {
         unsafe extern "system" fn OnEventNotify<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pchannel: ::windows::core::RawPtr, pdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -977,6 +1020,7 @@ pub trait IPrintAsyncNotifyChannel_Impl: Sized {
     fn SendNotification(&self, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
     fn CloseChannel(&self, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNotifyChannel {}
 impl IPrintAsyncNotifyChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyChannel_Impl, const OFFSET: isize>() -> IPrintAsyncNotifyChannel_Vtbl {
         unsafe extern "system" fn SendNotification<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1003,6 +1047,7 @@ pub trait IPrintAsyncNotifyDataObject_Impl: Sized {
     fn AcquireData(&self, ppnotificationdata: *mut *mut u8, psize: *mut u32, ppschema: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn ReleaseData(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNotifyDataObject {}
 impl IPrintAsyncNotifyDataObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyDataObject_Impl, const OFFSET: isize>() -> IPrintAsyncNotifyDataObject_Vtbl {
         unsafe extern "system" fn AcquireData<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyDataObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppnotificationdata: *mut *mut u8, psize: *mut u32, ppschema: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1029,6 +1074,7 @@ pub trait IPrintAsyncNotifyRegistration_Impl: Sized {
     fn RegisterForNotifications(&self) -> ::windows::core::Result<()>;
     fn UnregisterForNotifications(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNotifyRegistration {}
 impl IPrintAsyncNotifyRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyRegistration_Impl, const OFFSET: isize>() -> IPrintAsyncNotifyRegistration_Vtbl {
         unsafe extern "system" fn RegisterForNotifications<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1056,6 +1102,7 @@ pub trait IPrintAsyncNotifyServerReferral_Impl: Sized {
     fn AsyncGetServerReferral(&self, param0: &::core::option::Option<IAsyncGetSrvReferralCookie>) -> ::windows::core::Result<()>;
     fn SetServerReferral(&self, prmtserverreferral: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintAsyncNotifyServerReferral {}
 impl IPrintAsyncNotifyServerReferral_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyServerReferral_Impl, const OFFSET: isize>() -> IPrintAsyncNotifyServerReferral_Vtbl {
         unsafe extern "system" fn GetServerReferral<Identity: ::windows::core::IUnknownImpl, Impl: IPrintAsyncNotifyServerReferral_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1093,6 +1140,7 @@ impl IPrintAsyncNotifyServerReferral_Vtbl {
 pub trait IPrintBidiAsyncNotifyRegistration_Impl: Sized + IPrintAsyncNotifyRegistration_Impl {
     fn AsyncGetNewChannel(&self, param0: &::core::option::Option<IPrintAsyncNewChannelCookie>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintBidiAsyncNotifyRegistration {}
 impl IPrintBidiAsyncNotifyRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintBidiAsyncNotifyRegistration_Impl, const OFFSET: isize>() -> IPrintBidiAsyncNotifyRegistration_Vtbl {
         unsafe extern "system" fn AsyncGetNewChannel<Identity: ::windows::core::IUnknownImpl, Impl: IPrintBidiAsyncNotifyRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1109,6 +1157,7 @@ impl IPrintBidiAsyncNotifyRegistration_Vtbl {
 pub trait IPrintClassObjectFactory_Impl: Sized {
     fn GetPrintClassObject(&self, pszprintername: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppnewobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintClassObjectFactory {}
 impl IPrintClassObjectFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintClassObjectFactory_Impl, const OFFSET: isize>() -> IPrintClassObjectFactory_Vtbl {
         unsafe extern "system" fn GetPrintClassObject<Identity: ::windows::core::IUnknownImpl, Impl: IPrintClassObjectFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszprintername: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppnewobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1134,6 +1183,8 @@ pub trait IPrintCoreHelper_Impl: Sized {
     fn SetFontSubstitution(&self, psztruetypefontname: &::windows::core::PCWSTR, pszdevfontname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn CreateInstanceOfMSXMLObject(&self, rclsid: *const ::windows::core::GUID, punkouter: &::core::option::Option<::windows::core::IUnknown>, dwclscontext: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IPrintCoreHelper {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IPrintCoreHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelper_Impl, const OFFSET: isize>() -> IPrintCoreHelper_Vtbl {
@@ -1212,6 +1263,8 @@ pub trait IPrintCoreHelperPS_Impl: Sized + IPrintCoreHelper_Impl {
     fn GetOptionAttribute(&self, pszfeaturekeyword: &::windows::core::PCSTR, pszoptionkeyword: &::windows::core::PCSTR, pszattribute: &::windows::core::PCSTR, pdwdatatype: *mut u32, ppbdata: *mut *mut u8, pcbsize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IPrintCoreHelperPS {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IPrintCoreHelperPS_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelperPS_Impl, const OFFSET: isize>() -> IPrintCoreHelperPS_Vtbl {
         unsafe extern "system" fn GetGlobalAttribute<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelperPS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszattribute: ::windows::core::PCSTR, pdwdatatype: *mut u32, ppbdata: *mut *mut u8, pcbsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1246,6 +1299,8 @@ pub trait IPrintCoreHelperUni_Impl: Sized + IPrintCoreHelper_Impl {
     fn CreateDefaultGDLSnapshot(&self, dwflags: u32) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintCoreHelperUni {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IPrintCoreHelperUni_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelperUni_Impl, const OFFSET: isize>() -> IPrintCoreHelperUni_Vtbl {
         unsafe extern "system" fn CreateGDLSnapshot<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelperUni_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevmode: *mut super::Gdi::DEVMODEA, cbsize: u32, dwflags: u32, ppsnapshotstream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1279,6 +1334,8 @@ pub trait IPrintCoreHelperUni2_Impl: Sized + IPrintCoreHelper_Impl + IPrintCoreH
     fn GetNamedCommand(&self, pdevmode: *const super::Gdi::DEVMODEA, cbsize: u32, pszcommandname: &::windows::core::PCWSTR, ppcommandbytes: *mut *mut u8, pcbcommandsize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintCoreHelperUni2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IPrintCoreHelperUni2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelperUni2_Impl, const OFFSET: isize>() -> IPrintCoreHelperUni2_Vtbl {
         unsafe extern "system" fn GetNamedCommand<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreHelperUni2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevmode: *const super::Gdi::DEVMODEA, cbsize: u32, pszcommandname: ::windows::core::PCWSTR, ppcommandbytes: *mut *mut u8, pcbcommandsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1305,6 +1362,8 @@ pub trait IPrintCoreUI2_Impl: Sized + IPrintOemDriverUI_Impl {
     fn EnumOptions(&self, poemuiobj: *const OEMUIOBJ, dwflags: u32, pszfeaturekeyword: &::windows::core::PCSTR, pmszoptionlist: ::windows::core::PSTR, cbsize: u32, pcbneeded: *mut u32) -> ::windows::core::Result<()>;
     fn QuerySimulationSupport(&self, hprinter: super::super::Foundation::HANDLE, dwlevel: u32, pcaps: *mut u8, cbsize: u32, pcbneeded: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrintCoreUI2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPrintCoreUI2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintCoreUI2_Impl, const OFFSET: isize>() -> IPrintCoreUI2_Vtbl {
@@ -1392,6 +1451,8 @@ pub trait IPrintJob_Impl: Sized {
     fn SubmissionTime(&self) -> ::windows::core::Result<f64>;
     fn RequestCancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrintJob {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPrintJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintJob_Impl, const OFFSET: isize>() -> IPrintJob_Vtbl {
@@ -1488,6 +1549,8 @@ pub trait IPrintJobCollection_Impl: Sized + super::super::System::Com::IDispatch
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintJobCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintJobCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintJobCollection_Impl, const OFFSET: isize>() -> IPrintJobCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IPrintJobCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcount: *mut u32) -> ::windows::core::HRESULT {
@@ -1540,6 +1603,8 @@ pub trait IPrintOemCommon_Impl: Sized {
     fn DevMode(&self, dwmode: u32, poemdmparam: *mut OEMDMPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IPrintOemCommon {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IPrintOemCommon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemCommon_Impl, const OFFSET: isize>() -> IPrintOemCommon_Vtbl {
         unsafe extern "system" fn GetInfo<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemCommon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmode: u32, pbuffer: *mut ::core::ffi::c_void, cbsize: u32, pcbneeded: *mut u32) -> ::windows::core::HRESULT {
@@ -1568,6 +1633,8 @@ pub trait IPrintOemDriverUI_Impl: Sized {
     fn DrvUpgradeRegistrySetting(&self, hprinter: super::super::Foundation::HANDLE, pfeature: &::windows::core::PCSTR, poption: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn DrvUpdateUISetting(&self, pci: *mut ::core::ffi::c_void, poptitem: *mut ::core::ffi::c_void, dwpreviousselection: u32, dwmode: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrintOemDriverUI {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPrintOemDriverUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemDriverUI_Impl, const OFFSET: isize>() -> IPrintOemDriverUI_Vtbl {
@@ -1612,6 +1679,8 @@ pub trait IPrintOemUI_Impl: Sized + IPrintOemCommon_Impl {
     fn FontInstallerDlgProc(&self, hwnd: super::super::Foundation::HWND, usmsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
     fn UpdateExternalFonts(&self, hprinter: super::super::Foundation::HANDLE, hheap: super::super::Foundation::HANDLE, pwstrcartridges: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPrintOemUI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPrintOemUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemUI_Impl, const OFFSET: isize>() -> IPrintOemUI_Vtbl {
@@ -1702,6 +1771,8 @@ pub trait IPrintOemUI2_Impl: Sized + IPrintOemCommon_Impl + IPrintOemUI_Impl {
     fn DocumentEvent(&self, hprinter: super::super::Foundation::HANDLE, hdc: super::Gdi::HDC, iesc: i32, cbin: u32, pvin: *mut ::core::ffi::c_void, cbout: u32, pvout: *mut ::core::ffi::c_void, piresult: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPrintOemUI2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPrintOemUI2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemUI2_Impl, const OFFSET: isize>() -> IPrintOemUI2_Vtbl {
         unsafe extern "system" fn QueryJobAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemUI2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hprinter: super::super::Foundation::HANDLE, pdevmode: *const super::Gdi::DEVMODEA, dwlevel: u32, lpattributeinfo: *const u8) -> ::windows::core::HRESULT {
@@ -1737,6 +1808,8 @@ pub trait IPrintOemUIMXDC_Impl: Sized {
     fn AdjustDPI(&self, hprinter: super::super::Foundation::HANDLE, cbdevmode: u32, pdevmode: *const super::Gdi::DEVMODEA, cboemdm: u32, poemdm: *const ::core::ffi::c_void, pdpi: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IPrintOemUIMXDC {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IPrintOemUIMXDC_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemUIMXDC_Impl, const OFFSET: isize>() -> IPrintOemUIMXDC_Vtbl {
         unsafe extern "system" fn AdjustImageableArea<Identity: ::windows::core::IUnknownImpl, Impl: IPrintOemUIMXDC_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hprinter: super::super::Foundation::HANDLE, cbdevmode: u32, pdevmode: *const super::Gdi::DEVMODEA, cboemdm: u32, poemdm: *const ::core::ffi::c_void, prclimageablearea: *mut super::super::Foundation::RECTL) -> ::windows::core::HRESULT {
@@ -1770,6 +1843,7 @@ pub trait IPrintPipelineFilter_Impl: Sized {
     fn ShutdownOperation(&self) -> ::windows::core::Result<()>;
     fn StartOperation(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintPipelineFilter {}
 impl IPrintPipelineFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelineFilter_Impl, const OFFSET: isize>() -> IPrintPipelineFilter_Vtbl {
         unsafe extern "system" fn InitializeFilter<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelineFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinegotiation: ::windows::core::RawPtr, pipropertybag: ::windows::core::RawPtr, pipipelinecontrol: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1804,6 +1878,8 @@ pub trait IPrintPipelineManagerControl_Impl: Sized {
     fn FilterFinished(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IPrintPipelineManagerControl {}
+#[cfg(feature = "Win32_System_Com")]
 impl IPrintPipelineManagerControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelineManagerControl_Impl, const OFFSET: isize>() -> IPrintPipelineManagerControl_Vtbl {
         unsafe extern "system" fn RequestShutdown<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelineManagerControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrreason: ::windows::core::HRESULT, preason: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1829,6 +1905,7 @@ impl IPrintPipelineManagerControl_Vtbl {
 pub trait IPrintPipelineProgressReport_Impl: Sized {
     fn ReportProgress(&self, update: EXpsJobConsumption) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintPipelineProgressReport {}
 impl IPrintPipelineProgressReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelineProgressReport_Impl, const OFFSET: isize>() -> IPrintPipelineProgressReport_Vtbl {
         unsafe extern "system" fn ReportProgress<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelineProgressReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, update: EXpsJobConsumption) -> ::windows::core::HRESULT {
@@ -1848,6 +1925,8 @@ pub trait IPrintPipelinePropertyBag_Impl: Sized {
     fn GetProperty(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn DeleteProperty(&self, pszname: &::windows::core::PCWSTR) -> super::super::Foundation::BOOL;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintPipelinePropertyBag {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintPipelinePropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPipelinePropertyBag_Impl, const OFFSET: isize>() -> IPrintPipelinePropertyBag_Vtbl {
@@ -1890,6 +1969,8 @@ pub trait IPrintPreviewDxgiPackageTarget_Impl: Sized {
     fn InvalidatePreview(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi")]
+impl ::windows::core::RuntimeName for IPrintPreviewDxgiPackageTarget {}
+#[cfg(feature = "Win32_Graphics_Dxgi")]
 impl IPrintPreviewDxgiPackageTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPreviewDxgiPackageTarget_Impl, const OFFSET: isize>() -> IPrintPreviewDxgiPackageTarget_Vtbl {
         unsafe extern "system" fn SetJobPageCount<Identity: ::windows::core::IUnknownImpl, Impl: IPrintPreviewDxgiPackageTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, counttype: PageCountType, count: u32) -> ::windows::core::HRESULT {
@@ -1924,6 +2005,8 @@ pub trait IPrintReadStream_Impl: Sized {
     fn ReadBytes(&self, pvbuffer: *mut ::core::ffi::c_void, cbrequested: u32, pcbread: *mut u32, pbendoffile: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrintReadStream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPrintReadStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintReadStream_Impl, const OFFSET: isize>() -> IPrintReadStream_Vtbl {
         unsafe extern "system" fn Seek<Identity: ::windows::core::IUnknownImpl, Impl: IPrintReadStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dlibmove: i64, dworigin: u32, plibnewposition: *mut u64) -> ::windows::core::HRESULT {
@@ -1955,6 +2038,7 @@ impl IPrintReadStream_Vtbl {
 pub trait IPrintReadStreamFactory_Impl: Sized {
     fn GetStream(&self) -> ::windows::core::Result<IPrintReadStream>;
 }
+impl ::windows::core::RuntimeName for IPrintReadStreamFactory {}
 impl IPrintReadStreamFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintReadStreamFactory_Impl, const OFFSET: isize>() -> IPrintReadStreamFactory_Vtbl {
         unsafe extern "system" fn GetStream<Identity: ::windows::core::IUnknownImpl, Impl: IPrintReadStreamFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppstream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1979,6 +2063,8 @@ pub trait IPrintSchemaAsyncOperation_Impl: Sized + super::super::System::Com::ID
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaAsyncOperation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaAsyncOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaAsyncOperation_Impl, const OFFSET: isize>() -> IPrintSchemaAsyncOperation_Vtbl {
@@ -2007,6 +2093,8 @@ pub trait IPrintSchemaAsyncOperationEvent_Impl: Sized + super::super::System::Co
     fn Completed(&self, pticket: &::core::option::Option<IPrintSchemaTicket>, hroperation: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaAsyncOperationEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaAsyncOperationEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaAsyncOperationEvent_Impl, const OFFSET: isize>() -> IPrintSchemaAsyncOperationEvent_Vtbl {
         unsafe extern "system" fn Completed<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaAsyncOperationEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pticket: ::windows::core::RawPtr, hroperation: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -2030,6 +2118,8 @@ pub trait IPrintSchemaCapabilities_Impl: Sized + super::super::System::Com::IDis
     fn GetSelectedOptionInPrintTicket(&self, pfeature: &::core::option::Option<IPrintSchemaFeature>) -> ::windows::core::Result<IPrintSchemaOption>;
     fn GetOptions(&self, pfeature: &::core::option::Option<IPrintSchemaFeature>) -> ::windows::core::Result<IPrintSchemaOptionCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaCapabilities {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaCapabilities_Impl, const OFFSET: isize>() -> IPrintSchemaCapabilities_Vtbl {
@@ -2130,6 +2220,8 @@ pub trait IPrintSchemaCapabilities2_Impl: Sized + super::super::System::Com::IDi
     fn GetParameterDefinition(&self, bstrname: &super::super::Foundation::BSTR, bstrnamespaceuri: &super::super::Foundation::BSTR) -> ::windows::core::Result<IPrintSchemaParameterDefinition>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaCapabilities2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaCapabilities2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaCapabilities2_Impl, const OFFSET: isize>() -> IPrintSchemaCapabilities2_Vtbl {
         unsafe extern "system" fn GetParameterDefinition<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaCapabilities2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrnamespaceuri: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppparameterdefinition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2153,6 +2245,8 @@ impl IPrintSchemaCapabilities2_Vtbl {
 pub trait IPrintSchemaDisplayableElement_Impl: Sized + super::super::System::Com::IDispatch_Impl + IPrintSchemaElement_Impl {
     fn DisplayName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaDisplayableElement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaDisplayableElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaDisplayableElement_Impl, const OFFSET: isize>() -> IPrintSchemaDisplayableElement_Vtbl {
@@ -2179,6 +2273,8 @@ pub trait IPrintSchemaElement_Impl: Sized + super::super::System::Com::IDispatch
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn NamespaceUri(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaElement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaElement_Impl, const OFFSET: isize>() -> IPrintSchemaElement_Vtbl {
@@ -2234,6 +2330,8 @@ pub trait IPrintSchemaFeature_Impl: Sized + super::super::System::Com::IDispatch
     fn GetOption(&self, bstrname: &super::super::Foundation::BSTR, bstrnamespaceuri: &super::super::Foundation::BSTR) -> ::windows::core::Result<IPrintSchemaOption>;
     fn DisplayUI(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaFeature {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaFeature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaFeature_Impl, const OFFSET: isize>() -> IPrintSchemaFeature_Vtbl {
@@ -2304,6 +2402,8 @@ pub trait IPrintSchemaNUpOption_Impl: Sized + super::super::System::Com::IDispat
     fn PagesPerSheet(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaNUpOption {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaNUpOption_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaNUpOption_Impl, const OFFSET: isize>() -> IPrintSchemaNUpOption_Vtbl {
         unsafe extern "system" fn PagesPerSheet<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaNUpOption_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulpagespersheet: *mut u32) -> ::windows::core::HRESULT {
@@ -2329,6 +2429,8 @@ pub trait IPrintSchemaOption_Impl: Sized + super::super::System::Com::IDispatch_
     fn Constrained(&self) -> ::windows::core::Result<PrintSchemaConstrainedSetting>;
     fn GetPropertyValue(&self, bstrname: &super::super::Foundation::BSTR, bstrnamespaceuri: &super::super::Foundation::BSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaOption {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaOption_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaOption_Impl, const OFFSET: isize>() -> IPrintSchemaOption_Vtbl {
@@ -2382,6 +2484,8 @@ pub trait IPrintSchemaOptionCollection_Impl: Sized + super::super::System::Com::
     fn GetAt(&self, ulindex: u32) -> ::windows::core::Result<IPrintSchemaOption>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaOptionCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaOptionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaOptionCollection_Impl, const OFFSET: isize>() -> IPrintSchemaOptionCollection_Vtbl {
@@ -2438,6 +2542,8 @@ pub trait IPrintSchemaPageImageableSize_Impl: Sized + super::super::System::Com:
     fn ExtentWidthInMicrons(&self) -> ::windows::core::Result<u32>;
     fn ExtentHeightInMicrons(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaPageImageableSize {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaPageImageableSize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaPageImageableSize_Impl, const OFFSET: isize>() -> IPrintSchemaPageImageableSize_Vtbl {
@@ -2527,6 +2633,8 @@ pub trait IPrintSchemaPageMediaSizeOption_Impl: Sized + super::super::System::Co
     fn HeightInMicrons(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaPageMediaSizeOption {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaPageMediaSizeOption_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaPageMediaSizeOption_Impl, const OFFSET: isize>() -> IPrintSchemaPageMediaSizeOption_Vtbl {
         unsafe extern "system" fn WidthInMicrons<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaPageMediaSizeOption_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulwidth: *mut u32) -> ::windows::core::HRESULT {
@@ -2569,6 +2677,8 @@ pub trait IPrintSchemaParameterDefinition_Impl: Sized + super::super::System::Co
     fn RangeMin(&self) -> ::windows::core::Result<i32>;
     fn RangeMax(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaParameterDefinition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaParameterDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaParameterDefinition_Impl, const OFFSET: isize>() -> IPrintSchemaParameterDefinition_Vtbl {
@@ -2646,6 +2756,8 @@ pub trait IPrintSchemaParameterInitializer_Impl: Sized + super::super::System::C
     fn SetValue(&self, pvar: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaParameterInitializer {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaParameterInitializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaParameterInitializer_Impl, const OFFSET: isize>() -> IPrintSchemaParameterInitializer_Vtbl {
         unsafe extern "system" fn Value<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaParameterInitializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvar: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2685,6 +2797,8 @@ pub trait IPrintSchemaTicket_Impl: Sized + super::super::System::Com::IDispatch_
     fn JobCopiesAllDocuments(&self) -> ::windows::core::Result<u32>;
     fn SetJobCopiesAllDocuments(&self, uljobcopiesalldocuments: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaTicket {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaTicket_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaTicket_Impl, const OFFSET: isize>() -> IPrintSchemaTicket_Vtbl {
@@ -2785,6 +2899,8 @@ pub trait IPrintSchemaTicket2_Impl: Sized + super::super::System::Com::IDispatch
     fn GetParameterInitializer(&self, bstrname: &super::super::Foundation::BSTR, bstrnamespaceuri: &super::super::Foundation::BSTR) -> ::windows::core::Result<IPrintSchemaParameterInitializer>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintSchemaTicket2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintSchemaTicket2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaTicket2_Impl, const OFFSET: isize>() -> IPrintSchemaTicket2_Vtbl {
         unsafe extern "system" fn GetParameterInitializer<Identity: ::windows::core::IUnknownImpl, Impl: IPrintSchemaTicket2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrnamespaceuri: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppparameterinitializer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2814,6 +2930,8 @@ pub trait IPrintTicketProvider_Impl: Sized {
     fn GetPrintCapabilities(&self, pprintticket: &::core::option::Option<super::super::Data::Xml::MsXml::IXMLDOMDocument2>) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMDocument2>;
     fn ValidatePrintTicket(&self, pbaseticket: &::core::option::Option<super::super::Data::Xml::MsXml::IXMLDOMDocument2>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintTicketProvider {}
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IPrintTicketProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintTicketProvider_Impl, const OFFSET: isize>() -> IPrintTicketProvider_Vtbl {
@@ -2879,6 +2997,8 @@ pub trait IPrintTicketProvider2_Impl: Sized + IPrintTicketProvider_Impl {
     fn GetPrintDeviceResources(&self, pszlocalename: &::windows::core::PCWSTR, pprintticket: &::core::option::Option<super::super::Data::Xml::MsXml::IXMLDOMDocument2>) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMDocument2>;
 }
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintTicketProvider2 {}
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IPrintTicketProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintTicketProvider2_Impl, const OFFSET: isize>() -> IPrintTicketProvider2_Vtbl {
         unsafe extern "system" fn GetPrintDeviceCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IPrintTicketProvider2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprintticket: ::windows::core::RawPtr, ppdevicecapabilities: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2916,6 +3036,7 @@ impl IPrintTicketProvider2_Vtbl {
 pub trait IPrintUnidiAsyncNotifyRegistration_Impl: Sized + IPrintAsyncNotifyRegistration_Impl {
     fn AsyncGetNotification(&self, param0: &::core::option::Option<IAsyncGetSendNotificationCookie>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintUnidiAsyncNotifyRegistration {}
 impl IPrintUnidiAsyncNotifyRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintUnidiAsyncNotifyRegistration_Impl, const OFFSET: isize>() -> IPrintUnidiAsyncNotifyRegistration_Vtbl {
         unsafe extern "system" fn AsyncGetNotification<Identity: ::windows::core::IUnknownImpl, Impl: IPrintUnidiAsyncNotifyRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param0: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2936,6 +3057,7 @@ pub trait IPrintWriteStream_Impl: Sized {
     fn WriteBytes(&self, pvbuffer: *const ::core::ffi::c_void, cbbuffer: u32) -> ::windows::core::Result<u32>;
     fn Close(&self);
 }
+impl ::windows::core::RuntimeName for IPrintWriteStream {}
 impl IPrintWriteStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWriteStream_Impl, const OFFSET: isize>() -> IPrintWriteStream_Vtbl {
         unsafe extern "system" fn WriteBytes<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWriteStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvbuffer: *const ::core::ffi::c_void, cbbuffer: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT {
@@ -2967,6 +3089,7 @@ impl IPrintWriteStream_Vtbl {
 pub trait IPrintWriteStreamFlush_Impl: Sized {
     fn FlushData(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintWriteStreamFlush {}
 impl IPrintWriteStreamFlush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWriteStreamFlush_Impl, const OFFSET: isize>() -> IPrintWriteStreamFlush_Vtbl {
         unsafe extern "system" fn FlushData<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWriteStreamFlush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2985,6 +3108,8 @@ pub trait IPrinterBidiSetRequestCallback_Impl: Sized {
     fn Completed(&self, bstrresponse: &super::super::Foundation::BSTR, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrinterBidiSetRequestCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPrinterBidiSetRequestCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterBidiSetRequestCallback_Impl, const OFFSET: isize>() -> IPrinterBidiSetRequestCallback_Vtbl {
         unsafe extern "system" fn Completed<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterBidiSetRequestCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrresponse: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -3001,6 +3126,7 @@ impl IPrinterBidiSetRequestCallback_Vtbl {
 pub trait IPrinterExtensionAsyncOperation_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrinterExtensionAsyncOperation {}
 impl IPrinterExtensionAsyncOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionAsyncOperation_Impl, const OFFSET: isize>() -> IPrinterExtensionAsyncOperation_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionAsyncOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3021,6 +3147,8 @@ pub trait IPrinterExtensionContext_Impl: Sized + super::super::System::Com::IDis
     fn DriverProperties(&self) -> ::windows::core::Result<IPrinterPropertyBag>;
     fn UserProperties(&self) -> ::windows::core::Result<IPrinterPropertyBag>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterExtensionContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterExtensionContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionContext_Impl, const OFFSET: isize>() -> IPrinterExtensionContext_Vtbl {
@@ -3087,6 +3215,8 @@ pub trait IPrinterExtensionContextCollection_Impl: Sized + super::super::System:
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterExtensionContextCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterExtensionContextCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionContextCollection_Impl, const OFFSET: isize>() -> IPrinterExtensionContextCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionContextCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcount: *mut u32) -> ::windows::core::HRESULT {
@@ -3139,6 +3269,8 @@ pub trait IPrinterExtensionEvent_Impl: Sized + super::super::System::Com::IDispa
     fn OnPrinterQueuesEnumerated(&self, pcontextcollection: &::core::option::Option<IPrinterExtensionContextCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterExtensionEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterExtensionEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionEvent_Impl, const OFFSET: isize>() -> IPrinterExtensionEvent_Vtbl {
         unsafe extern "system" fn OnDriverEvent<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventargs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3171,6 +3303,8 @@ pub trait IPrinterExtensionEventArgs_Impl: Sized + super::super::System::Com::ID
     fn WindowModal(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn WindowParent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterExtensionEventArgs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterExtensionEventArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionEventArgs_Impl, const OFFSET: isize>() -> IPrinterExtensionEventArgs_Vtbl {
@@ -3270,6 +3404,7 @@ pub trait IPrinterExtensionManager_Impl: Sized {
     fn EnableEvents(&self, printerdriverid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn DisableEvents(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrinterExtensionManager {}
 impl IPrinterExtensionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionManager_Impl, const OFFSET: isize>() -> IPrinterExtensionManager_Vtbl {
         unsafe extern "system" fn EnableEvents<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, printerdriverid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -3297,6 +3432,8 @@ pub trait IPrinterExtensionRequest_Impl: Sized + super::super::System::Com::IDis
     fn Cancel(&self, hrstatus: ::windows::core::HRESULT, bstrlogmessage: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Complete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterExtensionRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterExtensionRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterExtensionRequest_Impl, const OFFSET: isize>() -> IPrinterExtensionRequest_Vtbl {
@@ -3333,6 +3470,8 @@ pub trait IPrinterPropertyBag_Impl: Sized + super::super::System::Com::IDispatch
     fn GetReadStream(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::IStream>;
     fn GetWriteStream(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterPropertyBag {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterPropertyBag_Impl, const OFFSET: isize>() -> IPrinterPropertyBag_Vtbl {
@@ -3442,6 +3581,8 @@ pub trait IPrinterQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn GetProperties(&self) -> ::windows::core::Result<IPrinterPropertyBag>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterQueue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueue_Impl, const OFFSET: isize>() -> IPrinterQueue_Vtbl {
         unsafe extern "system" fn Handle<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phprinter: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -3500,6 +3641,8 @@ pub trait IPrinterQueue2_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn GetPrinterQueueView(&self, ulviewoffset: u32, ulviewsize: u32) -> ::windows::core::Result<IPrinterQueueView>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterQueue2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterQueue2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueue2_Impl, const OFFSET: isize>() -> IPrinterQueue2_Vtbl {
         unsafe extern "system" fn SendBidiSetRequestAsync<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueue2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrbidirequest: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pcallback: ::windows::core::RawPtr, ppasyncoperation: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3539,6 +3682,8 @@ pub trait IPrinterQueueEvent_Impl: Sized + super::super::System::Com::IDispatch_
     fn OnBidiResponseReceived(&self, bstrresponse: &super::super::Foundation::BSTR, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterQueueEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterQueueEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueueEvent_Impl, const OFFSET: isize>() -> IPrinterQueueEvent_Vtbl {
         unsafe extern "system" fn OnBidiResponseReceived<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueueEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrresponse: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -3560,6 +3705,8 @@ pub trait IPrinterQueueView_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetViewRange(&self, ulviewoffset: u32, ulviewsize: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterQueueView {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterQueueView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueueView_Impl, const OFFSET: isize>() -> IPrinterQueueView_Vtbl {
         unsafe extern "system" fn SetViewRange<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueueView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulviewoffset: u32, ulviewsize: u32) -> ::windows::core::HRESULT {
@@ -3577,6 +3724,8 @@ impl IPrinterQueueView_Vtbl {
 pub trait IPrinterQueueViewEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnChanged(&self, pcollection: &::core::option::Option<IPrintJobCollection>, ulviewoffset: u32, ulviewsize: u32, ulcountjobsinprintqueue: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterQueueViewEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterQueueViewEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterQueueViewEvent_Impl, const OFFSET: isize>() -> IPrinterQueueViewEvent_Vtbl {
@@ -3597,6 +3746,8 @@ pub trait IPrinterScriptContext_Impl: Sized + super::super::System::Com::IDispat
     fn QueueProperties(&self) -> ::windows::core::Result<IPrinterScriptablePropertyBag>;
     fn UserProperties(&self) -> ::windows::core::Result<IPrinterScriptablePropertyBag>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterScriptContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterScriptContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptContext_Impl, const OFFSET: isize>() -> IPrinterScriptContext_Vtbl {
@@ -3657,6 +3808,8 @@ pub trait IPrinterScriptablePropertyBag_Impl: Sized + super::super::System::Com:
     fn GetReadStream(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<IPrinterScriptableStream>;
     fn GetWriteStream(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<IPrinterScriptableStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterScriptablePropertyBag {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterScriptablePropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptablePropertyBag_Impl, const OFFSET: isize>() -> IPrinterScriptablePropertyBag_Vtbl {
@@ -3769,6 +3922,8 @@ pub trait IPrinterScriptablePropertyBag2_Impl: Sized + super::super::System::Com
     fn GetReadStreamAsXML(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterScriptablePropertyBag2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterScriptablePropertyBag2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptablePropertyBag2_Impl, const OFFSET: isize>() -> IPrinterScriptablePropertyBag2_Vtbl {
         unsafe extern "system" fn GetReadStreamAsXML<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptablePropertyBag2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppxmlnode: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3793,6 +3948,8 @@ pub trait IPrinterScriptableSequentialStream_Impl: Sized + super::super::System:
     fn Read(&self, cbread: i32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn Write(&self, parray: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterScriptableSequentialStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterScriptableSequentialStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptableSequentialStream_Impl, const OFFSET: isize>() -> IPrinterScriptableSequentialStream_Vtbl {
@@ -3835,6 +3992,8 @@ pub trait IPrinterScriptableStream_Impl: Sized + super::super::System::Com::IDis
     fn SetSize(&self, lsize: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrinterScriptableStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrinterScriptableStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptableStream_Impl, const OFFSET: isize>() -> IPrinterScriptableStream_Vtbl {
         unsafe extern "system" fn Commit<Identity: ::windows::core::IUnknownImpl, Impl: IPrinterScriptableStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3873,6 +4032,7 @@ pub trait IXpsDocument_Impl: Sized {
     fn GetThumbnail(&self) -> ::windows::core::Result<IPartThumbnail>;
     fn SetThumbnail(&self, pthumbnail: &::core::option::Option<IPartThumbnail>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsDocument {}
 impl IXpsDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocument_Impl, const OFFSET: isize>() -> IXpsDocument_Vtbl {
         unsafe extern "system" fn GetThumbnail<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocument_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppthumbnail: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3910,6 +4070,7 @@ pub trait IXpsDocumentConsumer_Impl: Sized {
     fn CloseSender(&self) -> ::windows::core::Result<()>;
     fn GetNewEmptyPart(&self, uri: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppnewobject: *mut *mut ::core::ffi::c_void, ppwritestream: *mut ::core::option::Option<IPrintWriteStream>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsDocumentConsumer {}
 impl IXpsDocumentConsumer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentConsumer_Impl, const OFFSET: isize>() -> IXpsDocumentConsumer_Vtbl {
         unsafe extern "system" fn SendXpsUnknown<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentConsumer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3965,6 +4126,7 @@ impl IXpsDocumentConsumer_Vtbl {
 pub trait IXpsDocumentProvider_Impl: Sized {
     fn GetXpsPart(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IXpsDocumentProvider {}
 impl IXpsDocumentProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentProvider_Impl, const OFFSET: isize>() -> IXpsDocumentProvider_Vtbl {
         unsafe extern "system" fn GetXpsPart<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppixpspart: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3991,6 +4153,8 @@ pub trait IXpsPartIterator_Impl: Sized {
     fn IsDone(&self) -> super::super::Foundation::BOOL;
     fn Next(&self);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXpsPartIterator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXpsPartIterator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsPartIterator_Impl, const OFFSET: isize>() -> IXpsPartIterator_Vtbl {
@@ -4031,6 +4195,8 @@ pub trait IXpsRasterizationFactory_Impl: Sized {
     fn CreateRasterizer(&self, xpspage: &::core::option::Option<super::super::Storage::Xps::IXpsOMPage>, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE) -> ::windows::core::Result<IXpsRasterizer>;
 }
 #[cfg(feature = "Win32_Storage_Xps")]
+impl ::windows::core::RuntimeName for IXpsRasterizationFactory {}
+#[cfg(feature = "Win32_Storage_Xps")]
 impl IXpsRasterizationFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizationFactory_Impl, const OFFSET: isize>() -> IXpsRasterizationFactory_Vtbl {
         unsafe extern "system" fn CreateRasterizer<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizationFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xpspage: ::windows::core::RawPtr, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, ppixpsrasterizer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4054,6 +4220,8 @@ impl IXpsRasterizationFactory_Vtbl {
 pub trait IXpsRasterizationFactory1_Impl: Sized {
     fn CreateRasterizer(&self, xpspage: &::core::option::Option<super::super::Storage::Xps::IXpsOMPage>, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT) -> ::windows::core::Result<IXpsRasterizer>;
 }
+#[cfg(feature = "Win32_Storage_Xps")]
+impl ::windows::core::RuntimeName for IXpsRasterizationFactory1 {}
 #[cfg(feature = "Win32_Storage_Xps")]
 impl IXpsRasterizationFactory1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizationFactory1_Impl, const OFFSET: isize>() -> IXpsRasterizationFactory1_Vtbl {
@@ -4079,6 +4247,8 @@ pub trait IXpsRasterizationFactory2_Impl: Sized {
     fn CreateRasterizer(&self, xpspage: &::core::option::Option<super::super::Storage::Xps::IXpsOMPage>, dpix: f32, dpiy: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT, backgroundcolor: XPSRAS_BACKGROUND_COLOR) -> ::windows::core::Result<IXpsRasterizer>;
 }
 #[cfg(feature = "Win32_Storage_Xps")]
+impl ::windows::core::RuntimeName for IXpsRasterizationFactory2 {}
+#[cfg(feature = "Win32_Storage_Xps")]
 impl IXpsRasterizationFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizationFactory2_Impl, const OFFSET: isize>() -> IXpsRasterizationFactory2_Vtbl {
         unsafe extern "system" fn CreateRasterizer<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizationFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xpspage: ::windows::core::RawPtr, dpix: f32, dpiy: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT, backgroundcolor: XPSRAS_BACKGROUND_COLOR, ppixpsrasterizer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4103,6 +4273,8 @@ pub trait IXpsRasterizer_Impl: Sized {
     fn RasterizeRect(&self, x: i32, y: i32, width: i32, height: i32, notificationcallback: &::core::option::Option<IXpsRasterizerNotificationCallback>) -> ::windows::core::Result<super::Imaging::IWICBitmap>;
     fn SetMinimalLineWidth(&self, width: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Imaging")]
+impl ::windows::core::RuntimeName for IXpsRasterizer {}
 #[cfg(feature = "Win32_Graphics_Imaging")]
 impl IXpsRasterizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizer_Impl, const OFFSET: isize>() -> IXpsRasterizer_Vtbl {
@@ -4135,6 +4307,7 @@ impl IXpsRasterizer_Vtbl {
 pub trait IXpsRasterizerNotificationCallback_Impl: Sized {
     fn Continue(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsRasterizerNotificationCallback {}
 impl IXpsRasterizerNotificationCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizerNotificationCallback_Impl, const OFFSET: isize>() -> IXpsRasterizerNotificationCallback_Vtbl {
         unsafe extern "system" fn Continue<Identity: ::windows::core::IUnknownImpl, Impl: IXpsRasterizerNotificationCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
@@ -1,4 +1,5 @@
 pub trait IApoAcousticEchoCancellation_Impl: Sized {}
+impl ::windows::core::RuntimeName for IApoAcousticEchoCancellation {}
 impl IApoAcousticEchoCancellation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApoAcousticEchoCancellation_Impl, const OFFSET: isize>() -> IApoAcousticEchoCancellation_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -12,6 +13,7 @@ pub trait IApoAuxiliaryInputConfiguration_Impl: Sized {
     fn RemoveAuxiliaryInput(&self, dwinputid: u32) -> ::windows::core::Result<()>;
     fn IsInputFormatSupported(&self, prequestedinputformat: &::core::option::Option<IAudioMediaType>) -> ::windows::core::Result<IAudioMediaType>;
 }
+impl ::windows::core::RuntimeName for IApoAuxiliaryInputConfiguration {}
 impl IApoAuxiliaryInputConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApoAuxiliaryInputConfiguration_Impl, const OFFSET: isize>() -> IApoAuxiliaryInputConfiguration_Vtbl {
         unsafe extern "system" fn AddAuxiliaryInput<Identity: ::windows::core::IUnknownImpl, Impl: IApoAuxiliaryInputConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwinputid: u32, cbdatasize: u32, pbydata: *const u8, pinputconnection: *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::HRESULT {
@@ -49,6 +51,7 @@ impl IApoAuxiliaryInputConfiguration_Vtbl {
 pub trait IApoAuxiliaryInputRT_Impl: Sized {
     fn AcceptInput(&self, dwinputid: u32, pinputconnection: *const APO_CONNECTION_PROPERTY);
 }
+impl ::windows::core::RuntimeName for IApoAuxiliaryInputRT {}
 impl IApoAuxiliaryInputRT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApoAuxiliaryInputRT_Impl, const OFFSET: isize>() -> IApoAuxiliaryInputRT_Vtbl {
         unsafe extern "system" fn AcceptInput<Identity: ::windows::core::IUnknownImpl, Impl: IApoAuxiliaryInputRT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwinputid: u32, pinputconnection: *const APO_CONNECTION_PROPERTY) {
@@ -65,6 +68,7 @@ impl IApoAuxiliaryInputRT_Vtbl {
 pub trait IAudioDeviceModulesClient_Impl: Sized {
     fn SetAudioDeviceModulesManager(&self, paudiodevicemodulesmanager: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioDeviceModulesClient {}
 impl IAudioDeviceModulesClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioDeviceModulesClient_Impl, const OFFSET: isize>() -> IAudioDeviceModulesClient_Vtbl {
         unsafe extern "system" fn SetAudioDeviceModulesManager<Identity: ::windows::core::IUnknownImpl, Impl: IAudioDeviceModulesClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, paudiodevicemodulesmanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -88,6 +92,8 @@ pub trait IAudioMediaType_Impl: Sized {
     fn GetAudioFormat(&self) -> *mut super::WAVEFORMATEX;
     fn GetUncompressedAudioFormat(&self) -> ::windows::core::Result<UNCOMPRESSEDAUDIOFORMAT>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioMediaType {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioMediaType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioMediaType_Impl, const OFFSET: isize>() -> IAudioMediaType_Vtbl {
@@ -150,6 +156,7 @@ pub trait IAudioProcessingObject_Impl: Sized {
     fn IsOutputFormatSupported(&self, poppositeformat: &::core::option::Option<IAudioMediaType>, prequestedoutputformat: &::core::option::Option<IAudioMediaType>) -> ::windows::core::Result<IAudioMediaType>;
     fn GetInputChannelCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioProcessingObject {}
 impl IAudioProcessingObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObject_Impl, const OFFSET: isize>() -> IAudioProcessingObject_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -236,6 +243,7 @@ pub trait IAudioProcessingObjectConfiguration_Impl: Sized {
     fn LockForProcess(&self, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_DESCRIPTOR, u32numoutputconnections: u32, ppoutputconnections: *const *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::Result<()>;
     fn UnlockForProcess(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioProcessingObjectConfiguration {}
 impl IAudioProcessingObjectConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectConfiguration_Impl, const OFFSET: isize>() -> IAudioProcessingObjectConfiguration_Vtbl {
         unsafe extern "system" fn LockForProcess<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_DESCRIPTOR, u32numoutputconnections: u32, ppoutputconnections: *const *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::HRESULT {
@@ -261,6 +269,7 @@ impl IAudioProcessingObjectConfiguration_Vtbl {
 pub trait IAudioProcessingObjectLoggingService_Impl: Sized {
     fn ApoLog(&self, level: APO_LOG_LEVEL, format: &::windows::core::PCWSTR);
 }
+impl ::windows::core::RuntimeName for IAudioProcessingObjectLoggingService {}
 impl IAudioProcessingObjectLoggingService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectLoggingService_Impl, const OFFSET: isize>() -> IAudioProcessingObjectLoggingService_Vtbl {
         unsafe extern "system" fn ApoLog<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectLoggingService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, level: APO_LOG_LEVEL, format: ::windows::core::PCWSTR) {
@@ -279,6 +288,8 @@ pub trait IAudioProcessingObjectNotifications_Impl: Sized {
     fn GetApoNotificationRegistrationInfo(&self, aponotifications: *mut *mut APO_NOTIFICATION_DESCRIPTOR, count: *mut u32) -> ::windows::core::Result<()>;
     fn HandleNotification(&self, aponotification: *const APO_NOTIFICATION);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IAudioProcessingObjectNotifications {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IAudioProcessingObjectNotifications_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectNotifications_Impl, const OFFSET: isize>() -> IAudioProcessingObjectNotifications_Vtbl {
@@ -307,6 +318,7 @@ pub trait IAudioProcessingObjectRT_Impl: Sized {
     fn CalcInputFrames(&self, u32outputframecount: u32) -> u32;
     fn CalcOutputFrames(&self, u32inputframecount: u32) -> u32;
 }
+impl ::windows::core::RuntimeName for IAudioProcessingObjectRT {}
 impl IAudioProcessingObjectRT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectRT_Impl, const OFFSET: isize>() -> IAudioProcessingObjectRT_Vtbl {
         unsafe extern "system" fn APOProcess<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectRT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_PROPERTY, u32numoutputconnections: u32, ppoutputconnections: *mut *mut APO_CONNECTION_PROPERTY) {
@@ -338,6 +350,7 @@ impl IAudioProcessingObjectRT_Vtbl {
 pub trait IAudioProcessingObjectRTQueueService_Impl: Sized {
     fn GetRealTimeWorkQueue(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioProcessingObjectRTQueueService {}
 impl IAudioProcessingObjectRTQueueService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectRTQueueService_Impl, const OFFSET: isize>() -> IAudioProcessingObjectRTQueueService_Vtbl {
         unsafe extern "system" fn GetRealTimeWorkQueue<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectRTQueueService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, workqueueid: *mut u32) -> ::windows::core::HRESULT {
@@ -361,6 +374,7 @@ pub trait IAudioProcessingObjectVBR_Impl: Sized {
     fn CalcMaxInputFrames(&self, u32maxoutputframecount: u32) -> ::windows::core::Result<u32>;
     fn CalcMaxOutputFrames(&self, u32maxinputframecount: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioProcessingObjectVBR {}
 impl IAudioProcessingObjectVBR_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectVBR_Impl, const OFFSET: isize>() -> IAudioProcessingObjectVBR_Vtbl {
         unsafe extern "system" fn CalcMaxInputFrames<Identity: ::windows::core::IUnknownImpl, Impl: IAudioProcessingObjectVBR_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, u32maxoutputframecount: u32, pu32inputframecount: *mut u32) -> ::windows::core::HRESULT {
@@ -396,6 +410,7 @@ impl IAudioProcessingObjectVBR_Vtbl {
     }
 }
 pub trait IAudioSystemEffects_Impl: Sized {}
+impl ::windows::core::RuntimeName for IAudioSystemEffects {}
 impl IAudioSystemEffects_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffects_Impl, const OFFSET: isize>() -> IAudioSystemEffects_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -408,6 +423,8 @@ impl IAudioSystemEffects_Vtbl {
 pub trait IAudioSystemEffects2_Impl: Sized + IAudioSystemEffects_Impl {
     fn GetEffectsList(&self, ppeffectsids: *mut *mut ::windows::core::GUID, pceffects: *mut u32, event: super::super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioSystemEffects2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioSystemEffects2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffects2_Impl, const OFFSET: isize>() -> IAudioSystemEffects2_Vtbl {
@@ -427,6 +444,8 @@ pub trait IAudioSystemEffects3_Impl: Sized + IAudioSystemEffects_Impl + IAudioSy
     fn GetControllableSystemEffectsList(&self, effects: *mut *mut AUDIO_SYSTEMEFFECT, numeffects: *mut u32, event: super::super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn SetAudioSystemEffectState(&self, effectid: &::windows::core::GUID, state: AUDIO_SYSTEMEFFECT_STATE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioSystemEffects3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioSystemEffects3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffects3_Impl, const OFFSET: isize>() -> IAudioSystemEffects3_Vtbl {
@@ -455,6 +474,7 @@ pub trait IAudioSystemEffectsCustomFormats_Impl: Sized {
     fn GetFormat(&self, nformat: u32) -> ::windows::core::Result<IAudioMediaType>;
     fn GetFormatRepresentation(&self, nformat: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IAudioSystemEffectsCustomFormats {}
 impl IAudioSystemEffectsCustomFormats_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffectsCustomFormats_Impl, const OFFSET: isize>() -> IAudioSystemEffectsCustomFormats_Vtbl {
         unsafe extern "system" fn GetFormatCount<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffectsCustomFormats_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcformats: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
@@ -11,6 +11,8 @@ pub trait IDirectMusic_Impl: Sized {
     fn SetDirectSound(&self, pdirectsound: &::core::option::Option<super::DirectSound::IDirectSound>, hwnd: super::super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
+impl ::windows::core::RuntimeName for IDirectMusic {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 impl IDirectMusic_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusic_Impl, const OFFSET: isize>() -> IDirectMusic_Vtbl {
         unsafe extern "system" fn EnumPort<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusic_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwindex: u32, pportcaps: *mut DMUS_PORTCAPS) -> ::windows::core::HRESULT {
@@ -80,6 +82,8 @@ pub trait IDirectMusic8_Impl: Sized + IDirectMusic_Impl {
     fn SetExternalMasterClock(&self, pclock: &::core::option::Option<super::super::IReferenceClock>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
+impl ::windows::core::RuntimeName for IDirectMusic8 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 impl IDirectMusic8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusic8_Impl, const OFFSET: isize>() -> IDirectMusic8_Vtbl {
         unsafe extern "system" fn SetExternalMasterClock<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusic8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclock: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -108,6 +112,7 @@ pub trait IDirectMusicBuffer_Impl: Sized {
     fn SetStartTime(&self, rt: i64) -> ::windows::core::Result<()>;
     fn SetUsedBytes(&self, cb: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectMusicBuffer {}
 impl IDirectMusicBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicBuffer_Impl, const OFFSET: isize>() -> IDirectMusicBuffer_Vtbl {
         unsafe extern "system" fn Flush<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -200,6 +205,7 @@ pub trait IDirectMusicCollection_Impl: Sized {
     fn GetInstrument(&self, dwpatch: u32) -> ::windows::core::Result<IDirectMusicInstrument>;
     fn EnumInstrument(&self, dwindex: u32, pdwpatch: *mut u32, pwszname: &::windows::core::PCWSTR, dwnamelen: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectMusicCollection {}
 impl IDirectMusicCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicCollection_Impl, const OFFSET: isize>() -> IDirectMusicCollection_Vtbl {
         unsafe extern "system" fn GetInstrument<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwpatch: u32, ppinstrument: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -231,6 +237,7 @@ impl IDirectMusicCollection_Vtbl {
 pub trait IDirectMusicDownload_Impl: Sized {
     fn GetBuffer(&self, ppvbuffer: *mut *mut ::core::ffi::c_void, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectMusicDownload {}
 impl IDirectMusicDownload_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicDownload_Impl, const OFFSET: isize>() -> IDirectMusicDownload_Vtbl {
         unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicDownload_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppvbuffer: *mut *mut ::core::ffi::c_void, pdwsize: *mut u32) -> ::windows::core::HRESULT {
@@ -245,6 +252,7 @@ impl IDirectMusicDownload_Vtbl {
     }
 }
 pub trait IDirectMusicDownloadedInstrument_Impl: Sized {}
+impl ::windows::core::RuntimeName for IDirectMusicDownloadedInstrument {}
 impl IDirectMusicDownloadedInstrument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicDownloadedInstrument_Impl, const OFFSET: isize>() -> IDirectMusicDownloadedInstrument_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -257,6 +265,7 @@ pub trait IDirectMusicInstrument_Impl: Sized {
     fn GetPatch(&self, pdwpatch: *mut u32) -> ::windows::core::Result<()>;
     fn SetPatch(&self, dwpatch: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectMusicInstrument {}
 impl IDirectMusicInstrument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicInstrument_Impl, const OFFSET: isize>() -> IDirectMusicInstrument_Vtbl {
         unsafe extern "system" fn GetPatch<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicInstrument_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwpatch: *mut u32) -> ::windows::core::HRESULT {
@@ -299,6 +308,8 @@ pub trait IDirectMusicPort_Impl: Sized {
     fn SetDirectSound(&self, pdirectsound: &::core::option::Option<super::DirectSound::IDirectSound>, pdirectsoundbuffer: &::core::option::Option<super::DirectSound::IDirectSoundBuffer>) -> ::windows::core::Result<()>;
     fn GetFormat(&self, pwaveformatex: *mut super::WAVEFORMATEX, pdwwaveformatexsize: *mut u32, pdwbuffersize: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound", feature = "Win32_System_IO"))]
+impl ::windows::core::RuntimeName for IDirectMusicPort {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound", feature = "Win32_System_IO"))]
 impl IDirectMusicPort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicPort_Impl, const OFFSET: isize>() -> IDirectMusicPort_Vtbl {
@@ -426,6 +437,7 @@ pub trait IDirectMusicPortDownload_Impl: Sized {
     fn Download(&self, pidmdownload: &::core::option::Option<IDirectMusicDownload>) -> ::windows::core::Result<()>;
     fn Unload(&self, pidmdownload: &::core::option::Option<IDirectMusicDownload>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectMusicPortDownload {}
 impl IDirectMusicPortDownload_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicPortDownload_Impl, const OFFSET: isize>() -> IDirectMusicPortDownload_Vtbl {
         unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicPortDownload_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwdlid: u32, ppidmdownload: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -504,6 +516,8 @@ pub trait IDirectMusicSynth_Impl: Sized {
     fn GetFormat(&self, pwaveformatex: *mut super::WAVEFORMATEX, pdwwaveformatexsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetAppend(&self, pdwappend: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectMusicSynth {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectMusicSynth_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicSynth_Impl, const OFFSET: isize>() -> IDirectMusicSynth_Vtbl {
@@ -632,6 +646,8 @@ pub trait IDirectMusicSynth8_Impl: Sized + IDirectMusicSynth_Impl {
     fn AssignChannelToBuses(&self, dwchannelgroup: u32, dwchannel: u32, pdwbuses: *mut u32, cbuses: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectMusicSynth8 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectMusicSynth8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicSynth8_Impl, const OFFSET: isize>() -> IDirectMusicSynth8_Vtbl {
         unsafe extern "system" fn PlayVoice<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicSynth8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rt: i64, dwvoiceid: u32, dwchannelgroup: u32, dwchannel: u32, dwdlid: u32, prpitch: i32, vrvolume: i32, stvoicestart: u64, stloopstart: u64, stloopend: u64) -> ::windows::core::HRESULT {
@@ -683,6 +699,8 @@ pub trait IDirectMusicSynthSink_Impl: Sized {
     fn SetDirectSound(&self, pdirectsound: &::core::option::Option<super::DirectSound::IDirectSound>, pdirectsoundbuffer: &::core::option::Option<super::DirectSound::IDirectSoundBuffer>) -> ::windows::core::Result<()>;
     fn GetDesiredBufferSize(&self, pdwbuffersizeinsamples: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
+impl ::windows::core::RuntimeName for IDirectMusicSynthSink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 impl IDirectMusicSynthSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicSynthSink_Impl, const OFFSET: isize>() -> IDirectMusicSynthSink_Vtbl {
@@ -751,6 +769,7 @@ impl IDirectMusicSynthSink_Vtbl {
 pub trait IDirectMusicThru_Impl: Sized {
     fn ThruChannel(&self, dwsourcechannelgroup: u32, dwsourcechannel: u32, dwdestinationchannelgroup: u32, dwdestinationchannel: u32, pdestinationport: &::core::option::Option<IDirectMusicPort>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectMusicThru {}
 impl IDirectMusicThru_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicThru_Impl, const OFFSET: isize>() -> IDirectMusicThru_Vtbl {
         unsafe extern "system" fn ThruChannel<Identity: ::windows::core::IUnknownImpl, Impl: IDirectMusicThru_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsourcechannelgroup: u32, dwsourcechannel: u32, dwdestinationchannelgroup: u32, dwdestinationchannel: u32, pdestinationport: ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
@@ -10,6 +10,8 @@ pub trait IDirectSound_Impl: Sized {
     fn Initialize(&self, pcguiddevice: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectSound {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectSound_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound_Impl, const OFFSET: isize>() -> IDirectSound_Vtbl {
         unsafe extern "system" fn CreateSoundBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsbufferdesc: *const DSBUFFERDESC, ppdsbuffer: *mut ::windows::core::RawPtr, punkouter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -107,6 +109,8 @@ pub trait IDirectSound3DBuffer_Impl: Sized {
     fn SetPosition(&self, x: f32, y: f32, z: f32, dwapply: u32) -> ::windows::core::Result<()>;
     fn SetVelocity(&self, x: f32, y: f32, z: f32, dwapply: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for IDirectSound3DBuffer {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl IDirectSound3DBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound3DBuffer_Impl, const OFFSET: isize>() -> IDirectSound3DBuffer_Vtbl {
@@ -293,6 +297,8 @@ pub trait IDirectSound3DListener_Impl: Sized {
     fn CommitDeferredSettings(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ::windows::core::RuntimeName for IDirectSound3DListener {}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl IDirectSound3DListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound3DListener_Impl, const OFFSET: isize>() -> IDirectSound3DListener_Vtbl {
         unsafe extern "system" fn GetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound3DListener_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plistener: *mut DS3DLISTENER) -> ::windows::core::HRESULT {
@@ -434,6 +440,8 @@ pub trait IDirectSound8_Impl: Sized + IDirectSound_Impl {
     fn VerifyCertification(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectSound8 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectSound8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound8_Impl, const OFFSET: isize>() -> IDirectSound8_Vtbl {
         unsafe extern "system" fn VerifyCertification<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSound8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcertified: *mut u32) -> ::windows::core::HRESULT {
@@ -473,6 +481,7 @@ pub trait IDirectSoundBuffer_Impl: Sized {
     fn Unlock(&self, pvaudioptr1: *const ::core::ffi::c_void, dwaudiobytes1: u32, pvaudioptr2: *const ::core::ffi::c_void, dwaudiobytes2: u32) -> ::windows::core::Result<()>;
     fn Restore(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundBuffer {}
 impl IDirectSoundBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundBuffer_Impl, const OFFSET: isize>() -> IDirectSoundBuffer_Vtbl {
         unsafe extern "system" fn GetCaps<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdsbuffercaps: *mut DSBCAPS) -> ::windows::core::HRESULT {
@@ -626,6 +635,7 @@ pub trait IDirectSoundBuffer8_Impl: Sized + IDirectSoundBuffer_Impl {
     fn AcquireResources(&self, dwflags: u32, dweffectscount: u32, pdwresultcodes: *mut u32) -> ::windows::core::Result<()>;
     fn GetObjectInPath(&self, rguidobject: *const ::windows::core::GUID, dwindex: u32, rguidinterface: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundBuffer8 {}
 impl IDirectSoundBuffer8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundBuffer8_Impl, const OFFSET: isize>() -> IDirectSoundBuffer8_Vtbl {
         unsafe extern "system" fn SetFX<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundBuffer8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dweffectscount: u32, pdsfxdesc: *const DSEFFECTDESC, pdwresultcodes: *mut u32) -> ::windows::core::HRESULT {
@@ -659,6 +669,7 @@ pub trait IDirectSoundCapture_Impl: Sized {
     fn GetCaps(&self) -> ::windows::core::Result<DSCCAPS>;
     fn Initialize(&self, pcguiddevice: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundCapture {}
 impl IDirectSoundCapture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCapture_Impl, const OFFSET: isize>() -> IDirectSoundCapture_Vtbl {
         unsafe extern "system" fn CreateCaptureBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCapture_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdscbufferdesc: *const DSCBUFFERDESC, ppdscbuffer: *mut ::windows::core::RawPtr, punkouter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -704,6 +715,7 @@ pub trait IDirectSoundCaptureBuffer_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn Unlock(&self, pvaudioptr1: *const ::core::ffi::c_void, dwaudiobytes1: u32, pvaudioptr2: *const ::core::ffi::c_void, dwaudiobytes2: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundCaptureBuffer {}
 impl IDirectSoundCaptureBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureBuffer_Impl, const OFFSET: isize>() -> IDirectSoundCaptureBuffer_Vtbl {
         unsafe extern "system" fn GetCaps<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdscbcaps: *mut DSCBCAPS) -> ::windows::core::HRESULT {
@@ -784,6 +796,7 @@ pub trait IDirectSoundCaptureBuffer8_Impl: Sized + IDirectSoundCaptureBuffer_Imp
     fn GetObjectInPath(&self, rguidobject: *const ::windows::core::GUID, dwindex: u32, rguidinterface: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetFXStatus(&self, dweffectscount: u32, pdwfxstatus: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundCaptureBuffer8 {}
 impl IDirectSoundCaptureBuffer8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureBuffer8_Impl, const OFFSET: isize>() -> IDirectSoundCaptureBuffer8_Vtbl {
         unsafe extern "system" fn GetObjectInPath<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureBuffer8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rguidobject: *const ::windows::core::GUID, dwindex: u32, rguidinterface: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -813,6 +826,8 @@ pub trait IDirectSoundCaptureFXAec_Impl: Sized {
     fn GetStatus(&self) -> ::windows::core::Result<u32>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectSoundCaptureFXAec {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectSoundCaptureFXAec_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureFXAec_Impl, const OFFSET: isize>() -> IDirectSoundCaptureFXAec_Vtbl {
@@ -867,6 +882,8 @@ pub trait IDirectSoundCaptureFXNoiseSuppress_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectSoundCaptureFXNoiseSuppress {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectSoundCaptureFXNoiseSuppress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureFXNoiseSuppress_Impl, const OFFSET: isize>() -> IDirectSoundCaptureFXNoiseSuppress_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundCaptureFXNoiseSuppress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdscfxnoisesuppress: *const DSCFXNoiseSuppress) -> ::windows::core::HRESULT {
@@ -905,6 +922,7 @@ pub trait IDirectSoundFXChorus_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxchorus: *const DSFXChorus) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXChorus>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXChorus {}
 impl IDirectSoundFXChorus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXChorus_Impl, const OFFSET: isize>() -> IDirectSoundFXChorus_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXChorus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxchorus: *const DSFXChorus) -> ::windows::core::HRESULT {
@@ -937,6 +955,7 @@ pub trait IDirectSoundFXCompressor_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxcompressor: *const DSFXCompressor) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXCompressor>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXCompressor {}
 impl IDirectSoundFXCompressor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXCompressor_Impl, const OFFSET: isize>() -> IDirectSoundFXCompressor_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXCompressor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxcompressor: *const DSFXCompressor) -> ::windows::core::HRESULT {
@@ -969,6 +988,7 @@ pub trait IDirectSoundFXDistortion_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxdistortion: *const DSFXDistortion) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXDistortion>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXDistortion {}
 impl IDirectSoundFXDistortion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXDistortion_Impl, const OFFSET: isize>() -> IDirectSoundFXDistortion_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXDistortion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxdistortion: *const DSFXDistortion) -> ::windows::core::HRESULT {
@@ -1001,6 +1021,7 @@ pub trait IDirectSoundFXEcho_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxecho: *const DSFXEcho) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXEcho>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXEcho {}
 impl IDirectSoundFXEcho_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXEcho_Impl, const OFFSET: isize>() -> IDirectSoundFXEcho_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXEcho_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxecho: *const DSFXEcho) -> ::windows::core::HRESULT {
@@ -1033,6 +1054,7 @@ pub trait IDirectSoundFXFlanger_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxflanger: *const DSFXFlanger) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXFlanger>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXFlanger {}
 impl IDirectSoundFXFlanger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXFlanger_Impl, const OFFSET: isize>() -> IDirectSoundFXFlanger_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXFlanger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxflanger: *const DSFXFlanger) -> ::windows::core::HRESULT {
@@ -1065,6 +1087,7 @@ pub trait IDirectSoundFXGargle_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxgargle: *const DSFXGargle) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXGargle>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXGargle {}
 impl IDirectSoundFXGargle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXGargle_Impl, const OFFSET: isize>() -> IDirectSoundFXGargle_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXGargle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxgargle: *const DSFXGargle) -> ::windows::core::HRESULT {
@@ -1101,6 +1124,7 @@ pub trait IDirectSoundFXI3DL2Reverb_Impl: Sized {
     fn SetQuality(&self, lquality: i32) -> ::windows::core::Result<()>;
     fn GetQuality(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXI3DL2Reverb {}
 impl IDirectSoundFXI3DL2Reverb_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXI3DL2Reverb_Impl, const OFFSET: isize>() -> IDirectSoundFXI3DL2Reverb_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXI3DL2Reverb_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxi3dl2reverb: *const DSFXI3DL2Reverb) -> ::windows::core::HRESULT {
@@ -1169,6 +1193,7 @@ pub trait IDirectSoundFXParamEq_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxparameq: *const DSFXParamEq) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXParamEq>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXParamEq {}
 impl IDirectSoundFXParamEq_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXParamEq_Impl, const OFFSET: isize>() -> IDirectSoundFXParamEq_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXParamEq_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxparameq: *const DSFXParamEq) -> ::windows::core::HRESULT {
@@ -1201,6 +1226,7 @@ pub trait IDirectSoundFXWavesReverb_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxwavesreverb: *const DSFXWavesReverb) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXWavesReverb>;
 }
+impl ::windows::core::RuntimeName for IDirectSoundFXWavesReverb {}
 impl IDirectSoundFXWavesReverb_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXWavesReverb_Impl, const OFFSET: isize>() -> IDirectSoundFXWavesReverb_Vtbl {
         unsafe extern "system" fn SetAllParameters<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFXWavesReverb_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdsfxwavesreverb: *const DSFXWavesReverb) -> ::windows::core::HRESULT {
@@ -1234,6 +1260,8 @@ pub trait IDirectSoundFullDuplex_Impl: Sized {
     fn Initialize(&self, pcaptureguid: *const ::windows::core::GUID, prenderguid: *const ::windows::core::GUID, lpdscbufferdesc: *const DSCBUFFERDESC, lpdsbufferdesc: *const DSBUFFERDESC, hwnd: super::super::super::Foundation::HWND, dwlevel: u32, lplpdirectsoundcapturebuffer8: *mut ::core::option::Option<IDirectSoundCaptureBuffer8>, lplpdirectsoundbuffer8: *mut ::core::option::Option<IDirectSoundBuffer8>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectSoundFullDuplex {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDirectSoundFullDuplex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFullDuplex_Impl, const OFFSET: isize>() -> IDirectSoundFullDuplex_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundFullDuplex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcaptureguid: *const ::windows::core::GUID, prenderguid: *const ::windows::core::GUID, lpdscbufferdesc: *const DSCBUFFERDESC, lpdsbufferdesc: *const DSBUFFERDESC, hwnd: super::super::super::Foundation::HWND, dwlevel: u32, lplpdirectsoundcapturebuffer8: *mut ::windows::core::RawPtr, lplpdirectsoundbuffer8: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1251,6 +1279,8 @@ impl IDirectSoundFullDuplex_Vtbl {
 pub trait IDirectSoundNotify_Impl: Sized {
     fn SetNotificationPositions(&self, dwpositionnotifies: u32, pcpositionnotifies: *const DSBPOSITIONNOTIFY) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectSoundNotify {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectSoundNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectSoundNotify_Impl, const OFFSET: isize>() -> IDirectSoundNotify_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
@@ -1,6 +1,7 @@
 pub trait IAudioEndpointFormatControl_Impl: Sized {
     fn ResetToDefault(&self, resetflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioEndpointFormatControl {}
 impl IAudioEndpointFormatControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointFormatControl_Impl, const OFFSET: isize>() -> IAudioEndpointFormatControl_Vtbl {
         unsafe extern "system" fn ResetToDefault<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointFormatControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resetflags: u32) -> ::windows::core::HRESULT {
@@ -19,6 +20,8 @@ pub trait IAudioEndpointLastBufferControl_Impl: Sized {
     fn IsLastBufferControlSupported(&self) -> super::super::super::Foundation::BOOL;
     fn ReleaseOutputDataPointerForLastBuffer(&self, pconnectionproperty: *const super::Apo::APO_CONNECTION_PROPERTY);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_Apo"))]
+impl ::windows::core::RuntimeName for IAudioEndpointLastBufferControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_Apo"))]
 impl IAudioEndpointLastBufferControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointLastBufferControl_Impl, const OFFSET: isize>() -> IAudioEndpointLastBufferControl_Vtbl {
@@ -46,6 +49,7 @@ pub trait IAudioEndpointOffloadStreamMeter_Impl: Sized {
     fn GetMeterChannelCount(&self) -> ::windows::core::Result<u32>;
     fn GetMeteringData(&self, u32channelcount: u32) -> ::windows::core::Result<f32>;
 }
+impl ::windows::core::RuntimeName for IAudioEndpointOffloadStreamMeter {}
 impl IAudioEndpointOffloadStreamMeter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointOffloadStreamMeter_Impl, const OFFSET: isize>() -> IAudioEndpointOffloadStreamMeter_Vtbl {
         unsafe extern "system" fn GetMeterChannelCount<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointOffloadStreamMeter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pu32channelcount: *mut u32) -> ::windows::core::HRESULT {
@@ -84,6 +88,7 @@ pub trait IAudioEndpointOffloadStreamMute_Impl: Sized {
     fn SetMute(&self, bmuted: u8) -> ::windows::core::Result<()>;
     fn GetMute(&self) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IAudioEndpointOffloadStreamMute {}
 impl IAudioEndpointOffloadStreamMute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointOffloadStreamMute_Impl, const OFFSET: isize>() -> IAudioEndpointOffloadStreamMute_Vtbl {
         unsafe extern "system" fn SetMute<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointOffloadStreamMute_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bmuted: u8) -> ::windows::core::HRESULT {
@@ -118,6 +123,8 @@ pub trait IAudioEndpointOffloadStreamVolume_Impl: Sized {
     fn SetChannelVolumes(&self, u32channelcount: u32, pf32volumes: *const f32, u32curvetype: super::super::KernelStreaming::AUDIO_CURVE_TYPE, pcurveduration: *const i64) -> ::windows::core::Result<()>;
     fn GetChannelVolumes(&self, u32channelcount: u32) -> ::windows::core::Result<f32>;
 }
+#[cfg(feature = "Win32_Media_KernelStreaming")]
+impl ::windows::core::RuntimeName for IAudioEndpointOffloadStreamVolume {}
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 impl IAudioEndpointOffloadStreamVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointOffloadStreamVolume_Impl, const OFFSET: isize>() -> IAudioEndpointOffloadStreamVolume_Vtbl {
@@ -180,6 +187,8 @@ pub trait IAudioEndpointVolume_Impl: Sized {
     fn QueryHardwareSupport(&self) -> ::windows::core::Result<u32>;
     fn GetVolumeRange(&self, pflvolumemindb: *mut f32, pflvolumemaxdb: *mut f32, pflvolumeincrementdb: *mut f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioEndpointVolume {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioEndpointVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointVolume_Impl, const OFFSET: isize>() -> IAudioEndpointVolume_Vtbl {
@@ -346,6 +355,8 @@ pub trait IAudioEndpointVolumeCallback_Impl: Sized {
     fn OnNotify(&self, pnotify: *mut super::AUDIO_VOLUME_NOTIFICATION_DATA) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioEndpointVolumeCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioEndpointVolumeCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointVolumeCallback_Impl, const OFFSET: isize>() -> IAudioEndpointVolumeCallback_Vtbl {
         unsafe extern "system" fn OnNotify<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointVolumeCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnotify: *mut super::AUDIO_VOLUME_NOTIFICATION_DATA) -> ::windows::core::HRESULT {
@@ -363,6 +374,8 @@ impl IAudioEndpointVolumeCallback_Vtbl {
 pub trait IAudioEndpointVolumeEx_Impl: Sized + IAudioEndpointVolume_Impl {
     fn GetVolumeRangeChannel(&self, ichannel: u32, pflvolumemindb: *mut f32, pflvolumemaxdb: *mut f32, pflvolumeincrementdb: *mut f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioEndpointVolumeEx {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioEndpointVolumeEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointVolumeEx_Impl, const OFFSET: isize>() -> IAudioEndpointVolumeEx_Vtbl {
@@ -382,6 +395,8 @@ pub trait IAudioLfxControl_Impl: Sized {
     fn SetLocalEffectsState(&self, benabled: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetLocalEffectsState(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioLfxControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioLfxControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioLfxControl_Impl, const OFFSET: isize>() -> IAudioLfxControl_Vtbl {
@@ -417,6 +432,7 @@ pub trait IAudioMeterInformation_Impl: Sized {
     fn GetChannelsPeakValues(&self, u32channelcount: u32, afpeakvalues: *mut f32) -> ::windows::core::Result<()>;
     fn QueryHardwareSupport(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioMeterInformation {}
 impl IAudioMeterInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioMeterInformation_Impl, const OFFSET: isize>() -> IAudioMeterInformation_Vtbl {
         unsafe extern "system" fn GetPeakValue<Identity: ::windows::core::IUnknownImpl, Impl: IAudioMeterInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfpeak: *mut f32) -> ::windows::core::HRESULT {
@@ -477,6 +493,8 @@ pub trait IHardwareAudioEngineBase_Impl: Sized {
     fn SetGfxState(&self, pdevice: &::core::option::Option<super::IMMDevice>, _benable: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetGfxState(&self, pdevice: &::core::option::Option<super::IMMDevice>) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IHardwareAudioEngineBase {}
 #[cfg(feature = "Win32_Foundation")]
 impl IHardwareAudioEngineBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHardwareAudioEngineBase_Impl, const OFFSET: isize>() -> IHardwareAudioEngineBase_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
@@ -12,6 +12,8 @@ pub trait IXAPO_Impl: Sized {
     fn CalcOutputFrames(&self, inputframecount: u32) -> u32;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXAPO {}
+#[cfg(feature = "Win32_Foundation")]
 impl IXAPO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAPO_Impl, const OFFSET: isize>() -> IXAPO_Vtbl {
         unsafe extern "system" fn GetRegistrationProperties<Identity: ::windows::core::IUnknownImpl, Impl: IXAPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppregistrationproperties: *mut *mut XAPO_REGISTRATION_PROPERTIES) -> ::windows::core::HRESULT {
@@ -106,6 +108,7 @@ pub trait IXAPOHrtfParameters_Impl: Sized {
     fn SetSourceGain(&self, gain: f32) -> ::windows::core::Result<()>;
     fn SetEnvironment(&self, environment: HrtfEnvironment) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXAPOHrtfParameters {}
 impl IXAPOHrtfParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAPOHrtfParameters_Impl, const OFFSET: isize>() -> IXAPOHrtfParameters_Vtbl {
         unsafe extern "system" fn SetSourcePosition<Identity: ::windows::core::IUnknownImpl, Impl: IXAPOHrtfParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, position: *const HrtfPosition) -> ::windows::core::HRESULT {
@@ -144,6 +147,7 @@ pub trait IXAPOParameters_Impl: Sized {
     fn SetParameters(&self, pparameters: *const ::core::ffi::c_void, parameterbytesize: u32);
     fn GetParameters(&self, pparameters: *mut ::core::ffi::c_void, parameterbytesize: u32);
 }
+impl ::windows::core::RuntimeName for IXAPOParameters {}
 impl IXAPOParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAPOParameters_Impl, const OFFSET: isize>() -> IXAPOParameters_Vtbl {
         unsafe extern "system" fn SetParameters<Identity: ::windows::core::IUnknownImpl, Impl: IXAPOParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparameters: *const ::core::ffi::c_void, parameterbytesize: u32) {
@@ -179,6 +183,8 @@ pub trait IXAudio2_Impl: Sized {
     fn GetPerformanceData(&self, pperfdata: *mut XAUDIO2_PERFORMANCE_DATA);
     fn SetDebugConfiguration(&self, pdebugconfiguration: *const XAUDIO2_DEBUG_CONFIGURATION, preserved: *mut ::core::ffi::c_void);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXAudio2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXAudio2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2_Impl, const OFFSET: isize>() -> IXAudio2_Vtbl {
@@ -255,6 +261,7 @@ pub trait IXAudio2EngineCallback_Impl: Sized {
     fn OnProcessingPassEnd(&self);
     fn OnCriticalError(&self, error: ::windows::core::HRESULT);
 }
+impl ::windows::core::RuntimeName for IXAudio2EngineCallback {}
 impl IXAudio2EngineCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2EngineCallback_Impl, const OFFSET: isize>() -> IXAudio2EngineCallback_Vtbl {
         unsafe extern "system" fn OnProcessingPassStart<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2EngineCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -286,6 +293,7 @@ pub trait IXAudio2Extension_Impl: Sized {
     fn GetProcessingQuantum(&self, quantumnumerator: *mut u32, quantumdenominator: *mut u32);
     fn GetProcessor(&self, processor: *mut u32);
 }
+impl ::windows::core::RuntimeName for IXAudio2Extension {}
 impl IXAudio2Extension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2Extension_Impl, const OFFSET: isize>() -> IXAudio2Extension_Vtbl {
         unsafe extern "system" fn GetProcessingQuantum<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2Extension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, quantumnumerator: *mut u32, quantumdenominator: *mut u32) {
@@ -312,6 +320,8 @@ impl IXAudio2Extension_Vtbl {
 pub trait IXAudio2MasteringVoice_Impl: Sized + IXAudio2Voice_Impl {
     fn GetChannelMask(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXAudio2MasteringVoice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXAudio2MasteringVoice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2MasteringVoice_Impl, const OFFSET: isize>() -> IXAudio2MasteringVoice_Vtbl {
@@ -345,6 +355,8 @@ pub trait IXAudio2SourceVoice_Impl: Sized + IXAudio2Voice_Impl {
     fn GetFrequencyRatio(&self, pratio: *mut f32);
     fn SetSourceSampleRate(&self, newsourcesamplerate: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXAudio2SourceVoice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXAudio2SourceVoice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>() -> IXAudio2SourceVoice_Vtbl {
@@ -419,6 +431,8 @@ impl IXAudio2SourceVoice_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2SubmixVoice_Impl: Sized + IXAudio2Voice_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXAudio2SubmixVoice {}
+#[cfg(feature = "Win32_Foundation")]
 impl IXAudio2SubmixVoice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2SubmixVoice_Impl, const OFFSET: isize>() -> IXAudio2SubmixVoice_Vtbl {
         Self { base__: IXAudio2Voice_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -449,6 +463,8 @@ pub trait IXAudio2Voice_Impl: Sized {
     fn GetOutputMatrix(&self, pdestinationvoice: &::core::option::Option<IXAudio2Voice>, sourcechannels: u32, destinationchannels: u32, plevelmatrix: *mut f32);
     fn DestroyVoice(&self);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXAudio2Voice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXAudio2Voice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2Voice_Impl, const OFFSET: isize>() -> IXAudio2Voice_Vtbl {
@@ -582,6 +598,7 @@ pub trait IXAudio2VoiceCallback_Impl: Sized {
     fn OnLoopEnd(&self, pbuffercontext: *mut ::core::ffi::c_void);
     fn OnVoiceError(&self, pbuffercontext: *mut ::core::ffi::c_void, error: ::windows::core::HRESULT);
 }
+impl ::windows::core::RuntimeName for IXAudio2VoiceCallback {}
 impl IXAudio2VoiceCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>() -> IXAudio2VoiceCallback_Vtbl {
         unsafe extern "system" fn OnVoiceProcessingPassStart<Identity: ::windows::core::IUnknownImpl, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bytesrequired: u32) {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
@@ -1,6 +1,7 @@
 pub trait IActivateAudioInterfaceAsyncOperation_Impl: Sized {
     fn GetActivateResult(&self, activateresult: *mut ::windows::core::HRESULT, activatedinterface: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActivateAudioInterfaceAsyncOperation {}
 impl IActivateAudioInterfaceAsyncOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActivateAudioInterfaceAsyncOperation_Impl, const OFFSET: isize>() -> IActivateAudioInterfaceAsyncOperation_Vtbl {
         unsafe extern "system" fn GetActivateResult<Identity: ::windows::core::IUnknownImpl, Impl: IActivateAudioInterfaceAsyncOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, activateresult: *mut ::windows::core::HRESULT, activatedinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17,6 +18,7 @@ impl IActivateAudioInterfaceAsyncOperation_Vtbl {
 pub trait IActivateAudioInterfaceCompletionHandler_Impl: Sized {
     fn ActivateCompleted(&self, activateoperation: &::core::option::Option<IActivateAudioInterfaceAsyncOperation>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActivateAudioInterfaceCompletionHandler {}
 impl IActivateAudioInterfaceCompletionHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActivateAudioInterfaceCompletionHandler_Impl, const OFFSET: isize>() -> IActivateAudioInterfaceCompletionHandler_Vtbl {
         unsafe extern "system" fn ActivateCompleted<Identity: ::windows::core::IUnknownImpl, Impl: IActivateAudioInterfaceCompletionHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, activateoperation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -37,6 +39,8 @@ pub trait IAudioAmbisonicsControl_Impl: Sized {
     fn GetHeadTracking(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn SetRotation(&self, x: f32, y: f32, z: f32, w: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioAmbisonicsControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioAmbisonicsControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioAmbisonicsControl_Impl, const OFFSET: isize>() -> IAudioAmbisonicsControl_Vtbl {
@@ -84,6 +88,8 @@ pub trait IAudioAutoGainControl_Impl: Sized {
     fn SetEnabled(&self, benable: super::super::Foundation::BOOL, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioAutoGainControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioAutoGainControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioAutoGainControl_Impl, const OFFSET: isize>() -> IAudioAutoGainControl_Vtbl {
         unsafe extern "system" fn GetEnabled<Identity: ::windows::core::IUnknownImpl, Impl: IAudioAutoGainControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -113,6 +119,7 @@ impl IAudioAutoGainControl_Vtbl {
     }
 }
 pub trait IAudioBass_Impl: Sized + IPerChannelDbLevel_Impl {}
+impl ::windows::core::RuntimeName for IAudioBass {}
 impl IAudioBass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioBass_Impl, const OFFSET: isize>() -> IAudioBass_Vtbl {
         Self { base__: IPerChannelDbLevel_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -126,6 +133,7 @@ pub trait IAudioCaptureClient_Impl: Sized {
     fn ReleaseBuffer(&self, numframesread: u32) -> ::windows::core::Result<()>;
     fn GetNextPacketSize(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioCaptureClient {}
 impl IAudioCaptureClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioCaptureClient_Impl, const OFFSET: isize>() -> IAudioCaptureClient_Vtbl {
         unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IAudioCaptureClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdata: *mut *mut u8, pnumframestoread: *mut u32, pdwflags: *mut u32, pu64deviceposition: *mut u64, pu64qpcposition: *mut u64) -> ::windows::core::HRESULT {
@@ -164,6 +172,7 @@ pub trait IAudioChannelConfig_Impl: Sized {
     fn SetChannelConfig(&self, dwconfig: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetChannelConfig(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioChannelConfig {}
 impl IAudioChannelConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioChannelConfig_Impl, const OFFSET: isize>() -> IAudioChannelConfig_Vtbl {
         unsafe extern "system" fn SetChannelConfig<Identity: ::windows::core::IUnknownImpl, Impl: IAudioChannelConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwconfig: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -207,6 +216,8 @@ pub trait IAudioClient_Impl: Sized {
     fn SetEventHandle(&self, eventhandle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn GetService(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioClient {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClient_Impl, const OFFSET: isize>() -> IAudioClient_Vtbl {
@@ -321,6 +332,8 @@ pub trait IAudioClient2_Impl: Sized + IAudioClient_Impl {
     fn GetBufferSizeLimits(&self, pformat: *const WAVEFORMATEX, beventdriven: super::super::Foundation::BOOL, phnsminbufferduration: *mut i64, phnsmaxbufferduration: *mut i64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioClient2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioClient2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClient2_Impl, const OFFSET: isize>() -> IAudioClient2_Vtbl {
         unsafe extern "system" fn IsOffloadCapable<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClient2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, category: AUDIO_STREAM_CATEGORY, pboffloadcapable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -362,6 +375,8 @@ pub trait IAudioClient3_Impl: Sized + IAudioClient_Impl + IAudioClient2_Impl {
     fn InitializeSharedAudioStream(&self, streamflags: u32, periodinframes: u32, pformat: *const WAVEFORMATEX, audiosessionguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioClient3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioClient3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClient3_Impl, const OFFSET: isize>() -> IAudioClient3_Vtbl {
         unsafe extern "system" fn GetSharedModeEnginePeriod<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClient3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pformat: *const WAVEFORMATEX, pdefaultperiodinframes: *mut u32, pfundamentalperiodinframes: *mut u32, pminperiodinframes: *mut u32, pmaxperiodinframes: *mut u32) -> ::windows::core::HRESULT {
@@ -393,6 +408,7 @@ impl IAudioClient3_Vtbl {
 pub trait IAudioClientDuckingControl_Impl: Sized {
     fn SetDuckingOptionsForCurrentStream(&self, options: AUDIO_DUCKING_OPTIONS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioClientDuckingControl {}
 impl IAudioClientDuckingControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClientDuckingControl_Impl, const OFFSET: isize>() -> IAudioClientDuckingControl_Vtbl {
         unsafe extern "system" fn SetDuckingOptionsForCurrentStream<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClientDuckingControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: AUDIO_DUCKING_OPTIONS) -> ::windows::core::HRESULT {
@@ -414,6 +430,7 @@ pub trait IAudioClock_Impl: Sized {
     fn GetPosition(&self, pu64position: *mut u64, pu64qpcposition: *mut u64) -> ::windows::core::Result<()>;
     fn GetCharacteristics(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAudioClock {}
 impl IAudioClock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClock_Impl, const OFFSET: isize>() -> IAudioClock_Vtbl {
         unsafe extern "system" fn GetFrequency<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pu64frequency: *mut u64) -> ::windows::core::HRESULT {
@@ -457,6 +474,7 @@ impl IAudioClock_Vtbl {
 pub trait IAudioClock2_Impl: Sized {
     fn GetDevicePosition(&self, deviceposition: *mut u64, qpcposition: *mut u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioClock2 {}
 impl IAudioClock2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClock2_Impl, const OFFSET: isize>() -> IAudioClock2_Vtbl {
         unsafe extern "system" fn GetDevicePosition<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClock2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, deviceposition: *mut u64, qpcposition: *mut u64) -> ::windows::core::HRESULT {
@@ -473,6 +491,7 @@ impl IAudioClock2_Vtbl {
 pub trait IAudioClockAdjustment_Impl: Sized {
     fn SetSampleRate(&self, flsamplerate: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioClockAdjustment {}
 impl IAudioClockAdjustment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClockAdjustment_Impl, const OFFSET: isize>() -> IAudioClockAdjustment_Vtbl {
         unsafe extern "system" fn SetSampleRate<Identity: ::windows::core::IUnknownImpl, Impl: IAudioClockAdjustment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flsamplerate: f32) -> ::windows::core::HRESULT {
@@ -489,6 +508,7 @@ impl IAudioClockAdjustment_Vtbl {
 pub trait IAudioEffectsChangedNotificationClient_Impl: Sized {
     fn OnAudioEffectsChanged(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioEffectsChangedNotificationClient {}
 impl IAudioEffectsChangedNotificationClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEffectsChangedNotificationClient_Impl, const OFFSET: isize>() -> IAudioEffectsChangedNotificationClient_Vtbl {
         unsafe extern "system" fn OnAudioEffectsChanged<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEffectsChangedNotificationClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -509,6 +529,8 @@ pub trait IAudioEffectsManager_Impl: Sized {
     fn GetAudioEffects(&self, effects: *mut *mut AUDIO_EFFECT, numeffects: *mut u32) -> ::windows::core::Result<()>;
     fn SetAudioEffectState(&self, effectid: &::windows::core::GUID, state: AUDIO_EFFECT_STATE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioEffectsManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioEffectsManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEffectsManager_Impl, const OFFSET: isize>() -> IAudioEffectsManager_Vtbl {
@@ -548,6 +570,7 @@ pub trait IAudioFormatEnumerator_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetFormat(&self, index: u32) -> ::windows::core::Result<*mut WAVEFORMATEX>;
 }
+impl ::windows::core::RuntimeName for IAudioFormatEnumerator {}
 impl IAudioFormatEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioFormatEnumerator_Impl, const OFFSET: isize>() -> IAudioFormatEnumerator_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IAudioFormatEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -586,6 +609,7 @@ pub trait IAudioInputSelector_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<u32>;
     fn SetSelection(&self, nidselect: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioInputSelector {}
 impl IAudioInputSelector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioInputSelector_Impl, const OFFSET: isize>() -> IAudioInputSelector_Vtbl {
         unsafe extern "system" fn GetSelection<Identity: ::windows::core::IUnknownImpl, Impl: IAudioInputSelector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnidselected: *mut u32) -> ::windows::core::HRESULT {
@@ -620,6 +644,8 @@ pub trait IAudioLoudness_Impl: Sized {
     fn SetEnabled(&self, benable: super::super::Foundation::BOOL, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioLoudness {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioLoudness_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioLoudness_Impl, const OFFSET: isize>() -> IAudioLoudness_Vtbl {
         unsafe extern "system" fn GetEnabled<Identity: ::windows::core::IUnknownImpl, Impl: IAudioLoudness_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -649,6 +675,7 @@ impl IAudioLoudness_Vtbl {
     }
 }
 pub trait IAudioMidrange_Impl: Sized + IPerChannelDbLevel_Impl {}
+impl ::windows::core::RuntimeName for IAudioMidrange {}
 impl IAudioMidrange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioMidrange_Impl, const OFFSET: isize>() -> IAudioMidrange_Vtbl {
         Self { base__: IPerChannelDbLevel_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -662,6 +689,8 @@ pub trait IAudioMute_Impl: Sized {
     fn SetMute(&self, bmuted: super::super::Foundation::BOOL, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetMute(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioMute {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioMute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioMute_Impl, const OFFSET: isize>() -> IAudioMute_Vtbl {
@@ -695,6 +724,7 @@ pub trait IAudioOutputSelector_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<u32>;
     fn SetSelection(&self, nidselect: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioOutputSelector {}
 impl IAudioOutputSelector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioOutputSelector_Impl, const OFFSET: isize>() -> IAudioOutputSelector_Vtbl {
         unsafe extern "system" fn GetSelection<Identity: ::windows::core::IUnknownImpl, Impl: IAudioOutputSelector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnidselected: *mut u32) -> ::windows::core::HRESULT {
@@ -727,6 +757,7 @@ pub trait IAudioPeakMeter_Impl: Sized {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn GetLevel(&self, nchannel: u32) -> ::windows::core::Result<f32>;
 }
+impl ::windows::core::RuntimeName for IAudioPeakMeter {}
 impl IAudioPeakMeter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioPeakMeter_Impl, const OFFSET: isize>() -> IAudioPeakMeter_Vtbl {
         unsafe extern "system" fn GetChannelCount<Identity: ::windows::core::IUnknownImpl, Impl: IAudioPeakMeter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcchannels: *mut u32) -> ::windows::core::HRESULT {
@@ -765,6 +796,7 @@ pub trait IAudioRenderClient_Impl: Sized {
     fn GetBuffer(&self, numframesrequested: u32) -> ::windows::core::Result<*mut u8>;
     fn ReleaseBuffer(&self, numframeswritten: u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioRenderClient {}
 impl IAudioRenderClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioRenderClient_Impl, const OFFSET: isize>() -> IAudioRenderClient_Vtbl {
         unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IAudioRenderClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, numframesrequested: u32, ppdata: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -804,6 +836,7 @@ pub trait IAudioSessionControl_Impl: Sized {
     fn RegisterAudioSessionNotification(&self, newnotifications: &::core::option::Option<IAudioSessionEvents>) -> ::windows::core::Result<()>;
     fn UnregisterAudioSessionNotification(&self, newnotifications: &::core::option::Option<IAudioSessionEvents>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioSessionControl {}
 impl IAudioSessionControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionControl_Impl, const OFFSET: isize>() -> IAudioSessionControl_Vtbl {
         unsafe extern "system" fn GetState<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut AudioSessionState) -> ::windows::core::HRESULT {
@@ -901,6 +934,8 @@ pub trait IAudioSessionControl2_Impl: Sized + IAudioSessionControl_Impl {
     fn SetDuckingPreference(&self, optout: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioSessionControl2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioSessionControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionControl2_Impl, const OFFSET: isize>() -> IAudioSessionControl2_Vtbl {
         unsafe extern "system" fn GetSessionIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -963,6 +998,7 @@ pub trait IAudioSessionEnumerator_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<i32>;
     fn GetSession(&self, sessioncount: i32) -> ::windows::core::Result<IAudioSessionControl>;
 }
+impl ::windows::core::RuntimeName for IAudioSessionEnumerator {}
 impl IAudioSessionEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionEnumerator_Impl, const OFFSET: isize>() -> IAudioSessionEnumerator_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sessioncount: *mut i32) -> ::windows::core::HRESULT {
@@ -1007,6 +1043,8 @@ pub trait IAudioSessionEvents_Impl: Sized {
     fn OnStateChanged(&self, newstate: AudioSessionState) -> ::windows::core::Result<()>;
     fn OnSessionDisconnected(&self, disconnectreason: AudioSessionDisconnectReason) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioSessionEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAudioSessionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionEvents_Impl, const OFFSET: isize>() -> IAudioSessionEvents_Vtbl {
@@ -1064,6 +1102,7 @@ pub trait IAudioSessionManager_Impl: Sized {
     fn GetAudioSessionControl(&self, audiosessionguid: *const ::windows::core::GUID, streamflags: u32) -> ::windows::core::Result<IAudioSessionControl>;
     fn GetSimpleAudioVolume(&self, audiosessionguid: *const ::windows::core::GUID, streamflags: u32) -> ::windows::core::Result<ISimpleAudioVolume>;
 }
+impl ::windows::core::RuntimeName for IAudioSessionManager {}
 impl IAudioSessionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionManager_Impl, const OFFSET: isize>() -> IAudioSessionManager_Vtbl {
         unsafe extern "system" fn GetAudioSessionControl<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, audiosessionguid: *const ::windows::core::GUID, streamflags: u32, sessioncontrol: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1105,6 +1144,7 @@ pub trait IAudioSessionManager2_Impl: Sized + IAudioSessionManager_Impl {
     fn RegisterDuckNotification(&self, sessionid: &::windows::core::PCWSTR, ducknotification: &::core::option::Option<IAudioVolumeDuckNotification>) -> ::windows::core::Result<()>;
     fn UnregisterDuckNotification(&self, ducknotification: &::core::option::Option<IAudioVolumeDuckNotification>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioSessionManager2 {}
 impl IAudioSessionManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionManager2_Impl, const OFFSET: isize>() -> IAudioSessionManager2_Vtbl {
         unsafe extern "system" fn GetSessionEnumerator<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sessionenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1154,6 +1194,7 @@ impl IAudioSessionManager2_Vtbl {
 pub trait IAudioSessionNotification_Impl: Sized {
     fn OnSessionCreated(&self, newsession: &::core::option::Option<IAudioSessionControl>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioSessionNotification {}
 impl IAudioSessionNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionNotification_Impl, const OFFSET: isize>() -> IAudioSessionNotification_Vtbl {
         unsafe extern "system" fn OnSessionCreated<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSessionNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newsession: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1172,6 +1213,7 @@ pub trait IAudioStateMonitor_Impl: Sized {
     fn UnregisterCallback(&self, registration: i64);
     fn GetSoundLevel(&self) -> AudioStateMonitorSoundLevel;
 }
+impl ::windows::core::RuntimeName for IAudioStateMonitor {}
 impl IAudioStateMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioStateMonitor_Impl, const OFFSET: isize>() -> IAudioStateMonitor_Vtbl {
         unsafe extern "system" fn RegisterCallback<Identity: ::windows::core::IUnknownImpl, Impl: IAudioStateMonitor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, callback: ::windows::core::RawPtr, context: *const ::core::ffi::c_void, registration: *mut i64) -> ::windows::core::HRESULT {
@@ -1213,6 +1255,7 @@ pub trait IAudioStreamVolume_Impl: Sized {
     fn SetAllVolumes(&self, dwcount: u32, pfvolumes: *const f32) -> ::windows::core::Result<()>;
     fn GetAllVolumes(&self, dwcount: u32, pfvolumes: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioStreamVolume {}
 impl IAudioStreamVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioStreamVolume_Impl, const OFFSET: isize>() -> IAudioStreamVolume_Vtbl {
         unsafe extern "system" fn GetChannelCount<Identity: ::windows::core::IUnknownImpl, Impl: IAudioStreamVolume_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -1270,6 +1313,8 @@ pub trait IAudioSystemEffectsPropertyChangeNotificationClient_Impl: Sized {
     fn OnPropertyChanged(&self, r#type: __MIDL___MIDL_itf_mmdeviceapi_0000_0008_0002, key: &super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IAudioSystemEffectsPropertyChangeNotificationClient {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IAudioSystemEffectsPropertyChangeNotificationClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffectsPropertyChangeNotificationClient_Impl, const OFFSET: isize>() -> IAudioSystemEffectsPropertyChangeNotificationClient_Vtbl {
         unsafe extern "system" fn OnPropertyChanged<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffectsPropertyChangeNotificationClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: __MIDL___MIDL_itf_mmdeviceapi_0000_0008_0002, key: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::HRESULT {
@@ -1293,6 +1338,8 @@ pub trait IAudioSystemEffectsPropertyStore_Impl: Sized {
     fn RegisterPropertyChangeNotification(&self, callback: &::core::option::Option<IAudioSystemEffectsPropertyChangeNotificationClient>) -> ::windows::core::Result<()>;
     fn UnregisterPropertyChangeNotification(&self, callback: &::core::option::Option<IAudioSystemEffectsPropertyChangeNotificationClient>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IAudioSystemEffectsPropertyStore {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IAudioSystemEffectsPropertyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSystemEffectsPropertyStore_Impl, const OFFSET: isize>() -> IAudioSystemEffectsPropertyStore_Vtbl {
@@ -1365,6 +1412,7 @@ impl IAudioSystemEffectsPropertyStore_Vtbl {
     }
 }
 pub trait IAudioTreble_Impl: Sized + IPerChannelDbLevel_Impl {}
+impl ::windows::core::RuntimeName for IAudioTreble {}
 impl IAudioTreble_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioTreble_Impl, const OFFSET: isize>() -> IAudioTreble_Vtbl {
         Self { base__: IPerChannelDbLevel_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1377,6 +1425,7 @@ pub trait IAudioVolumeDuckNotification_Impl: Sized {
     fn OnVolumeDuckNotification(&self, sessionid: &::windows::core::PCWSTR, countcommunicationsessions: u32) -> ::windows::core::Result<()>;
     fn OnVolumeUnduckNotification(&self, sessionid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioVolumeDuckNotification {}
 impl IAudioVolumeDuckNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioVolumeDuckNotification_Impl, const OFFSET: isize>() -> IAudioVolumeDuckNotification_Vtbl {
         unsafe extern "system" fn OnVolumeDuckNotification<Identity: ::windows::core::IUnknownImpl, Impl: IAudioVolumeDuckNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sessionid: ::windows::core::PCWSTR, countcommunicationsessions: u32) -> ::windows::core::HRESULT {
@@ -1400,6 +1449,7 @@ impl IAudioVolumeDuckNotification_Vtbl {
     }
 }
 pub trait IAudioVolumeLevel_Impl: Sized + IPerChannelDbLevel_Impl {}
+impl ::windows::core::RuntimeName for IAudioVolumeLevel {}
 impl IAudioVolumeLevel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioVolumeLevel_Impl, const OFFSET: isize>() -> IAudioVolumeLevel_Vtbl {
         Self { base__: IPerChannelDbLevel_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1415,6 +1465,7 @@ pub trait IChannelAudioVolume_Impl: Sized {
     fn SetAllVolumes(&self, dwcount: u32, pfvolumes: *const f32, eventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetAllVolumes(&self, dwcount: u32, pfvolumes: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IChannelAudioVolume {}
 impl IChannelAudioVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChannelAudioVolume_Impl, const OFFSET: isize>() -> IChannelAudioVolume_Vtbl {
         unsafe extern "system" fn GetChannelCount<Identity: ::windows::core::IUnknownImpl, Impl: IChannelAudioVolume_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -1478,6 +1529,8 @@ pub trait IConnector_Impl: Sized {
     fn GetConnectorIdConnectedTo(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetDeviceIdConnectedTo(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IConnector {}
 #[cfg(feature = "Win32_Foundation")]
 impl IConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConnector_Impl, const OFFSET: isize>() -> IConnector_Vtbl {
@@ -1576,6 +1629,7 @@ impl IConnector_Vtbl {
 pub trait IControlChangeNotify_Impl: Sized {
     fn OnNotify(&self, dwsenderprocessid: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IControlChangeNotify {}
 impl IControlChangeNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IControlChangeNotify_Impl, const OFFSET: isize>() -> IControlChangeNotify_Vtbl {
         unsafe extern "system" fn OnNotify<Identity: ::windows::core::IUnknownImpl, Impl: IControlChangeNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsenderprocessid: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1593,6 +1647,7 @@ pub trait IControlInterface_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetIID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IControlInterface {}
 impl IControlInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IControlInterface_Impl, const OFFSET: isize>() -> IControlInterface_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IControlInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwstrname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1633,6 +1688,7 @@ pub trait IDeviceSpecificProperty_Impl: Sized {
     fn SetValue(&self, pvvalue: *const ::core::ffi::c_void, cbvalue: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Get4BRange(&self, plmin: *mut i32, plmax: *mut i32, plstepping: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDeviceSpecificProperty {}
 impl IDeviceSpecificProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceSpecificProperty_Impl, const OFFSET: isize>() -> IDeviceSpecificProperty_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceSpecificProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvtype: *mut u16) -> ::windows::core::HRESULT {
@@ -1683,6 +1739,8 @@ pub trait IDeviceTopology_Impl: Sized {
     fn GetDeviceId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetSignalPath(&self, pipartfrom: &::core::option::Option<IPart>, pipartto: &::core::option::Option<IPart>, brejectmixedpaths: super::super::Foundation::BOOL) -> ::windows::core::Result<IPartsList>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDeviceTopology {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDeviceTopology_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceTopology_Impl, const OFFSET: isize>() -> IDeviceTopology_Vtbl {
@@ -1786,6 +1844,8 @@ pub trait IMMDevice_Impl: Sized {
     fn GetState(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IMMDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IMMDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMDevice_Impl, const OFFSET: isize>() -> IMMDevice_Vtbl {
         unsafe extern "system" fn Activate<Identity: ::windows::core::IUnknownImpl, Impl: IMMDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, dwclsctx: super::super::System::Com::CLSCTX, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1843,6 +1903,8 @@ pub trait IMMDeviceActivator_Impl: Sized {
     fn Activate(&self, iid: *const ::windows::core::GUID, pdevice: &::core::option::Option<IMMDevice>, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMMDeviceActivator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMMDeviceActivator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMDeviceActivator_Impl, const OFFSET: isize>() -> IMMDeviceActivator_Vtbl {
         unsafe extern "system" fn Activate<Identity: ::windows::core::IUnknownImpl, Impl: IMMDeviceActivator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, pdevice: ::windows::core::RawPtr, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1860,6 +1922,7 @@ pub trait IMMDeviceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn Item(&self, ndevice: u32) -> ::windows::core::Result<IMMDevice>;
 }
+impl ::windows::core::RuntimeName for IMMDeviceCollection {}
 impl IMMDeviceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMDeviceCollection_Impl, const OFFSET: isize>() -> IMMDeviceCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IMMDeviceCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcdevices: *mut u32) -> ::windows::core::HRESULT {
@@ -1901,6 +1964,7 @@ pub trait IMMDeviceEnumerator_Impl: Sized {
     fn RegisterEndpointNotificationCallback(&self, pclient: &::core::option::Option<IMMNotificationClient>) -> ::windows::core::Result<()>;
     fn UnregisterEndpointNotificationCallback(&self, pclient: &::core::option::Option<IMMNotificationClient>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMMDeviceEnumerator {}
 impl IMMDeviceEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMDeviceEnumerator_Impl, const OFFSET: isize>() -> IMMDeviceEnumerator_Vtbl {
         unsafe extern "system" fn EnumAudioEndpoints<Identity: ::windows::core::IUnknownImpl, Impl: IMMDeviceEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dataflow: EDataFlow, dwstatemask: u32, ppdevices: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1962,6 +2026,7 @@ impl IMMDeviceEnumerator_Vtbl {
 pub trait IMMEndpoint_Impl: Sized {
     fn GetDataFlow(&self) -> ::windows::core::Result<EDataFlow>;
 }
+impl ::windows::core::RuntimeName for IMMEndpoint {}
 impl IMMEndpoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMEndpoint_Impl, const OFFSET: isize>() -> IMMEndpoint_Vtbl {
         unsafe extern "system" fn GetDataFlow<Identity: ::windows::core::IUnknownImpl, Impl: IMMEndpoint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdataflow: *mut EDataFlow) -> ::windows::core::HRESULT {
@@ -1989,6 +2054,8 @@ pub trait IMMNotificationClient_Impl: Sized {
     fn OnDefaultDeviceChanged(&self, flow: EDataFlow, role: ERole, pwstrdefaultdeviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn OnPropertyValueChanged(&self, pwstrdeviceid: &::windows::core::PCWSTR, key: &super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMMNotificationClient {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMMNotificationClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMNotificationClient_Impl, const OFFSET: isize>() -> IMMNotificationClient_Vtbl {
@@ -2037,6 +2104,8 @@ pub trait IMessageFilter_Impl: Sized {
     fn MessagePending(&self, htaskcallee: super::HTASK, dwtickcount: u32, dwpendingtype: u32) -> u32;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMessageFilter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMessageFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMessageFilter_Impl, const OFFSET: isize>() -> IMessageFilter_Vtbl {
         unsafe extern "system" fn HandleInComingCall<Identity: ::windows::core::IUnknownImpl, Impl: IMessageFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcalltype: u32, htaskcaller: super::HTASK, dwtickcount: u32, lpinterfaceinfo: *const super::super::System::Com::INTERFACEINFO) -> u32 {
@@ -2080,6 +2149,7 @@ pub trait IPart_Impl: Sized {
     fn RegisterControlChangeCallback(&self, riid: *const ::windows::core::GUID, pnotify: &::core::option::Option<IControlChangeNotify>) -> ::windows::core::Result<()>;
     fn UnregisterControlChangeCallback(&self, pnotify: &::core::option::Option<IControlChangeNotify>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPart {}
 impl IPart_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPart_Impl, const OFFSET: isize>() -> IPart_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IPart_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwstrname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2232,6 +2302,7 @@ pub trait IPartsList_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetPart(&self, nindex: u32) -> ::windows::core::Result<IPart>;
 }
+impl ::windows::core::RuntimeName for IPartsList {}
 impl IPartsList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPartsList_Impl, const OFFSET: isize>() -> IPartsList_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IPartsList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT {
@@ -2274,6 +2345,7 @@ pub trait IPerChannelDbLevel_Impl: Sized {
     fn SetLevelUniform(&self, fleveldb: f32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetLevelAllChannels(&self, alevelsdb: *const f32, cchannels: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPerChannelDbLevel {}
 impl IPerChannelDbLevel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPerChannelDbLevel_Impl, const OFFSET: isize>() -> IPerChannelDbLevel_Vtbl {
         unsafe extern "system" fn GetChannelCount<Identity: ::windows::core::IUnknownImpl, Impl: IPerChannelDbLevel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcchannels: *mut u32) -> ::windows::core::HRESULT {
@@ -2340,6 +2412,8 @@ pub trait ISimpleAudioVolume_Impl: Sized {
     fn GetMute(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimpleAudioVolume {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISimpleAudioVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleAudioVolume_Impl, const OFFSET: isize>() -> ISimpleAudioVolume_Vtbl {
         unsafe extern "system" fn SetMasterVolume<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleAudioVolume_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flevel: f32, eventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2397,6 +2471,8 @@ pub trait ISpatialAudioClient_Impl: Sized {
     fn IsSpatialAudioStreamAvailable(&self, streamuuid: *const ::windows::core::GUID, auxiliaryinfo: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
     fn ActivateSpatialAudioStream(&self, activationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, riid: *const ::windows::core::GUID, stream: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpatialAudioClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpatialAudioClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioClient_Impl, const OFFSET: isize>() -> ISpatialAudioClient_Vtbl {
@@ -2486,6 +2562,8 @@ pub trait ISpatialAudioClient2_Impl: Sized + ISpatialAudioClient_Impl {
     fn GetMaxFrameCountForCategory(&self, category: AUDIO_STREAM_CATEGORY, offloadenabled: super::super::Foundation::BOOL, objectformat: *const WAVEFORMATEX) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpatialAudioClient2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpatialAudioClient2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioClient2_Impl, const OFFSET: isize>() -> ISpatialAudioClient2_Vtbl {
         unsafe extern "system" fn IsOffloadCapable<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioClient2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, category: AUDIO_STREAM_CATEGORY, isoffloadcapable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2527,6 +2605,7 @@ pub trait ISpatialAudioMetadataClient_Impl: Sized {
     fn ActivateSpatialAudioMetadataCopier(&self) -> ::windows::core::Result<ISpatialAudioMetadataCopier>;
     fn ActivateSpatialAudioMetadataReader(&self) -> ::windows::core::Result<ISpatialAudioMetadataReader>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioMetadataClient {}
 impl ISpatialAudioMetadataClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataClient_Impl, const OFFSET: isize>() -> ISpatialAudioMetadataClient_Vtbl {
         unsafe extern "system" fn ActivateSpatialAudioMetadataItems<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxitemcount: u16, framecount: u16, metadataitemsbuffer: *mut ::windows::core::RawPtr, metadataitems: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2596,6 +2675,7 @@ pub trait ISpatialAudioMetadataCopier_Impl: Sized {
     fn CopyMetadataForFrames(&self, copyframecount: u16, copymode: SpatialAudioMetadataCopyMode, dstmetadataitems: &::core::option::Option<ISpatialAudioMetadataItems>) -> ::windows::core::Result<u16>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioMetadataCopier {}
 impl ISpatialAudioMetadataCopier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataCopier_Impl, const OFFSET: isize>() -> ISpatialAudioMetadataCopier_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataCopier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, metadataitems: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2637,6 +2717,7 @@ pub trait ISpatialAudioMetadataItems_Impl: Sized {
     fn GetMaxValueBufferLength(&self) -> ::windows::core::Result<u32>;
     fn GetInfo(&self) -> ::windows::core::Result<SpatialAudioMetadataItemsInfo>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioMetadataItems {}
 impl ISpatialAudioMetadataItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataItems_Impl, const OFFSET: isize>() -> ISpatialAudioMetadataItems_Vtbl {
         unsafe extern "system" fn GetFrameCount<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, framecount: *mut u16) -> ::windows::core::HRESULT {
@@ -2712,6 +2793,7 @@ pub trait ISpatialAudioMetadataItemsBuffer_Impl: Sized {
     fn AttachToPopulatedBuffer(&self, buffer: *mut u8, bufferlength: u32) -> ::windows::core::Result<()>;
     fn DetachBuffer(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioMetadataItemsBuffer {}
 impl ISpatialAudioMetadataItemsBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataItemsBuffer_Impl, const OFFSET: isize>() -> ISpatialAudioMetadataItemsBuffer_Vtbl {
         unsafe extern "system" fn AttachToBuffer<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataItemsBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer: *mut u8, bufferlength: u32) -> ::windows::core::HRESULT {
@@ -2746,6 +2828,7 @@ pub trait ISpatialAudioMetadataReader_Impl: Sized {
     fn ReadNextItemCommand(&self, commandid: *mut u8, valuebuffer: *mut ::core::ffi::c_void, maxvaluebufferlength: u32, valuebufferlength: *mut u32) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioMetadataReader {}
 impl ISpatialAudioMetadataReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataReader_Impl, const OFFSET: isize>() -> ISpatialAudioMetadataReader_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, metadataitems: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2786,6 +2869,7 @@ pub trait ISpatialAudioMetadataWriter_Impl: Sized {
     fn WriteNextItemCommand(&self, commandid: u8, valuebuffer: *const ::core::ffi::c_void, valuebufferlength: u32) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioMetadataWriter {}
 impl ISpatialAudioMetadataWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataWriter_Impl, const OFFSET: isize>() -> ISpatialAudioMetadataWriter_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioMetadataWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, metadataitems: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2826,6 +2910,8 @@ pub trait ISpatialAudioObject_Impl: Sized + ISpatialAudioObjectBase_Impl {
     fn SetVolume(&self, volume: f32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpatialAudioObject {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpatialAudioObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObject_Impl, const OFFSET: isize>() -> ISpatialAudioObject_Vtbl {
         unsafe extern "system" fn SetPosition<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, x: f32, y: f32, z: f32) -> ::windows::core::HRESULT {
@@ -2855,6 +2941,8 @@ pub trait ISpatialAudioObjectBase_Impl: Sized {
     fn IsActive(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetAudioObjectType(&self) -> ::windows::core::Result<AudioObjectType>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpatialAudioObjectBase {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpatialAudioObjectBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectBase_Impl, const OFFSET: isize>() -> ISpatialAudioObjectBase_Vtbl {
@@ -2912,6 +3000,8 @@ pub trait ISpatialAudioObjectForHrtf_Impl: Sized + ISpatialAudioObjectBase_Impl 
     fn SetDirectivity(&self, directivity: *const SpatialAudioHrtfDirectivityUnion) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpatialAudioObjectForHrtf {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpatialAudioObjectForHrtf_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectForHrtf_Impl, const OFFSET: isize>() -> ISpatialAudioObjectForHrtf_Vtbl {
         unsafe extern "system" fn SetPosition<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectForHrtf_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, x: f32, y: f32, z: f32) -> ::windows::core::HRESULT {
@@ -2963,6 +3053,8 @@ pub trait ISpatialAudioObjectForMetadataCommands_Impl: Sized + ISpatialAudioObje
     fn WriteNextMetadataCommand(&self, commandid: u8, valuebuffer: *const ::core::ffi::c_void, valuebufferlength: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpatialAudioObjectForMetadataCommands {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpatialAudioObjectForMetadataCommands_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectForMetadataCommands_Impl, const OFFSET: isize>() -> ISpatialAudioObjectForMetadataCommands_Vtbl {
         unsafe extern "system" fn WriteNextMetadataCommand<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectForMetadataCommands_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, commandid: u8, valuebuffer: *const ::core::ffi::c_void, valuebufferlength: u32) -> ::windows::core::HRESULT {
@@ -2983,6 +3075,8 @@ impl ISpatialAudioObjectForMetadataCommands_Vtbl {
 pub trait ISpatialAudioObjectForMetadataItems_Impl: Sized + ISpatialAudioObjectBase_Impl {
     fn GetSpatialAudioMetadataItems(&self) -> ::windows::core::Result<ISpatialAudioMetadataItems>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpatialAudioObjectForMetadataItems {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpatialAudioObjectForMetadataItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectForMetadataItems_Impl, const OFFSET: isize>() -> ISpatialAudioObjectForMetadataItems_Vtbl {
@@ -3009,6 +3103,7 @@ impl ISpatialAudioObjectForMetadataItems_Vtbl {
 pub trait ISpatialAudioObjectRenderStream_Impl: Sized + ISpatialAudioObjectRenderStreamBase_Impl {
     fn ActivateSpatialAudioObject(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObject>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioObjectRenderStream {}
 impl ISpatialAudioObjectRenderStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStream_Impl, const OFFSET: isize>() -> ISpatialAudioObjectRenderStream_Vtbl {
         unsafe extern "system" fn ActivateSpatialAudioObject<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: AudioObjectType, audioobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3040,6 +3135,7 @@ pub trait ISpatialAudioObjectRenderStreamBase_Impl: Sized {
     fn BeginUpdatingAudioObjects(&self, availabledynamicobjectcount: *mut u32, framecountperbuffer: *mut u32) -> ::windows::core::Result<()>;
     fn EndUpdatingAudioObjects(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioObjectRenderStreamBase {}
 impl ISpatialAudioObjectRenderStreamBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamBase_Impl, const OFFSET: isize>() -> ISpatialAudioObjectRenderStreamBase_Vtbl {
         unsafe extern "system" fn GetAvailableDynamicObjectCount<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamBase_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut u32) -> ::windows::core::HRESULT {
@@ -3101,6 +3197,7 @@ impl ISpatialAudioObjectRenderStreamBase_Vtbl {
 pub trait ISpatialAudioObjectRenderStreamForHrtf_Impl: Sized + ISpatialAudioObjectRenderStreamBase_Impl {
     fn ActivateSpatialAudioObjectForHrtf(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObjectForHrtf>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioObjectRenderStreamForHrtf {}
 impl ISpatialAudioObjectRenderStreamForHrtf_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamForHrtf_Impl, const OFFSET: isize>() -> ISpatialAudioObjectRenderStreamForHrtf_Vtbl {
         unsafe extern "system" fn ActivateSpatialAudioObjectForHrtf<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamForHrtf_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: AudioObjectType, audioobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3127,6 +3224,7 @@ pub trait ISpatialAudioObjectRenderStreamForMetadata_Impl: Sized + ISpatialAudio
     fn ActivateSpatialAudioObjectForMetadataCommands(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObjectForMetadataCommands>;
     fn ActivateSpatialAudioObjectForMetadataItems(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObjectForMetadataItems>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioObjectRenderStreamForMetadata {}
 impl ISpatialAudioObjectRenderStreamForMetadata_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamForMetadata_Impl, const OFFSET: isize>() -> ISpatialAudioObjectRenderStreamForMetadata_Vtbl {
         unsafe extern "system" fn ActivateSpatialAudioObjectForMetadataCommands<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamForMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: AudioObjectType, audioobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3164,6 +3262,7 @@ impl ISpatialAudioObjectRenderStreamForMetadata_Vtbl {
 pub trait ISpatialAudioObjectRenderStreamNotify_Impl: Sized {
     fn OnAvailableDynamicObjectCountChange(&self, sender: &::core::option::Option<ISpatialAudioObjectRenderStreamBase>, hnscompliancedeadlinetime: i64, availabledynamicobjectcountchange: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpatialAudioObjectRenderStreamNotify {}
 impl ISpatialAudioObjectRenderStreamNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamNotify_Impl, const OFFSET: isize>() -> ISpatialAudioObjectRenderStreamNotify_Vtbl {
         unsafe extern "system" fn OnAvailableDynamicObjectCountChange<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialAudioObjectRenderStreamNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, hnscompliancedeadlinetime: i64, availabledynamicobjectcountchange: u32) -> ::windows::core::HRESULT {
@@ -3181,6 +3280,7 @@ impl ISpatialAudioObjectRenderStreamNotify_Vtbl {
     }
 }
 pub trait ISubunit_Impl: Sized {}
+impl ::windows::core::RuntimeName for ISubunit {}
 impl ISubunit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISubunit_Impl, const OFFSET: isize>() -> ISubunit_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
@@ -2,6 +2,7 @@ pub trait IComponentAuthenticate_Impl: Sized {
     fn SACAuth(&self, dwprotocolid: u32, dwpass: u32, pbdatain: *const u8, dwdatainlen: u32, ppbdataout: *mut *mut u8, pdwdataoutlen: *mut u32) -> ::windows::core::Result<()>;
     fn SACGetProtocols(&self, ppdwprotocols: *mut *mut u32, pdwprotocolcount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComponentAuthenticate {}
 impl IComponentAuthenticate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentAuthenticate_Impl, const OFFSET: isize>() -> IComponentAuthenticate_Vtbl {
         unsafe extern "system" fn SACAuth<Identity: ::windows::core::IUnknownImpl, Impl: IComponentAuthenticate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwprotocolid: u32, dwpass: u32, pbdatain: *const u8, dwdatainlen: u32, ppbdataout: *mut *mut u8, pdwdataoutlen: *mut u32) -> ::windows::core::HRESULT {
@@ -37,6 +38,7 @@ pub trait IMDSPDevice_Impl: Sized {
     fn GetFormatSupport(&self, pformatex: *mut *mut _WAVEFORMATEX, pnformatcount: *mut u32, pppwszmimetype: *mut *mut ::windows::core::PWSTR, pnmimetypecount: *mut u32) -> ::windows::core::Result<()>;
     fn SendOpaqueCommand(&self, pcommand: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDSPDevice {}
 impl IMDSPDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDevice_Impl, const OFFSET: isize>() -> IMDSPDevice_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT {
@@ -151,6 +153,8 @@ pub trait IMDSPDevice2_Impl: Sized + IMDSPDevice_Impl {
     fn GetCanonicalName(&self, pwszpnpname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMDSPDevice2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IMDSPDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDevice2_Impl, const OFFSET: isize>() -> IMDSPDevice2_Vtbl {
         unsafe extern "system" fn GetStorage<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszstoragename: ::windows::core::PCWSTR, ppstorage: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -199,6 +203,8 @@ pub trait IMDSPDevice3_Impl: Sized + IMDSPDevice_Impl + IMDSPDevice2_Impl {
     fn DeviceIoControl(&self, dwiocontrolcode: u32, lpinbuffer: *const u8, ninbuffersize: u32, lpoutbuffer: *mut u8, pnoutbuffersize: *mut u32) -> ::windows::core::Result<()>;
     fn FindStorage(&self, findscope: WMDM_FIND_SCOPE, pwszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<IMDSPStorage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMDSPDevice3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IMDSPDevice3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDevice3_Impl, const OFFSET: isize>() -> IMDSPDevice3_Vtbl {
@@ -268,6 +274,7 @@ pub trait IMDSPDeviceControl_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn Seek(&self, fumode: u32, noffset: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDSPDeviceControl {}
 impl IMDSPDeviceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDeviceControl_Impl, const OFFSET: isize>() -> IMDSPDeviceControl_Vtbl {
         unsafe extern "system" fn GetDCStatus<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDeviceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -341,6 +348,7 @@ impl IMDSPDeviceControl_Vtbl {
 pub trait IMDSPDirectTransfer_Impl: Sized {
     fn TransferToDevice(&self, pwszsourcefilepath: &::windows::core::PCWSTR, psourceoperation: &::core::option::Option<IWMDMOperation>, fuflags: u32, pwszdestinationname: &::windows::core::PCWSTR, psourcemetadata: &::core::option::Option<IWMDMMetaData>, ptransferprogress: &::core::option::Option<IWMDMProgress>) -> ::windows::core::Result<IMDSPStorage>;
 }
+impl ::windows::core::RuntimeName for IMDSPDirectTransfer {}
 impl IMDSPDirectTransfer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDirectTransfer_Impl, const OFFSET: isize>() -> IMDSPDirectTransfer_Vtbl {
         unsafe extern "system" fn TransferToDevice<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPDirectTransfer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszsourcefilepath: ::windows::core::PCWSTR, psourceoperation: ::windows::core::RawPtr, fuflags: u32, pwszdestinationname: ::windows::core::PCWSTR, psourcemetadata: ::windows::core::RawPtr, ptransferprogress: ::windows::core::RawPtr, ppnewobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -366,6 +374,7 @@ pub trait IMDSPEnumDevice_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IMDSPEnumDevice>;
 }
+impl ::windows::core::RuntimeName for IMDSPEnumDevice {}
 impl IMDSPEnumDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPEnumDevice_Impl, const OFFSET: isize>() -> IMDSPEnumDevice_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPEnumDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppdevice: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -418,6 +427,7 @@ pub trait IMDSPEnumStorage_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IMDSPEnumStorage>;
 }
+impl ::windows::core::RuntimeName for IMDSPEnumStorage {}
 impl IMDSPEnumStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPEnumStorage_Impl, const OFFSET: isize>() -> IMDSPEnumStorage_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPEnumStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppstorage: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -474,6 +484,7 @@ pub trait IMDSPObject_Impl: Sized {
     fn Move(&self, fumode: u32, pprogress: &::core::option::Option<IWMDMProgress>, ptarget: &::core::option::Option<IMDSPStorage>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDSPObject {}
 impl IMDSPObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPObject_Impl, const OFFSET: isize>() -> IMDSPObject_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fumode: u32) -> ::windows::core::HRESULT {
@@ -536,6 +547,7 @@ pub trait IMDSPObject2_Impl: Sized + IMDSPObject_Impl {
     fn ReadOnClearChannel(&self, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
     fn WriteOnClearChannel(&self, pdata: *const u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDSPObject2 {}
 impl IMDSPObject2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPObject2_Impl, const OFFSET: isize>() -> IMDSPObject2_Vtbl {
         unsafe extern "system" fn ReadOnClearChannel<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPObject2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT {
@@ -567,6 +579,7 @@ pub trait IMDSPObjectInfo_Impl: Sized {
     fn GetLastPlayPosition(&self) -> ::windows::core::Result<u32>;
     fn GetLongestPlayPosition(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMDSPObjectInfo {}
 impl IMDSPObjectInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPObjectInfo_Impl, const OFFSET: isize>() -> IMDSPObjectInfo_Vtbl {
         unsafe extern "system" fn GetPlayLength<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPObjectInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT {
@@ -652,6 +665,7 @@ impl IMDSPObjectInfo_Vtbl {
 pub trait IMDSPRevoked_Impl: Sized {
     fn GetRevocationURL(&self, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDSPRevoked {}
 impl IMDSPRevoked_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPRevoked_Impl, const OFFSET: isize>() -> IMDSPRevoked_Vtbl {
         unsafe extern "system" fn GetRevocationURL<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPRevoked_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32) -> ::windows::core::HRESULT {
@@ -677,6 +691,7 @@ pub trait IMDSPStorage_Impl: Sized {
     fn EnumStorage(&self) -> ::windows::core::Result<IMDSPEnumStorage>;
     fn SendOpaqueCommand(&self, pcommand: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDSPStorage {}
 impl IMDSPStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage_Impl, const OFFSET: isize>() -> IMDSPStorage_Vtbl {
         unsafe extern "system" fn SetAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwattributes: u32, pformat: *const _WAVEFORMATEX) -> ::windows::core::HRESULT {
@@ -779,6 +794,8 @@ pub trait IMDSPStorage2_Impl: Sized + IMDSPStorage_Impl {
     fn GetAttributes2(&self, pdwattributes: *mut u32, pdwattributesex: *mut u32, paudioformat: *mut _WAVEFORMATEX, pvideoformat: *mut _VIDEOINFOHEADER) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMDSPStorage2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMDSPStorage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage2_Impl, const OFFSET: isize>() -> IMDSPStorage2_Vtbl {
         unsafe extern "system" fn GetStorage<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszstoragename: ::windows::core::PCWSTR, ppstorage: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -831,6 +848,8 @@ pub trait IMDSPStorage3_Impl: Sized + IMDSPStorage_Impl + IMDSPStorage2_Impl {
     fn SetMetadata(&self, pmetadata: &::core::option::Option<IWMDMMetaData>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMDSPStorage3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMDSPStorage3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage3_Impl, const OFFSET: isize>() -> IMDSPStorage3_Vtbl {
         unsafe extern "system" fn GetMetadata<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmetadata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -862,6 +881,8 @@ pub trait IMDSPStorage4_Impl: Sized + IMDSPStorage_Impl + IMDSPStorage2_Impl + I
     fn FindStorage(&self, findscope: WMDM_FIND_SCOPE, pwszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<IMDSPStorage>;
     fn GetParent(&self) -> ::windows::core::Result<IMDSPStorage>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMDSPStorage4 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMDSPStorage4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorage4_Impl, const OFFSET: isize>() -> IMDSPStorage4_Vtbl {
@@ -938,6 +959,7 @@ pub trait IMDSPStorageGlobals_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IMDSPDevice>;
     fn GetRootStorage(&self) -> ::windows::core::Result<IMDSPStorage>;
 }
+impl ::windows::core::RuntimeName for IMDSPStorageGlobals {}
 impl IMDSPStorageGlobals_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorageGlobals_Impl, const OFFSET: isize>() -> IMDSPStorageGlobals_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IMDSPStorageGlobals_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcapabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -1030,6 +1052,7 @@ pub trait IMDServiceProvider_Impl: Sized {
     fn GetDeviceCount(&self) -> ::windows::core::Result<u32>;
     fn EnumDevices(&self) -> ::windows::core::Result<IMDSPEnumDevice>;
 }
+impl ::windows::core::RuntimeName for IMDServiceProvider {}
 impl IMDServiceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDServiceProvider_Impl, const OFFSET: isize>() -> IMDServiceProvider_Vtbl {
         unsafe extern "system" fn GetDeviceCount<Identity: ::windows::core::IUnknownImpl, Impl: IMDServiceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -1067,6 +1090,7 @@ impl IMDServiceProvider_Vtbl {
 pub trait IMDServiceProvider2_Impl: Sized + IMDServiceProvider_Impl {
     fn CreateDevice(&self, pwszdevicepath: &::windows::core::PCWSTR, pdwcount: *mut u32, pppdevicearray: *mut *mut ::core::option::Option<IMDSPDevice>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDServiceProvider2 {}
 impl IMDServiceProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDServiceProvider2_Impl, const OFFSET: isize>() -> IMDServiceProvider2_Vtbl {
         unsafe extern "system" fn CreateDevice<Identity: ::windows::core::IUnknownImpl, Impl: IMDServiceProvider2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszdevicepath: ::windows::core::PCWSTR, pdwcount: *mut u32, pppdevicearray: *mut *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1083,6 +1107,7 @@ impl IMDServiceProvider2_Vtbl {
 pub trait IMDServiceProvider3_Impl: Sized + IMDServiceProvider_Impl + IMDServiceProvider2_Impl {
     fn SetDeviceEnumPreference(&self, dwenumpref: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDServiceProvider3 {}
 impl IMDServiceProvider3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDServiceProvider3_Impl, const OFFSET: isize>() -> IMDServiceProvider3_Vtbl {
         unsafe extern "system" fn SetDeviceEnumPreference<Identity: ::windows::core::IUnknownImpl, Impl: IMDServiceProvider3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwenumpref: u32) -> ::windows::core::HRESULT {
@@ -1099,6 +1124,7 @@ impl IMDServiceProvider3_Vtbl {
 pub trait ISCPSecureAuthenticate_Impl: Sized {
     fn GetSecureQuery(&self) -> ::windows::core::Result<ISCPSecureQuery>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureAuthenticate {}
 impl ISCPSecureAuthenticate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureAuthenticate_Impl, const OFFSET: isize>() -> ISCPSecureAuthenticate_Vtbl {
         unsafe extern "system" fn GetSecureQuery<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureAuthenticate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsecurequery: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1121,6 +1147,7 @@ impl ISCPSecureAuthenticate_Vtbl {
 pub trait ISCPSecureAuthenticate2_Impl: Sized + ISCPSecureAuthenticate_Impl {
     fn GetSCPSession(&self) -> ::windows::core::Result<ISCPSession>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureAuthenticate2 {}
 impl ISCPSecureAuthenticate2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureAuthenticate2_Impl, const OFFSET: isize>() -> ISCPSecureAuthenticate2_Vtbl {
         unsafe extern "system" fn GetSCPSession<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureAuthenticate2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppscpsession: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1145,6 +1172,7 @@ pub trait ISCPSecureExchange_Impl: Sized {
     fn ObjectData(&self, pdata: *mut u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
     fn TransferComplete(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureExchange {}
 impl ISCPSecureExchange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureExchange_Impl, const OFFSET: isize>() -> ISCPSecureExchange_Vtbl {
         unsafe extern "system" fn TransferContainerData<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureExchange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const u8, dwsize: u32, pfureadyflags: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT {
@@ -1176,6 +1204,7 @@ impl ISCPSecureExchange_Vtbl {
 pub trait ISCPSecureExchange2_Impl: Sized + ISCPSecureExchange_Impl {
     fn TransferContainerData2(&self, pdata: *const u8, dwsize: u32, pprogresscallback: &::core::option::Option<IWMDMProgress3>, pfureadyflags: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureExchange2 {}
 impl ISCPSecureExchange2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureExchange2_Impl, const OFFSET: isize>() -> ISCPSecureExchange2_Vtbl {
         unsafe extern "system" fn TransferContainerData2<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureExchange2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const u8, dwsize: u32, pprogresscallback: ::windows::core::RawPtr, pfureadyflags: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT {
@@ -1194,6 +1223,7 @@ pub trait ISCPSecureExchange3_Impl: Sized + ISCPSecureExchange_Impl + ISCPSecure
     fn GetObjectDataOnClearChannel(&self, pdevice: &::core::option::Option<IMDSPDevice>, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
     fn TransferCompleteForDevice(&self, pdevice: &::core::option::Option<IMDSPDevice>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureExchange3 {}
 impl ISCPSecureExchange3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureExchange3_Impl, const OFFSET: isize>() -> ISCPSecureExchange3_Vtbl {
         unsafe extern "system" fn TransferContainerDataOnClearChannel<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureExchange3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevice: ::windows::core::RawPtr, pdata: *const u8, dwsize: u32, pprogresscallback: ::windows::core::RawPtr, pfureadyflags: *mut u32) -> ::windows::core::HRESULT {
@@ -1234,6 +1264,7 @@ pub trait ISCPSecureQuery_Impl: Sized {
     fn MakeDecision(&self, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: &::core::option::Option<IMDSPStorageGlobals>, ppexchange: *mut ::core::option::Option<ISCPSecureExchange>, abmac: *mut u8) -> ::windows::core::Result<()>;
     fn GetRights(&self, pdata: *const u8, dwsize: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstgglobals: &::core::option::Option<IMDSPStorageGlobals>, pprights: *mut *mut WMDMRIGHTS, pnrightscount: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureQuery {}
 impl ISCPSecureQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureQuery_Impl, const OFFSET: isize>() -> ISCPSecureQuery_Vtbl {
         unsafe extern "system" fn GetDataDemands<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfuflags: *mut u32, pdwminrightsdata: *mut u32, pdwminexaminedata: *mut u32, pdwmindecidedata: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT {
@@ -1271,6 +1302,7 @@ impl ISCPSecureQuery_Vtbl {
 pub trait ISCPSecureQuery2_Impl: Sized + ISCPSecureQuery_Impl {
     fn MakeDecision2(&self, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: &::core::option::Option<IMDSPStorageGlobals>, pappcertapp: *const u8, dwappcertapplen: u32, pappcertsp: *const u8, dwappcertsplen: u32, pszrevocationurl: *mut ::windows::core::PWSTR, pdwrevocationurllen: *mut u32, pdwrevocationbitflag: *mut u32, pqwfilesize: *mut u64, punknown: &::core::option::Option<::windows::core::IUnknown>, ppexchange: *mut ::core::option::Option<ISCPSecureExchange>, abmac: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureQuery2 {}
 impl ISCPSecureQuery2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureQuery2_Impl, const OFFSET: isize>() -> ISCPSecureQuery2_Vtbl {
         unsafe extern "system" fn MakeDecision2<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureQuery2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: ::windows::core::RawPtr, pappcertapp: *const u8, dwappcertapplen: u32, pappcertsp: *const u8, dwappcertsplen: u32, pszrevocationurl: *mut ::windows::core::PWSTR, pdwrevocationurllen: *mut u32, pdwrevocationbitflag: *mut u32, pqwfilesize: *mut u64, punknown: *mut ::core::ffi::c_void, ppexchange: *mut ::windows::core::RawPtr, abmac: *mut u8) -> ::windows::core::HRESULT {
@@ -1309,6 +1341,7 @@ pub trait ISCPSecureQuery3_Impl: Sized + ISCPSecureQuery_Impl + ISCPSecureQuery2
     fn GetRightsOnClearChannel(&self, pdata: *const u8, dwsize: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstgglobals: &::core::option::Option<IMDSPStorageGlobals>, pprogresscallback: &::core::option::Option<IWMDMProgress3>, pprights: *mut *mut WMDMRIGHTS, pnrightscount: *mut u32) -> ::windows::core::Result<()>;
     fn MakeDecisionOnClearChannel(&self, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: &::core::option::Option<IMDSPStorageGlobals>, pprogresscallback: &::core::option::Option<IWMDMProgress3>, pappcertapp: *const u8, dwappcertapplen: u32, pappcertsp: *const u8, dwappcertsplen: u32, pszrevocationurl: *mut ::windows::core::PWSTR, pdwrevocationurllen: *mut u32, pdwrevocationbitflag: *mut u32, pqwfilesize: *mut u64, punknown: &::core::option::Option<::windows::core::IUnknown>, ppexchange: *mut ::core::option::Option<ISCPSecureExchange>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISCPSecureQuery3 {}
 impl ISCPSecureQuery3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureQuery3_Impl, const OFFSET: isize>() -> ISCPSecureQuery3_Vtbl {
         unsafe extern "system" fn GetRightsOnClearChannel<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSecureQuery3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const u8, dwsize: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstgglobals: ::windows::core::RawPtr, pprogresscallback: ::windows::core::RawPtr, pprights: *mut *mut WMDMRIGHTS, pnrightscount: *mut u32) -> ::windows::core::HRESULT {
@@ -1357,6 +1390,7 @@ pub trait ISCPSession_Impl: Sized {
     fn EndSession(&self, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
     fn GetSecureQuery(&self) -> ::windows::core::Result<ISCPSecureQuery>;
 }
+impl ::windows::core::RuntimeName for ISCPSession {}
 impl ISCPSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSession_Impl, const OFFSET: isize>() -> ISCPSession_Vtbl {
         unsafe extern "system" fn BeginSession<Identity: ::windows::core::IUnknownImpl, Impl: ISCPSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidevice: ::windows::core::RawPtr, pctx: *const u8, dwsizectx: u32) -> ::windows::core::HRESULT {
@@ -1404,6 +1438,7 @@ pub trait IWMDMDevice_Impl: Sized {
     fn GetFormatSupport(&self, ppformatex: *mut *mut _WAVEFORMATEX, pnformatcount: *mut u32, pppwszmimetype: *mut *mut ::windows::core::PWSTR, pnmimetypecount: *mut u32) -> ::windows::core::Result<()>;
     fn SendOpaqueCommand(&self, pcommand: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMDevice {}
 impl IWMDMDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDevice_Impl, const OFFSET: isize>() -> IWMDMDevice_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT {
@@ -1518,6 +1553,8 @@ pub trait IWMDMDevice2_Impl: Sized + IWMDMDevice_Impl {
     fn GetCanonicalName(&self, pwszpnpname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMDMDevice2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IWMDMDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDevice2_Impl, const OFFSET: isize>() -> IWMDMDevice2_Vtbl {
         unsafe extern "system" fn GetStorage<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszstoragename: ::windows::core::PCWSTR, ppstorage: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1566,6 +1603,8 @@ pub trait IWMDMDevice3_Impl: Sized + IWMDMDevice_Impl + IWMDMDevice2_Impl {
     fn DeviceIoControl(&self, dwiocontrolcode: u32, lpinbuffer: *const u8, ninbuffersize: u32, lpoutbuffer: *mut u8, pnoutbuffersize: *mut u32) -> ::windows::core::Result<()>;
     fn FindStorage(&self, findscope: WMDM_FIND_SCOPE, pwszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<IWMDMStorage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMDMDevice3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IWMDMDevice3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDevice3_Impl, const OFFSET: isize>() -> IWMDMDevice3_Vtbl {
@@ -1635,6 +1674,7 @@ pub trait IWMDMDeviceControl_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn Seek(&self, fumode: u32, noffset: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMDeviceControl {}
 impl IWMDMDeviceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDeviceControl_Impl, const OFFSET: isize>() -> IWMDMDeviceControl_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDeviceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -1709,6 +1749,7 @@ pub trait IWMDMDeviceSession_Impl: Sized {
     fn BeginSession(&self, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
     fn EndSession(&self, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMDeviceSession {}
 impl IWMDMDeviceSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDeviceSession_Impl, const OFFSET: isize>() -> IWMDMDeviceSession_Vtbl {
         unsafe extern "system" fn BeginSession<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMDeviceSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::HRESULT {
@@ -1737,6 +1778,7 @@ pub trait IWMDMEnumDevice_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IWMDMEnumDevice>;
 }
+impl ::windows::core::RuntimeName for IWMDMEnumDevice {}
 impl IWMDMEnumDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMEnumDevice_Impl, const OFFSET: isize>() -> IWMDMEnumDevice_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMEnumDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppdevice: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1789,6 +1831,7 @@ pub trait IWMDMEnumStorage_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IWMDMEnumStorage>;
 }
+impl ::windows::core::RuntimeName for IWMDMEnumStorage {}
 impl IWMDMEnumStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMEnumStorage_Impl, const OFFSET: isize>() -> IWMDMEnumStorage_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMEnumStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppstorage: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1847,6 +1890,8 @@ pub trait IWMDMLogger_Impl: Sized {
     fn GetSizeParams(&self, pdwmaxsize: *mut u32, pdwshrinktosize: *mut u32) -> ::windows::core::Result<()>;
     fn SetSizeParams(&self, dwmaxsize: u32, dwshrinktosize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDMLogger {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDMLogger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMLogger_Impl, const OFFSET: isize>() -> IWMDMLogger_Vtbl {
@@ -1924,6 +1969,7 @@ pub trait IWMDMMetaData_Impl: Sized {
     fn QueryByIndex(&self, iindex: u32, ppwszname: *mut *mut u16, ptype: *mut WMDM_TAG_DATATYPE, ppvalue: *mut *mut u8, pcblength: *mut u32) -> ::windows::core::Result<()>;
     fn GetItemCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IWMDMMetaData {}
 impl IWMDMMetaData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMMetaData_Impl, const OFFSET: isize>() -> IWMDMMetaData_Vtbl {
         unsafe extern "system" fn AddItem<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMMetaData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: WMDM_TAG_DATATYPE, pwsztagname: ::windows::core::PCWSTR, pvalue: *const u8, ilength: u32) -> ::windows::core::HRESULT {
@@ -1967,6 +2013,7 @@ impl IWMDMMetaData_Vtbl {
 pub trait IWMDMNotification_Impl: Sized {
     fn WMDMMessage(&self, dwmessagetype: u32, pwszcanonicalname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMNotification {}
 impl IWMDMNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMNotification_Impl, const OFFSET: isize>() -> IWMDMNotification_Vtbl {
         unsafe extern "system" fn WMDMMessage<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmessagetype: u32, pwszcanonicalname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1989,6 +2036,7 @@ pub trait IWMDMObjectInfo_Impl: Sized {
     fn GetLastPlayPosition(&self) -> ::windows::core::Result<u32>;
     fn GetLongestPlayPosition(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IWMDMObjectInfo {}
 impl IWMDMObjectInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMObjectInfo_Impl, const OFFSET: isize>() -> IWMDMObjectInfo_Vtbl {
         unsafe extern "system" fn GetPlayLength<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMObjectInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT {
@@ -2083,6 +2131,7 @@ pub trait IWMDMOperation_Impl: Sized {
     fn TransferObjectData(&self, pdata: *mut u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
     fn End(&self, phcompletioncode: *const ::windows::core::HRESULT, pnewobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMOperation {}
 impl IWMDMOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMOperation_Impl, const OFFSET: isize>() -> IWMDMOperation_Vtbl {
         unsafe extern "system" fn BeginRead<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2159,6 +2208,8 @@ pub trait IWMDMOperation2_Impl: Sized + IWMDMOperation_Impl {
     fn GetObjectAttributes2(&self, pdwattributes: *mut u32, pdwattributesex: *mut u32, paudioformat: *mut _WAVEFORMATEX, pvideoformat: *mut _VIDEOINFOHEADER) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDMOperation2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMDMOperation2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMOperation2_Impl, const OFFSET: isize>() -> IWMDMOperation2_Vtbl {
         unsafe extern "system" fn SetObjectAttributes2<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMOperation2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwattributes: u32, dwattributesex: u32, pformat: *const _WAVEFORMATEX, pvideoformat: *const _VIDEOINFOHEADER) -> ::windows::core::HRESULT {
@@ -2184,6 +2235,7 @@ impl IWMDMOperation2_Vtbl {
 pub trait IWMDMOperation3_Impl: Sized + IWMDMOperation_Impl {
     fn TransferObjectDataOnClearChannel(&self, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMOperation3 {}
 impl IWMDMOperation3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMOperation3_Impl, const OFFSET: isize>() -> IWMDMOperation3_Vtbl {
         unsafe extern "system" fn TransferObjectDataOnClearChannel<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMOperation3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT {
@@ -2205,6 +2257,7 @@ pub trait IWMDMProgress_Impl: Sized {
     fn Progress(&self, dwtranspiredticks: u32) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMProgress {}
 impl IWMDMProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMProgress_Impl, const OFFSET: isize>() -> IWMDMProgress_Vtbl {
         unsafe extern "system" fn Begin<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwestimatedticks: u32) -> ::windows::core::HRESULT {
@@ -2236,6 +2289,7 @@ impl IWMDMProgress_Vtbl {
 pub trait IWMDMProgress2_Impl: Sized + IWMDMProgress_Impl {
     fn End2(&self, hrcompletioncode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMProgress2 {}
 impl IWMDMProgress2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMProgress2_Impl, const OFFSET: isize>() -> IWMDMProgress2_Vtbl {
         unsafe extern "system" fn End2<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMProgress2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrcompletioncode: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -2254,6 +2308,7 @@ pub trait IWMDMProgress3_Impl: Sized + IWMDMProgress_Impl + IWMDMProgress2_Impl 
     fn Progress3(&self, eventid: &::windows::core::GUID, dwtranspiredticks: u32, pcontext: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
     fn End3(&self, eventid: &::windows::core::GUID, hrcompletioncode: ::windows::core::HRESULT, pcontext: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMProgress3 {}
 impl IWMDMProgress3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMProgress3_Impl, const OFFSET: isize>() -> IWMDMProgress3_Vtbl {
         unsafe extern "system" fn Begin3<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMProgress3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventid: ::windows::core::GUID, dwestimatedticks: u32, pcontext: *mut OPAQUECOMMAND) -> ::windows::core::HRESULT {
@@ -2285,6 +2340,7 @@ impl IWMDMProgress3_Vtbl {
 pub trait IWMDMRevoked_Impl: Sized {
     fn GetRevocationURL(&self, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32, pdwrevokedbitflag: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMRevoked {}
 impl IWMDMRevoked_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMRevoked_Impl, const OFFSET: isize>() -> IWMDMRevoked_Vtbl {
         unsafe extern "system" fn GetRevocationURL<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMRevoked_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32, pdwrevokedbitflag: *mut u32) -> ::windows::core::HRESULT {
@@ -2309,6 +2365,7 @@ pub trait IWMDMStorage_Impl: Sized {
     fn EnumStorage(&self) -> ::windows::core::Result<IWMDMEnumStorage>;
     fn SendOpaqueCommand(&self, pcommand: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMStorage {}
 impl IWMDMStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorage_Impl, const OFFSET: isize>() -> IWMDMStorage_Vtbl {
         unsafe extern "system" fn SetAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwattributes: u32, pformat: *const _WAVEFORMATEX) -> ::windows::core::HRESULT {
@@ -2398,6 +2455,8 @@ pub trait IWMDMStorage2_Impl: Sized + IWMDMStorage_Impl {
     fn GetAttributes2(&self, pdwattributes: *mut u32, pdwattributesex: *mut u32, paudioformat: *mut _WAVEFORMATEX, pvideoformat: *mut _VIDEOINFOHEADER) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDMStorage2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMDMStorage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorage2_Impl, const OFFSET: isize>() -> IWMDMStorage2_Vtbl {
         unsafe extern "system" fn GetStorage<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszstoragename: ::windows::core::PCWSTR, ppstorage: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2439,6 +2498,8 @@ pub trait IWMDMStorage3_Impl: Sized + IWMDMStorage_Impl + IWMDMStorage2_Impl {
     fn CreateEmptyMetadataObject(&self) -> ::windows::core::Result<IWMDMMetaData>;
     fn SetEnumPreference(&self, pmode: *mut WMDM_STORAGE_ENUM_MODE, nviews: u32, pviews: *const WMDMMetadataView) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDMStorage3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDMStorage3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorage3_Impl, const OFFSET: isize>() -> IWMDMStorage3_Vtbl {
@@ -2495,6 +2556,8 @@ pub trait IWMDMStorage4_Impl: Sized + IWMDMStorage_Impl + IWMDMStorage2_Impl + I
     fn FindStorage(&self, findscope: WMDM_FIND_SCOPE, pwszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<IWMDMStorage>;
     fn GetParent(&self) -> ::windows::core::Result<IWMDMStorage>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDMStorage4 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDMStorage4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorage4_Impl, const OFFSET: isize>() -> IWMDMStorage4_Vtbl {
@@ -2567,6 +2630,7 @@ pub trait IWMDMStorageControl_Impl: Sized {
     fn Read(&self, fumode: u32, pwszfile: &::windows::core::PCWSTR, pprogress: &::core::option::Option<IWMDMProgress>, poperation: &::core::option::Option<IWMDMOperation>) -> ::windows::core::Result<()>;
     fn Move(&self, fumode: u32, ptargetobject: &::core::option::Option<IWMDMStorage>, pprogress: &::core::option::Option<IWMDMProgress>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMStorageControl {}
 impl IWMDMStorageControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageControl_Impl, const OFFSET: isize>() -> IWMDMStorageControl_Vtbl {
         unsafe extern "system" fn Insert<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fumode: u32, pwszfile: ::windows::core::PCWSTR, poperation: ::windows::core::RawPtr, pprogress: ::windows::core::RawPtr, ppnewobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2616,6 +2680,7 @@ impl IWMDMStorageControl_Vtbl {
 pub trait IWMDMStorageControl2_Impl: Sized + IWMDMStorageControl_Impl {
     fn Insert2(&self, fumode: u32, pwszfilesource: &::windows::core::PCWSTR, pwszfiledest: &::windows::core::PCWSTR, poperation: &::core::option::Option<IWMDMOperation>, pprogress: &::core::option::Option<IWMDMProgress>, punknown: &::core::option::Option<::windows::core::IUnknown>, ppnewobject: *mut ::core::option::Option<IWMDMStorage>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMStorageControl2 {}
 impl IWMDMStorageControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageControl2_Impl, const OFFSET: isize>() -> IWMDMStorageControl2_Vtbl {
         unsafe extern "system" fn Insert2<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fumode: u32, pwszfilesource: ::windows::core::PCWSTR, pwszfiledest: ::windows::core::PCWSTR, poperation: ::windows::core::RawPtr, pprogress: ::windows::core::RawPtr, punknown: *mut ::core::ffi::c_void, ppnewobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2632,6 +2697,7 @@ impl IWMDMStorageControl2_Vtbl {
 pub trait IWMDMStorageControl3_Impl: Sized + IWMDMStorageControl_Impl + IWMDMStorageControl2_Impl {
     fn Insert3(&self, fumode: u32, futype: u32, pwszfilesource: &::windows::core::PCWSTR, pwszfiledest: &::windows::core::PCWSTR, poperation: &::core::option::Option<IWMDMOperation>, pprogress: &::core::option::Option<IWMDMProgress>, pmetadata: &::core::option::Option<IWMDMMetaData>, punknown: &::core::option::Option<::windows::core::IUnknown>, ppnewobject: *mut ::core::option::Option<IWMDMStorage>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMStorageControl3 {}
 impl IWMDMStorageControl3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageControl3_Impl, const OFFSET: isize>() -> IWMDMStorageControl3_Vtbl {
         unsafe extern "system" fn Insert3<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageControl3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fumode: u32, futype: u32, pwszfilesource: ::windows::core::PCWSTR, pwszfiledest: ::windows::core::PCWSTR, poperation: ::windows::core::RawPtr, pprogress: ::windows::core::RawPtr, pmetadata: ::windows::core::RawPtr, punknown: *mut ::core::ffi::c_void, ppnewobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2654,6 +2720,7 @@ pub trait IWMDMStorageGlobals_Impl: Sized {
     fn GetStatus(&self) -> ::windows::core::Result<u32>;
     fn Initialize(&self, fumode: u32, pprogress: &::core::option::Option<IWMDMProgress>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDMStorageGlobals {}
 impl IWMDMStorageGlobals_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageGlobals_Impl, const OFFSET: isize>() -> IWMDMStorageGlobals_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IWMDMStorageGlobals_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcapabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -2723,6 +2790,7 @@ pub trait IWMDeviceManager_Impl: Sized {
     fn GetDeviceCount(&self) -> ::windows::core::Result<u32>;
     fn EnumDevices(&self) -> ::windows::core::Result<IWMDMEnumDevice>;
 }
+impl ::windows::core::RuntimeName for IWMDeviceManager {}
 impl IWMDeviceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceManager_Impl, const OFFSET: isize>() -> IWMDeviceManager_Vtbl {
         unsafe extern "system" fn GetRevision<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwrevision: *mut u32) -> ::windows::core::HRESULT {
@@ -2774,6 +2842,7 @@ pub trait IWMDeviceManager2_Impl: Sized + IWMDeviceManager_Impl {
     fn EnumDevices2(&self) -> ::windows::core::Result<IWMDMEnumDevice>;
     fn Reinitialize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDeviceManager2 {}
 impl IWMDeviceManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceManager2_Impl, const OFFSET: isize>() -> IWMDeviceManager2_Vtbl {
         unsafe extern "system" fn GetDeviceFromCanonicalName<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszcanonicalname: ::windows::core::PCWSTR, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2817,6 +2886,7 @@ impl IWMDeviceManager2_Vtbl {
 pub trait IWMDeviceManager3_Impl: Sized + IWMDeviceManager_Impl + IWMDeviceManager2_Impl {
     fn SetDeviceEnumPreference(&self, dwenumpref: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDeviceManager3 {}
 impl IWMDeviceManager3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceManager3_Impl, const OFFSET: isize>() -> IWMDeviceManager3_Vtbl {
         unsafe extern "system" fn SetDeviceEnumPreference<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceManager3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwenumpref: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/impl.rs
@@ -5,6 +5,8 @@ pub trait IXMLGraphBuilder_Impl: Sized {
     fn BuildFromXMLFile(&self, pgraph: &::core::option::Option<super::IGraphBuilder>, wszfilename: &::windows::core::PCWSTR, wszbaseurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXMLGraphBuilder {}
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXMLGraphBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXMLGraphBuilder_Impl, const OFFSET: isize>() -> IXMLGraphBuilder_Vtbl {
         unsafe extern "system" fn BuildFromXML<Identity: ::windows::core::IUnknownImpl, Impl: IXMLGraphBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pgraph: ::windows::core::RawPtr, pxml: ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
@@ -9,6 +9,7 @@ pub trait IAMAnalogVideoDecoder_Impl: Sized {
     fn SetOutputEnable(&self, loutputenable: i32) -> ::windows::core::Result<()>;
     fn OutputEnable(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IAMAnalogVideoDecoder {}
 impl IAMAnalogVideoDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMAnalogVideoDecoder_Impl, const OFFSET: isize>() -> IAMAnalogVideoDecoder_Vtbl {
         unsafe extern "system" fn AvailableTVFormats<Identity: ::windows::core::IUnknownImpl, Impl: IAMAnalogVideoDecoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lanalogvideostandard: *mut i32) -> ::windows::core::HRESULT {
@@ -118,6 +119,7 @@ pub trait IAMAnalogVideoEncoder_Impl: Sized {
     fn SetCCEnable(&self, lccenable: i32) -> ::windows::core::Result<()>;
     fn CCEnable(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IAMAnalogVideoEncoder {}
 impl IAMAnalogVideoEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMAnalogVideoEncoder_Impl, const OFFSET: isize>() -> IAMAnalogVideoEncoder_Vtbl {
         unsafe extern "system" fn AvailableTVFormats<Identity: ::windows::core::IUnknownImpl, Impl: IAMAnalogVideoEncoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lanalogvideostandard: *mut i32) -> ::windows::core::HRESULT {
@@ -200,6 +202,8 @@ pub trait IAMAsyncReaderTimestampScaling_Impl: Sized {
     fn SetTimestampMode(&self, fraw: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMAsyncReaderTimestampScaling {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAMAsyncReaderTimestampScaling_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMAsyncReaderTimestampScaling_Impl, const OFFSET: isize>() -> IAMAsyncReaderTimestampScaling_Vtbl {
         unsafe extern "system" fn GetTimestampMode<Identity: ::windows::core::IUnknownImpl, Impl: IAMAsyncReaderTimestampScaling_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfraw: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -247,6 +251,8 @@ pub trait IAMAudioInputMixer_Impl: Sized {
     fn Bass(&self) -> ::windows::core::Result<f64>;
     fn BassRange(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMAudioInputMixer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMAudioInputMixer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMAudioInputMixer_Impl, const OFFSET: isize>() -> IAMAudioInputMixer_Vtbl {
@@ -411,6 +417,7 @@ impl IAMAudioInputMixer_Vtbl {
 pub trait IAMAudioRendererStats_Impl: Sized {
     fn GetStatParam(&self, dwparam: u32, pdwparam1: *mut u32, pdwparam2: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMAudioRendererStats {}
 impl IAMAudioRendererStats_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMAudioRendererStats_Impl, const OFFSET: isize>() -> IAMAudioRendererStats_Vtbl {
         unsafe extern "system" fn GetStatParam<Identity: ::windows::core::IUnknownImpl, Impl: IAMAudioRendererStats_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwparam: u32, pdwparam1: *mut u32, pdwparam2: *mut u32) -> ::windows::core::HRESULT {
@@ -428,6 +435,7 @@ pub trait IAMBufferNegotiation_Impl: Sized {
     fn SuggestAllocatorProperties(&self, pprop: *const ALLOCATOR_PROPERTIES) -> ::windows::core::Result<()>;
     fn GetAllocatorProperties(&self) -> ::windows::core::Result<ALLOCATOR_PROPERTIES>;
 }
+impl ::windows::core::RuntimeName for IAMBufferNegotiation {}
 impl IAMBufferNegotiation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMBufferNegotiation_Impl, const OFFSET: isize>() -> IAMBufferNegotiation_Vtbl {
         unsafe extern "system" fn SuggestAllocatorProperties<Identity: ::windows::core::IUnknownImpl, Impl: IAMBufferNegotiation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprop: *const ALLOCATOR_PROPERTIES) -> ::windows::core::HRESULT {
@@ -461,6 +469,7 @@ pub trait IAMCameraControl_Impl: Sized {
     fn Set(&self, property: i32, lvalue: i32, flags: i32) -> ::windows::core::Result<()>;
     fn Get(&self, property: i32, lvalue: *mut i32, flags: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMCameraControl {}
 impl IAMCameraControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMCameraControl_Impl, const OFFSET: isize>() -> IAMCameraControl_Vtbl {
         unsafe extern "system" fn GetRange<Identity: ::windows::core::IUnknownImpl, Impl: IAMCameraControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, property: i32, pmin: *mut i32, pmax: *mut i32, psteppingdelta: *mut i32, pdefault: *mut i32, pcapsflags: *mut i32) -> ::windows::core::HRESULT {
@@ -495,6 +504,7 @@ pub trait IAMCertifiedOutputProtection_Impl: Sized {
     fn ProtectionCommand(&self, cmd: *const AMCOPPCommand) -> ::windows::core::Result<()>;
     fn ProtectionStatus(&self, pstatusinput: *const AMCOPPStatusInput) -> ::windows::core::Result<AMCOPPStatusOutput>;
 }
+impl ::windows::core::RuntimeName for IAMCertifiedOutputProtection {}
 impl IAMCertifiedOutputProtection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMCertifiedOutputProtection_Impl, const OFFSET: isize>() -> IAMCertifiedOutputProtection_Vtbl {
         unsafe extern "system" fn KeyExchange<Identity: ::windows::core::IUnknownImpl, Impl: IAMCertifiedOutputProtection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prandom: *mut ::windows::core::GUID, varlencertgh: *mut *mut u8, pdwlengthcertgh: *mut u32) -> ::windows::core::HRESULT {
@@ -545,6 +555,8 @@ pub trait IAMChannelInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn ContactEmail(&self, pbstrcontactemail: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMChannelInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMChannelInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMChannelInfo_Impl, const OFFSET: isize>() -> IAMChannelInfo_Vtbl {
         unsafe extern "system" fn ChannelName<Identity: ::windows::core::IUnknownImpl, Impl: IAMChannelInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrchannelname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -594,6 +606,7 @@ impl IAMChannelInfo_Vtbl {
 pub trait IAMClockAdjust_Impl: Sized {
     fn SetClockDelta(&self, rtdelta: i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMClockAdjust {}
 impl IAMClockAdjust_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMClockAdjust_Impl, const OFFSET: isize>() -> IAMClockAdjust_Vtbl {
         unsafe extern "system" fn SetClockDelta<Identity: ::windows::core::IUnknownImpl, Impl: IAMClockAdjust_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rtdelta: i64) -> ::windows::core::HRESULT {
@@ -611,6 +624,7 @@ pub trait IAMClockSlave_Impl: Sized {
     fn SetErrorTolerance(&self, dwtolerance: u32) -> ::windows::core::Result<()>;
     fn GetErrorTolerance(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAMClockSlave {}
 impl IAMClockSlave_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMClockSlave_Impl, const OFFSET: isize>() -> IAMClockSlave_Vtbl {
         unsafe extern "system" fn SetErrorTolerance<Identity: ::windows::core::IUnknownImpl, Impl: IAMClockSlave_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtolerance: u32) -> ::windows::core::HRESULT {
@@ -645,6 +659,8 @@ pub trait IAMCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Item(&self, litem: i32) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMCollection_Impl, const OFFSET: isize>() -> IAMCollection_Vtbl {
@@ -695,6 +711,7 @@ impl IAMCollection_Vtbl {
 pub trait IAMCopyCaptureFileProgress_Impl: Sized {
     fn Progress(&self, iprogress: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMCopyCaptureFileProgress {}
 impl IAMCopyCaptureFileProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMCopyCaptureFileProgress_Impl, const OFFSET: isize>() -> IAMCopyCaptureFileProgress_Vtbl {
         unsafe extern "system" fn Progress<Identity: ::windows::core::IUnknownImpl, Impl: IAMCopyCaptureFileProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iprogress: i32) -> ::windows::core::HRESULT {
@@ -716,6 +733,8 @@ pub trait IAMCrossbar_Impl: Sized {
     fn get_IsRoutedTo(&self, outputpinindex: i32) -> ::windows::core::Result<i32>;
     fn get_CrossbarPinInfo(&self, isinputpin: super::super::Foundation::BOOL, pinindex: i32, pinindexrelated: *mut i32, physicaltype: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMCrossbar {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMCrossbar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMCrossbar_Impl, const OFFSET: isize>() -> IAMCrossbar_Vtbl {
@@ -766,6 +785,7 @@ impl IAMCrossbar_Vtbl {
 pub trait IAMDecoderCaps_Impl: Sized {
     fn GetDecoderCaps(&self, dwcapindex: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAMDecoderCaps {}
 impl IAMDecoderCaps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMDecoderCaps_Impl, const OFFSET: isize>() -> IAMDecoderCaps_Vtbl {
         unsafe extern "system" fn GetDecoderCaps<Identity: ::windows::core::IUnknownImpl, Impl: IAMDecoderCaps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcapindex: u32, lpdwcap: *mut u32) -> ::windows::core::HRESULT {
@@ -792,6 +812,7 @@ pub trait IAMDevMemoryAllocator_Impl: Sized {
     fn Free(&self, pbuffer: *mut u8) -> ::windows::core::Result<()>;
     fn GetDevMemoryObject(&self, ppunkinnner: *mut ::core::option::Option<::windows::core::IUnknown>, punkouter: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMDevMemoryAllocator {}
 impl IAMDevMemoryAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMDevMemoryAllocator_Impl, const OFFSET: isize>() -> IAMDevMemoryAllocator_Vtbl {
         unsafe extern "system" fn GetInfo<Identity: ::windows::core::IUnknownImpl, Impl: IAMDevMemoryAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcbtotalfree: *mut u32, pdwcblargestfree: *mut u32, pdwcbtotalmemory: *mut u32, pdwcbminimumchunk: *mut u32) -> ::windows::core::HRESULT {
@@ -837,6 +858,7 @@ pub trait IAMDevMemoryControl_Impl: Sized {
     fn WriteSync(&self) -> ::windows::core::Result<()>;
     fn GetDevId(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAMDevMemoryControl {}
 impl IAMDevMemoryControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMDevMemoryControl_Impl, const OFFSET: isize>() -> IAMDevMemoryControl_Vtbl {
         unsafe extern "system" fn QueryWriteSync<Identity: ::windows::core::IUnknownImpl, Impl: IAMDevMemoryControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -876,6 +898,7 @@ pub trait IAMDeviceRemoval_Impl: Sized {
     fn Reassociate(&self) -> ::windows::core::Result<()>;
     fn Disassociate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMDeviceRemoval {}
 impl IAMDeviceRemoval_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMDeviceRemoval_Impl, const OFFSET: isize>() -> IAMDeviceRemoval_Vtbl {
         unsafe extern "system" fn DeviceInfo<Identity: ::windows::core::IUnknownImpl, Impl: IAMDeviceRemoval_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclsidinterfaceclass: *mut ::windows::core::GUID, pwszsymboliclink: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -915,6 +938,8 @@ pub trait IAMDirectSound_Impl: Sized {
     fn SetFocusWindow(&self, param0: super::super::Foundation::HWND, param1: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetFocusWindow(&self, param0: *mut super::super::Foundation::HWND, param1: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
+impl ::windows::core::RuntimeName for IAMDirectSound {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 impl IAMDirectSound_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMDirectSound_Impl, const OFFSET: isize>() -> IAMDirectSound_Vtbl {
@@ -998,6 +1023,7 @@ pub trait IAMDroppedFrames_Impl: Sized {
     fn GetDroppedInfo(&self, lsize: i32, plarray: *mut i32, plnumcopied: *mut i32) -> ::windows::core::Result<()>;
     fn GetAverageFrameSize(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IAMDroppedFrames {}
 impl IAMDroppedFrames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMDroppedFrames_Impl, const OFFSET: isize>() -> IAMDroppedFrames_Vtbl {
         unsafe extern "system" fn GetNumDropped<Identity: ::windows::core::IUnknownImpl, Impl: IAMDroppedFrames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pldropped: *mut i32) -> ::windows::core::HRESULT {
@@ -1060,6 +1086,7 @@ pub trait IAMExtDevice_Impl: Sized {
     fn SetDevicePort(&self, deviceport: i32) -> ::windows::core::Result<()>;
     fn DevicePort(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IAMExtDevice {}
 impl IAMExtDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtDevice_Impl, const OFFSET: isize>() -> IAMExtDevice_Vtbl {
         unsafe extern "system" fn GetCapability<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, capability: i32, pvalue: *mut i32, pdblvalue: *mut f64) -> ::windows::core::HRESULT {
@@ -1178,6 +1205,7 @@ pub trait IAMExtTransport_Impl: Sized {
     fn EditStart(&self) -> ::windows::core::Result<i32>;
     fn SetEditStart(&self, value: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMExtTransport {}
 impl IAMExtTransport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtTransport_Impl, const OFFSET: isize>() -> IAMExtTransport_Vtbl {
         unsafe extern "system" fn GetCapability<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtTransport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, capability: i32, pvalue: *mut i32, pdblvalue: *mut f64) -> ::windows::core::HRESULT {
@@ -1429,6 +1457,8 @@ pub trait IAMExtendedErrorInfo_Impl: Sized + super::super::System::Com::IDispatc
     fn ErrorCode(&self, perrorcode: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMExtendedErrorInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMExtendedErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtendedErrorInfo_Impl, const OFFSET: isize>() -> IAMExtendedErrorInfo_Vtbl {
         unsafe extern "system" fn HasError<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtendedErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phaserror: *mut i16) -> ::windows::core::HRESULT {
@@ -1467,6 +1497,8 @@ pub trait IAMExtendedSeeking_Impl: Sized + super::super::System::Com::IDispatch_
     fn SetPlaybackSpeed(&self, speed: f64) -> ::windows::core::Result<()>;
     fn PlaybackSpeed(&self, pspeed: *mut f64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMExtendedSeeking {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMExtendedSeeking_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMExtendedSeeking_Impl, const OFFSET: isize>() -> IAMExtendedSeeking_Vtbl {
@@ -1523,6 +1555,7 @@ impl IAMExtendedSeeking_Vtbl {
 pub trait IAMFilterGraphCallback_Impl: Sized {
     fn UnableToRender(&self, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMFilterGraphCallback {}
 impl IAMFilterGraphCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMFilterGraphCallback_Impl, const OFFSET: isize>() -> IAMFilterGraphCallback_Vtbl {
         unsafe extern "system" fn UnableToRender<Identity: ::windows::core::IUnknownImpl, Impl: IAMFilterGraphCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppin: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1539,6 +1572,7 @@ impl IAMFilterGraphCallback_Vtbl {
 pub trait IAMFilterMiscFlags_Impl: Sized {
     fn GetMiscFlags(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for IAMFilterMiscFlags {}
 impl IAMFilterMiscFlags_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMFilterMiscFlags_Impl, const OFFSET: isize>() -> IAMFilterMiscFlags_Vtbl {
         unsafe extern "system" fn GetMiscFlags<Identity: ::windows::core::IUnknownImpl, Impl: IAMFilterMiscFlags_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -1557,6 +1591,8 @@ pub trait IAMGraphBuilderCallback_Impl: Sized {
     fn SelectedFilter(&self, pmon: &::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<()>;
     fn CreatedFilter(&self, pfil: &::core::option::Option<IBaseFilter>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAMGraphBuilderCallback {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAMGraphBuilderCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMGraphBuilderCallback_Impl, const OFFSET: isize>() -> IAMGraphBuilderCallback_Vtbl {
@@ -1586,6 +1622,8 @@ pub trait IAMGraphStreams_Impl: Sized {
     fn SyncUsingStreamOffset(&self, busestreamoffset: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SetMaxGraphLatency(&self, rtmaxgraphlatency: i64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMGraphStreams {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMGraphStreams_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMGraphStreams_Impl, const OFFSET: isize>() -> IAMGraphStreams_Vtbl {
@@ -1618,6 +1656,7 @@ impl IAMGraphStreams_Vtbl {
 pub trait IAMLatency_Impl: Sized {
     fn GetLatency(&self) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IAMLatency {}
 impl IAMLatency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMLatency_Impl, const OFFSET: isize>() -> IAMLatency_Vtbl {
         unsafe extern "system" fn GetLatency<Identity: ::windows::core::IUnknownImpl, Impl: IAMLatency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prtlatency: *mut i64) -> ::windows::core::HRESULT {
@@ -1653,6 +1692,8 @@ pub trait IAMLine21Decoder_Impl: Sized {
     fn GetDrawBackgroundMode(&self, lpmode: *mut AM_LINE21_DRAWBGMODE) -> ::windows::core::Result<()>;
     fn SetDrawBackgroundMode(&self, mode: AM_LINE21_DRAWBGMODE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IAMLine21Decoder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IAMLine21Decoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMLine21Decoder_Impl, const OFFSET: isize>() -> IAMLine21Decoder_Vtbl {
@@ -1759,6 +1800,8 @@ pub trait IAMMediaContent_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn MoreInfoText(&self, pbstrmoreinfotext: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMMediaContent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMMediaContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaContent_Impl, const OFFSET: isize>() -> IAMMediaContent_Vtbl {
         unsafe extern "system" fn AuthorName<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaContent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrauthorname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1854,6 +1897,8 @@ pub trait IAMMediaContent2_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn PlaylistCount(&self, pnumberentries: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMMediaContent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMMediaContent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaContent2_Impl, const OFFSET: isize>() -> IAMMediaContent2_Vtbl {
         unsafe extern "system" fn get_MediaParameter<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaContent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, entrynum: i32, bstrname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbstrvalue: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1890,6 +1935,8 @@ pub trait IAMMediaStream_Impl: Sized + IMediaStream_Impl {
     fn JoinFilter(&self, pmediastreamfilter: &::core::option::Option<IMediaStreamFilter>) -> ::windows::core::Result<()>;
     fn JoinFilterGraph(&self, pfiltergraph: &::core::option::Option<IFilterGraph>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAMMediaStream {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAMMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaStream_Impl, const OFFSET: isize>() -> IAMMediaStream_Vtbl {
@@ -1951,6 +1998,8 @@ pub trait IAMMediaTypeSample_Impl: Sized + IStreamSample_Impl {
     fn GetMediaTime(&self, ptimestart: *mut i64, ptimeend: *mut i64) -> ::windows::core::Result<()>;
     fn SetMediaTime(&self, ptimestart: *const i64, ptimeend: *const i64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMMediaTypeSample {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMMediaTypeSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaTypeSample_Impl, const OFFSET: isize>() -> IAMMediaTypeSample_Vtbl {
@@ -2085,6 +2134,8 @@ pub trait IAMMediaTypeStream_Impl: Sized + IMediaStream_Impl {
     fn SetStreamAllocatorRequirements(&self, pprops: *const ALLOCATOR_PROPERTIES) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMMediaTypeStream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAMMediaTypeStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaTypeStream_Impl, const OFFSET: isize>() -> IAMMediaTypeStream_Vtbl {
         unsafe extern "system" fn GetFormat<Identity: ::windows::core::IUnknownImpl, Impl: IAMMediaTypeStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmediatype: *mut AM_MEDIA_TYPE, dwflags: u32) -> ::windows::core::HRESULT {
@@ -2147,6 +2198,8 @@ pub trait IAMMultiMediaStream_Impl: Sized + IMultiMediaStream_Impl {
     fn OpenMoniker(&self, pctx: &::core::option::Option<super::super::System::Com::IBindCtx>, pmoniker: &::core::option::Option<super::super::System::Com::IMoniker>, dwflags: u32) -> ::windows::core::Result<()>;
     fn Render(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAMMultiMediaStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAMMultiMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMMultiMediaStream_Impl, const OFFSET: isize>() -> IAMMultiMediaStream_Vtbl {
@@ -2243,6 +2296,8 @@ pub trait IAMNetShowConfig_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn EnableHTTP(&self, penablehttp: *mut i16) -> ::windows::core::Result<()>;
     fn SetEnableHTTP(&self, enablehttp: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMNetShowConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMNetShowConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMNetShowConfig_Impl, const OFFSET: isize>() -> IAMNetShowConfig_Vtbl {
@@ -2399,6 +2454,8 @@ pub trait IAMNetShowExProps_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SourceLink(&self, pbstrsourcelink: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMNetShowExProps {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMNetShowExProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMNetShowExProps_Impl, const OFFSET: isize>() -> IAMNetShowExProps_Vtbl {
         unsafe extern "system" fn SourceProtocol<Identity: ::windows::core::IUnknownImpl, Impl: IAMNetShowExProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psourceprotocol: *mut i32) -> ::windows::core::HRESULT {
@@ -2469,6 +2526,8 @@ pub trait IAMNetShowPreroll_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Preroll(&self, pfpreroll: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMNetShowPreroll {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMNetShowPreroll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMNetShowPreroll_Impl, const OFFSET: isize>() -> IAMNetShowPreroll_Vtbl {
         unsafe extern "system" fn SetPreroll<Identity: ::windows::core::IUnknownImpl, Impl: IAMNetShowPreroll_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fpreroll: i16) -> ::windows::core::HRESULT {
@@ -2501,6 +2560,8 @@ pub trait IAMNetworkStatus_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn IsBroadcast(&self, pisbroadcast: *mut i16) -> ::windows::core::Result<()>;
     fn BufferingProgress(&self, pbufferingprogress: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMNetworkStatus {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMNetworkStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMNetworkStatus_Impl, const OFFSET: isize>() -> IAMNetworkStatus_Vtbl {
@@ -2558,6 +2619,7 @@ pub trait IAMOpenProgress_Impl: Sized {
     fn QueryProgress(&self, plltotal: *mut i64, pllcurrent: *mut i64) -> ::windows::core::Result<()>;
     fn AbortOperation(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMOpenProgress {}
 impl IAMOpenProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMOpenProgress_Impl, const OFFSET: isize>() -> IAMOpenProgress_Vtbl {
         unsafe extern "system" fn QueryProgress<Identity: ::windows::core::IUnknownImpl, Impl: IAMOpenProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plltotal: *mut i64, pllcurrent: *mut i64) -> ::windows::core::HRESULT {
@@ -2585,6 +2647,7 @@ pub trait IAMOverlayFX_Impl: Sized {
     fn SetOverlayFX(&self, dwoverlayfx: u32) -> ::windows::core::Result<()>;
     fn GetOverlayFX(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAMOverlayFX {}
 impl IAMOverlayFX_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMOverlayFX_Impl, const OFFSET: isize>() -> IAMOverlayFX_Vtbl {
         unsafe extern "system" fn QueryOverlayFXCaps<Identity: ::windows::core::IUnknownImpl, Impl: IAMOverlayFX_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpdwoverlayfxcaps: *mut u32) -> ::windows::core::HRESULT {
@@ -2630,6 +2693,7 @@ pub trait IAMParse_Impl: Sized {
     fn SetParseTime(&self, rtcurrent: i64) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMParse {}
 impl IAMParse_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMParse_Impl, const OFFSET: isize>() -> IAMParse_Vtbl {
         unsafe extern "system" fn GetParseTime<Identity: ::windows::core::IUnknownImpl, Impl: IAMParse_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prtcurrent: *mut i64) -> ::windows::core::HRESULT {
@@ -2667,6 +2731,7 @@ impl IAMParse_Vtbl {
 pub trait IAMPhysicalPinInfo_Impl: Sized {
     fn GetPhysicalType(&self, ptype: *mut i32, ppsztype: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMPhysicalPinInfo {}
 impl IAMPhysicalPinInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMPhysicalPinInfo_Impl, const OFFSET: isize>() -> IAMPhysicalPinInfo_Vtbl {
         unsafe extern "system" fn GetPhysicalType<Identity: ::windows::core::IUnknownImpl, Impl: IAMPhysicalPinInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut i32, ppsztype: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2687,6 +2752,7 @@ pub trait IAMPlayList_Impl: Sized {
     fn GetNamedEvent(&self, pwszeventname: &::windows::core::PCWSTR, dwitemindex: u32, ppitem: *mut ::core::option::Option<IAMPlayListItem>, pdwflags: *mut u32) -> ::windows::core::Result<()>;
     fn GetRepeatInfo(&self, pdwrepeatcount: *mut u32, pdwrepeatstart: *mut u32, pdwrepeatend: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMPlayList {}
 impl IAMPlayList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMPlayList_Impl, const OFFSET: isize>() -> IAMPlayList_Vtbl {
         unsafe extern "system" fn GetFlags<Identity: ::windows::core::IUnknownImpl, Impl: IAMPlayList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -2759,6 +2825,8 @@ pub trait IAMPlayListItem_Impl: Sized {
     fn GetLinkURL(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetScanDuration(&self, dwsourceindex: u32) -> ::windows::core::Result<i64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMPlayListItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMPlayListItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMPlayListItem_Impl, const OFFSET: isize>() -> IAMPlayListItem_Vtbl {
@@ -2913,6 +2981,8 @@ pub trait IAMPluginControl_Impl: Sized {
     fn IsLegacyDisabled(&self, dllname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMPluginControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAMPluginControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMPluginControl_Impl, const OFFSET: isize>() -> IAMPluginControl_Vtbl {
         unsafe extern "system" fn GetPreferredClsid<Identity: ::windows::core::IUnknownImpl, Impl: IAMPluginControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, subtype: *const ::windows::core::GUID, clsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2985,6 +3055,7 @@ pub trait IAMPushSource_Impl: Sized + IAMLatency_Impl {
     fn GetMaxStreamOffset(&self) -> ::windows::core::Result<i64>;
     fn SetMaxStreamOffset(&self, rtmaxoffset: i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMPushSource {}
 impl IAMPushSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMPushSource_Impl, const OFFSET: isize>() -> IAMPushSource_Vtbl {
         unsafe extern "system" fn GetPushSourceFlags<Identity: ::windows::core::IUnknownImpl, Impl: IAMPushSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pflags: *mut u32) -> ::windows::core::HRESULT {
@@ -3052,6 +3123,7 @@ impl IAMPushSource_Vtbl {
 pub trait IAMRebuild_Impl: Sized {
     fn RebuildNow(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMRebuild {}
 impl IAMRebuild_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMRebuild_Impl, const OFFSET: isize>() -> IAMRebuild_Vtbl {
         unsafe extern "system" fn RebuildNow<Identity: ::windows::core::IUnknownImpl, Impl: IAMRebuild_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3068,6 +3140,7 @@ impl IAMRebuild_Vtbl {
 pub trait IAMResourceControl_Impl: Sized {
     fn Reserve(&self, dwflags: u32, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMResourceControl {}
 impl IAMResourceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMResourceControl_Impl, const OFFSET: isize>() -> IAMResourceControl_Vtbl {
         unsafe extern "system" fn Reserve<Identity: ::windows::core::IUnknownImpl, Impl: IAMResourceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3090,6 +3163,8 @@ pub trait IAMStats_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetIndex(&self, szname: &super::super::Foundation::BSTR, lcreate: i32) -> ::windows::core::Result<i32>;
     fn AddValue(&self, lindex: i32, dvalue: f64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAMStats {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAMStats_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMStats_Impl, const OFFSET: isize>() -> IAMStats_Vtbl {
@@ -3157,6 +3232,8 @@ pub trait IAMStreamConfig_Impl: Sized {
     fn GetStreamCaps(&self, iindex: i32, ppmt: *mut *mut AM_MEDIA_TYPE, pscc: *mut u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMStreamConfig {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAMStreamConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMStreamConfig_Impl, const OFFSET: isize>() -> IAMStreamConfig_Vtbl {
         unsafe extern "system" fn SetFormat<Identity: ::windows::core::IUnknownImpl, Impl: IAMStreamConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmt: *mut AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -3204,6 +3281,8 @@ pub trait IAMStreamControl_Impl: Sized {
     fn GetInfo(&self) -> ::windows::core::Result<AM_STREAM_INFO>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMStreamControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAMStreamControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMStreamControl_Impl, const OFFSET: isize>() -> IAMStreamControl_Vtbl {
         unsafe extern "system" fn StartAt<Identity: ::windows::core::IUnknownImpl, Impl: IAMStreamControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptstart: *const i64, dwcookie: u32) -> ::windows::core::HRESULT {
@@ -3244,6 +3323,8 @@ pub trait IAMStreamSelect_Impl: Sized {
     fn Info(&self, lindex: i32, ppmt: *mut *mut AM_MEDIA_TYPE, pdwflags: *mut u32, plcid: *mut u32, pdwgroup: *mut u32, ppszname: *mut ::windows::core::PWSTR, ppobject: *mut ::core::option::Option<::windows::core::IUnknown>, ppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Enable(&self, lindex: i32, dwflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMStreamSelect {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMStreamSelect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMStreamSelect_Impl, const OFFSET: isize>() -> IAMStreamSelect_Vtbl {
@@ -3287,6 +3368,7 @@ pub trait IAMTVAudio_Impl: Sized {
     fn RegisterNotificationCallBack(&self, pnotify: &::core::option::Option<IAMTunerNotification>, levents: i32) -> ::windows::core::Result<()>;
     fn UnRegisterNotificationCallBack(&self, pnotify: &::core::option::Option<IAMTunerNotification>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMTVAudio {}
 impl IAMTVAudio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTVAudio_Impl, const OFFSET: isize>() -> IAMTVAudio_Vtbl {
         unsafe extern "system" fn GetHardwareSupportedTVAudioModes<Identity: ::windows::core::IUnknownImpl, Impl: IAMTVAudio_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plmodes: *mut i32) -> ::windows::core::HRESULT {
@@ -3354,6 +3436,7 @@ impl IAMTVAudio_Vtbl {
 pub trait IAMTVAudioNotification_Impl: Sized {
     fn OnEvent(&self, event: AMTVAudioEventType) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMTVAudioNotification {}
 impl IAMTVAudioNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTVAudioNotification_Impl, const OFFSET: isize>() -> IAMTVAudioNotification_Vtbl {
         unsafe extern "system" fn OnEvent<Identity: ::windows::core::IUnknownImpl, Impl: IAMTVAudioNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, event: AMTVAudioEventType) -> ::windows::core::HRESULT {
@@ -3381,6 +3464,8 @@ pub trait IAMTVTuner_Impl: Sized + IAMTuner_Impl {
     fn VideoFrequency(&self) -> ::windows::core::Result<i32>;
     fn AudioFrequency(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMTVTuner {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMTVTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTVTuner_Impl, const OFFSET: isize>() -> IAMTVTuner_Vtbl {
@@ -3512,6 +3597,7 @@ pub trait IAMTimecodeDisplay_Impl: Sized {
     fn GetTCDisplay(&self, param: i32) -> ::windows::core::Result<i32>;
     fn SetTCDisplay(&self, param: i32, value: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMTimecodeDisplay {}
 impl IAMTimecodeDisplay_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTimecodeDisplay_Impl, const OFFSET: isize>() -> IAMTimecodeDisplay_Vtbl {
         unsafe extern "system" fn GetTCDisplayEnable<Identity: ::windows::core::IUnknownImpl, Impl: IAMTimecodeDisplay_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstate: *mut i32) -> ::windows::core::HRESULT {
@@ -3566,6 +3652,7 @@ pub trait IAMTimecodeGenerator_Impl: Sized {
     fn SetTimecode(&self, ptimecodesample: *mut super::TIMECODE_SAMPLE) -> ::windows::core::Result<()>;
     fn GetTimecode(&self) -> ::windows::core::Result<super::TIMECODE_SAMPLE>;
 }
+impl ::windows::core::RuntimeName for IAMTimecodeGenerator {}
 impl IAMTimecodeGenerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTimecodeGenerator_Impl, const OFFSET: isize>() -> IAMTimecodeGenerator_Vtbl {
         unsafe extern "system" fn GetTCGMode<Identity: ::windows::core::IUnknownImpl, Impl: IAMTimecodeGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param: i32, pvalue: *mut i32) -> ::windows::core::HRESULT {
@@ -3637,6 +3724,7 @@ pub trait IAMTimecodeReader_Impl: Sized {
     fn VITCLine(&self) -> ::windows::core::Result<i32>;
     fn GetTimecode(&self) -> ::windows::core::Result<super::TIMECODE_SAMPLE>;
 }
+impl ::windows::core::RuntimeName for IAMTimecodeReader {}
 impl IAMTimecodeReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTimecodeReader_Impl, const OFFSET: isize>() -> IAMTimecodeReader_Vtbl {
         unsafe extern "system" fn GetTCRMode<Identity: ::windows::core::IUnknownImpl, Impl: IAMTimecodeReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, param: i32, pvalue: *mut i32) -> ::windows::core::HRESULT {
@@ -3713,6 +3801,8 @@ pub trait IAMTuner_Impl: Sized {
     fn RegisterNotificationCallBack(&self, pnotify: &::core::option::Option<IAMTunerNotification>, levents: i32) -> ::windows::core::Result<()>;
     fn UnRegisterNotificationCallBack(&self, pnotify: &::core::option::Option<IAMTunerNotification>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMTuner {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTuner_Impl, const OFFSET: isize>() -> IAMTuner_Vtbl {
@@ -3847,6 +3937,7 @@ impl IAMTuner_Vtbl {
 pub trait IAMTunerNotification_Impl: Sized {
     fn OnEvent(&self, event: AMTunerEventType) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMTunerNotification {}
 impl IAMTunerNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMTunerNotification_Impl, const OFFSET: isize>() -> IAMTunerNotification_Vtbl {
         unsafe extern "system" fn OnEvent<Identity: ::windows::core::IUnknownImpl, Impl: IAMTunerNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, event: AMTunerEventType) -> ::windows::core::HRESULT {
@@ -3866,6 +3957,8 @@ pub trait IAMVfwCaptureDialogs_Impl: Sized {
     fn ShowDialog(&self, idialog: i32, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn SendDriverMessage(&self, idialog: i32, umsg: i32, dw1: i32, dw2: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMVfwCaptureDialogs {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMVfwCaptureDialogs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVfwCaptureDialogs_Impl, const OFFSET: isize>() -> IAMVfwCaptureDialogs_Vtbl {
@@ -3902,6 +3995,8 @@ pub trait IAMVfwCompressDialogs_Impl: Sized {
     fn SetState(&self, pstate: *const ::core::ffi::c_void, cbstate: i32) -> ::windows::core::Result<()>;
     fn SendDriverMessage(&self, umsg: i32, dw1: i32, dw2: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMVfwCompressDialogs {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAMVfwCompressDialogs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVfwCompressDialogs_Impl, const OFFSET: isize>() -> IAMVfwCompressDialogs_Vtbl {
@@ -3952,6 +4047,8 @@ pub trait IAMVideoAccelerator_Impl: Sized {
     fn QueryRenderStatus(&self, dwtypeindex: u32, dwbufferindex: u32, dwflags: u32) -> ::windows::core::Result<()>;
     fn DisplayFrame(&self, dwfliptoindex: u32, pmediasample: &::core::option::Option<IMediaSample>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IAMVideoAccelerator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IAMVideoAccelerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoAccelerator_Impl, const OFFSET: isize>() -> IAMVideoAccelerator_Vtbl {
@@ -4042,6 +4139,8 @@ pub trait IAMVideoAcceleratorNotify_Impl: Sized {
     fn GetCreateVideoAcceleratorData(&self, pguid: *const ::windows::core::GUID, pdwsizemiscdata: *mut u32, ppmiscdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
+impl ::windows::core::RuntimeName for IAMVideoAcceleratorNotify {}
+#[cfg(feature = "Win32_Graphics_DirectDraw")]
 impl IAMVideoAcceleratorNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoAcceleratorNotify_Impl, const OFFSET: isize>() -> IAMVideoAcceleratorNotify_Vtbl {
         unsafe extern "system" fn GetUncompSurfacesInfo<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoAcceleratorNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguid: *const ::windows::core::GUID, puncompbufferinfo: *mut AMVAUncompBufferInfo) -> ::windows::core::HRESULT {
@@ -4083,6 +4182,7 @@ pub trait IAMVideoCompression_Impl: Sized {
     fn OverrideKeyFrame(&self, framenumber: i32) -> ::windows::core::Result<()>;
     fn OverrideFrameSize(&self, framenumber: i32, size: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMVideoCompression {}
 impl IAMVideoCompression_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoCompression_Impl, const OFFSET: isize>() -> IAMVideoCompression_Vtbl {
         unsafe extern "system" fn SetKeyFrameRate<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoCompression_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keyframerate: i32) -> ::windows::core::HRESULT {
@@ -4193,6 +4293,8 @@ pub trait IAMVideoControl_Impl: Sized {
     fn GetFrameRateList(&self, ppin: &::core::option::Option<IPin>, iindex: i32, dimensions: &super::super::Foundation::SIZE, listsize: *mut i32, framerates: *mut *mut i64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAMVideoControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAMVideoControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoControl_Impl, const OFFSET: isize>() -> IAMVideoControl_Vtbl {
         unsafe extern "system" fn GetCaps<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppin: ::windows::core::RawPtr, pcapsflags: *mut i32) -> ::windows::core::HRESULT {
@@ -4267,6 +4369,7 @@ pub trait IAMVideoDecimationProperties_Impl: Sized {
     fn QueryDecimationUsage(&self) -> ::windows::core::Result<DECIMATION_USAGE>;
     fn SetDecimationUsage(&self, usage: DECIMATION_USAGE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMVideoDecimationProperties {}
 impl IAMVideoDecimationProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoDecimationProperties_Impl, const OFFSET: isize>() -> IAMVideoDecimationProperties_Vtbl {
         unsafe extern "system" fn QueryDecimationUsage<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoDecimationProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpusage: *mut DECIMATION_USAGE) -> ::windows::core::HRESULT {
@@ -4300,6 +4403,7 @@ pub trait IAMVideoProcAmp_Impl: Sized {
     fn Set(&self, property: i32, lvalue: i32, flags: i32) -> ::windows::core::Result<()>;
     fn Get(&self, property: i32, lvalue: *mut i32, flags: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMVideoProcAmp {}
 impl IAMVideoProcAmp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoProcAmp_Impl, const OFFSET: isize>() -> IAMVideoProcAmp_Vtbl {
         unsafe extern "system" fn GetRange<Identity: ::windows::core::IUnknownImpl, Impl: IAMVideoProcAmp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, property: i32, pmin: *mut i32, pmax: *mut i32, psteppingdelta: *mut i32, pdefault: *mut i32, pcapsflags: *mut i32) -> ::windows::core::HRESULT {
@@ -4349,6 +4453,8 @@ pub trait IAMWstDecoder_Impl: Sized {
     fn GetCurrentPage(&self, pwstpage: *mut AM_WST_PAGE) -> ::windows::core::Result<()>;
     fn SetCurrentPage(&self, wstpage: &AM_WST_PAGE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IAMWstDecoder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IAMWstDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMWstDecoder_Impl, const OFFSET: isize>() -> IAMWstDecoder_Vtbl {
@@ -4472,6 +4578,7 @@ pub trait IAMovieSetup_Impl: Sized {
     fn Register(&self) -> ::windows::core::Result<()>;
     fn Unregister(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMovieSetup {}
 impl IAMovieSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMovieSetup_Impl, const OFFSET: isize>() -> IAMovieSetup_Vtbl {
         unsafe extern "system" fn Register<Identity: ::windows::core::IUnknownImpl, Impl: IAMovieSetup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4499,6 +4606,8 @@ pub trait IATSCChannelTuneRequest_Impl: Sized + super::super::System::Com::IDisp
     fn MinorChannel(&self) -> ::windows::core::Result<i32>;
     fn SetMinorChannel(&self, minorchannel: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IATSCChannelTuneRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IATSCChannelTuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSCChannelTuneRequest_Impl, const OFFSET: isize>() -> IATSCChannelTuneRequest_Vtbl {
@@ -4533,6 +4642,8 @@ pub trait IATSCComponentType_Impl: Sized + super::super::System::Com::IDispatch_
     fn Flags(&self) -> ::windows::core::Result<i32>;
     fn SetFlags(&self, flags: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IATSCComponentType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IATSCComponentType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSCComponentType_Impl, const OFFSET: isize>() -> IATSCComponentType_Vtbl {
@@ -4569,6 +4680,8 @@ pub trait IATSCLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn TSID(&self) -> ::windows::core::Result<i32>;
     fn SetTSID(&self, tsid: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IATSCLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IATSCLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSCLocator_Impl, const OFFSET: isize>() -> IATSCLocator_Vtbl {
@@ -4622,6 +4735,8 @@ pub trait IATSCLocator2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetProgramNumber(&self, programnumber: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IATSCLocator2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IATSCLocator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSCLocator2_Impl, const OFFSET: isize>() -> IATSCLocator2_Vtbl {
         unsafe extern "system" fn ProgramNumber<Identity: ::windows::core::IUnknownImpl, Impl: IATSCLocator2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, programnumber: *mut i32) -> ::windows::core::HRESULT {
@@ -4661,6 +4776,8 @@ pub trait IATSCTuningSpace_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn MaxPhysicalChannel(&self) -> ::windows::core::Result<i32>;
     fn SetMaxPhysicalChannel(&self, newmaxphysicalchannelval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IATSCTuningSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IATSCTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSCTuningSpace_Impl, const OFFSET: isize>() -> IATSCTuningSpace_Vtbl {
@@ -4759,6 +4876,7 @@ pub trait IATSC_EIT_Impl: Sized {
     fn GetRecordDescriptorByIndex(&self, dwrecordindex: u32, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetRecordDescriptorByTag(&self, dwrecordindex: u32, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IATSC_EIT {}
 impl IATSC_EIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_EIT_Impl, const OFFSET: isize>() -> IATSC_EIT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_EIT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4914,6 +5032,7 @@ pub trait IATSC_ETT_Impl: Sized {
     fn GetEtmId(&self) -> ::windows::core::Result<u32>;
     fn GetExtendedMessageText(&self, pdwlength: *mut u32, pptext: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IATSC_ETT {}
 impl IATSC_ETT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_ETT_Impl, const OFFSET: isize>() -> IATSC_ETT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_ETT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4987,6 +5106,7 @@ pub trait IATSC_MGT_Impl: Sized {
     fn GetTableDescriptorByIndex(&self, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetTableDescriptorByTag(&self, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IATSC_MGT {}
 impl IATSC_MGT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_MGT_Impl, const OFFSET: isize>() -> IATSC_MGT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_MGT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5139,6 +5259,7 @@ pub trait IATSC_STT_Impl: Sized {
     fn GetTableDescriptorByIndex(&self, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetTableDescriptorByTag(&self, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IATSC_STT {}
 impl IATSC_STT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_STT_Impl, const OFFSET: isize>() -> IATSC_STT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_STT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5262,6 +5383,8 @@ pub trait IATSC_VCT_Impl: Sized {
     fn GetTableDescriptorByIndex(&self, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetTableDescriptorByTag(&self, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IATSC_VCT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IATSC_VCT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IATSC_VCT_Impl, const OFFSET: isize>() -> IATSC_VCT_Vtbl {
@@ -5567,6 +5690,8 @@ pub trait IAnalogAudioComponentType_Impl: Sized + super::super::System::Com::IDi
     fn SetAnalogAudioMode(&self, mode: TVAudioMode) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAnalogAudioComponentType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAnalogAudioComponentType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogAudioComponentType_Impl, const OFFSET: isize>() -> IAnalogAudioComponentType_Vtbl {
         unsafe extern "system" fn AnalogAudioMode<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogAudioComponentType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: *mut TVAudioMode) -> ::windows::core::HRESULT {
@@ -5600,6 +5725,8 @@ pub trait IAnalogLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn VideoStandard(&self) -> ::windows::core::Result<AnalogVideoStandard>;
     fn SetVideoStandard(&self, avs: AnalogVideoStandard) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAnalogLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAnalogLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogLocator_Impl, const OFFSET: isize>() -> IAnalogLocator_Vtbl {
@@ -5638,6 +5765,8 @@ pub trait IAnalogRadioTuningSpace_Impl: Sized + super::super::System::Com::IDisp
     fn Step(&self) -> ::windows::core::Result<i32>;
     fn SetStep(&self, newstepval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAnalogRadioTuningSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAnalogRadioTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogRadioTuningSpace_Impl, const OFFSET: isize>() -> IAnalogRadioTuningSpace_Vtbl {
@@ -5709,6 +5838,8 @@ pub trait IAnalogRadioTuningSpace2_Impl: Sized + super::super::System::Com::IDis
     fn SetCountryCode(&self, newcountrycodeval: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAnalogRadioTuningSpace2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAnalogRadioTuningSpace2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogRadioTuningSpace2_Impl, const OFFSET: isize>() -> IAnalogRadioTuningSpace2_Vtbl {
         unsafe extern "system" fn CountryCode<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogRadioTuningSpace2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, countrycodeval: *mut i32) -> ::windows::core::HRESULT {
@@ -5748,6 +5879,8 @@ pub trait IAnalogTVTuningSpace_Impl: Sized + super::super::System::Com::IDispatc
     fn CountryCode(&self) -> ::windows::core::Result<i32>;
     fn SetCountryCode(&self, newcountrycodeval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAnalogTVTuningSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAnalogTVTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnalogTVTuningSpace_Impl, const OFFSET: isize>() -> IAnalogTVTuningSpace_Vtbl {
@@ -5841,6 +5974,7 @@ pub trait IAsyncReader_Impl: Sized {
     fn BeginFlush(&self) -> ::windows::core::Result<()>;
     fn EndFlush(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAsyncReader {}
 impl IAsyncReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncReader_Impl, const OFFSET: isize>() -> IAsyncReader_Vtbl {
         unsafe extern "system" fn RequestAllocator<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppreferred: ::windows::core::RawPtr, pprops: *const ALLOCATOR_PROPERTIES, ppactual: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5921,6 +6055,7 @@ pub trait IAtscContentAdvisoryDescriptor_Impl: Sized {
     fn GetRecordRatingValue(&self, bindexouter: u8, bindexinner: u8) -> ::windows::core::Result<u8>;
     fn GetRecordRatingDescriptionText(&self, bindex: u8, pblength: *mut u8, pptext: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAtscContentAdvisoryDescriptor {}
 impl IAtscContentAdvisoryDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAtscContentAdvisoryDescriptor_Impl, const OFFSET: isize>() -> IAtscContentAdvisoryDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IAtscContentAdvisoryDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -6035,6 +6170,8 @@ pub trait IAtscPsipParser_Impl: Sized {
     fn GetSTT(&self) -> ::windows::core::Result<IATSC_STT>;
     fn GetEAS(&self, pid: u16) -> ::windows::core::Result<ISCTE_EAS>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAtscPsipParser {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAtscPsipParser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAtscPsipParser_Impl, const OFFSET: isize>() -> IAtscPsipParser_Vtbl {
@@ -6177,6 +6314,7 @@ pub trait IAttributeGet_Impl: Sized {
     fn GetAttribIndexed(&self, lindex: i32, pguidattribute: *mut ::windows::core::GUID, pbattribute: *mut u8, pdwattributelength: *mut u32) -> ::windows::core::Result<()>;
     fn GetAttrib(&self, guidattribute: &::windows::core::GUID, pbattribute: *mut u8, pdwattributelength: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAttributeGet {}
 impl IAttributeGet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAttributeGet_Impl, const OFFSET: isize>() -> IAttributeGet_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IAttributeGet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -6214,6 +6352,7 @@ impl IAttributeGet_Vtbl {
 pub trait IAttributeSet_Impl: Sized {
     fn SetAttrib(&self, guidattribute: &::windows::core::GUID, pbattribute: *const u8, dwattributelength: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAttributeSet {}
 impl IAttributeSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAttributeSet_Impl, const OFFSET: isize>() -> IAttributeSet_Vtbl {
         unsafe extern "system" fn SetAttrib<Identity: ::windows::core::IUnknownImpl, Impl: IAttributeSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidattribute: ::windows::core::GUID, pbattribute: *const u8, dwattributelength: u32) -> ::windows::core::HRESULT {
@@ -6232,6 +6371,8 @@ pub trait IAudioData_Impl: Sized + IMemoryData_Impl {
     fn GetFormat(&self) -> ::windows::core::Result<super::Audio::WAVEFORMATEX>;
     fn SetFormat(&self, lpwaveformat: *const super::Audio::WAVEFORMATEX) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Media_Audio")]
+impl ::windows::core::RuntimeName for IAudioData {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl IAudioData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioData_Impl, const OFFSET: isize>() -> IAudioData_Vtbl {
@@ -6267,6 +6408,8 @@ pub trait IAudioMediaStream_Impl: Sized + IMediaStream_Impl {
     fn SetFormat(&self, lpwaveformat: *const super::Audio::WAVEFORMATEX) -> ::windows::core::Result<()>;
     fn CreateSample(&self, paudiodata: &::core::option::Option<IAudioData>, dwflags: u32) -> ::windows::core::Result<IAudioStreamSample>;
 }
+#[cfg(feature = "Win32_Media_Audio")]
+impl ::windows::core::RuntimeName for IAudioMediaStream {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl IAudioMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioMediaStream_Impl, const OFFSET: isize>() -> IAudioMediaStream_Vtbl {
@@ -6313,6 +6456,8 @@ pub trait IAudioStreamSample_Impl: Sized + IStreamSample_Impl {
     fn GetAudioData(&self) -> ::windows::core::Result<IAudioData>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioStreamSample {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioStreamSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioStreamSample_Impl, const OFFSET: isize>() -> IAudioStreamSample_Vtbl {
         unsafe extern "system" fn GetAudioData<Identity: ::windows::core::IUnknownImpl, Impl: IAudioStreamSample_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppaudio: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6335,6 +6480,8 @@ impl IAudioStreamSample_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAuxInTuningSpace_Impl: Sized + super::super::System::Com::IDispatch_Impl + ITuningSpace_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAuxInTuningSpace {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAuxInTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAuxInTuningSpace_Impl, const OFFSET: isize>() -> IAuxInTuningSpace_Vtbl {
         Self { base__: ITuningSpace_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -6348,6 +6495,8 @@ pub trait IAuxInTuningSpace2_Impl: Sized + super::super::System::Com::IDispatch_
     fn CountryCode(&self) -> ::windows::core::Result<i32>;
     fn SetCountryCode(&self, newcountrycodeval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAuxInTuningSpace2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAuxInTuningSpace2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAuxInTuningSpace2_Impl, const OFFSET: isize>() -> IAuxInTuningSpace2_Vtbl {
@@ -6386,6 +6535,8 @@ pub trait IBDAComparable_Impl: Sized {
     fn HashEquivalent(&self, dwflags: u32) -> ::windows::core::Result<i64>;
     fn HashEquivalentIncremental(&self, partialresult: i64, dwflags: u32) -> ::windows::core::Result<i64>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBDAComparable {}
 #[cfg(feature = "Win32_System_Com")]
 impl IBDAComparable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDAComparable_Impl, const OFFSET: isize>() -> IBDAComparable_Vtbl {
@@ -6474,6 +6625,8 @@ pub trait IBDACreateTuneRequestEx_Impl: Sized {
     fn CreateTuneRequestEx(&self, tunerequestiid: *const ::windows::core::GUID) -> ::windows::core::Result<ITuneRequest>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBDACreateTuneRequestEx {}
+#[cfg(feature = "Win32_System_Com")]
 impl IBDACreateTuneRequestEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDACreateTuneRequestEx_Impl, const OFFSET: isize>() -> IBDACreateTuneRequestEx_Vtbl {
         unsafe extern "system" fn CreateTuneRequestEx<Identity: ::windows::core::IUnknownImpl, Impl: IBDACreateTuneRequestEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tunerequestiid: *const ::windows::core::GUID, tunerequest: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6497,6 +6650,7 @@ pub trait IBDA_AUX_Impl: Sized {
     fn QueryCapabilities(&self) -> ::windows::core::Result<u32>;
     fn EnumCapability(&self, dwindex: u32, dwinputid: *mut u32, pconnectortype: *mut ::windows::core::GUID, conntypenum: *mut u32, numvideostds: *mut u32, analogstds: *mut u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_AUX {}
 impl IBDA_AUX_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_AUX_Impl, const OFFSET: isize>() -> IBDA_AUX_Vtbl {
         unsafe extern "system" fn QueryCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_AUX_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwnumauxinputsbstr: *mut u32) -> ::windows::core::HRESULT {
@@ -6528,6 +6682,7 @@ impl IBDA_AUX_Vtbl {
 pub trait IBDA_AutoDemodulate_Impl: Sized {
     fn put_AutoDemodulate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_AutoDemodulate {}
 impl IBDA_AutoDemodulate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_AutoDemodulate_Impl, const OFFSET: isize>() -> IBDA_AutoDemodulate_Vtbl {
         unsafe extern "system" fn put_AutoDemodulate<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_AutoDemodulate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6546,6 +6701,7 @@ pub trait IBDA_AutoDemodulateEx_Impl: Sized + IBDA_AutoDemodulate_Impl {
     fn get_SupportedVideoFormats(&self, pulamtunermodetype: *mut u32, pulanalogvideostandard: *mut u32) -> ::windows::core::Result<()>;
     fn get_AuxInputCount(&self, pulcompositecount: *mut u32, pulsvideocount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_AutoDemodulateEx {}
 impl IBDA_AutoDemodulateEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_AutoDemodulateEx_Impl, const OFFSET: isize>() -> IBDA_AutoDemodulateEx_Vtbl {
         unsafe extern "system" fn get_SupportedDeviceNodeTypes<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_AutoDemodulateEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulcdevicenodetypesmax: u32, pulcdevicenodetypes: *mut u32, pguiddevicenodetypes: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -6587,6 +6743,8 @@ pub trait IBDA_ConditionalAccess_Impl: Sized {
     fn GetModuleUI(&self, bydialognumber: u8) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn InformUIClosed(&self, bydialognumber: u8, closereason: UICloseReasonType) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_ConditionalAccess {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_ConditionalAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_ConditionalAccess_Impl, const OFFSET: isize>() -> IBDA_ConditionalAccess_Vtbl {
@@ -6679,6 +6837,8 @@ pub trait IBDA_ConditionalAccessEx_Impl: Sized {
     fn CreateDialogRequestNumber(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_ConditionalAccessEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBDA_ConditionalAccessEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_ConditionalAccessEx_Impl, const OFFSET: isize>() -> IBDA_ConditionalAccessEx_Vtbl {
         unsafe extern "system" fn CheckEntitlementToken<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_ConditionalAccessEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uldialogrequest: u32, bstrlanguage: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, requesttype: BDA_CONDITIONALACCESS_REQUESTTYPE, ulcbentitlementtokenlen: u32, pbentitlementtoken: *const u8, puldescramblestatus: *mut u32) -> ::windows::core::HRESULT {
@@ -6744,6 +6904,8 @@ pub trait IBDA_DRIDRMService_Impl: Sized {
     fn GetPairingStatus(&self, penumpairingstatus: *mut BDA_DrmPairingError) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_DRIDRMService {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBDA_DRIDRMService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRIDRMService_Impl, const OFFSET: isize>() -> IBDA_DRIDRMService_Vtbl {
         unsafe extern "system" fn SetDRM<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRIDRMService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrnewdrm: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6781,6 +6943,7 @@ pub trait IBDA_DRIWMDRMSession_Impl: Sized {
     fn GetHMSAssociationData(&self) -> ::windows::core::Result<()>;
     fn GetLastCardeaError(&self, pdwerror: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_DRIWMDRMSession {}
 impl IBDA_DRIWMDRMSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRIWMDRMSession_Impl, const OFFSET: isize>() -> IBDA_DRIWMDRMSession_Vtbl {
         unsafe extern "system" fn AcknowledgeLicense<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRIWMDRMSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrlicenseack: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -6839,6 +7002,8 @@ pub trait IBDA_DRM_Impl: Sized {
     fn PerformDRMPairing(&self, fsync: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_DRM {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBDA_DRM_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRM_Impl, const OFFSET: isize>() -> IBDA_DRM_Vtbl {
         unsafe extern "system" fn GetDRMPairingStatus<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRM_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32, pherror: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -6866,6 +7031,8 @@ pub trait IBDA_DRMService_Impl: Sized {
     fn SetDRM(&self, puuidnewdrm: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetDRMStatus(&self, pbstrdrmuuidlist: *mut super::super::Foundation::BSTR, drmuuid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_DRMService {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_DRMService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DRMService_Impl, const OFFSET: isize>() -> IBDA_DRMService_Vtbl {
@@ -6895,6 +7062,7 @@ pub trait IBDA_DeviceControl_Impl: Sized {
     fn CommitChanges(&self) -> ::windows::core::Result<()>;
     fn GetChangeState(&self, pstate: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_DeviceControl {}
 impl IBDA_DeviceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DeviceControl_Impl, const OFFSET: isize>() -> IBDA_DeviceControl_Vtbl {
         unsafe extern "system" fn StartChanges<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DeviceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6932,6 +7100,8 @@ impl IBDA_DeviceControl_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IBDA_DiagnosticProperties_Impl: Sized + super::super::System::Com::StructuredStorage::IPropertyBag_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBDA_DiagnosticProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IBDA_DiagnosticProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DiagnosticProperties_Impl, const OFFSET: isize>() -> IBDA_DiagnosticProperties_Vtbl {
         Self { base__: super::super::System::Com::StructuredStorage::IPropertyBag_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -6956,6 +7126,7 @@ pub trait IBDA_DigitalDemodulator_Impl: Sized {
     fn SetSpectralInversion(&self, pspectralinversion: *const SpectralInversion) -> ::windows::core::Result<()>;
     fn SpectralInversion(&self, pspectralinversion: *mut SpectralInversion) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_DigitalDemodulator {}
 impl IBDA_DigitalDemodulator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DigitalDemodulator_Impl, const OFFSET: isize>() -> IBDA_DigitalDemodulator_Vtbl {
         unsafe extern "system" fn SetModulationType<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DigitalDemodulator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmodulationtype: *const ModulationType) -> ::windows::core::HRESULT {
@@ -7060,6 +7231,7 @@ pub trait IBDA_DigitalDemodulator2_Impl: Sized + IBDA_DigitalDemodulator_Impl {
     fn SetPilot(&self, ppilot: *const Pilot) -> ::windows::core::Result<()>;
     fn Pilot(&self, ppilot: *mut Pilot) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_DigitalDemodulator2 {}
 impl IBDA_DigitalDemodulator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DigitalDemodulator2_Impl, const OFFSET: isize>() -> IBDA_DigitalDemodulator2_Vtbl {
         unsafe extern "system" fn SetGuardInterval<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DigitalDemodulator2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguardinterval: *const GuardInterval) -> ::windows::core::HRESULT {
@@ -7124,6 +7296,7 @@ pub trait IBDA_DigitalDemodulator3_Impl: Sized + IBDA_DigitalDemodulator_Impl + 
     fn SetPLPNumber(&self, pplpnumber: *const u32) -> ::windows::core::Result<()>;
     fn PLPNumber(&self, pplpnumber: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_DigitalDemodulator3 {}
 impl IBDA_DigitalDemodulator3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DigitalDemodulator3_Impl, const OFFSET: isize>() -> IBDA_DigitalDemodulator3_Vtbl {
         unsafe extern "system" fn SetSignalTimeouts<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DigitalDemodulator3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psignaltimeouts: *const BDA_SIGNAL_TIMEOUTS) -> ::windows::core::HRESULT {
@@ -7167,6 +7340,8 @@ pub trait IBDA_DiseqCommand_Impl: Sized {
     fn put_DiseqSendCommand(&self, ulrequestid: u32, ulcbcommandlen: u32, pbcommand: *const u8) -> ::windows::core::Result<()>;
     fn get_DiseqResponse(&self, ulrequestid: u32, pulcbresponselen: *mut u32, pbresponse: *mut u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_DiseqCommand {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_DiseqCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_DiseqCommand_Impl, const OFFSET: isize>() -> IBDA_DiseqCommand_Vtbl {
@@ -7217,6 +7392,7 @@ impl IBDA_DiseqCommand_Vtbl {
 pub trait IBDA_EasMessage_Impl: Sized {
     fn get_EasMessage(&self, uleventid: u32, ppeasobject: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_EasMessage {}
 impl IBDA_EasMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_EasMessage_Impl, const OFFSET: isize>() -> IBDA_EasMessage_Vtbl {
         unsafe extern "system" fn get_EasMessage<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_EasMessage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uleventid: u32, ppeasobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7238,6 +7414,8 @@ pub trait IBDA_Encoder_Impl: Sized {
     fn SetParameters(&self, audiobitratemode: u32, audiobitrate: u32, audiomethodid: u32, audioprogram: u32, videobitratemode: u32, videobitrate: u32, videomethodid: u32) -> ::windows::core::Result<()>;
     fn GetState(&self, audiobitratemax: *mut u32, audiobitratemin: *mut u32, audiobitratemode: *mut u32, audiobitratestepping: *mut u32, audiobitrate: *mut u32, audiomethodid: *mut u32, availableaudioprograms: *mut u32, audioprogram: *mut u32, videobitratemax: *mut u32, videobitratemin: *mut u32, videobitratemode: *mut u32, videobitrate: *mut u32, videobitratestepping: *mut u32, videomethodid: *mut u32, signalsourceid: *mut u32, signalformat: *mut u64, signallock: *mut super::super::Foundation::BOOL, signallevel: *mut i32, signaltonoiseratio: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_Encoder {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_Encoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_Encoder_Impl, const OFFSET: isize>() -> IBDA_Encoder_Vtbl {
@@ -7308,6 +7486,7 @@ pub trait IBDA_EthernetFilter_Impl: Sized {
     fn PutMulticastMode(&self, ulmodemask: u32) -> ::windows::core::Result<()>;
     fn GetMulticastMode(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBDA_EthernetFilter {}
 impl IBDA_EthernetFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_EthernetFilter_Impl, const OFFSET: isize>() -> IBDA_EthernetFilter_Vtbl {
         unsafe extern "system" fn GetMulticastListSize<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_EthernetFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcbaddresses: *mut u32) -> ::windows::core::HRESULT {
@@ -7357,6 +7536,7 @@ impl IBDA_EthernetFilter_Vtbl {
 pub trait IBDA_EventingService_Impl: Sized {
     fn CompleteEvent(&self, uleventid: u32, uleventresult: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_EventingService {}
 impl IBDA_EventingService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_EventingService_Impl, const OFFSET: isize>() -> IBDA_EventingService_Vtbl {
         unsafe extern "system" fn CompleteEvent<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_EventingService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uleventid: u32, uleventresult: u32) -> ::windows::core::HRESULT {
@@ -7380,6 +7560,8 @@ pub trait IBDA_FDC_Impl: Sized {
     fn RemoveTid(&self, tidstoremove: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetTableSection(&self, pid: *mut u32, maxbuffersize: u32, actualsize: *mut u32, secbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_FDC {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_FDC_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_FDC_Impl, const OFFSET: isize>() -> IBDA_FDC_Vtbl {
@@ -7459,6 +7641,7 @@ pub trait IBDA_FrequencyFilter_Impl: Sized {
     fn SetFrequencyMultiplier(&self, ulmultiplier: u32) -> ::windows::core::Result<()>;
     fn FrequencyMultiplier(&self, pulmultiplier: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_FrequencyFilter {}
 impl IBDA_FrequencyFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_FrequencyFilter_Impl, const OFFSET: isize>() -> IBDA_FrequencyFilter_Vtbl {
         unsafe extern "system" fn SetAutotune<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_FrequencyFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ultransponder: u32) -> ::windows::core::HRESULT {
@@ -7551,6 +7734,8 @@ pub trait IBDA_GuideDataDeliveryService_Impl: Sized {
     fn GetServiceInfoFromTuneXml(&self, bstrtunexml: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_GuideDataDeliveryService {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBDA_GuideDataDeliveryService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_GuideDataDeliveryService_Impl, const OFFSET: isize>() -> IBDA_GuideDataDeliveryService_Vtbl {
         unsafe extern "system" fn GetGuideDataType<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_GuideDataDeliveryService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguiddatatype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -7619,6 +7804,7 @@ pub trait IBDA_IPSinkControl_Impl: Sized {
     fn GetMulticastList(&self, pulcbsize: *mut u32, pbbuffer: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetAdapterIPAddress(&self, pulcbsize: *mut u32, pbbuffer: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_IPSinkControl {}
 impl IBDA_IPSinkControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPSinkControl_Impl, const OFFSET: isize>() -> IBDA_IPSinkControl_Vtbl {
         unsafe extern "system" fn GetMulticastList<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPSinkControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcbsize: *mut u32, pbbuffer: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -7647,6 +7833,8 @@ pub trait IBDA_IPSinkInfo_Impl: Sized {
     fn AdapterIPAddress(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn AdapterDescription(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_IPSinkInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_IPSinkInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPSinkInfo_Impl, const OFFSET: isize>() -> IBDA_IPSinkInfo_Vtbl {
@@ -7695,6 +7883,7 @@ pub trait IBDA_IPV4Filter_Impl: Sized {
     fn PutMulticastMode(&self, ulmodemask: u32) -> ::windows::core::Result<()>;
     fn GetMulticastMode(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBDA_IPV4Filter {}
 impl IBDA_IPV4Filter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPV4Filter_Impl, const OFFSET: isize>() -> IBDA_IPV4Filter_Vtbl {
         unsafe extern "system" fn GetMulticastListSize<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPV4Filter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcbaddresses: *mut u32) -> ::windows::core::HRESULT {
@@ -7748,6 +7937,7 @@ pub trait IBDA_IPV6Filter_Impl: Sized {
     fn PutMulticastMode(&self, ulmodemask: u32) -> ::windows::core::Result<()>;
     fn GetMulticastMode(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBDA_IPV6Filter {}
 impl IBDA_IPV6Filter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPV6Filter_Impl, const OFFSET: isize>() -> IBDA_IPV6Filter_Vtbl {
         unsafe extern "system" fn GetMulticastListSize<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_IPV6Filter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcbaddresses: *mut u32) -> ::windows::core::HRESULT {
@@ -7797,6 +7987,7 @@ impl IBDA_IPV6Filter_Vtbl {
 pub trait IBDA_ISDBConditionalAccess_Impl: Sized {
     fn SetIsdbCasRequest(&self, ulrequestid: u32, ulcbrequestbufferlen: u32, pbrequestbuffer: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_ISDBConditionalAccess {}
 impl IBDA_ISDBConditionalAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_ISDBConditionalAccess_Impl, const OFFSET: isize>() -> IBDA_ISDBConditionalAccess_Vtbl {
         unsafe extern "system" fn SetIsdbCasRequest<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_ISDBConditionalAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulrequestid: u32, ulcbrequestbufferlen: u32, pbrequestbuffer: *const u8) -> ::windows::core::HRESULT {
@@ -7818,6 +8009,7 @@ pub trait IBDA_LNBInfo_Impl: Sized {
     fn SetHighLowSwitchFrequency(&self, ulswitchfrequency: u32) -> ::windows::core::Result<()>;
     fn HighLowSwitchFrequency(&self, pulswitchfrequency: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_LNBInfo {}
 impl IBDA_LNBInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_LNBInfo_Impl, const OFFSET: isize>() -> IBDA_LNBInfo_Vtbl {
         unsafe extern "system" fn SetLocalOscilatorFrequencyLowBand<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_LNBInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulloflow: u32) -> ::windows::core::HRESULT {
@@ -7868,6 +8060,7 @@ pub trait IBDA_MUX_Impl: Sized {
     fn SetPidList(&self, ulpidlistcount: u32, pbpidlistbuffer: *const BDA_MUX_PIDLISTITEM) -> ::windows::core::Result<()>;
     fn GetPidList(&self, pulpidlistcount: *mut u32, pbpidlistbuffer: *mut BDA_MUX_PIDLISTITEM) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_MUX {}
 impl IBDA_MUX_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_MUX_Impl, const OFFSET: isize>() -> IBDA_MUX_Vtbl {
         unsafe extern "system" fn SetPidList<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_MUX_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulpidlistcount: u32, pbpidlistbuffer: *const BDA_MUX_PIDLISTITEM) -> ::windows::core::HRESULT {
@@ -7896,6 +8089,8 @@ pub trait IBDA_NameValueService_Impl: Sized {
     fn GetValue(&self, bstrname: &super::super::Foundation::BSTR, bstrlanguage: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetValue(&self, uldialogrequest: u32, bstrlanguage: &super::super::Foundation::BSTR, bstrname: &super::super::Foundation::BSTR, bstrvalue: &super::super::Foundation::BSTR, ulreserved: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_NameValueService {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_NameValueService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_NameValueService_Impl, const OFFSET: isize>() -> IBDA_NameValueService_Vtbl {
@@ -7946,6 +8141,7 @@ pub trait IBDA_NetworkProvider_Impl: Sized {
     fn RegisterDeviceFilter(&self, punkfiltercontrol: &::core::option::Option<::windows::core::IUnknown>, ppvregisitrationcontext: *mut u32) -> ::windows::core::Result<()>;
     fn UnRegisterDeviceFilter(&self, pvregistrationcontext: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_NetworkProvider {}
 impl IBDA_NetworkProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_NetworkProvider_Impl, const OFFSET: isize>() -> IBDA_NetworkProvider_Vtbl {
         unsafe extern "system" fn PutSignalSource<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_NetworkProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulsignalsource: u32) -> ::windows::core::HRESULT {
@@ -8002,6 +8198,7 @@ pub trait IBDA_NullTransform_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_NullTransform {}
 impl IBDA_NullTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_NullTransform_Impl, const OFFSET: isize>() -> IBDA_NullTransform_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_NullTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8025,6 +8222,7 @@ pub trait IBDA_PinControl_Impl: Sized {
     fn GetPinType(&self, pulpintype: *mut u32) -> ::windows::core::Result<()>;
     fn RegistrationContext(&self, pulregistrationctx: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_PinControl {}
 impl IBDA_PinControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_PinControl_Impl, const OFFSET: isize>() -> IBDA_PinControl_Vtbl {
         unsafe extern "system" fn GetPinID<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_PinControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulpinid: *mut u32) -> ::windows::core::HRESULT {
@@ -8061,6 +8259,7 @@ pub trait IBDA_SignalProperties_Impl: Sized {
     fn PutTuningSpace(&self, guidtuningspace: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetTuningSpace(&self, pguidtuingspace: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_SignalProperties {}
 impl IBDA_SignalProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_SignalProperties_Impl, const OFFSET: isize>() -> IBDA_SignalProperties_Vtbl {
         unsafe extern "system" fn PutNetworkType<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_SignalProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidnetworktype: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -8120,6 +8319,8 @@ pub trait IBDA_SignalStatistics_Impl: Sized {
     fn SetSampleTime(&self, lmssampletime: i32) -> ::windows::core::Result<()>;
     fn SampleTime(&self, plmssampletime: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_SignalStatistics {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_SignalStatistics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_SignalStatistics_Impl, const OFFSET: isize>() -> IBDA_SignalStatistics_Vtbl {
@@ -8195,6 +8396,7 @@ pub trait IBDA_TIF_REGISTRATION_Impl: Sized {
     fn RegisterTIFEx(&self, ptifinputpin: &::core::option::Option<IPin>, ppvregistrationcontext: *mut u32, ppmpeg2datacontrol: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UnregisterTIF(&self, pvregistrationcontext: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_TIF_REGISTRATION {}
 impl IBDA_TIF_REGISTRATION_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_TIF_REGISTRATION_Impl, const OFFSET: isize>() -> IBDA_TIF_REGISTRATION_Vtbl {
         unsafe extern "system" fn RegisterTIFEx<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_TIF_REGISTRATION_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptifinputpin: ::windows::core::RawPtr, ppvregistrationcontext: *mut u32, ppmpeg2datacontrol: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8231,6 +8433,8 @@ pub trait IBDA_Topology_Impl: Sized {
     fn CreateTopology(&self, ulinputpinid: u32, uloutputpinid: u32) -> ::windows::core::Result<()>;
     fn GetControlNode(&self, ulinputpinid: u32, uloutputpinid: u32, ulnodetype: u32, ppcontrolnode: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_Topology {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBDA_Topology_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_Topology_Impl, const OFFSET: isize>() -> IBDA_Topology_Vtbl {
@@ -8311,6 +8515,7 @@ impl IBDA_Topology_Vtbl {
 pub trait IBDA_TransportStreamInfo_Impl: Sized {
     fn PatTableTickCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBDA_TransportStreamInfo {}
 impl IBDA_TransportStreamInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_TransportStreamInfo_Impl, const OFFSET: isize>() -> IBDA_TransportStreamInfo_Vtbl {
         unsafe extern "system" fn PatTableTickCount<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_TransportStreamInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppattickcount: *mut u32) -> ::windows::core::HRESULT {
@@ -8334,6 +8539,7 @@ pub trait IBDA_TransportStreamSelector_Impl: Sized {
     fn SetTSID(&self, ustsid: u16) -> ::windows::core::Result<()>;
     fn GetTSInformation(&self, pultsinformationbufferlen: *mut u32, pbtsinformationbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_TransportStreamSelector {}
 impl IBDA_TransportStreamSelector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_TransportStreamSelector_Impl, const OFFSET: isize>() -> IBDA_TransportStreamSelector_Vtbl {
         unsafe extern "system" fn SetTSID<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_TransportStreamSelector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ustsid: u16) -> ::windows::core::HRESULT {
@@ -8361,6 +8567,7 @@ pub trait IBDA_UserActivityService_Impl: Sized {
     fn GetUserActivityInterval(&self) -> ::windows::core::Result<u32>;
     fn UserActivityDetected(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_UserActivityService {}
 impl IBDA_UserActivityService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_UserActivityService_Impl, const OFFSET: isize>() -> IBDA_UserActivityService_Vtbl {
         unsafe extern "system" fn SetCurrentTunerUseReason<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_UserActivityService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwusereason: u32) -> ::windows::core::HRESULT {
@@ -8399,6 +8606,7 @@ pub trait IBDA_VoidTransform_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_VoidTransform {}
 impl IBDA_VoidTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_VoidTransform_Impl, const OFFSET: isize>() -> IBDA_VoidTransform_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_VoidTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8427,6 +8635,7 @@ pub trait IBDA_WMDRMSession_Impl: Sized {
     fn RenewLicense(&self, ulinxmrlicenselen: u32, pbinxmrlicense: *const u8, ulentitlementtokenlen: u32, pbentitlementtoken: *const u8, puldescramblestatus: *mut u32, puloutxmrlicenselen: *mut u32, pboutxmrlicense: *mut u8) -> ::windows::core::Result<()>;
     fn GetKeyInfo(&self, pulkeyinfolen: *mut u32, pbkeyinfo: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBDA_WMDRMSession {}
 impl IBDA_WMDRMSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_WMDRMSession_Impl, const OFFSET: isize>() -> IBDA_WMDRMSession_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_WMDRMSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxcapturetoken: *mut u32, maxstreamingpid: *mut u32, maxlicense: *mut u32, minsecuritylevel: *mut u32, revinfosequencenumber: *mut u32, revinfoissuedtime: *mut u64, revinfottl: *mut u32, revlistversion: *mut u32, ulstate: *mut u32) -> ::windows::core::HRESULT {
@@ -8495,6 +8704,8 @@ pub trait IBDA_WMDRMTuner_Impl: Sized {
     fn GetStartCodeProfile(&self, pulstartcodeprofilelen: *mut u32, pbstartcodeprofile: *mut u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBDA_WMDRMTuner {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBDA_WMDRMTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_WMDRMTuner_Impl, const OFFSET: isize>() -> IBDA_WMDRMTuner_Vtbl {
         unsafe extern "system" fn PurchaseEntitlement<Identity: ::windows::core::IUnknownImpl, Impl: IBDA_WMDRMTuner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uldialogrequest: u32, bstrlanguage: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ulpurchasetokenlen: u32, pbpurchasetoken: *const u8, puldescramblestatus: *mut u32, pulcapturetokenlen: *mut u32, pbcapturetoken: *mut u8) -> ::windows::core::HRESULT {
@@ -8554,6 +8765,8 @@ pub trait IBPCSatelliteTuner_Impl: Sized + IAMTuner_Impl {
     fn IsTapingPermitted(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBPCSatelliteTuner {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBPCSatelliteTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBPCSatelliteTuner_Impl, const OFFSET: isize>() -> IBPCSatelliteTuner_Vtbl {
         unsafe extern "system" fn get_DefaultSubChannelTypes<Identity: ::windows::core::IUnknownImpl, Impl: IBPCSatelliteTuner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pldefaultvideotype: *mut i32, pldefaultaudiotype: *mut i32) -> ::windows::core::HRESULT {
@@ -8590,6 +8803,8 @@ pub trait IBaseFilter_Impl: Sized + super::super::System::Com::IPersist_Impl + I
     fn JoinFilterGraph(&self, pgraph: &::core::option::Option<IFilterGraph>, pname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn QueryVendorInfo(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBaseFilter {}
 #[cfg(feature = "Win32_System_Com")]
 impl IBaseFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBaseFilter_Impl, const OFFSET: isize>() -> IBaseFilter_Vtbl {
@@ -8664,6 +8879,7 @@ pub trait IBaseVideoMixer_Impl: Sized {
     fn GetClockPeriod(&self) -> ::windows::core::Result<i32>;
     fn SetClockPeriod(&self, bvalue: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBaseVideoMixer {}
 impl IBaseVideoMixer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBaseVideoMixer_Impl, const OFFSET: isize>() -> IBaseVideoMixer_Vtbl {
         unsafe extern "system" fn SetLeadPin<Identity: ::windows::core::IUnknownImpl, Impl: IBaseVideoMixer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ipin: i32) -> ::windows::core::HRESULT {
@@ -8748,6 +8964,8 @@ pub trait IBasicAudio_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Balance(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBasicAudio {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBasicAudio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBasicAudio_Impl, const OFFSET: isize>() -> IBasicAudio_Vtbl {
         unsafe extern "system" fn SetVolume<Identity: ::windows::core::IUnknownImpl, Impl: IBasicAudio_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lvolume: i32) -> ::windows::core::HRESULT {
@@ -8829,6 +9047,8 @@ pub trait IBasicVideo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsUsingDefaultSource(&self) -> ::windows::core::Result<()>;
     fn IsUsingDefaultDestination(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBasicVideo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBasicVideo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBasicVideo_Impl, const OFFSET: isize>() -> IBasicVideo_Vtbl {
@@ -9115,6 +9335,8 @@ pub trait IBasicVideo2_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn GetPreferredAspectRatio(&self, plaspectx: *mut i32, plaspecty: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBasicVideo2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBasicVideo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBasicVideo2_Impl, const OFFSET: isize>() -> IBasicVideo2_Vtbl {
         unsafe extern "system" fn GetPreferredAspectRatio<Identity: ::windows::core::IUnknownImpl, Impl: IBasicVideo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plaspectx: *mut i32, plaspecty: *mut i32) -> ::windows::core::HRESULT {
@@ -9131,6 +9353,7 @@ impl IBasicVideo2_Vtbl {
 pub trait IBroadcastEvent_Impl: Sized {
     fn Fire(&self, eventid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBroadcastEvent {}
 impl IBroadcastEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBroadcastEvent_Impl, const OFFSET: isize>() -> IBroadcastEvent_Vtbl {
         unsafe extern "system" fn Fire<Identity: ::windows::core::IUnknownImpl, Impl: IBroadcastEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -9147,6 +9370,7 @@ impl IBroadcastEvent_Vtbl {
 pub trait IBroadcastEventEx_Impl: Sized + IBroadcastEvent_Impl {
     fn FireEx(&self, eventid: &::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBroadcastEventEx {}
 impl IBroadcastEventEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBroadcastEventEx_Impl, const OFFSET: isize>() -> IBroadcastEventEx_Vtbl {
         unsafe extern "system" fn FireEx<Identity: ::windows::core::IUnknownImpl, Impl: IBroadcastEventEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventid: ::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32) -> ::windows::core::HRESULT {
@@ -9164,6 +9388,7 @@ pub trait IBufferingTime_Impl: Sized {
     fn GetBufferingTime(&self, pdwmilliseconds: *mut u32) -> ::windows::core::Result<()>;
     fn SetBufferingTime(&self, dwmilliseconds: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBufferingTime {}
 impl IBufferingTime_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBufferingTime_Impl, const OFFSET: isize>() -> IBufferingTime_Vtbl {
         unsafe extern "system" fn GetBufferingTime<Identity: ::windows::core::IUnknownImpl, Impl: IBufferingTime_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwmilliseconds: *mut u32) -> ::windows::core::HRESULT {
@@ -9198,6 +9423,8 @@ pub trait ICAT_Impl: Sized {
     fn RegisterForWhenCurrent(&self, hnexttableiscurrent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICAT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICAT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICAT_Impl, const OFFSET: isize>() -> ICAT_Vtbl {
@@ -9291,6 +9518,7 @@ pub trait ICCSubStreamFiltering_Impl: Sized {
     fn SubstreamTypes(&self) -> ::windows::core::Result<i32>;
     fn SetSubstreamTypes(&self, types: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICCSubStreamFiltering {}
 impl ICCSubStreamFiltering_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICCSubStreamFiltering_Impl, const OFFSET: isize>() -> ICCSubStreamFiltering_Vtbl {
         unsafe extern "system" fn SubstreamTypes<Identity: ::windows::core::IUnknownImpl, Impl: ICCSubStreamFiltering_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptypes: *mut i32) -> ::windows::core::HRESULT {
@@ -9372,6 +9600,7 @@ pub trait ICameraControl_Impl: Sized {
     fn get_PrivacyMode(&self, pvalue: *mut i32, pflags: *mut i32) -> ::windows::core::Result<()>;
     fn put_PrivacyMode(&self, value: i32, flags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICameraControl {}
 impl ICameraControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICameraControl_Impl, const OFFSET: isize>() -> ICameraControl_Vtbl {
         unsafe extern "system" fn get_Exposure<Identity: ::windows::core::IUnknownImpl, Impl: ICameraControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut i32, pflags: *mut i32) -> ::windows::core::HRESULT {
@@ -9696,6 +9925,7 @@ pub trait ICaptionServiceDescriptor_Impl: Sized {
     fn GetEasyReader(&self, bindex: u8) -> ::windows::core::Result<u8>;
     fn GetWideAspectRatio(&self, bindex: u8) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for ICaptionServiceDescriptor {}
 impl ICaptionServiceDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICaptionServiceDescriptor_Impl, const OFFSET: isize>() -> ICaptionServiceDescriptor_Vtbl {
         unsafe extern "system" fn GetNumberOfServices<Identity: ::windows::core::IUnknownImpl, Impl: ICaptionServiceDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -9784,6 +10014,8 @@ pub trait ICaptureGraphBuilder_Impl: Sized {
     fn CopyCaptureFile(&self, lpwstrold: &::windows::core::PCWSTR, lpwstrnew: &::windows::core::PCWSTR, fallowescabort: i32, pcallback: &::core::option::Option<IAMCopyCaptureFileProgress>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ICaptureGraphBuilder {}
+#[cfg(feature = "Win32_System_Com")]
 impl ICaptureGraphBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICaptureGraphBuilder_Impl, const OFFSET: isize>() -> ICaptureGraphBuilder_Vtbl {
         unsafe extern "system" fn SetFiltergraph<Identity: ::windows::core::IUnknownImpl, Impl: ICaptureGraphBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfg: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9860,6 +10092,8 @@ pub trait ICaptureGraphBuilder2_Impl: Sized {
     fn CopyCaptureFile(&self, lpwstrold: &::windows::core::PCWSTR, lpwstrnew: &::windows::core::PCWSTR, fallowescabort: i32, pcallback: &::core::option::Option<IAMCopyCaptureFileProgress>) -> ::windows::core::Result<()>;
     fn FindPin(&self, psource: &::core::option::Option<::windows::core::IUnknown>, pindir: PIN_DIRECTION, pcategory: *const ::windows::core::GUID, ptype: *const ::windows::core::GUID, funconnected: super::super::Foundation::BOOL, num: i32) -> ::windows::core::Result<IPin>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICaptureGraphBuilder2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICaptureGraphBuilder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICaptureGraphBuilder2_Impl, const OFFSET: isize>() -> ICaptureGraphBuilder2_Vtbl {
@@ -9943,6 +10177,8 @@ pub trait IChannelIDTuneRequest_Impl: Sized + super::super::System::Com::IDispat
     fn SetChannelID(&self, channelid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IChannelIDTuneRequest {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IChannelIDTuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChannelIDTuneRequest_Impl, const OFFSET: isize>() -> IChannelIDTuneRequest_Vtbl {
         unsafe extern "system" fn ChannelID<Identity: ::windows::core::IUnknownImpl, Impl: IChannelIDTuneRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, channelid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -9976,6 +10212,8 @@ pub trait IChannelTuneRequest_Impl: Sized + super::super::System::Com::IDispatch
     fn Channel(&self) -> ::windows::core::Result<i32>;
     fn SetChannel(&self, channel: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IChannelTuneRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IChannelTuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChannelTuneRequest_Impl, const OFFSET: isize>() -> IChannelTuneRequest_Vtbl {
@@ -10017,6 +10255,8 @@ pub trait IComponent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetDescription(&self, description: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IComponent>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComponent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComponent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponent_Impl, const OFFSET: isize>() -> IComponent_Vtbl {
@@ -10132,6 +10372,8 @@ pub trait IComponentType_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SetMediaType(&self, mediatype: *const AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IComponentType>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComponentType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComponentType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentType_Impl, const OFFSET: isize>() -> IComponentType_Vtbl {
@@ -10311,6 +10553,8 @@ pub trait IComponentTypes_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Clone(&self) -> ::windows::core::Result<IComponentTypes>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComponentTypes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComponentTypes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentTypes_Impl, const OFFSET: isize>() -> IComponentTypes_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IComponentTypes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -10417,6 +10661,8 @@ pub trait IComponents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn put_Item(&self, index: &super::super::System::Com::VARIANT, ppcomponent: &::core::option::Option<IComponent>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComponents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComponents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponents_Impl, const OFFSET: isize>() -> IComponents_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IComponents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -10522,6 +10768,8 @@ pub trait IComponentsOld_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Clone(&self) -> ::windows::core::Result<IComponents>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComponentsOld {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComponentsOld_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentsOld_Impl, const OFFSET: isize>() -> IComponentsOld_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IComponentsOld_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -10622,6 +10870,8 @@ pub trait IConfigAsfWriter_Impl: Sized {
     fn GetIndexMode(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_WindowsMediaFormat"))]
+impl ::windows::core::RuntimeName for IConfigAsfWriter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_WindowsMediaFormat"))]
 impl IConfigAsfWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConfigAsfWriter_Impl, const OFFSET: isize>() -> IConfigAsfWriter_Vtbl {
         unsafe extern "system" fn ConfigureFilterUsingProfileId<Identity: ::windows::core::IUnknownImpl, Impl: IConfigAsfWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwprofileid: u32) -> ::windows::core::HRESULT {
@@ -10712,6 +10962,8 @@ pub trait IConfigAsfWriter2_Impl: Sized + IConfigAsfWriter_Impl {
     fn ResetMultiPassState(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_WindowsMediaFormat"))]
+impl ::windows::core::RuntimeName for IConfigAsfWriter2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_WindowsMediaFormat"))]
 impl IConfigAsfWriter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConfigAsfWriter2_Impl, const OFFSET: isize>() -> IConfigAsfWriter2_Vtbl {
         unsafe extern "system" fn StreamNumFromPin<Identity: ::windows::core::IUnknownImpl, Impl: IConfigAsfWriter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppin: ::windows::core::RawPtr, pwstreamnum: *mut u16) -> ::windows::core::HRESULT {
@@ -10759,6 +11011,8 @@ pub trait IConfigAviMux_Impl: Sized {
     fn SetOutputCompatibilityIndex(&self, foldindex: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetOutputCompatibilityIndex(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IConfigAviMux {}
 #[cfg(feature = "Win32_Foundation")]
 impl IConfigAviMux_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConfigAviMux_Impl, const OFFSET: isize>() -> IConfigAviMux_Vtbl {
@@ -10812,6 +11066,7 @@ pub trait IConfigInterleaving_Impl: Sized {
     fn put_Interleaving(&self, prtinterleave: *const i64, prtpreroll: *const i64) -> ::windows::core::Result<()>;
     fn get_Interleaving(&self, prtinterleave: *mut i64, prtpreroll: *mut i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IConfigInterleaving {}
 impl IConfigInterleaving_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConfigInterleaving_Impl, const OFFSET: isize>() -> IConfigInterleaving_Vtbl {
         unsafe extern "system" fn SetMode<Identity: ::windows::core::IUnknownImpl, Impl: IConfigInterleaving_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: InterleavingMode) -> ::windows::core::HRESULT {
@@ -10857,6 +11112,8 @@ pub trait ICreateDevEnum_Impl: Sized {
     fn CreateClassEnumerator(&self, clsiddeviceclass: *const ::windows::core::GUID, ppenummoniker: *mut ::core::option::Option<super::super::System::Com::IEnumMoniker>, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ICreateDevEnum {}
+#[cfg(feature = "Win32_System_Com")]
 impl ICreateDevEnum_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateDevEnum_Impl, const OFFSET: isize>() -> ICreateDevEnum_Vtbl {
         unsafe extern "system" fn CreateClassEnumerator<Identity: ::windows::core::IUnknownImpl, Impl: ICreateDevEnum_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsiddeviceclass: *const ::windows::core::GUID, ppenummoniker: *mut ::windows::core::RawPtr, dwflags: u32) -> ::windows::core::HRESULT {
@@ -10874,6 +11131,8 @@ impl ICreateDevEnum_Vtbl {
 pub trait ICreatePropBagOnRegKey_Impl: Sized {
     fn Create(&self, hkey: super::super::System::Registry::HKEY, subkey: &::windows::core::PCWSTR, uloptions: u32, samdesired: u32, iid: *const ::windows::core::GUID, ppbag: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Registry")]
+impl ::windows::core::RuntimeName for ICreatePropBagOnRegKey {}
 #[cfg(feature = "Win32_System_Registry")]
 impl ICreatePropBagOnRegKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreatePropBagOnRegKey_Impl, const OFFSET: isize>() -> ICreatePropBagOnRegKey_Vtbl {
@@ -10898,6 +11157,8 @@ pub trait IDDrawExclModeVideo_Impl: Sized {
     fn GetNativeVideoProps(&self, pdwvideowidth: *mut u32, pdwvideoheight: *mut u32, pdwpictaspectratiox: *mut u32, pdwpictaspectratioy: *mut u32) -> ::windows::core::Result<()>;
     fn SetCallbackInterface(&self, pcallback: &::core::option::Option<IDDrawExclModeVideoCallback>, dwflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IDDrawExclModeVideo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IDDrawExclModeVideo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDDrawExclModeVideo_Impl, const OFFSET: isize>() -> IDDrawExclModeVideo_Vtbl {
@@ -10958,6 +11219,8 @@ pub trait IDDrawExclModeVideoCallback_Impl: Sized {
     fn OnUpdateSize(&self, dwwidth: u32, dwheight: u32, dwarwidth: u32, dwarheight: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDDrawExclModeVideoCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDDrawExclModeVideoCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDDrawExclModeVideoCallback_Impl, const OFFSET: isize>() -> IDDrawExclModeVideoCallback_Vtbl {
         unsafe extern "system" fn OnUpdateOverlay<Identity: ::windows::core::IUnknownImpl, Impl: IDDrawExclModeVideoCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bbefore: super::super::Foundation::BOOL, dwflags: u32, boldvisible: super::super::Foundation::BOOL, prcoldsrc: *const super::super::Foundation::RECT, prcolddest: *const super::super::Foundation::RECT, bnewvisible: super::super::Foundation::BOOL, prcnewsrc: *const super::super::Foundation::RECT, prcnewdest: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -10989,6 +11252,7 @@ impl IDDrawExclModeVideoCallback_Vtbl {
 pub trait IDMOWrapperFilter_Impl: Sized {
     fn Init(&self, clsiddmo: *const ::windows::core::GUID, catdmo: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDMOWrapperFilter {}
 impl IDMOWrapperFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMOWrapperFilter_Impl, const OFFSET: isize>() -> IDMOWrapperFilter_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IDMOWrapperFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsiddmo: *const ::windows::core::GUID, catdmo: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -11007,6 +11271,8 @@ pub trait IDShowPlugin_Impl: Sized {
     fn URL(&self, purl: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn UserAgent(&self, puseragent: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDShowPlugin {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDShowPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDShowPlugin_Impl, const OFFSET: isize>() -> IDShowPlugin_Vtbl {
@@ -11041,6 +11307,8 @@ pub trait IDTFilter_Impl: Sized {
     fn BlockUnRatedDelay(&self) -> ::windows::core::Result<i32>;
     fn SetBlockUnRatedDelay(&self, msecsdelaybeforeblock: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDTFilter {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDTFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilter_Impl, const OFFSET: isize>() -> IDTFilter_Vtbl {
@@ -11131,6 +11399,8 @@ pub trait IDTFilter2_Impl: Sized + IDTFilter_Impl {
     fn GetLastErrorCode(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDTFilter2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDTFilter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilter2_Impl, const OFFSET: isize>() -> IDTFilter2_Vtbl {
         unsafe extern "system" fn ChallengeUrl<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrchallengeurl: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -11178,6 +11448,8 @@ pub trait IDTFilter3_Impl: Sized + IDTFilter_Impl + IDTFilter2_Impl {
     fn SetRights(&self, bstrrights: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDTFilter3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDTFilter3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilter3_Impl, const OFFSET: isize>() -> IDTFilter3_Vtbl {
         unsafe extern "system" fn GetProtectionType<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilter3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprotectiontype: *mut ProtType) -> ::windows::core::HRESULT {
@@ -11221,6 +11493,7 @@ impl IDTFilter3_Vtbl {
 pub trait IDTFilterConfig_Impl: Sized {
     fn GetSecureChannelObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IDTFilterConfig {}
 impl IDTFilterConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilterConfig_Impl, const OFFSET: isize>() -> IDTFilterConfig_Vtbl {
         unsafe extern "system" fn GetSecureChannelObject<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilterConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunkdrmsecurechannel: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11243,6 +11516,8 @@ impl IDTFilterConfig_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDTFilterEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDTFilterEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDTFilterEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilterEvents_Impl, const OFFSET: isize>() -> IDTFilterEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -11254,6 +11529,7 @@ impl IDTFilterEvents_Vtbl {
 pub trait IDTFilterLicenseRenewal_Impl: Sized {
     fn GetLicenseRenewalData(&self, ppwszfilename: *mut ::windows::core::PWSTR, ppwszexpiredkid: *mut ::windows::core::PWSTR, ppwsztunerid: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDTFilterLicenseRenewal {}
 impl IDTFilterLicenseRenewal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilterLicenseRenewal_Impl, const OFFSET: isize>() -> IDTFilterLicenseRenewal_Vtbl {
         unsafe extern "system" fn GetLicenseRenewalData<Identity: ::windows::core::IUnknownImpl, Impl: IDTFilterLicenseRenewal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszfilename: *mut ::windows::core::PWSTR, ppwszexpiredkid: *mut ::windows::core::PWSTR, ppwsztunerid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -11269,6 +11545,8 @@ impl IDTFilterLicenseRenewal_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBCLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl + ILocator_Impl + IDigitalLocator_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBCLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBCLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBCLocator_Impl, const OFFSET: isize>() -> IDVBCLocator_Vtbl {
@@ -11291,6 +11569,8 @@ pub trait IDVBSLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn Elevation(&self) -> ::windows::core::Result<i32>;
     fn SetElevation(&self, elevation: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBSLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBSLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBSLocator_Impl, const OFFSET: isize>() -> IDVBSLocator_Vtbl {
@@ -11409,6 +11689,8 @@ pub trait IDVBSLocator2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SignalPilot(&self) -> ::windows::core::Result<Pilot>;
     fn SetSignalPilot(&self, pilotval: Pilot) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBSLocator2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBSLocator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBSLocator2_Impl, const OFFSET: isize>() -> IDVBSLocator2_Vtbl {
@@ -11560,6 +11842,8 @@ pub trait IDVBSTuningSpace_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn SetSpectralInversion(&self, spectralinversionval: SpectralInversion) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBSTuningSpace {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBSTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBSTuningSpace_Impl, const OFFSET: isize>() -> IDVBSTuningSpace_Vtbl {
         unsafe extern "system" fn LowOscillator<Identity: ::windows::core::IUnknownImpl, Impl: IDVBSTuningSpace_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lowoscillator: *mut i32) -> ::windows::core::HRESULT {
@@ -11677,6 +11961,8 @@ pub trait IDVBTLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn OtherFrequencyInUse(&self) -> ::windows::core::Result<i16>;
     fn SetOtherFrequencyInUse(&self, otherfrequencyinuseval: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBTLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBTLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTLocator_Impl, const OFFSET: isize>() -> IDVBTLocator_Vtbl {
@@ -11820,6 +12106,8 @@ pub trait IDVBTLocator2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetPhysicalLayerPipeId(&self, physicallayerpipeidval: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBTLocator2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBTLocator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTLocator2_Impl, const OFFSET: isize>() -> IDVBTLocator2_Vtbl {
         unsafe extern "system" fn PhysicalLayerPipeId<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTLocator2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, physicallayerpipeidval: *mut i32) -> ::windows::core::HRESULT {
@@ -11857,6 +12145,8 @@ pub trait IDVBTuneRequest_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn SID(&self) -> ::windows::core::Result<i32>;
     fn SetSID(&self, sid: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBTuneRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBTuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTuneRequest_Impl, const OFFSET: isize>() -> IDVBTuneRequest_Vtbl {
@@ -11928,6 +12218,8 @@ pub trait IDVBTuningSpace_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn SetSystemType(&self, systype: DVBSystemType) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBTuningSpace {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTuningSpace_Impl, const OFFSET: isize>() -> IDVBTuningSpace_Vtbl {
         unsafe extern "system" fn SystemType<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTuningSpace_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, systype: *mut DVBSystemType) -> ::windows::core::HRESULT {
@@ -11961,6 +12253,8 @@ pub trait IDVBTuningSpace2_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn NetworkID(&self) -> ::windows::core::Result<i32>;
     fn SetNetworkID(&self, networkid: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDVBTuningSpace2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDVBTuningSpace2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVBTuningSpace2_Impl, const OFFSET: isize>() -> IDVBTuningSpace2_Vtbl {
@@ -12009,6 +12303,8 @@ pub trait IDVB_BAT_Impl: Sized {
     fn RegisterForWhenCurrent(&self, hnexttableiscurrent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_BAT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDVB_BAT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_BAT_Impl, const OFFSET: isize>() -> IDVB_BAT_Vtbl {
@@ -12176,6 +12472,8 @@ pub trait IDVB_DIT_Impl: Sized {
     fn GetTransitionFlag(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_DIT {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDVB_DIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_DIT_Impl, const OFFSET: isize>() -> IDVB_DIT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_DIT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12228,6 +12526,8 @@ pub trait IDVB_EIT_Impl: Sized {
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_EIT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDVB_EIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_EIT_Impl, const OFFSET: isize>() -> IDVB_EIT_Vtbl {
@@ -12467,6 +12767,8 @@ pub trait IDVB_EIT2_Impl: Sized + IDVB_EIT_Impl {
     fn GetRecordSection(&self, dwrecordindex: u32) -> ::windows::core::Result<u8>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_EIT2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDVB_EIT2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_EIT2_Impl, const OFFSET: isize>() -> IDVB_EIT2_Vtbl {
         unsafe extern "system" fn GetSegmentInfo<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_EIT2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbtid: *mut u8, pbsegment: *mut u8) -> ::windows::core::HRESULT {
@@ -12515,6 +12817,8 @@ pub trait IDVB_NIT_Impl: Sized {
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_NIT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDVB_NIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_NIT_Impl, const OFFSET: isize>() -> IDVB_NIT_Vtbl {
@@ -12703,6 +13007,7 @@ pub trait IDVB_RST_Impl: Sized {
     fn GetRecordEventId(&self, dwrecordindex: u32) -> ::windows::core::Result<u16>;
     fn GetRecordRunningStatus(&self, dwrecordindex: u32) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDVB_RST {}
 impl IDVB_RST_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_RST_Impl, const OFFSET: isize>() -> IDVB_RST_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_RST_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12812,6 +13117,8 @@ pub trait IDVB_SDT_Impl: Sized {
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_SDT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDVB_SDT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_SDT_Impl, const OFFSET: isize>() -> IDVB_SDT_Vtbl {
@@ -13028,6 +13335,8 @@ pub trait IDVB_SIT_Impl: Sized {
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVB_SIT {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDVB_SIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_SIT_Impl, const OFFSET: isize>() -> IDVB_SIT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_SIT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13187,6 +13496,7 @@ pub trait IDVB_ST_Impl: Sized {
     fn GetDataLength(&self) -> ::windows::core::Result<u16>;
     fn GetData(&self) -> ::windows::core::Result<*mut u8>;
 }
+impl ::windows::core::RuntimeName for IDVB_ST {}
 impl IDVB_ST_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_ST_Impl, const OFFSET: isize>() -> IDVB_ST_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_ST_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13231,6 +13541,7 @@ pub trait IDVB_TDT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>) -> ::windows::core::Result<()>;
     fn GetUTCTime(&self) -> ::windows::core::Result<MPEG_DATE_AND_TIME>;
 }
+impl ::windows::core::RuntimeName for IDVB_TDT {}
 impl IDVB_TDT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_TDT_Impl, const OFFSET: isize>() -> IDVB_TDT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_TDT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13266,6 +13577,7 @@ pub trait IDVB_TOT_Impl: Sized {
     fn GetTableDescriptorByIndex(&self, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetTableDescriptorByTag(&self, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDVB_TOT {}
 impl IDVB_TOT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_TOT_Impl, const OFFSET: isize>() -> IDVB_TOT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDVB_TOT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13328,6 +13640,7 @@ pub trait IDVEnc_Impl: Sized {
     fn get_IFormatResolution(&self, videoformat: *mut i32, dvformat: *mut i32, resolution: *mut i32, fdvinfo: u8, sdvinfo: *mut DVINFO) -> ::windows::core::Result<()>;
     fn put_IFormatResolution(&self, videoformat: i32, dvformat: i32, resolution: i32, fdvinfo: u8, sdvinfo: *const DVINFO) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDVEnc {}
 impl IDVEnc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVEnc_Impl, const OFFSET: isize>() -> IDVEnc_Vtbl {
         unsafe extern "system" fn get_IFormatResolution<Identity: ::windows::core::IUnknownImpl, Impl: IDVEnc_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, videoformat: *mut i32, dvformat: *mut i32, resolution: *mut i32, fdvinfo: u8, sdvinfo: *mut DVINFO) -> ::windows::core::HRESULT {
@@ -13355,6 +13668,8 @@ pub trait IDVRGB219_Impl: Sized {
     fn SetRGB219(&self, bstate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDVRGB219 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDVRGB219_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVRGB219_Impl, const OFFSET: isize>() -> IDVRGB219_Vtbl {
         unsafe extern "system" fn SetRGB219<Identity: ::windows::core::IUnknownImpl, Impl: IDVRGB219_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstate: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -13371,6 +13686,7 @@ impl IDVRGB219_Vtbl {
 pub trait IDVSplitter_Impl: Sized {
     fn DiscardAlternateVideoFrames(&self, ndiscard: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDVSplitter {}
 impl IDVSplitter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDVSplitter_Impl, const OFFSET: isize>() -> IDVSplitter_Vtbl {
         unsafe extern "system" fn DiscardAlternateVideoFrames<Identity: ::windows::core::IUnknownImpl, Impl: IDVSplitter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ndiscard: i32) -> ::windows::core::HRESULT {
@@ -13391,6 +13707,7 @@ pub trait IDecimateVideoImage_Impl: Sized {
     fn SetDecimationImageSize(&self, lwidth: i32, lheight: i32) -> ::windows::core::Result<()>;
     fn ResetDecimationImageSize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDecimateVideoImage {}
 impl IDecimateVideoImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDecimateVideoImage_Impl, const OFFSET: isize>() -> IDecimateVideoImage_Vtbl {
         unsafe extern "system" fn SetDecimationImageSize<Identity: ::windows::core::IUnknownImpl, Impl: IDecimateVideoImage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lwidth: i32, lheight: i32) -> ::windows::core::HRESULT {
@@ -13419,6 +13736,7 @@ pub trait IDeferredCommand_Impl: Sized {
     fn Postpone(&self, newtime: f64) -> ::windows::core::Result<()>;
     fn GetHResult(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
+impl ::windows::core::RuntimeName for IDeferredCommand {}
 impl IDeferredCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeferredCommand_Impl, const OFFSET: isize>() -> IDeferredCommand_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: IDeferredCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13468,6 +13786,8 @@ impl IDeferredCommand_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDigitalCableLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl + ILocator_Impl + IDigitalLocator_Impl + IATSCLocator_Impl + IATSCLocator2_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDigitalCableLocator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDigitalCableLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDigitalCableLocator_Impl, const OFFSET: isize>() -> IDigitalCableLocator_Vtbl {
         Self { base__: IATSCLocator2_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -13483,6 +13803,8 @@ pub trait IDigitalCableTuneRequest_Impl: Sized + super::super::System::Com::IDis
     fn SourceID(&self) -> ::windows::core::Result<i32>;
     fn SetSourceID(&self, sourceid: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDigitalCableTuneRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDigitalCableTuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDigitalCableTuneRequest_Impl, const OFFSET: isize>() -> IDigitalCableTuneRequest_Vtbl {
@@ -13541,6 +13863,8 @@ pub trait IDigitalCableTuningSpace_Impl: Sized + super::super::System::Com::IDis
     fn MaxSourceID(&self) -> ::windows::core::Result<i32>;
     fn SetMaxSourceID(&self, newmaxsourceidval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDigitalCableTuningSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDigitalCableTuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDigitalCableTuningSpace_Impl, const OFFSET: isize>() -> IDigitalCableTuningSpace_Vtbl {
@@ -13627,6 +13951,8 @@ impl IDigitalCableTuningSpace_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDigitalLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl + ILocator_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDigitalLocator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDigitalLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDigitalLocator_Impl, const OFFSET: isize>() -> IDigitalLocator_Vtbl {
         Self { base__: ILocator_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -13640,6 +13966,8 @@ pub trait IDirectDrawMediaSample_Impl: Sized {
     fn GetSurfaceAndReleaseLock(&self, ppdirectdrawsurface: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface>, prect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
     fn LockMediaSamplePointer(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IDirectDrawMediaSample {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IDirectDrawMediaSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawMediaSample_Impl, const OFFSET: isize>() -> IDirectDrawMediaSample_Vtbl {
@@ -13667,6 +13995,8 @@ impl IDirectDrawMediaSample_Vtbl {
 pub trait IDirectDrawMediaSampleAllocator_Impl: Sized {
     fn GetDirectDraw(&self) -> ::windows::core::Result<super::super::Graphics::DirectDraw::IDirectDraw>;
 }
+#[cfg(feature = "Win32_Graphics_DirectDraw")]
+impl ::windows::core::RuntimeName for IDirectDrawMediaSampleAllocator {}
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 impl IDirectDrawMediaSampleAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawMediaSampleAllocator_Impl, const OFFSET: isize>() -> IDirectDrawMediaSampleAllocator_Vtbl {
@@ -13696,6 +14026,8 @@ pub trait IDirectDrawMediaStream_Impl: Sized + IMediaStream_Impl {
     fn CreateSample(&self, psurface: &::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface>, prect: *const super::super::Foundation::RECT, dwflags: u32) -> ::windows::core::Result<IDirectDrawStreamSample>;
     fn GetTimePerFrame(&self) -> ::windows::core::Result<i64>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IDirectDrawMediaStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IDirectDrawMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawMediaStream_Impl, const OFFSET: isize>() -> IDirectDrawMediaStream_Vtbl {
@@ -13767,6 +14099,8 @@ pub trait IDirectDrawStreamSample_Impl: Sized + IStreamSample_Impl {
     fn SetRect(&self, prect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IDirectDrawStreamSample {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IDirectDrawStreamSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawStreamSample_Impl, const OFFSET: isize>() -> IDirectDrawStreamSample_Vtbl {
         unsafe extern "system" fn GetSurface<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawStreamSample_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdirectdrawsurface: *mut ::windows::core::RawPtr, prect: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -13808,6 +14142,8 @@ pub trait IDirectDrawVideo_Impl: Sized {
     fn UseWhenFullScreen(&self, usewhenfullscreen: i32) -> ::windows::core::Result<()>;
     fn WillUseFullScreen(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_Graphics_DirectDraw")]
+impl ::windows::core::RuntimeName for IDirectDrawVideo {}
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 impl IDirectDrawVideo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectDrawVideo_Impl, const OFFSET: isize>() -> IDirectDrawVideo_Vtbl {
@@ -13970,6 +14306,7 @@ pub trait IDistributorNotify_Impl: Sized {
     fn SetSyncSource(&self, pclock: &::core::option::Option<super::IReferenceClock>) -> ::windows::core::Result<()>;
     fn NotifyGraphChange(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDistributorNotify {}
 impl IDistributorNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDistributorNotify_Impl, const OFFSET: isize>() -> IDistributorNotify_Vtbl {
         unsafe extern "system" fn Stop<Identity: ::windows::core::IUnknownImpl, Impl: IDistributorNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14017,6 +14354,8 @@ pub trait IDrawVideoImage_Impl: Sized {
     fn DrawVideoImageDraw(&self, hdc: super::super::Graphics::Gdi::HDC, lprcsrc: *const super::super::Foundation::RECT, lprcdst: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IDrawVideoImage {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IDrawVideoImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDrawVideoImage_Impl, const OFFSET: isize>() -> IDrawVideoImage_Vtbl {
         unsafe extern "system" fn DrawVideoImageBegin<Identity: ::windows::core::IUnknownImpl, Impl: IDrawVideoImage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14054,6 +14393,7 @@ pub trait IDvbCableDeliverySystemDescriptor_Impl: Sized {
     fn GetSymbolRate(&self) -> ::windows::core::Result<u32>;
     fn GetFECInner(&self) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDvbCableDeliverySystemDescriptor {}
 impl IDvbCableDeliverySystemDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbCableDeliverySystemDescriptor_Impl, const OFFSET: isize>() -> IDvbCableDeliverySystemDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbCableDeliverySystemDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14159,6 +14499,8 @@ pub trait IDvbComponentDescriptor_Impl: Sized {
     fn GetTextW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbComponentDescriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDvbComponentDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbComponentDescriptor_Impl, const OFFSET: isize>() -> IDvbComponentDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbComponentDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14254,6 +14596,7 @@ pub trait IDvbContentDescriptor_Impl: Sized {
     fn GetRecordContentNibbles(&self, brecordindex: u8, pbvallevel1: *mut u8, pbvallevel2: *mut u8) -> ::windows::core::Result<()>;
     fn GetRecordUserNibbles(&self, brecordindex: u8, pbval1: *mut u8, pbval2: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbContentDescriptor {}
 impl IDvbContentDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbContentDescriptor_Impl, const OFFSET: isize>() -> IDvbContentDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbContentDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14318,6 +14661,7 @@ pub trait IDvbContentIdentifierDescriptor_Impl: Sized {
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u8>;
     fn GetRecordCrid(&self, brecordindex: u8, pbtype: *mut u8, pblocation: *mut u8, pblength: *mut u8, ppbbytes: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbContentIdentifierDescriptor {}
 impl IDvbContentIdentifierDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbContentIdentifierDescriptor_Impl, const OFFSET: isize>() -> IDvbContentIdentifierDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbContentIdentifierDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14381,6 +14725,7 @@ pub trait IDvbDataBroadcastDescriptor_Impl: Sized {
     fn GetTextLength(&self) -> ::windows::core::Result<u8>;
     fn GetText(&self, pblen: *mut u8, pbval: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbDataBroadcastDescriptor {}
 impl IDvbDataBroadcastDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbDataBroadcastDescriptor_Impl, const OFFSET: isize>() -> IDvbDataBroadcastDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbDataBroadcastDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14493,6 +14838,7 @@ pub trait IDvbDataBroadcastIDDescriptor_Impl: Sized {
     fn GetDataBroadcastID(&self) -> ::windows::core::Result<u16>;
     fn GetIDSelectorBytes(&self, pblen: *mut u8, pbval: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbDataBroadcastIDDescriptor {}
 impl IDvbDataBroadcastIDDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbDataBroadcastIDDescriptor_Impl, const OFFSET: isize>() -> IDvbDataBroadcastIDDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbDataBroadcastIDDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14550,6 +14896,7 @@ pub trait IDvbDefaultAuthorityDescriptor_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u8>;
     fn GetDefaultAuthority(&self, pblength: *mut u8, ppbbytes: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbDefaultAuthorityDescriptor {}
 impl IDvbDefaultAuthorityDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbDefaultAuthorityDescriptor_Impl, const OFFSET: isize>() -> IDvbDefaultAuthorityDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbDefaultAuthorityDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14604,6 +14951,8 @@ pub trait IDvbExtendedEventDescriptor_Impl: Sized {
     fn GetConcatenatedTextW(&self, followingdescriptor: &::core::option::Option<IDvbExtendedEventDescriptor>, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetRecordItemRawBytes(&self, brecordindex: u8, ppbrawitem: *mut *mut u8, pbitemlength: *mut u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbExtendedEventDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvbExtendedEventDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbExtendedEventDescriptor_Impl, const OFFSET: isize>() -> IDvbExtendedEventDescriptor_Vtbl {
@@ -14730,6 +15079,7 @@ pub trait IDvbFrequencyListDescriptor_Impl: Sized {
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u8>;
     fn GetRecordCentreFrequency(&self, brecordindex: u8) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IDvbFrequencyListDescriptor {}
 impl IDvbFrequencyListDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbFrequencyListDescriptor_Impl, const OFFSET: isize>() -> IDvbFrequencyListDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbFrequencyListDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14801,6 +15151,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
     }
 }
 pub trait IDvbHDSimulcastLogicalChannelDescriptor_Impl: Sized + IDvbLogicalChannelDescriptor_Impl + IDvbLogicalChannelDescriptor2_Impl {}
+impl ::windows::core::RuntimeName for IDvbHDSimulcastLogicalChannelDescriptor {}
 impl IDvbHDSimulcastLogicalChannelDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbHDSimulcastLogicalChannelDescriptor_Impl, const OFFSET: isize>() -> IDvbHDSimulcastLogicalChannelDescriptor_Vtbl {
         Self { base__: IDvbLogicalChannelDescriptor2_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -14819,6 +15170,7 @@ pub trait IDvbLinkageDescriptor_Impl: Sized {
     fn GetPrivateDataLength(&self) -> ::windows::core::Result<u8>;
     fn GetPrivateData(&self, pblen: *mut u8, pbdata: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbLinkageDescriptor {}
 impl IDvbLinkageDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLinkageDescriptor_Impl, const OFFSET: isize>() -> IDvbLinkageDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLinkageDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -14931,6 +15283,8 @@ pub trait IDvbLogicalChannel2Descriptor_Impl: Sized + IDvbLogicalChannelDescript
     fn GetListRecordLogicalChannelAndVisibility(&self, blistindex: u8, brecordindex: u8) -> ::windows::core::Result<u16>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbLogicalChannel2Descriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDvbLogicalChannel2Descriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLogicalChannel2Descriptor_Impl, const OFFSET: isize>() -> IDvbLogicalChannel2Descriptor_Vtbl {
         unsafe extern "system" fn GetCountOfLists<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLogicalChannel2Descriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15038,6 +15392,7 @@ pub trait IDvbLogicalChannelDescriptor_Impl: Sized {
     fn GetRecordServiceId(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
     fn GetRecordLogicalChannelNumber(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IDvbLogicalChannelDescriptor {}
 impl IDvbLogicalChannelDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLogicalChannelDescriptor_Impl, const OFFSET: isize>() -> IDvbLogicalChannelDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLogicalChannelDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15111,6 +15466,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
 pub trait IDvbLogicalChannelDescriptor2_Impl: Sized + IDvbLogicalChannelDescriptor_Impl {
     fn GetRecordLogicalChannelAndVisibility(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IDvbLogicalChannelDescriptor2 {}
 impl IDvbLogicalChannelDescriptor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLogicalChannelDescriptor2_Impl, const OFFSET: isize>() -> IDvbLogicalChannelDescriptor2_Vtbl {
         unsafe extern "system" fn GetRecordLogicalChannelAndVisibility<Identity: ::windows::core::IUnknownImpl, Impl: IDvbLogicalChannelDescriptor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, brecordindex: u8, pwval: *mut u16) -> ::windows::core::HRESULT {
@@ -15142,6 +15498,8 @@ pub trait IDvbMultilingualServiceNameDescriptor_Impl: Sized {
     fn GetRecordServiceProviderNameW(&self, brecordindex: u8, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetRecordServiceNameW(&self, brecordindex: u8, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbMultilingualServiceNameDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvbMultilingualServiceNameDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbMultilingualServiceNameDescriptor_Impl, const OFFSET: isize>() -> IDvbMultilingualServiceNameDescriptor_Vtbl {
@@ -15233,6 +15591,8 @@ pub trait IDvbNetworkNameDescriptor_Impl: Sized {
     fn GetNetworkNameW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbNetworkNameDescriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDvbNetworkNameDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbNetworkNameDescriptor_Impl, const OFFSET: isize>() -> IDvbNetworkNameDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbNetworkNameDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15297,6 +15657,7 @@ pub trait IDvbParentalRatingDescriptor_Impl: Sized {
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u8>;
     fn GetRecordRating(&self, brecordindex: u8, pszcountrycode: *mut u8, pbval: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvbParentalRatingDescriptor {}
 impl IDvbParentalRatingDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbParentalRatingDescriptor_Impl, const OFFSET: isize>() -> IDvbParentalRatingDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbParentalRatingDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15354,6 +15715,7 @@ pub trait IDvbPrivateDataSpecifierDescriptor_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u8>;
     fn GetPrivateDataSpecifier(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IDvbPrivateDataSpecifierDescriptor {}
 impl IDvbPrivateDataSpecifierDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbPrivateDataSpecifierDescriptor_Impl, const OFFSET: isize>() -> IDvbPrivateDataSpecifierDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbPrivateDataSpecifierDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15411,6 +15773,7 @@ pub trait IDvbSatelliteDeliverySystemDescriptor_Impl: Sized {
     fn GetSymbolRate(&self) -> ::windows::core::Result<u32>;
     fn GetFECInner(&self) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDvbSatelliteDeliverySystemDescriptor {}
 impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSatelliteDeliverySystemDescriptor_Impl, const OFFSET: isize>() -> IDvbSatelliteDeliverySystemDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSatelliteDeliverySystemDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15539,6 +15902,8 @@ pub trait IDvbServiceAttributeDescriptor_Impl: Sized {
     fn GetRecordVisibleServiceFlag(&self, brecordindex: u8) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbServiceAttributeDescriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDvbServiceAttributeDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceAttributeDescriptor_Impl, const OFFSET: isize>() -> IDvbServiceAttributeDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceAttributeDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15632,6 +15997,8 @@ pub trait IDvbServiceDescriptor_Impl: Sized {
     fn GetProcessedServiceName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetServiceNameEmphasized(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbServiceDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvbServiceDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceDescriptor_Impl, const OFFSET: isize>() -> IDvbServiceDescriptor_Vtbl {
@@ -15745,6 +16112,8 @@ pub trait IDvbServiceDescriptor2_Impl: Sized + IDvbServiceDescriptor_Impl {
     fn GetServiceNameW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbServiceDescriptor2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDvbServiceDescriptor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceDescriptor2_Impl, const OFFSET: isize>() -> IDvbServiceDescriptor2_Vtbl {
         unsafe extern "system" fn GetServiceProviderNameW2<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceDescriptor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, convmode: DVB_STRCONV_MODE, pbstrname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -15786,6 +16155,7 @@ pub trait IDvbServiceListDescriptor_Impl: Sized {
     fn GetRecordServiceId(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
     fn GetRecordServiceType(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDvbServiceListDescriptor {}
 impl IDvbServiceListDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceListDescriptor_Impl, const OFFSET: isize>() -> IDvbServiceListDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbServiceListDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -15864,6 +16234,8 @@ pub trait IDvbShortEventDescriptor_Impl: Sized {
     fn GetEventNameW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetTextW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvbShortEventDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvbShortEventDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbShortEventDescriptor_Impl, const OFFSET: isize>() -> IDvbShortEventDescriptor_Vtbl {
@@ -15946,6 +16318,7 @@ pub trait IDvbSiParser_Impl: Sized {
     fn GetDIT(&self, dwtimeout: u32) -> ::windows::core::Result<IDVB_DIT>;
     fn GetSIT(&self, dwtimeout: u32) -> ::windows::core::Result<IDVB_SIT>;
 }
+impl ::windows::core::RuntimeName for IDvbSiParser {}
 impl IDvbSiParser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSiParser_Impl, const OFFSET: isize>() -> IDvbSiParser_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSiParser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkmpeg2data: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -16133,6 +16506,7 @@ impl IDvbSiParser_Vtbl {
 pub trait IDvbSiParser2_Impl: Sized + IDvbSiParser_Impl {
     fn GetEIT2(&self, tableid: u8, pwserviceid: *const u16, pbsegment: *const u8) -> ::windows::core::Result<IDVB_EIT2>;
 }
+impl ::windows::core::RuntimeName for IDvbSiParser2 {}
 impl IDvbSiParser2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSiParser2_Impl, const OFFSET: isize>() -> IDvbSiParser2_Vtbl {
         unsafe extern "system" fn GetEIT2<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSiParser2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tableid: u8, pwserviceid: *const u16, pbsegment: *const u8, ppeit: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -16161,6 +16535,7 @@ pub trait IDvbSubtitlingDescriptor_Impl: Sized {
     fn GetRecordCompositionPageID(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
     fn GetRecordAncillaryPageID(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IDvbSubtitlingDescriptor {}
 impl IDvbSubtitlingDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSubtitlingDescriptor_Impl, const OFFSET: isize>() -> IDvbSubtitlingDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbSubtitlingDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -16264,6 +16639,7 @@ pub trait IDvbTeletextDescriptor_Impl: Sized {
     fn GetRecordMagazineNumber(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
     fn GetRecordPageNumber(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDvbTeletextDescriptor {}
 impl IDvbTeletextDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbTeletextDescriptor_Impl, const OFFSET: isize>() -> IDvbTeletextDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbTeletextDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -16373,6 +16749,7 @@ pub trait IDvbTerrestrial2DeliverySystemDescriptor_Impl: Sized {
     fn GetOtherFrequencyFlag(&self) -> ::windows::core::Result<u8>;
     fn GetTFSFlag(&self) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDvbTerrestrial2DeliverySystemDescriptor {}
 impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbTerrestrial2DeliverySystemDescriptor_Impl, const OFFSET: isize>() -> IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbTerrestrial2DeliverySystemDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -16552,6 +16929,7 @@ pub trait IDvbTerrestrialDeliverySystemDescriptor_Impl: Sized {
     fn GetTransmissionMode(&self) -> ::windows::core::Result<u8>;
     fn GetOtherFrequencyFlag(&self) -> ::windows::core::Result<u8>;
 }
+impl ::windows::core::RuntimeName for IDvbTerrestrialDeliverySystemDescriptor {}
 impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvbTerrestrialDeliverySystemDescriptor_Impl, const OFFSET: isize>() -> IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IDvbTerrestrialDeliverySystemDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -16698,6 +17076,7 @@ pub trait IDvdCmd_Impl: Sized {
     fn WaitForStart(&self) -> ::windows::core::Result<()>;
     fn WaitForEnd(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDvdCmd {}
 impl IDvdCmd_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdCmd_Impl, const OFFSET: isize>() -> IDvdCmd_Vtbl {
         unsafe extern "system" fn WaitForStart<Identity: ::windows::core::IUnknownImpl, Impl: IDvdCmd_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -16758,6 +17137,8 @@ pub trait IDvdControl_Impl: Sized {
     fn MouseSelect(&self, point: &super::super::Foundation::POINT) -> ::windows::core::Result<()>;
     fn ChapterPlayAutoStop(&self, ultitle: u32, ulchapter: u32, ulchapterstoplay: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvdControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvdControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdControl_Impl, const OFFSET: isize>() -> IDvdControl_Vtbl {
@@ -17022,6 +17403,8 @@ pub trait IDvdControl2_Impl: Sized {
     fn SelectDefaultAudioLanguage(&self, language: u32, audioextension: DVD_AUDIO_LANG_EXT) -> ::windows::core::Result<()>;
     fn SelectDefaultSubpictureLanguage(&self, language: u32, subpictureextension: DVD_SUBPICTURE_LANG_EXT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvdControl2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvdControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdControl2_Impl, const OFFSET: isize>() -> IDvdControl2_Vtbl {
@@ -17388,6 +17771,8 @@ pub trait IDvdGraphBuilder_Impl: Sized {
     fn RenderDvdVideoVolume(&self, lpcwszpathname: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<AM_DVD_RENDERSTATUS>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvdGraphBuilder {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDvdGraphBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdGraphBuilder_Impl, const OFFSET: isize>() -> IDvdGraphBuilder_Vtbl {
         unsafe extern "system" fn GetFiltergraph<Identity: ::windows::core::IUnknownImpl, Impl: IDvdGraphBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppgb: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -17454,6 +17839,8 @@ pub trait IDvdInfo_Impl: Sized {
     fn GetTitleParentalLevels(&self, ultitle: u32) -> ::windows::core::Result<u32>;
     fn GetRoot(&self, proot: ::windows::core::PSTR, ulbufsize: u32, pulactualsize: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvdInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvdInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdInfo_Impl, const OFFSET: isize>() -> IDvdInfo_Vtbl {
@@ -17729,6 +18116,8 @@ pub trait IDvdInfo2_Impl: Sized {
     fn GetButtonRect(&self, ulbutton: u32) -> ::windows::core::Result<super::super::Foundation::RECT>;
     fn IsSubpictureStreamEnabled(&self, ulstreamnum: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDvdInfo2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDvdInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdInfo2_Impl, const OFFSET: isize>() -> IDvdInfo2_Vtbl {
@@ -18122,6 +18511,7 @@ pub trait IDvdState_Impl: Sized {
     fn GetDiscID(&self) -> ::windows::core::Result<u64>;
     fn GetParentalLevel(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IDvdState {}
 impl IDvdState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDvdState_Impl, const OFFSET: isize>() -> IDvdState_Vtbl {
         unsafe extern "system" fn GetDiscID<Identity: ::windows::core::IUnknownImpl, Impl: IDvdState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulluniqueid: *mut u64) -> ::windows::core::HRESULT {
@@ -18161,6 +18551,8 @@ pub trait IESCloseMmiEvent_Impl: Sized + IESEvent_Impl {
     fn GetDialogNumber(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESCloseMmiEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESCloseMmiEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESCloseMmiEvent_Impl, const OFFSET: isize>() -> IESCloseMmiEvent_Vtbl {
         unsafe extern "system" fn GetDialogNumber<Identity: ::windows::core::IUnknownImpl, Impl: IESCloseMmiEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdialognumber: *mut u32) -> ::windows::core::HRESULT {
@@ -18188,6 +18580,8 @@ pub trait IESEvent_Impl: Sized {
     fn GetData(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetStringData(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESEvent_Impl, const OFFSET: isize>() -> IESEvent_Vtbl {
@@ -18258,6 +18652,8 @@ pub trait IESEventFactory_Impl: Sized {
     fn CreateESEvent(&self, pserviceprovider: &::core::option::Option<::windows::core::IUnknown>, dweventid: u32, guideventtype: &::windows::core::GUID, dweventdatalength: u32, peventdata: *const u8, bstrbaseurl: &super::super::Foundation::BSTR, pinitcontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IESEvent>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IESEventFactory {}
+#[cfg(feature = "Win32_Foundation")]
 impl IESEventFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESEventFactory_Impl, const OFFSET: isize>() -> IESEventFactory_Vtbl {
         unsafe extern "system" fn CreateESEvent<Identity: ::windows::core::IUnknownImpl, Impl: IESEventFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pserviceprovider: *mut ::core::ffi::c_void, dweventid: u32, guideventtype: ::windows::core::GUID, dweventdatalength: u32, peventdata: *const u8, bstrbaseurl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pinitcontext: *mut ::core::ffi::c_void, ppesevent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18280,6 +18676,7 @@ impl IESEventFactory_Vtbl {
 pub trait IESEventService_Impl: Sized {
     fn FireESEvent(&self, pesevent: &::core::option::Option<IESEvent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IESEventService {}
 impl IESEventService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESEventService_Impl, const OFFSET: isize>() -> IESEventService_Vtbl {
         unsafe extern "system" fn FireESEvent<Identity: ::windows::core::IUnknownImpl, Impl: IESEventService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pesevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18301,6 +18698,7 @@ pub trait IESEventServiceConfiguration_Impl: Sized {
     fn SetGraph(&self, pgraph: &::core::option::Option<IFilterGraph>) -> ::windows::core::Result<()>;
     fn RemoveGraph(&self, pgraph: &::core::option::Option<IFilterGraph>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IESEventServiceConfiguration {}
 impl IESEventServiceConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESEventServiceConfiguration_Impl, const OFFSET: isize>() -> IESEventServiceConfiguration_Vtbl {
         unsafe extern "system" fn SetParent<Identity: ::windows::core::IUnknownImpl, Impl: IESEventServiceConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventservice: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18350,6 +18748,7 @@ impl IESEventServiceConfiguration_Vtbl {
 pub trait IESEvents_Impl: Sized {
     fn OnESEventReceived(&self, guideventtype: &::windows::core::GUID, pesevent: &::core::option::Option<IESEvent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IESEvents {}
 impl IESEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESEvents_Impl, const OFFSET: isize>() -> IESEvents_Vtbl {
         unsafe extern "system" fn OnESEventReceived<Identity: ::windows::core::IUnknownImpl, Impl: IESEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guideventtype: ::windows::core::GUID, pesevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18372,6 +18771,8 @@ pub trait IESFileExpiryDateEvent_Impl: Sized + IESEvent_Impl {
     fn IsEntitlementTokenPresent(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn DoesExpireAfterFirstUse(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESFileExpiryDateEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESFileExpiryDateEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESFileExpiryDateEvent_Impl, const OFFSET: isize>() -> IESFileExpiryDateEvent_Vtbl {
@@ -18463,6 +18864,8 @@ pub trait IESIsdbCasResponseEvent_Impl: Sized + IESEvent_Impl {
     fn GetResponseData(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESIsdbCasResponseEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESIsdbCasResponseEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESIsdbCasResponseEvent_Impl, const OFFSET: isize>() -> IESIsdbCasResponseEvent_Vtbl {
         unsafe extern "system" fn GetRequestId<Identity: ::windows::core::IUnknownImpl, Impl: IESIsdbCasResponseEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prequestid: *mut u32) -> ::windows::core::HRESULT {
@@ -18535,6 +18938,8 @@ pub trait IESLicenseRenewalResultEvent_Impl: Sized + IESEvent_Impl {
     fn GetEntitlementToken(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetExpiryDate(&self) -> ::windows::core::Result<u64>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESLicenseRenewalResultEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESLicenseRenewalResultEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESLicenseRenewalResultEvent_Impl, const OFFSET: isize>() -> IESLicenseRenewalResultEvent_Vtbl {
@@ -18686,6 +19091,8 @@ pub trait IESOpenMmiEvent_Impl: Sized + IESEvent_Impl {
     fn GetDialogStringData(&self, pbstrbaseurl: *mut super::super::Foundation::BSTR, pbstrdata: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESOpenMmiEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESOpenMmiEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESOpenMmiEvent_Impl, const OFFSET: isize>() -> IESOpenMmiEvent_Vtbl {
         unsafe extern "system" fn GetDialogNumber<Identity: ::windows::core::IUnknownImpl, Impl: IESOpenMmiEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdialogrequest: *mut u32, pdialognumber: *mut u32) -> ::windows::core::HRESULT {
@@ -18739,6 +19146,8 @@ pub trait IESRequestTunerEvent_Impl: Sized + IESEvent_Impl {
     fn GetConsequences(&self) -> ::windows::core::Result<u8>;
     fn GetEstimatedTime(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESRequestTunerEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESRequestTunerEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESRequestTunerEvent_Impl, const OFFSET: isize>() -> IESRequestTunerEvent_Vtbl {
@@ -18803,6 +19212,8 @@ pub trait IESValueUpdatedEvent_Impl: Sized + IESEvent_Impl {
     fn GetValueNames(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IESValueUpdatedEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IESValueUpdatedEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IESValueUpdatedEvent_Impl, const OFFSET: isize>() -> IESValueUpdatedEvent_Vtbl {
         unsafe extern "system" fn GetValueNames<Identity: ::windows::core::IUnknownImpl, Impl: IESValueUpdatedEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrnames: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -18830,6 +19241,8 @@ pub trait IETFilter_Impl: Sized {
     fn GetLastErrorCode(&self) -> ::windows::core::Result<()>;
     fn SetRecordingOn(&self, frecstate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IETFilter {}
 #[cfg(feature = "Win32_Foundation")]
 impl IETFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IETFilter_Impl, const OFFSET: isize>() -> IETFilter_Vtbl {
@@ -18887,6 +19300,7 @@ pub trait IETFilterConfig_Impl: Sized {
     fn InitLicense(&self, licenseid: i32) -> ::windows::core::Result<()>;
     fn GetSecureChannelObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IETFilterConfig {}
 impl IETFilterConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IETFilterConfig_Impl, const OFFSET: isize>() -> IETFilterConfig_Vtbl {
         unsafe extern "system" fn InitLicense<Identity: ::windows::core::IUnknownImpl, Impl: IETFilterConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, licenseid: i32) -> ::windows::core::HRESULT {
@@ -18918,6 +19332,8 @@ impl IETFilterConfig_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IETFilterEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IETFilterEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IETFilterEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IETFilterEvents_Impl, const OFFSET: isize>() -> IETFilterEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -18936,6 +19352,8 @@ pub trait IEncoderAPI_Impl: Sized {
     fn GetValue(&self, api: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetValue(&self, api: *const ::windows::core::GUID, value: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEncoderAPI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEncoderAPI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEncoderAPI_Impl, const OFFSET: isize>() -> IEncoderAPI_Vtbl {
@@ -19009,6 +19427,8 @@ pub trait IEnumComponentTypes_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumComponentTypes>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumComponentTypes {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumComponentTypes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumComponentTypes_Impl, const OFFSET: isize>() -> IEnumComponentTypes_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumComponentTypes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -19056,6 +19476,8 @@ pub trait IEnumComponents_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumComponents>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumComponents {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumComponents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumComponents_Impl, const OFFSET: isize>() -> IEnumComponents_Vtbl {
@@ -19105,6 +19527,8 @@ pub trait IEnumFilters_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumFilters>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumFilters {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumFilters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFilters_Impl, const OFFSET: isize>() -> IEnumFilters_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFilters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cfilters: u32, ppfilter: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -19151,6 +19575,7 @@ pub trait IEnumGuideDataProperties_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumGuideDataProperties>;
 }
+impl ::windows::core::RuntimeName for IEnumGuideDataProperties {}
 impl IEnumGuideDataProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumGuideDataProperties_Impl, const OFFSET: isize>() -> IEnumGuideDataProperties_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumGuideDataProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppprop: *mut ::windows::core::RawPtr, pcelt: *mut u32) -> ::windows::core::HRESULT {
@@ -19198,6 +19623,8 @@ pub trait IEnumMSVidGraphSegment_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumMSVidGraphSegment>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumMSVidGraphSegment {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumMSVidGraphSegment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMSVidGraphSegment_Impl, const OFFSET: isize>() -> IEnumMSVidGraphSegment_Vtbl {
@@ -19247,6 +19674,8 @@ pub trait IEnumMediaTypes_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumMediaTypes>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumMediaTypes {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumMediaTypes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMediaTypes_Impl, const OFFSET: isize>() -> IEnumMediaTypes_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMediaTypes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cmediatypes: u32, ppmediatypes: *mut *mut AM_MEDIA_TYPE, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -19293,6 +19722,7 @@ pub trait IEnumPIDMap_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumPIDMap>;
 }
+impl ::windows::core::RuntimeName for IEnumPIDMap {}
 impl IEnumPIDMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPIDMap_Impl, const OFFSET: isize>() -> IEnumPIDMap_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPIDMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32, ppidmap: *mut PID_MAP, pcreceived: *mut u32) -> ::windows::core::HRESULT {
@@ -19339,6 +19769,7 @@ pub trait IEnumPins_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumPins>;
 }
+impl ::windows::core::RuntimeName for IEnumPins {}
 impl IEnumPins_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPins_Impl, const OFFSET: isize>() -> IEnumPins_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPins_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cpins: u32, pppins: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -19385,6 +19816,7 @@ pub trait IEnumRegFilters_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumRegFilters>;
 }
+impl ::windows::core::RuntimeName for IEnumRegFilters {}
 impl IEnumRegFilters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRegFilters_Impl, const OFFSET: isize>() -> IEnumRegFilters_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRegFilters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cfilters: u32, apregfilter: *mut *mut REGFILTER, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -19431,6 +19863,7 @@ pub trait IEnumStreamBufferRecordingAttrib_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumStreamBufferRecordingAttrib>;
 }
+impl ::windows::core::RuntimeName for IEnumStreamBufferRecordingAttrib {}
 impl IEnumStreamBufferRecordingAttrib_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumStreamBufferRecordingAttrib_Impl, const OFFSET: isize>() -> IEnumStreamBufferRecordingAttrib_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumStreamBufferRecordingAttrib_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32, pstreambufferattribute: *mut STREAMBUFFER_ATTRIBUTE, pcreceived: *mut u32) -> ::windows::core::HRESULT {
@@ -19477,6 +19910,7 @@ pub trait IEnumStreamIdMap_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumStreamIdMap>;
 }
+impl ::windows::core::RuntimeName for IEnumStreamIdMap {}
 impl IEnumStreamIdMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumStreamIdMap_Impl, const OFFSET: isize>() -> IEnumStreamIdMap_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumStreamIdMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32, pstreamidmap: *mut STREAM_ID_MAP, pcreceived: *mut u32) -> ::windows::core::HRESULT {
@@ -19525,6 +19959,8 @@ pub trait IEnumTuneRequests_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTuneRequests>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumTuneRequests {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumTuneRequests_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTuneRequests_Impl, const OFFSET: isize>() -> IEnumTuneRequests_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTuneRequests_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppprop: *mut ::windows::core::RawPtr, pcelt: *mut u32) -> ::windows::core::HRESULT {
@@ -19572,6 +20008,8 @@ pub trait IEnumTuningSpaces_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumTuningSpaces>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumTuningSpaces {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumTuningSpaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTuningSpaces_Impl, const OFFSET: isize>() -> IEnumTuningSpaces_Vtbl {
@@ -19622,6 +20060,8 @@ pub trait IEvalRat_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MostRestrictiveRating(&self, ensystem1: EnTvRat_System, enenlevel1: EnTvRat_GenericLevel, lbfenattr1: i32, ensystem2: EnTvRat_System, enenlevel2: EnTvRat_GenericLevel, lbfenattr2: i32, pensystem: *mut EnTvRat_System, penenlevel: *mut EnTvRat_GenericLevel, plbfenattr: *mut i32) -> ::windows::core::Result<()>;
     fn TestRating(&self, enshowsystem: EnTvRat_System, enshowlevel: EnTvRat_GenericLevel, lbfenshowattributes: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEvalRat {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEvalRat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEvalRat_Impl, const OFFSET: isize>() -> IEvalRat_Vtbl {
@@ -19687,6 +20127,8 @@ pub trait IFileSinkFilter_Impl: Sized {
     fn GetCurFile(&self, ppszfilename: *mut ::windows::core::PWSTR, pmt: *mut AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileSinkFilter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFileSinkFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSinkFilter_Impl, const OFFSET: isize>() -> IFileSinkFilter_Vtbl {
         unsafe extern "system" fn SetFileName<Identity: ::windows::core::IUnknownImpl, Impl: IFileSinkFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfilename: ::windows::core::PCWSTR, pmt: *const AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -19714,6 +20156,8 @@ pub trait IFileSinkFilter2_Impl: Sized + IFileSinkFilter_Impl {
     fn SetMode(&self, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetMode(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileSinkFilter2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFileSinkFilter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSinkFilter2_Impl, const OFFSET: isize>() -> IFileSinkFilter2_Vtbl {
@@ -19749,6 +20193,8 @@ pub trait IFileSourceFilter_Impl: Sized {
     fn GetCurFile(&self, ppszfilename: *mut ::windows::core::PWSTR, pmt: *mut AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileSourceFilter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFileSourceFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSourceFilter_Impl, const OFFSET: isize>() -> IFileSourceFilter_Vtbl {
         unsafe extern "system" fn Load<Identity: ::windows::core::IUnknownImpl, Impl: IFileSourceFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfilename: ::windows::core::PCWSTR, pmt: *const AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -19778,6 +20224,8 @@ pub trait IFilterChain_Impl: Sized {
     fn StopChain(&self, pstartfilter: &::core::option::Option<IBaseFilter>, pendfilter: &::core::option::Option<IBaseFilter>) -> ::windows::core::Result<()>;
     fn RemoveChain(&self, pstartfilter: &::core::option::Option<IBaseFilter>, pendfilter: &::core::option::Option<IBaseFilter>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IFilterChain {}
 #[cfg(feature = "Win32_System_Com")]
 impl IFilterChain_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterChain_Impl, const OFFSET: isize>() -> IFilterChain_Vtbl {
@@ -19824,6 +20272,8 @@ pub trait IFilterGraph_Impl: Sized {
     fn Disconnect(&self, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<()>;
     fn SetDefaultSyncSource(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFilterGraph {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFilterGraph_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterGraph_Impl, const OFFSET: isize>() -> IFilterGraph_Vtbl {
@@ -19902,6 +20352,8 @@ pub trait IFilterGraph2_Impl: Sized + IFilterGraph_Impl + IGraphBuilder_Impl {
     fn RenderEx(&self, ppinout: &::core::option::Option<IPin>, dwflags: u32, pvcontext: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFilterGraph2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFilterGraph2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterGraph2_Impl, const OFFSET: isize>() -> IFilterGraph2_Vtbl {
         unsafe extern "system" fn AddSourceFilterForMoniker<Identity: ::windows::core::IUnknownImpl, Impl: IFilterGraph2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmoniker: ::windows::core::RawPtr, pctx: ::windows::core::RawPtr, lpcwstrfiltername: ::windows::core::PCWSTR, ppfilter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19941,6 +20393,8 @@ pub trait IFilterGraph3_Impl: Sized + IFilterGraph_Impl + IGraphBuilder_Impl + I
     fn SetSyncSourceEx(&self, pclockformostoffiltergraph: &::core::option::Option<super::IReferenceClock>, pclockforfilter: &::core::option::Option<super::IReferenceClock>, pfilter: &::core::option::Option<IBaseFilter>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFilterGraph3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFilterGraph3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterGraph3_Impl, const OFFSET: isize>() -> IFilterGraph3_Vtbl {
         unsafe extern "system" fn SetSyncSourceEx<Identity: ::windows::core::IUnknownImpl, Impl: IFilterGraph3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclockformostoffiltergraph: ::windows::core::RawPtr, pclockforfilter: ::windows::core::RawPtr, pfilter: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19965,6 +20419,8 @@ pub trait IFilterInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Filename(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetFilename(&self, strfilename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFilterInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFilterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterInfo_Impl, const OFFSET: isize>() -> IFilterInfo_Vtbl {
@@ -20078,6 +20534,8 @@ pub trait IFilterMapper_Impl: Sized {
     fn EnumMatchingFilters(&self, ppenum: *mut ::core::option::Option<IEnumRegFilters>, dwmerit: u32, binputneeded: super::super::Foundation::BOOL, clsinmaj: &::windows::core::GUID, clsinsub: &::windows::core::GUID, brender: super::super::Foundation::BOOL, boututneeded: super::super::Foundation::BOOL, clsoutmaj: &::windows::core::GUID, clsoutsub: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFilterMapper {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFilterMapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterMapper_Impl, const OFFSET: isize>() -> IFilterMapper_Vtbl {
         unsafe extern "system" fn RegisterFilter<Identity: ::windows::core::IUnknownImpl, Impl: IFilterMapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: ::windows::core::GUID, name: ::windows::core::PCWSTR, dwmerit: u32) -> ::windows::core::HRESULT {
@@ -20150,6 +20608,8 @@ pub trait IFilterMapper2_Impl: Sized {
     fn EnumMatchingFilters(&self, ppenum: *mut ::core::option::Option<super::super::System::Com::IEnumMoniker>, dwflags: u32, bexactmatch: super::super::Foundation::BOOL, dwmerit: u32, binputneeded: super::super::Foundation::BOOL, cinputtypes: u32, pinputtypes: *const ::windows::core::GUID, pmedin: *const REGPINMEDIUM, ppincategoryin: *const ::windows::core::GUID, brender: super::super::Foundation::BOOL, boutputneeded: super::super::Foundation::BOOL, coutputtypes: u32, poutputtypes: *const ::windows::core::GUID, pmedout: *const REGPINMEDIUM, ppincategoryout: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFilterMapper2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFilterMapper2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterMapper2_Impl, const OFFSET: isize>() -> IFilterMapper2_Vtbl {
         unsafe extern "system" fn CreateCategory<Identity: ::windows::core::IUnknownImpl, Impl: IFilterMapper2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsidcategory: *const ::windows::core::GUID, dwcategorymerit: u32, description: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -20207,6 +20667,8 @@ pub trait IFilterMapper3_Impl: Sized + IFilterMapper2_Impl {
     fn GetICreateDevEnum(&self) -> ::windows::core::Result<ICreateDevEnum>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFilterMapper3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFilterMapper3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterMapper3_Impl, const OFFSET: isize>() -> IFilterMapper3_Vtbl {
         unsafe extern "system" fn GetICreateDevEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFilterMapper3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -20234,6 +20696,7 @@ pub trait IFrequencyMap_Impl: Sized {
     fn get_DefaultFrequencyMapping(&self, ulcountrycode: u32, pulcount: *mut u32, ppullist: *mut *mut u32) -> ::windows::core::Result<()>;
     fn get_CountryCodeList(&self, pulcount: *mut u32, ppullist: *mut *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFrequencyMap {}
 impl IFrequencyMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFrequencyMap_Impl, const OFFSET: isize>() -> IFrequencyMap_Vtbl {
         unsafe extern "system" fn get_FrequencyMapping<Identity: ::windows::core::IUnknownImpl, Impl: IFrequencyMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulcount: *mut u32, ppullist: *mut *mut u32) -> ::windows::core::HRESULT {
@@ -20306,6 +20769,8 @@ pub trait IFullScreenVideo_Impl: Sized {
     fn GetCaption(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetDefault(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFullScreenVideo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFullScreenVideo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFullScreenVideo_Impl, const OFFSET: isize>() -> IFullScreenVideo_Vtbl {
@@ -20463,6 +20928,8 @@ pub trait IFullScreenVideoEx_Impl: Sized + IFullScreenVideo_Impl {
     fn IsKeepPixelAspectRatio(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IFullScreenVideoEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IFullScreenVideoEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFullScreenVideoEx_Impl, const OFFSET: isize>() -> IFullScreenVideoEx_Vtbl {
         unsafe extern "system" fn SetAcceleratorTable<Identity: ::windows::core::IUnknownImpl, Impl: IFullScreenVideoEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, haccel: super::super::UI::WindowsAndMessaging::HACCEL) -> ::windows::core::HRESULT {
@@ -20509,6 +20976,7 @@ pub trait IGenericDescriptor_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u8>;
     fn GetBody(&self) -> ::windows::core::Result<*mut u8>;
 }
+impl ::windows::core::RuntimeName for IGenericDescriptor {}
 impl IGenericDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGenericDescriptor_Impl, const OFFSET: isize>() -> IGenericDescriptor_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IGenericDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbdesc: *const u8, bcount: i32) -> ::windows::core::HRESULT {
@@ -20565,6 +21033,7 @@ pub trait IGenericDescriptor2_Impl: Sized + IGenericDescriptor_Impl {
     fn Initialize2(&self, pbdesc: *const u8, wcount: u16) -> ::windows::core::Result<()>;
     fn GetLength2(&self) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IGenericDescriptor2 {}
 impl IGenericDescriptor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGenericDescriptor2_Impl, const OFFSET: isize>() -> IGenericDescriptor2_Vtbl {
         unsafe extern "system" fn Initialize2<Identity: ::windows::core::IUnknownImpl, Impl: IGenericDescriptor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbdesc: *const u8, wcount: u16) -> ::windows::core::HRESULT {
@@ -20598,6 +21067,8 @@ pub trait IGetCapabilitiesKey_Impl: Sized {
     fn GetCapabilitiesKey(&self) -> ::windows::core::Result<super::super::System::Registry::HKEY>;
 }
 #[cfg(feature = "Win32_System_Registry")]
+impl ::windows::core::RuntimeName for IGetCapabilitiesKey {}
+#[cfg(feature = "Win32_System_Registry")]
 impl IGetCapabilitiesKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetCapabilitiesKey_Impl, const OFFSET: isize>() -> IGetCapabilitiesKey_Vtbl {
         unsafe extern "system" fn GetCapabilitiesKey<Identity: ::windows::core::IUnknownImpl, Impl: IGetCapabilitiesKey_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phkey: *mut super::super::System::Registry::HKEY) -> ::windows::core::HRESULT {
@@ -20621,6 +21092,8 @@ impl IGetCapabilitiesKey_Vtbl {
 pub trait IGpnvsCommonBase_Impl: Sized {
     fn GetValueUpdateName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGpnvsCommonBase {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGpnvsCommonBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGpnvsCommonBase_Impl, const OFFSET: isize>() -> IGpnvsCommonBase_Vtbl {
@@ -20651,6 +21124,8 @@ pub trait IGraphBuilder_Impl: Sized + IFilterGraph_Impl {
     fn Abort(&self) -> ::windows::core::Result<()>;
     fn ShouldOperationContinue(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IGraphBuilder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IGraphBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGraphBuilder_Impl, const OFFSET: isize>() -> IGraphBuilder_Vtbl {
@@ -20723,6 +21198,8 @@ pub trait IGraphConfig_Impl: Sized {
     fn GetFilterFlags(&self, pfilter: &::core::option::Option<IBaseFilter>, pdwflags: *mut u32) -> ::windows::core::Result<()>;
     fn RemoveFilterEx(&self, pfilter: &::core::option::Option<IBaseFilter>, flags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IGraphConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IGraphConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGraphConfig_Impl, const OFFSET: isize>() -> IGraphConfig_Vtbl {
@@ -20803,6 +21280,7 @@ impl IGraphConfig_Vtbl {
 pub trait IGraphConfigCallback_Impl: Sized {
     fn Reconfigure(&self, pvcontext: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGraphConfigCallback {}
 impl IGraphConfigCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGraphConfigCallback_Impl, const OFFSET: isize>() -> IGraphConfigCallback_Vtbl {
         unsafe extern "system" fn Reconfigure<Identity: ::windows::core::IUnknownImpl, Impl: IGraphConfigCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvcontext: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -20819,6 +21297,7 @@ impl IGraphConfigCallback_Vtbl {
 pub trait IGraphVersion_Impl: Sized {
     fn QueryVersion(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IGraphVersion {}
 impl IGraphVersion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGraphVersion_Impl, const OFFSET: isize>() -> IGraphVersion_Vtbl {
         unsafe extern "system" fn QueryVersion<Identity: ::windows::core::IUnknownImpl, Impl: IGraphVersion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pversion: *mut i32) -> ::windows::core::HRESULT {
@@ -20847,6 +21326,8 @@ pub trait IGuideData_Impl: Sized {
     fn GetScheduleEntryIDs(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
     fn GetScheduleEntryProperties(&self, varscheduleentrydescriptionid: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IEnumGuideDataProperties>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGuideData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGuideData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGuideData_Impl, const OFFSET: isize>() -> IGuideData_Vtbl {
@@ -20941,6 +21422,8 @@ pub trait IGuideDataEvent_Impl: Sized {
     fn ScheduleDeleted(&self, varscheduleentrydescriptionid: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGuideDataEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGuideDataEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGuideDataEvent_Impl, const OFFSET: isize>() -> IGuideDataEvent_Vtbl {
         unsafe extern "system" fn GuideDataAcquired<Identity: ::windows::core::IUnknownImpl, Impl: IGuideDataEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -20997,6 +21480,7 @@ pub trait IGuideDataLoader_Impl: Sized {
     fn Init(&self, pguidestore: &::core::option::Option<IGuideData>) -> ::windows::core::Result<()>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGuideDataLoader {}
 impl IGuideDataLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGuideDataLoader_Impl, const OFFSET: isize>() -> IGuideDataLoader_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IGuideDataLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidestore: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21025,6 +21509,8 @@ pub trait IGuideDataProperty_Impl: Sized {
     fn Language(&self) -> ::windows::core::Result<i32>;
     fn Value(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGuideDataProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGuideDataProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGuideDataProperty_Impl, const OFFSET: isize>() -> IGuideDataProperty_Vtbl {
@@ -21076,6 +21562,7 @@ pub trait IIPDVDec_Impl: Sized {
     fn IPDisplay(&self) -> ::windows::core::Result<i32>;
     fn SetIPDisplay(&self, displaypix: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIPDVDec {}
 impl IIPDVDec_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIPDVDec_Impl, const OFFSET: isize>() -> IIPDVDec_Vtbl {
         unsafe extern "system" fn IPDisplay<Identity: ::windows::core::IUnknownImpl, Impl: IIPDVDec_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, displaypix: *mut i32) -> ::windows::core::HRESULT {
@@ -21107,6 +21594,8 @@ impl IIPDVDec_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IISDBSLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl + ILocator_Impl + IDigitalLocator_Impl + IDVBSLocator_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IISDBSLocator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IISDBSLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDBSLocator_Impl, const OFFSET: isize>() -> IISDBSLocator_Vtbl {
         Self { base__: IDVBSLocator_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -21130,6 +21619,7 @@ pub trait IISDB_BIT_Impl: Sized {
     fn GetRecordDescriptorByTag(&self, dwrecordindex: u32, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IISDB_BIT {}
 impl IISDB_BIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_BIT_Impl, const OFFSET: isize>() -> IISDB_BIT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_BIT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21292,6 +21782,7 @@ pub trait IISDB_CDT_Impl: Sized {
     fn GetDataModule(&self) -> ::windows::core::Result<*mut u8>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IISDB_CDT {}
 impl IISDB_CDT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_CDT_Impl, const OFFSET: isize>() -> IISDB_CDT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_CDT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr, bsectionnumber: u8) -> ::windows::core::HRESULT {
@@ -21443,6 +21934,7 @@ pub trait IISDB_EMM_Impl: Sized {
     fn GetIndividualEmmMessage(&self, punknown: &::core::option::Option<::windows::core::IUnknown>, pwlength: *mut u16, ppbmessage: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IISDB_EMM {}
 impl IISDB_EMM_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_EMM_Impl, const OFFSET: isize>() -> IISDB_EMM_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_EMM_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21526,6 +22018,7 @@ pub trait IISDB_LDT_Impl: Sized {
     fn GetRecordDescriptorByTag(&self, dwrecordindex: u32, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IISDB_LDT {}
 impl IISDB_LDT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_LDT_Impl, const OFFSET: isize>() -> IISDB_LDT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_LDT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21673,6 +22166,7 @@ pub trait IISDB_NBIT_Impl: Sized {
     fn GetRecordDescriptorByTag(&self, dwrecordindex: u32, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IISDB_NBIT {}
 impl IISDB_NBIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_NBIT_Impl, const OFFSET: isize>() -> IISDB_NBIT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_NBIT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21856,6 +22350,8 @@ pub trait IISDB_SDT_Impl: Sized + IDVB_SDT_Impl {
     fn GetRecordEITUserDefinedFlags(&self, dwrecordindex: u32) -> ::windows::core::Result<u8>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IISDB_SDT {}
+#[cfg(feature = "Win32_Foundation")]
 impl IISDB_SDT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_SDT_Impl, const OFFSET: isize>() -> IISDB_SDT_Vtbl {
         unsafe extern "system" fn GetRecordEITUserDefinedFlags<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_SDT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwrecordindex: u32, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -21897,6 +22393,7 @@ pub trait IISDB_SDTT_Impl: Sized {
     fn GetRecordDescriptorByTag(&self, dwrecordindex: u32, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
     fn GetVersionHash(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IISDB_SDTT {}
 impl IISDB_SDTT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_SDTT_Impl, const OFFSET: isize>() -> IISDB_SDTT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IISDB_SDTT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psectionlist: ::windows::core::RawPtr, pmpegdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -22153,6 +22650,8 @@ pub trait IIsdbAudioComponentDescriptor_Impl: Sized {
     fn GetTextW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbAudioComponentDescriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IIsdbAudioComponentDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbAudioComponentDescriptor_Impl, const OFFSET: isize>() -> IIsdbAudioComponentDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbAudioComponentDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -22332,6 +22831,8 @@ pub trait IIsdbCAContractInformationDescriptor_Impl: Sized {
     fn GetFeeNameW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbCAContractInformationDescriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IIsdbCAContractInformationDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbCAContractInformationDescriptor_Impl, const OFFSET: isize>() -> IIsdbCAContractInformationDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbCAContractInformationDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -22458,6 +22959,7 @@ pub trait IIsdbCADescriptor_Impl: Sized {
     fn GetCAPID(&self) -> ::windows::core::Result<u16>;
     fn GetPrivateDataBytes(&self, pbbufferlength: *mut u8, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIsdbCADescriptor {}
 impl IIsdbCADescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbCADescriptor_Impl, const OFFSET: isize>() -> IIsdbCADescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbCADescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -22542,6 +23044,7 @@ pub trait IIsdbCAServiceDescriptor_Impl: Sized {
     fn GetMessageControl(&self) -> ::windows::core::Result<u8>;
     fn GetServiceIds(&self, pbnumserviceids: *mut u8, pwserviceids: *mut u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIsdbCAServiceDescriptor {}
 impl IIsdbCAServiceDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbCAServiceDescriptor_Impl, const OFFSET: isize>() -> IIsdbCAServiceDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbCAServiceDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -22632,6 +23135,8 @@ pub trait IIsdbComponentGroupDescriptor_Impl: Sized {
     fn GetRecordTotalBitRate(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
     fn GetRecordTextW(&self, brecordindex: u8, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbComponentGroupDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IIsdbComponentGroupDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbComponentGroupDescriptor_Impl, const OFFSET: isize>() -> IIsdbComponentGroupDescriptor_Vtbl {
@@ -22789,6 +23294,8 @@ pub trait IIsdbDataContentDescriptor_Impl: Sized {
     fn GetTextW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbDataContentDescriptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IIsdbDataContentDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbDataContentDescriptor_Impl, const OFFSET: isize>() -> IIsdbDataContentDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbDataContentDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -22920,6 +23427,7 @@ pub trait IIsdbDigitalCopyControlDescriptor_Impl: Sized {
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u8>;
     fn GetRecordCopyControl(&self, brecordindex: u8, pbcomponenttag: *mut u8, pbdigitalrecordingcontroldata: *mut u8, pbcopycontroltype: *mut u8, pbapscontroldata: *mut u8, pbmaximumbitrate: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIsdbDigitalCopyControlDescriptor {}
 impl IIsdbDigitalCopyControlDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbDigitalCopyControlDescriptor_Impl, const OFFSET: isize>() -> IIsdbDigitalCopyControlDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbDigitalCopyControlDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -22998,6 +23506,8 @@ pub trait IIsdbDownloadContentDescriptor_Impl: Sized {
     fn GetTextLanguageCode(&self, szcode: *mut u8) -> ::windows::core::Result<()>;
     fn GetTextW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbDownloadContentDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IIsdbDownloadContentDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbDownloadContentDescriptor_Impl, const OFFSET: isize>() -> IIsdbDownloadContentDescriptor_Vtbl {
@@ -23210,6 +23720,7 @@ pub trait IIsdbEmergencyInformationDescriptor_Impl: Sized {
     fn GetSignalLevel(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
     fn GetAreaCode(&self, brecordindex: u8, ppwval: *mut *mut u16, pbnumareacodes: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIsdbEmergencyInformationDescriptor {}
 impl IIsdbEmergencyInformationDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbEmergencyInformationDescriptor_Impl, const OFFSET: isize>() -> IIsdbEmergencyInformationDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbEmergencyInformationDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -23307,6 +23818,7 @@ pub trait IIsdbEventGroupDescriptor_Impl: Sized {
     fn GetCountOfRefRecords(&self) -> ::windows::core::Result<u8>;
     fn GetRefRecordEvent(&self, brecordindex: u8, pworiginalnetworkid: *mut u16, pwtransportstreamid: *mut u16, pwserviceid: *mut u16, pweventid: *mut u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIsdbEventGroupDescriptor {}
 impl IIsdbEventGroupDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbEventGroupDescriptor_Impl, const OFFSET: isize>() -> IIsdbEventGroupDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbEventGroupDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -23397,6 +23909,7 @@ pub trait IIsdbHierarchicalTransmissionDescriptor_Impl: Sized {
     fn GetFutureUse2(&self) -> ::windows::core::Result<u8>;
     fn GetReferencePid(&self) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IIsdbHierarchicalTransmissionDescriptor {}
 impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbHierarchicalTransmissionDescriptor_Impl, const OFFSET: isize>() -> IIsdbHierarchicalTransmissionDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbHierarchicalTransmissionDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -23489,6 +24002,8 @@ pub trait IIsdbLogoTransmissionDescriptor_Impl: Sized {
     fn GetDownloadDataId(&self) -> ::windows::core::Result<u16>;
     fn GetLogoCharW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbLogoTransmissionDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IIsdbLogoTransmissionDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbLogoTransmissionDescriptor_Impl, const OFFSET: isize>() -> IIsdbLogoTransmissionDescriptor_Vtbl {
@@ -23594,6 +24109,7 @@ pub trait IIsdbSIParameterDescriptor_Impl: Sized {
     fn GetTableDescriptionLength(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
     fn GetTableDescriptionBytes(&self, brecordindex: u8, pbbufferlength: *mut u8, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIsdbSIParameterDescriptor {}
 impl IIsdbSIParameterDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbSIParameterDescriptor_Impl, const OFFSET: isize>() -> IIsdbSIParameterDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbSIParameterDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -23706,6 +24222,8 @@ pub trait IIsdbSeriesDescriptor_Impl: Sized {
     fn GetLastEpisodeNumber(&self) -> ::windows::core::Result<u16>;
     fn GetSeriesNameW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbSeriesDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IIsdbSeriesDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbSeriesDescriptor_Impl, const OFFSET: isize>() -> IIsdbSeriesDescriptor_Vtbl {
@@ -23828,6 +24346,7 @@ pub trait IIsdbSiParser2_Impl: Sized + IDvbSiParser_Impl + IDvbSiParser2_Impl {
     fn GetCDT(&self, tableid: u8, bsectionnumber: u8, pwdownloaddataid: *const u16) -> ::windows::core::Result<IISDB_CDT>;
     fn GetEMM(&self, pid: u16, wtableidext: u16) -> ::windows::core::Result<IISDB_EMM>;
 }
+impl ::windows::core::RuntimeName for IIsdbSiParser2 {}
 impl IIsdbSiParser2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbSiParser2_Impl, const OFFSET: isize>() -> IIsdbSiParser2_Vtbl {
         unsafe extern "system" fn GetSDT2<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbSiParser2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tableid: u8, pwtransportstreamid: *const u16, ppsdt: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -23933,6 +24452,8 @@ pub trait IIsdbTSInformationDescriptor_Impl: Sized {
     fn GetRecordNumberOfServices(&self, brecordindex: u8) -> ::windows::core::Result<u8>;
     fn GetRecordServiceIdByIndex(&self, brecordindex: u8, bserviceindex: u8) -> ::windows::core::Result<u16>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsdbTSInformationDescriptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IIsdbTSInformationDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbTSInformationDescriptor_Impl, const OFFSET: isize>() -> IIsdbTSInformationDescriptor_Vtbl {
@@ -24049,6 +24570,7 @@ pub trait IIsdbTerrestrialDeliverySystemDescriptor_Impl: Sized {
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u8>;
     fn GetRecordFrequency(&self, brecordindex: u8) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IIsdbTerrestrialDeliverySystemDescriptor {}
 impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbTerrestrialDeliverySystemDescriptor_Impl, const OFFSET: isize>() -> IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IIsdbTerrestrialDeliverySystemDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -24147,6 +24669,7 @@ pub trait IKsNodeControl_Impl: Sized {
     fn SetNodeId(&self, dwnodeid: u32) -> ::windows::core::Result<()>;
     fn SetKsControl(&self, pkscontrol: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IKsNodeControl {}
 impl IKsNodeControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsNodeControl_Impl, const OFFSET: isize>() -> IKsNodeControl_Vtbl {
         unsafe extern "system" fn SetNodeId<Identity: ::windows::core::IUnknownImpl, Impl: IKsNodeControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwnodeid: u32) -> ::windows::core::HRESULT {
@@ -24180,6 +24703,8 @@ pub trait IKsTopologyInfo_Impl: Sized {
     fn get_NodeType(&self, dwnodeid: u32) -> ::windows::core::Result<::windows::core::GUID>;
     fn CreateNodeInstance(&self, dwnodeid: u32, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Media_KernelStreaming")]
+impl ::windows::core::RuntimeName for IKsTopologyInfo {}
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 impl IKsTopologyInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsTopologyInfo_Impl, const OFFSET: isize>() -> IKsTopologyInfo_Vtbl {
@@ -24281,6 +24806,8 @@ pub trait ILanguageComponentType_Impl: Sized + super::super::System::Com::IDispa
     fn SetLangID(&self, langid: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILanguageComponentType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILanguageComponentType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageComponentType_Impl, const OFFSET: isize>() -> ILanguageComponentType_Vtbl {
         unsafe extern "system" fn LangID<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageComponentType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, langid: *mut i32) -> ::windows::core::HRESULT {
@@ -24327,6 +24854,8 @@ pub trait ILocator_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetSymbolRate(&self, rate: i32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<ILocator>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILocator_Impl, const OFFSET: isize>() -> ILocator_Vtbl {
@@ -24486,6 +25015,8 @@ pub trait IMPEG2Component_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn SetProgramNumber(&self, programnumber: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMPEG2Component {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMPEG2Component_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2Component_Impl, const OFFSET: isize>() -> IMPEG2Component_Vtbl {
         unsafe extern "system" fn PID<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2Component_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pid: *mut i32) -> ::windows::core::HRESULT {
@@ -24556,6 +25087,8 @@ pub trait IMPEG2ComponentType_Impl: Sized + super::super::System::Com::IDispatch
     fn SetStreamType(&self, mp2streamtype: MPEG2StreamType) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMPEG2ComponentType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMPEG2ComponentType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2ComponentType_Impl, const OFFSET: isize>() -> IMPEG2ComponentType_Vtbl {
         unsafe extern "system" fn StreamType<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2ComponentType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mp2streamtype: *mut MPEG2StreamType) -> ::windows::core::HRESULT {
@@ -24589,6 +25122,7 @@ pub trait IMPEG2PIDMap_Impl: Sized {
     fn UnmapPID(&self, culpid: u32, pulpid: *const u32) -> ::windows::core::Result<()>;
     fn EnumPIDMap(&self) -> ::windows::core::Result<IEnumPIDMap>;
 }
+impl ::windows::core::RuntimeName for IMPEG2PIDMap {}
 impl IMPEG2PIDMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2PIDMap_Impl, const OFFSET: isize>() -> IMPEG2PIDMap_Vtbl {
         unsafe extern "system" fn MapPID<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2PIDMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, culpid: u32, pulpid: *const u32, mediasamplecontent: MEDIA_SAMPLE_CONTENT) -> ::windows::core::HRESULT {
@@ -24628,6 +25162,7 @@ pub trait IMPEG2StreamIdMap_Impl: Sized {
     fn UnmapStreamId(&self, culstreamid: u32, pulstreamid: *const u32) -> ::windows::core::Result<()>;
     fn EnumStreamIdMap(&self) -> ::windows::core::Result<IEnumStreamIdMap>;
 }
+impl ::windows::core::RuntimeName for IMPEG2StreamIdMap {}
 impl IMPEG2StreamIdMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2StreamIdMap_Impl, const OFFSET: isize>() -> IMPEG2StreamIdMap_Vtbl {
         unsafe extern "system" fn MapStreamId<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2StreamIdMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulstreamid: u32, mediasamplecontent: u32, ulsubstreamfiltervalue: u32, idataoffset: i32) -> ::windows::core::HRESULT {
@@ -24669,6 +25204,8 @@ pub trait IMPEG2TuneRequest_Impl: Sized + super::super::System::Com::IDispatch_I
     fn ProgNo(&self) -> ::windows::core::Result<i32>;
     fn SetProgNo(&self, progno: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMPEG2TuneRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMPEG2TuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2TuneRequest_Impl, const OFFSET: isize>() -> IMPEG2TuneRequest_Vtbl {
@@ -24721,6 +25258,8 @@ pub trait IMPEG2TuneRequestFactory_Impl: Sized + super::super::System::Com::IDis
     fn CreateTuneRequest(&self, tuningspace: &::core::option::Option<ITuningSpace>) -> ::windows::core::Result<IMPEG2TuneRequest>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMPEG2TuneRequestFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMPEG2TuneRequestFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2TuneRequestFactory_Impl, const OFFSET: isize>() -> IMPEG2TuneRequestFactory_Vtbl {
         unsafe extern "system" fn CreateTuneRequest<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2TuneRequestFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tuningspace: ::windows::core::RawPtr, tunerequest: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -24744,6 +25283,7 @@ impl IMPEG2TuneRequestFactory_Vtbl {
     }
 }
 pub trait IMPEG2TuneRequestSupport_Impl: Sized {}
+impl ::windows::core::RuntimeName for IMPEG2TuneRequestSupport {}
 impl IMPEG2TuneRequestSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2TuneRequestSupport_Impl, const OFFSET: isize>() -> IMPEG2TuneRequestSupport_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -24760,6 +25300,7 @@ pub trait IMPEG2_TIF_CONTROL_Impl: Sized {
     fn GetPIDCount(&self) -> ::windows::core::Result<u32>;
     fn GetPIDs(&self, pulcpids: *mut u32, pulpids: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMPEG2_TIF_CONTROL {}
 impl IMPEG2_TIF_CONTROL_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2_TIF_CONTROL_Impl, const OFFSET: isize>() -> IMPEG2_TIF_CONTROL_Vtbl {
         unsafe extern "system" fn RegisterTIF<Identity: ::windows::core::IUnknownImpl, Impl: IMPEG2_TIF_CONTROL_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punktif: *mut ::core::ffi::c_void, ppvregistrationcontext: *mut u32) -> ::windows::core::HRESULT {
@@ -24818,6 +25359,8 @@ pub trait IMSEventBinder_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Unbind(&self, cancelcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSEventBinder {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSEventBinder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSEventBinder_Impl, const OFFSET: isize>() -> IMSEventBinder_Vtbl {
         unsafe extern "system" fn Bind<Identity: ::windows::core::IUnknownImpl, Impl: IMSEventBinder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventobject: ::windows::core::RawPtr, eventname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, eventhandler: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, cancelid: *mut i32) -> ::windows::core::HRESULT {
@@ -24858,6 +25401,8 @@ pub trait IMSVidAnalogTuner_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetSAP(&self, fsapon: i16) -> ::windows::core::Result<()>;
     fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32, fsignalpresent: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAnalogTuner {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAnalogTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAnalogTuner_Impl, const OFFSET: isize>() -> IMSVidAnalogTuner_Vtbl {
@@ -24960,6 +25505,8 @@ pub trait IMSVidAnalogTuner2_Impl: Sized + super::super::System::Com::IDispatch_
     fn NumAuxInputs(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAnalogTuner2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAnalogTuner2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAnalogTuner2_Impl, const OFFSET: isize>() -> IMSVidAnalogTuner2_Vtbl {
         unsafe extern "system" fn TVFormats<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAnalogTuner2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, formats: *mut i32) -> ::windows::core::HRESULT {
@@ -25009,6 +25556,8 @@ impl IMSVidAnalogTuner2_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAnalogTunerEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidInputDeviceEvent_Impl + IMSVidTunerEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAnalogTunerEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAnalogTunerEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAnalogTunerEvent_Impl, const OFFSET: isize>() -> IMSVidAnalogTunerEvent_Vtbl {
         Self { base__: IMSVidTunerEvent_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -25024,6 +25573,8 @@ pub trait IMSVidAudioRenderer_Impl: Sized + super::super::System::Com::IDispatch
     fn SetBalance(&self, lbal: i32) -> ::windows::core::Result<()>;
     fn Balance(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAudioRenderer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAudioRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAudioRenderer_Impl, const OFFSET: isize>() -> IMSVidAudioRenderer_Vtbl {
@@ -25079,6 +25630,8 @@ pub trait IMSVidAudioRendererDevices_Impl: Sized + super::super::System::Com::ID
     fn Add(&self, pdb: &::core::option::Option<IMSVidAudioRenderer>) -> ::windows::core::Result<()>;
     fn Remove(&self, v: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAudioRendererDevices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAudioRendererDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAudioRendererDevices_Impl, const OFFSET: isize>() -> IMSVidAudioRendererDevices_Vtbl {
@@ -25141,6 +25694,8 @@ impl IMSVidAudioRendererDevices_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAudioRendererEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDeviceEvent_Impl + IMSVidOutputDeviceEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAudioRendererEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAudioRendererEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAudioRendererEvent_Impl, const OFFSET: isize>() -> IMSVidAudioRendererEvent_Vtbl {
         Self { base__: IMSVidOutputDeviceEvent_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -25160,6 +25715,8 @@ pub trait IMSVidAudioRendererEvent2_Impl: Sized + super::super::System::Com::IDi
     fn AVDecCommonInputFormat(&self) -> ::windows::core::Result<()>;
     fn AVDecCommonOutputFormat(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidAudioRendererEvent2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidAudioRendererEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidAudioRendererEvent2_Impl, const OFFSET: isize>() -> IMSVidAudioRendererEvent2_Vtbl {
@@ -25225,6 +25782,8 @@ pub trait IMSVidClosedCaptioning_Impl: Sized + super::super::System::Com::IDispa
     fn SetEnable(&self, on: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidClosedCaptioning {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidClosedCaptioning_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidClosedCaptioning_Impl, const OFFSET: isize>() -> IMSVidClosedCaptioning_Vtbl {
         unsafe extern "system" fn Enable<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidClosedCaptioning_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, on: *mut i16) -> ::windows::core::HRESULT {
@@ -25259,6 +25818,8 @@ pub trait IMSVidClosedCaptioning2_Impl: Sized + super::super::System::Com::IDisp
     fn SetService(&self, on: MSVidCCService) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidClosedCaptioning2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidClosedCaptioning2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidClosedCaptioning2_Impl, const OFFSET: isize>() -> IMSVidClosedCaptioning2_Vtbl {
         unsafe extern "system" fn Service<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidClosedCaptioning2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, on: *mut MSVidCCService) -> ::windows::core::HRESULT {
@@ -25292,6 +25853,8 @@ pub trait IMSVidClosedCaptioning3_Impl: Sized + super::super::System::Com::IDisp
     fn TeleTextFilter(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidClosedCaptioning3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidClosedCaptioning3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidClosedCaptioning3_Impl, const OFFSET: isize>() -> IMSVidClosedCaptioning3_Vtbl {
         unsafe extern "system" fn TeleTextFilter<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidClosedCaptioning3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkttfilter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -25317,6 +25880,8 @@ pub trait IMSVidCompositionSegment_Impl: Sized + super::super::System::Com::IPer
     fn Up(&self) -> ::windows::core::Result<IMSVidGraphSegment>;
     fn Down(&self) -> ::windows::core::Result<IMSVidGraphSegment>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMSVidCompositionSegment {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMSVidCompositionSegment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidCompositionSegment_Impl, const OFFSET: isize>() -> IMSVidCompositionSegment_Vtbl {
@@ -25404,6 +25969,8 @@ pub trait IMSVidCtl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DisableAudio(&self) -> ::windows::core::Result<()>;
     fn ViewNext(&self, v: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidCtl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidCtl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidCtl_Impl, const OFFSET: isize>() -> IMSVidCtl_Vtbl {
@@ -25802,6 +26369,8 @@ impl IMSVidCtl_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidDataServices_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDevice_Impl + IMSVidFeature_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidDataServices {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidDataServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDataServices_Impl, const OFFSET: isize>() -> IMSVidDataServices_Vtbl {
         Self { base__: IMSVidFeature_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -25812,6 +26381,8 @@ impl IMSVidDataServices_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidDataServicesEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDeviceEvent_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidDataServicesEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidDataServicesEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDataServicesEvent_Impl, const OFFSET: isize>() -> IMSVidDataServicesEvent_Vtbl {
@@ -25833,6 +26404,8 @@ pub trait IMSVidDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _ClassID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn IsEqualDevice(&self, device: &::core::option::Option<IMSVidDevice>) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDevice_Impl, const OFFSET: isize>() -> IMSVidDevice_Vtbl {
@@ -25951,6 +26524,8 @@ pub trait IMSVidDevice2_Impl: Sized {
     fn DevicePath(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMSVidDevice2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMSVidDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDevice2_Impl, const OFFSET: isize>() -> IMSVidDevice2_Vtbl {
         unsafe extern "system" fn DevicePath<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, devpath: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -25975,6 +26550,8 @@ pub trait IMSVidDeviceEvent_Impl: Sized + super::super::System::Com::IDispatch_I
     fn StateChange(&self, lpd: &::core::option::Option<IMSVidDevice>, oldstate: i32, newstate: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidDeviceEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidDeviceEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDeviceEvent_Impl, const OFFSET: isize>() -> IMSVidDeviceEvent_Vtbl {
         unsafe extern "system" fn StateChange<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidDeviceEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpd: ::windows::core::RawPtr, oldstate: i32, newstate: i32) -> ::windows::core::HRESULT {
@@ -25995,6 +26572,8 @@ pub trait IMSVidEVR_Impl: Sized + super::super::System::Com::IDispatch_Impl + IM
     fn SetSuppressEffects(&self, bsuppress: i16) -> ::windows::core::Result<()>;
     fn SuppressEffects(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidEVR {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidEVR_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidEVR_Impl, const OFFSET: isize>() -> IMSVidEVR_Vtbl {
@@ -26047,6 +26626,8 @@ pub trait IMSVidEVREvent_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn OnUserEvent(&self, leventcode: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidEVREvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidEVREvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidEVREvent_Impl, const OFFSET: isize>() -> IMSVidEVREvent_Vtbl {
         unsafe extern "system" fn OnUserEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidEVREvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, leventcode: i32) -> ::windows::core::HRESULT {
@@ -26065,6 +26646,8 @@ pub trait IMSVidEncoder_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn VideoEncoderInterface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn AudioEncoderInterface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidEncoder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidEncoder_Impl, const OFFSET: isize>() -> IMSVidEncoder_Vtbl {
@@ -26103,6 +26686,8 @@ impl IMSVidEncoder_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFeature_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDevice_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidFeature {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidFeature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFeature_Impl, const OFFSET: isize>() -> IMSVidFeature_Vtbl {
         Self { base__: IMSVidDevice_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -26113,6 +26698,8 @@ impl IMSVidFeature_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFeatureEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDeviceEvent_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidFeatureEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidFeatureEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFeatureEvent_Impl, const OFFSET: isize>() -> IMSVidFeatureEvent_Vtbl {
@@ -26130,6 +26717,8 @@ pub trait IMSVidFeatures_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Add(&self, pdb: &::core::option::Option<IMSVidFeature>) -> ::windows::core::Result<()>;
     fn Remove(&self, v: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidFeatures {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidFeatures_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFeatures_Impl, const OFFSET: isize>() -> IMSVidFeatures_Vtbl {
@@ -26195,6 +26784,8 @@ pub trait IMSVidFilePlayback_Impl: Sized + super::super::System::Com::IDispatch_
     fn SetFileName(&self, filename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidFilePlayback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidFilePlayback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFilePlayback_Impl, const OFFSET: isize>() -> IMSVidFilePlayback_Vtbl {
         unsafe extern "system" fn FileName<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFilePlayback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -26229,6 +26820,8 @@ pub trait IMSVidFilePlayback2_Impl: Sized + super::super::System::Com::IDispatch
     fn Set__SourceFilter(&self, filename: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidFilePlayback2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidFilePlayback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFilePlayback2_Impl, const OFFSET: isize>() -> IMSVidFilePlayback2_Vtbl {
         unsafe extern "system" fn Set_SourceFilter<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFilePlayback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -26254,6 +26847,8 @@ impl IMSVidFilePlayback2_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFilePlaybackEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidInputDeviceEvent_Impl + IMSVidPlaybackEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidFilePlaybackEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidFilePlaybackEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidFilePlaybackEvent_Impl, const OFFSET: isize>() -> IMSVidFilePlaybackEvent_Vtbl {
         Self { base__: IMSVidPlaybackEvent_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -26268,6 +26863,8 @@ pub trait IMSVidGenericSink_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SinkStreams(&self) -> ::windows::core::Result<MSVidSinkStreams>;
     fn SetSinkStreams(&self, streams: MSVidSinkStreams) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidGenericSink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidGenericSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGenericSink_Impl, const OFFSET: isize>() -> IMSVidGenericSink_Vtbl {
@@ -26309,6 +26906,8 @@ pub trait IMSVidGenericSink2_Impl: Sized + super::super::System::Com::IDispatch_
     fn ResetFilterList(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidGenericSink2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidGenericSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGenericSink2_Impl, const OFFSET: isize>() -> IMSVidGenericSink2_Vtbl {
         unsafe extern "system" fn AddFilter<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGenericSink2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -26349,6 +26948,8 @@ pub trait IMSVidGraphSegment_Impl: Sized + super::super::System::Com::IPersist_I
     fn OnEventNotify(&self, leventcode: i32, leventparm1: isize, leventparm2: isize) -> ::windows::core::Result<()>;
     fn Decompose(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMSVidGraphSegment {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMSVidGraphSegment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGraphSegment_Impl, const OFFSET: isize>() -> IMSVidGraphSegment_Vtbl {
@@ -26495,6 +27096,8 @@ pub trait IMSVidGraphSegmentContainer_Impl: Sized {
     fn GetFocus(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMSVidGraphSegmentContainer {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMSVidGraphSegmentContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGraphSegmentContainer_Impl, const OFFSET: isize>() -> IMSVidGraphSegmentContainer_Vtbl {
         unsafe extern "system" fn Graph<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGraphSegmentContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppgraph: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -26629,6 +27232,7 @@ pub trait IMSVidGraphSegmentUserInput_Impl: Sized {
     fn MouseMove(&self, buttonstate: i16, shiftstate: i16, x: i32, y: i32) -> ::windows::core::Result<()>;
     fn MouseUp(&self, buttonstate: i16, shiftstate: i16, x: i32, y: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMSVidGraphSegmentUserInput {}
 impl IMSVidGraphSegmentUserInput_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGraphSegmentUserInput_Impl, const OFFSET: isize>() -> IMSVidGraphSegmentUserInput_Vtbl {
         unsafe extern "system" fn Click<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidGraphSegmentUserInput_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -26693,6 +27297,8 @@ pub trait IMSVidInputDevice_Impl: Sized + super::super::System::Com::IDispatch_I
     fn View(&self, v: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidInputDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidInputDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidInputDevice_Impl, const OFFSET: isize>() -> IMSVidInputDevice_Vtbl {
         unsafe extern "system" fn IsViewable<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidInputDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, v: *const super::super::System::Com::VARIANT, pfviewable: *mut i16) -> ::windows::core::HRESULT {
@@ -26724,6 +27330,8 @@ impl IMSVidInputDevice_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidInputDeviceEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidInputDeviceEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidInputDeviceEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidInputDeviceEvent_Impl, const OFFSET: isize>() -> IMSVidInputDeviceEvent_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -26740,6 +27348,8 @@ pub trait IMSVidInputDevices_Impl: Sized + super::super::System::Com::IDispatch_
     fn Add(&self, pdb: &::core::option::Option<IMSVidInputDevice>) -> ::windows::core::Result<()>;
     fn Remove(&self, v: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidInputDevices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidInputDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidInputDevices_Impl, const OFFSET: isize>() -> IMSVidInputDevices_Vtbl {
@@ -26802,6 +27412,8 @@ impl IMSVidInputDevices_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidOutputDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDevice_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidOutputDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidOutputDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidOutputDevice_Impl, const OFFSET: isize>() -> IMSVidOutputDevice_Vtbl {
         Self { base__: IMSVidDevice_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -26812,6 +27424,8 @@ impl IMSVidOutputDevice_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidOutputDeviceEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDeviceEvent_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidOutputDeviceEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidOutputDeviceEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidOutputDeviceEvent_Impl, const OFFSET: isize>() -> IMSVidOutputDeviceEvent_Vtbl {
@@ -26829,6 +27443,8 @@ pub trait IMSVidOutputDevices_Impl: Sized + super::super::System::Com::IDispatch
     fn Add(&self, pdb: &::core::option::Option<IMSVidOutputDevice>) -> ::windows::core::Result<()>;
     fn Remove(&self, v: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidOutputDevices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidOutputDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidOutputDevices_Impl, const OFFSET: isize>() -> IMSVidOutputDevices_Vtbl {
@@ -26905,6 +27521,8 @@ pub trait IMSVidPlayback_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn PositionMode(&self) -> ::windows::core::Result<PositionModeList>;
     fn Length(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidPlayback {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidPlayback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidPlayback_Impl, const OFFSET: isize>() -> IMSVidPlayback_Vtbl {
@@ -27041,6 +27659,8 @@ pub trait IMSVidPlaybackEvent_Impl: Sized + super::super::System::Com::IDispatch
     fn EndOfMedia(&self, lpd: &::core::option::Option<IMSVidPlayback>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidPlaybackEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidPlaybackEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidPlaybackEvent_Impl, const OFFSET: isize>() -> IMSVidPlaybackEvent_Vtbl {
         unsafe extern "system" fn EndOfMedia<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidPlaybackEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpd: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -27068,6 +27688,8 @@ pub trait IMSVidRect_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetHWnd(&self, hwndval: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn SetRect(&self, rectval: &::core::option::Option<IMSVidRect>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidRect {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidRect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidRect_Impl, const OFFSET: isize>() -> IMSVidRect_Vtbl {
@@ -27187,6 +27809,8 @@ pub trait IMSVidStreamBufferRecordingControl_Impl: Sized + super::super::System:
     fn RecordingAttribute(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferRecordingControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferRecordingControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferRecordingControl_Impl, const OFFSET: isize>() -> IMSVidStreamBufferRecordingControl_Vtbl {
         unsafe extern "system" fn StartTime<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferRecordingControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rtstart: *mut i32) -> ::windows::core::HRESULT {
@@ -27291,6 +27915,8 @@ pub trait IMSVidStreamBufferSink_Impl: Sized + super::super::System::Com::IDispa
     fn SBESink(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSink_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSink_Vtbl {
         unsafe extern "system" fn get_ContentRecorder<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfilename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, precordingiunknown: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -27366,6 +27992,8 @@ pub trait IMSVidStreamBufferSink2_Impl: Sized + super::super::System::Com::IDisp
     fn UnlockProfile(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSink2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSink2_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSink2_Vtbl {
         unsafe extern "system" fn UnlockProfile<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSink2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -27400,6 +28028,8 @@ pub trait IMSVidStreamBufferSink3_Impl: Sized + super::super::System::Com::IDisp
     fn _DataAnalysisFilter(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn LicenseErrorCode(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSink3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSink3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSink3_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSink3_Vtbl {
@@ -27598,6 +28228,8 @@ pub trait IMSVidStreamBufferSinkEvent_Impl: Sized + super::super::System::Com::I
     fn WriteFailure(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSinkEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSinkEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSinkEvent_Vtbl {
         unsafe extern "system" fn CertificateFailure<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -27632,6 +28264,8 @@ pub trait IMSVidStreamBufferSinkEvent2_Impl: Sized + super::super::System::Com::
     fn EncryptionOff(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSinkEvent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSinkEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent2_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSinkEvent2_Vtbl {
         unsafe extern "system" fn EncryptionOn<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -27659,6 +28293,8 @@ pub trait IMSVidStreamBufferSinkEvent3_Impl: Sized + super::super::System::Com::
     fn LicenseChange(&self, dwprot: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSinkEvent3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSinkEvent3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent3_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSinkEvent3_Vtbl {
         unsafe extern "system" fn LicenseChange<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwprot: i32) -> ::windows::core::HRESULT {
@@ -27676,6 +28312,8 @@ impl IMSVidStreamBufferSinkEvent3_Vtbl {
 pub trait IMSVidStreamBufferSinkEvent4_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDeviceEvent_Impl + IMSVidOutputDeviceEvent_Impl + IMSVidStreamBufferSinkEvent_Impl + IMSVidStreamBufferSinkEvent2_Impl + IMSVidStreamBufferSinkEvent3_Impl {
     fn WriteFailureClear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSinkEvent4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSinkEvent4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSinkEvent4_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSinkEvent4_Vtbl {
@@ -27700,6 +28338,8 @@ pub trait IMSVidStreamBufferSource_Impl: Sized + super::super::System::Com::IDis
     fn SetUnratedDelay(&self, dwdelay: i32) -> ::windows::core::Result<()>;
     fn SBESource(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSource {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSource_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSource_Vtbl {
@@ -27780,6 +28420,8 @@ pub trait IMSVidStreamBufferSource2_Impl: Sized + super::super::System::Com::IDi
     fn WSTCounter(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSource2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSource2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSource2_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSource2_Vtbl {
         unsafe extern "system" fn put_RateEx<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSource2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwrate: f64, dwframespersecond: u32) -> ::windows::core::HRESULT {
@@ -27857,6 +28499,8 @@ pub trait IMSVidStreamBufferSourceEvent_Impl: Sized + super::super::System::Com:
     fn StaleFileDeleted(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSourceEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSourceEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSourceEvent_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSourceEvent_Vtbl {
         unsafe extern "system" fn CertificateFailure<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSourceEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -27926,6 +28570,8 @@ pub trait IMSVidStreamBufferSourceEvent2_Impl: Sized + super::super::System::Com
     fn RateChange(&self, qwnewrate: f64, qwoldrate: f64) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSourceEvent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSourceEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSourceEvent2_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSourceEvent2_Vtbl {
         unsafe extern "system" fn RateChange<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSourceEvent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, qwnewrate: f64, qwoldrate: f64) -> ::windows::core::HRESULT {
@@ -27947,6 +28593,8 @@ pub trait IMSVidStreamBufferSourceEvent3_Impl: Sized + super::super::System::Com
     fn COPPUnblocked(&self) -> ::windows::core::Result<()>;
     fn ContentPrimarilyAudio(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferSourceEvent3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferSourceEvent3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferSourceEvent3_Impl, const OFFSET: isize>() -> IMSVidStreamBufferSourceEvent3_Vtbl {
@@ -28000,6 +28648,8 @@ pub trait IMSVidStreamBufferV2SourceEvent_Impl: Sized + super::super::System::Co
     fn BroadcastEventEx(&self, guid: &super::super::Foundation::BSTR, param1: u32, param2: u32, param3: u32, param4: u32) -> ::windows::core::Result<()>;
     fn ContentPrimarilyAudio(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidStreamBufferV2SourceEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidStreamBufferV2SourceEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidStreamBufferV2SourceEvent_Impl, const OFFSET: isize>() -> IMSVidStreamBufferV2SourceEvent_Vtbl {
@@ -28073,6 +28723,8 @@ pub trait IMSVidTuner_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn SetTuningSpace(&self, plts: &::core::option::Option<ITuningSpace>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidTuner {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidTuner_Impl, const OFFSET: isize>() -> IMSVidTuner_Vtbl {
         unsafe extern "system" fn Tune<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidTuner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptr: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -28124,6 +28776,8 @@ pub trait IMSVidTunerEvent_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn TuneChanged(&self, lpd: &::core::option::Option<IMSVidTuner>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidTunerEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidTunerEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidTunerEvent_Impl, const OFFSET: isize>() -> IMSVidTunerEvent_Vtbl {
         unsafe extern "system" fn TuneChanged<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidTunerEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpd: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -28145,6 +28799,8 @@ pub trait IMSVidVMR9_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn SuppressEffects(&self) -> ::windows::core::Result<i16>;
     fn Allocator(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVMR9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVMR9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVMR9_Impl, const OFFSET: isize>() -> IMSVidVMR9_Vtbl {
@@ -28228,6 +28884,8 @@ pub trait IMSVidVRGraphSegment_Impl: Sized + super::super::System::Com::IPersist
     fn DisplayChange(&self) -> ::windows::core::Result<()>;
     fn RePaint(&self, hdc: super::super::Graphics::Gdi::HDC) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMSVidVRGraphSegment {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IMSVidVRGraphSegment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVRGraphSegment_Impl, const OFFSET: isize>() -> IMSVidVRGraphSegment_Vtbl {
@@ -28416,6 +29074,8 @@ impl IMSVidVRGraphSegment_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoInputDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDevice_Impl + IMSVidInputDevice_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVideoInputDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVideoInputDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoInputDevice_Impl, const OFFSET: isize>() -> IMSVidVideoInputDevice_Vtbl {
         Self { base__: IMSVidInputDevice_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -28457,6 +29117,8 @@ pub trait IMSVidVideoRenderer_Impl: Sized + super::super::System::Com::IDispatch
     fn DecimateInput(&self) -> ::windows::core::Result<i16>;
     fn SetDecimateInput(&self, pdeci: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVideoRenderer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVideoRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRenderer_Impl, const OFFSET: isize>() -> IMSVidVideoRenderer_Vtbl {
@@ -28761,6 +29423,8 @@ pub trait IMSVidVideoRenderer2_Impl: Sized + super::super::System::Com::IDispatc
     fn SuppressEffects(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVideoRenderer2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVideoRenderer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRenderer2_Impl, const OFFSET: isize>() -> IMSVidVideoRenderer2_Vtbl {
         unsafe extern "system" fn Allocator<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRenderer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, allocpresent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -28846,6 +29510,8 @@ pub trait IMSVidVideoRendererDevices_Impl: Sized + super::super::System::Com::ID
     fn Remove(&self, v: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVideoRendererDevices {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVideoRendererDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRendererDevices_Impl, const OFFSET: isize>() -> IMSVidVideoRendererDevices_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRendererDevices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lcount: *mut i32) -> ::windows::core::HRESULT {
@@ -28909,6 +29575,8 @@ pub trait IMSVidVideoRendererEvent_Impl: Sized + super::super::System::Com::IDis
     fn OverlayUnavailable(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVideoRendererEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVideoRendererEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRendererEvent_Impl, const OFFSET: isize>() -> IMSVidVideoRendererEvent_Vtbl {
         unsafe extern "system" fn OverlayUnavailable<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRendererEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -28926,6 +29594,8 @@ impl IMSVidVideoRendererEvent_Vtbl {
 pub trait IMSVidVideoRendererEvent2_Impl: Sized + super::super::System::Com::IDispatch_Impl + IMSVidDeviceEvent_Impl + IMSVidOutputDeviceEvent_Impl {
     fn OverlayUnavailable(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidVideoRendererEvent2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidVideoRendererEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidVideoRendererEvent2_Impl, const OFFSET: isize>() -> IMSVidVideoRendererEvent2_Vtbl {
@@ -29038,6 +29708,8 @@ pub trait IMSVidWebDVD_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn DVDScreenInMouseCoordinates(&self) -> ::windows::core::Result<IMSVidRect>;
     fn SetDVDScreenInMouseCoordinates(&self, prect: &::core::option::Option<IMSVidRect>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidWebDVD {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidWebDVD_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidWebDVD_Impl, const OFFSET: isize>() -> IMSVidWebDVD_Vtbl {
@@ -29931,6 +30603,8 @@ pub trait IMSVidWebDVD2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn put_Bookmark(&self, pdata: *const u8, dwdatalength: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidWebDVD2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidWebDVD2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidWebDVD2_Impl, const OFFSET: isize>() -> IMSVidWebDVD2_Vtbl {
         unsafe extern "system" fn get_Bookmark<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidWebDVD2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdata: *mut *mut u8, pdatalength: *mut u32) -> ::windows::core::HRESULT {
@@ -29970,6 +30644,8 @@ pub trait IMSVidWebDVDAdm_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn BookmarkOnStop(&self) -> ::windows::core::Result<i16>;
     fn SetBookmarkOnStop(&self, newval: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidWebDVDAdm {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidWebDVDAdm_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidWebDVDAdm_Impl, const OFFSET: isize>() -> IMSVidWebDVDAdm_Vtbl {
@@ -30134,6 +30810,8 @@ pub trait IMSVidWebDVDEvent_Impl: Sized + super::super::System::Com::IDispatch_I
     fn ChangeVideoPresMode(&self, benabled: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidWebDVDEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidWebDVDEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidWebDVDEvent_Impl, const OFFSET: isize>() -> IMSVidWebDVDEvent_Vtbl {
         unsafe extern "system" fn DVDNotify<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidWebDVDEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, leventcode: i32, lparam1: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, lparam2: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -30287,6 +30965,8 @@ pub trait IMSVidXDS_Impl: Sized + super::super::System::Com::IDispatch_Impl + IM
     fn ChannelChangeInterface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidXDS {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidXDS_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidXDS_Impl, const OFFSET: isize>() -> IMSVidXDS_Vtbl {
         unsafe extern "system" fn ChannelChangeInterface<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidXDS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkcc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -30311,6 +30991,8 @@ pub trait IMSVidXDSEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn RatingChange(&self, prevratingsystem: EnTvRat_System, prevlevel: EnTvRat_GenericLevel, prevattributes: BfEnTvRat_GenericAttributes, newratingsystem: EnTvRat_System, newlevel: EnTvRat_GenericLevel, newattributes: BfEnTvRat_GenericAttributes) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSVidXDSEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSVidXDSEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidXDSEvent_Impl, const OFFSET: isize>() -> IMSVidXDSEvent_Vtbl {
         unsafe extern "system" fn RatingChange<Identity: ::windows::core::IUnknownImpl, Impl: IMSVidXDSEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prevratingsystem: EnTvRat_System, prevlevel: EnTvRat_GenericLevel, prevattributes: BfEnTvRat_GenericAttributes, newratingsystem: EnTvRat_System, newlevel: EnTvRat_GenericLevel, newattributes: BfEnTvRat_GenericAttributes) -> ::windows::core::HRESULT {
@@ -30327,6 +31009,7 @@ impl IMSVidXDSEvent_Vtbl {
 pub trait IMceBurnerControl_Impl: Sized {
     fn GetBurnerNoDecryption(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMceBurnerControl {}
 impl IMceBurnerControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMceBurnerControl_Impl, const OFFSET: isize>() -> IMceBurnerControl_Vtbl {
         unsafe extern "system" fn GetBurnerNoDecryption<Identity: ::windows::core::IUnknownImpl, Impl: IMceBurnerControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -30352,6 +31035,8 @@ pub trait IMediaControl_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn RegFilterCollection(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn StopWhenReady(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMediaControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMediaControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaControl_Impl, const OFFSET: isize>() -> IMediaControl_Vtbl {
@@ -30451,6 +31136,8 @@ pub trait IMediaEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FreeEventParams(&self, levcode: i32, lparam1: isize, lparam2: isize) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMediaEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMediaEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaEvent_Impl, const OFFSET: isize>() -> IMediaEvent_Vtbl {
         unsafe extern "system" fn GetEventHandle<Identity: ::windows::core::IUnknownImpl, Impl: IMediaEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hevent: *mut isize) -> ::windows::core::HRESULT {
@@ -30516,6 +31203,8 @@ pub trait IMediaEventEx_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn GetNotifyFlags(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMediaEventEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMediaEventEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaEventEx_Impl, const OFFSET: isize>() -> IMediaEventEx_Vtbl {
         unsafe extern "system" fn SetNotifyWindow<Identity: ::windows::core::IUnknownImpl, Impl: IMediaEventEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: isize, lmsg: i32, linstancedata: isize) -> ::windows::core::HRESULT {
@@ -30553,6 +31242,7 @@ impl IMediaEventEx_Vtbl {
 pub trait IMediaEventSink_Impl: Sized {
     fn Notify(&self, eventcode: i32, eventparam1: isize, eventparam2: isize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMediaEventSink {}
 impl IMediaEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaEventSink_Impl, const OFFSET: isize>() -> IMediaEventSink_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IMediaEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventcode: i32, eventparam1: isize, eventparam2: isize) -> ::windows::core::HRESULT {
@@ -30575,6 +31265,8 @@ pub trait IMediaFilter_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn SetSyncSource(&self, pclock: &::core::option::Option<super::IReferenceClock>) -> ::windows::core::Result<()>;
     fn GetSyncSource(&self) -> ::windows::core::Result<super::IReferenceClock>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMediaFilter {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMediaFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaFilter_Impl, const OFFSET: isize>() -> IMediaFilter_Vtbl {
@@ -30642,6 +31334,7 @@ pub trait IMediaParamInfo_Impl: Sized {
     fn GetSupportedTimeFormat(&self, dwformatindex: u32) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetCurrentTimeFormat(&self, pguidtimeformat: *mut ::windows::core::GUID, ptimedata: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMediaParamInfo {}
 impl IMediaParamInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaParamInfo_Impl, const OFFSET: isize>() -> IMediaParamInfo_Vtbl {
         unsafe extern "system" fn GetParamCount<Identity: ::windows::core::IUnknownImpl, Impl: IMediaParamInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwparams: *mut u32) -> ::windows::core::HRESULT {
@@ -30725,6 +31418,7 @@ pub trait IMediaParams_Impl: Sized {
     fn FlushEnvelope(&self, dwparamindex: u32, reftimestart: i64, reftimeend: i64) -> ::windows::core::Result<()>;
     fn SetTimeFormat(&self, guidtimeformat: &::windows::core::GUID, mptimedata: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMediaParams {}
 impl IMediaParams_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaParams_Impl, const OFFSET: isize>() -> IMediaParams_Vtbl {
         unsafe extern "system" fn GetParam<Identity: ::windows::core::IUnknownImpl, Impl: IMediaParams_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwparamindex: u32, pvalue: *mut f32) -> ::windows::core::HRESULT {
@@ -30785,6 +31479,8 @@ pub trait IMediaPosition_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn CanSeekForward(&self) -> ::windows::core::Result<i32>;
     fn CanSeekBackward(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMediaPosition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMediaPosition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaPosition_Impl, const OFFSET: isize>() -> IMediaPosition_Vtbl {
@@ -30909,6 +31605,8 @@ pub trait IMediaPropertyBag_Impl: Sized + super::super::System::Com::StructuredS
     fn EnumProperty(&self, iproperty: u32, pvarpropertyname: *mut super::super::System::Com::VARIANT, pvarpropertyvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMediaPropertyBag {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IMediaPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaPropertyBag_Impl, const OFFSET: isize>() -> IMediaPropertyBag_Vtbl {
         unsafe extern "system" fn EnumProperty<Identity: ::windows::core::IUnknownImpl, Impl: IMediaPropertyBag_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iproperty: u32, pvarpropertyname: *mut super::super::System::Com::VARIANT, pvarpropertyvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -30944,6 +31642,8 @@ pub trait IMediaSample_Impl: Sized {
     fn GetMediaTime(&self, ptimestart: *mut i64, ptimeend: *mut i64) -> ::windows::core::Result<()>;
     fn SetMediaTime(&self, ptimestart: *const i64, ptimeend: *const i64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMediaSample {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMediaSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSample_Impl, const OFFSET: isize>() -> IMediaSample_Vtbl {
@@ -31069,6 +31769,8 @@ pub trait IMediaSample2_Impl: Sized + IMediaSample_Impl {
     fn SetProperties(&self, cbproperties: u32, pbproperties: *const u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMediaSample2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMediaSample2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSample2_Impl, const OFFSET: isize>() -> IMediaSample2_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSample2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbproperties: u32, pbproperties: *mut u8) -> ::windows::core::HRESULT {
@@ -31100,6 +31802,7 @@ impl IMediaSample2_Vtbl {
 pub trait IMediaSample2Config_Impl: Sized {
     fn GetSurface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IMediaSample2Config {}
 impl IMediaSample2Config_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSample2Config_Impl, const OFFSET: isize>() -> IMediaSample2Config_Vtbl {
         unsafe extern "system" fn GetSurface<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSample2Config_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdirect3dsurface9: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -31138,6 +31841,7 @@ pub trait IMediaSeeking_Impl: Sized {
     fn GetRate(&self) -> ::windows::core::Result<f64>;
     fn GetPreroll(&self) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IMediaSeeking {}
 impl IMediaSeeking_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSeeking_Impl, const OFFSET: isize>() -> IMediaSeeking_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IMediaSeeking_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcapabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -31306,6 +32010,7 @@ pub trait IMediaStream_Impl: Sized {
     fn CreateSharedSample(&self, pexistingsample: &::core::option::Option<IStreamSample>, dwflags: u32) -> ::windows::core::Result<IStreamSample>;
     fn SendEndOfStream(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMediaStream {}
 impl IMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaStream_Impl, const OFFSET: isize>() -> IMediaStream_Vtbl {
         unsafe extern "system" fn GetMultiMediaStream<Identity: ::windows::core::IUnknownImpl, Impl: IMediaStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmultimediastream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31382,6 +32087,8 @@ pub trait IMediaStreamFilter_Impl: Sized + super::super::System::Com::IPersist_I
     fn Flush(&self, bcanceleos: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn EndOfStream(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMediaStreamFilter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMediaStreamFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaStreamFilter_Impl, const OFFSET: isize>() -> IMediaStreamFilter_Vtbl {
@@ -31477,6 +32184,8 @@ pub trait IMediaTypeInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Subtype(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMediaTypeInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMediaTypeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaTypeInfo_Impl, const OFFSET: isize>() -> IMediaTypeInfo_Vtbl {
         unsafe extern "system" fn Type<Identity: ::windows::core::IUnknownImpl, Impl: IMediaTypeInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strtype: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -31519,6 +32228,7 @@ pub trait IMemAllocator_Impl: Sized {
     fn GetBuffer(&self, ppbuffer: *mut ::core::option::Option<IMediaSample>, pstarttime: *const i64, pendtime: *const i64, dwflags: u32) -> ::windows::core::Result<()>;
     fn ReleaseBuffer(&self, pbuffer: &::core::option::Option<IMediaSample>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMemAllocator {}
 impl IMemAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMemAllocator_Impl, const OFFSET: isize>() -> IMemAllocator_Vtbl {
         unsafe extern "system" fn SetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IMemAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prequest: *const ALLOCATOR_PROPERTIES, pactual: *mut ALLOCATOR_PROPERTIES) -> ::windows::core::HRESULT {
@@ -31581,6 +32291,7 @@ pub trait IMemAllocatorCallbackTemp_Impl: Sized + IMemAllocator_Impl {
     fn SetNotify(&self, pnotify: &::core::option::Option<IMemAllocatorNotifyCallbackTemp>) -> ::windows::core::Result<()>;
     fn GetFreeCount(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IMemAllocatorCallbackTemp {}
 impl IMemAllocatorCallbackTemp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMemAllocatorCallbackTemp_Impl, const OFFSET: isize>() -> IMemAllocatorCallbackTemp_Vtbl {
         unsafe extern "system" fn SetNotify<Identity: ::windows::core::IUnknownImpl, Impl: IMemAllocatorCallbackTemp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnotify: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31612,6 +32323,7 @@ impl IMemAllocatorCallbackTemp_Vtbl {
 pub trait IMemAllocatorNotifyCallbackTemp_Impl: Sized {
     fn NotifyRelease(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMemAllocatorNotifyCallbackTemp {}
 impl IMemAllocatorNotifyCallbackTemp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMemAllocatorNotifyCallbackTemp_Impl, const OFFSET: isize>() -> IMemAllocatorNotifyCallbackTemp_Vtbl {
         unsafe extern "system" fn NotifyRelease<Identity: ::windows::core::IUnknownImpl, Impl: IMemAllocatorNotifyCallbackTemp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -31634,6 +32346,8 @@ pub trait IMemInputPin_Impl: Sized {
     fn ReceiveMultiple(&self, psamples: *const ::core::option::Option<IMediaSample>, nsamples: i32) -> ::windows::core::Result<i32>;
     fn ReceiveCanBlock(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMemInputPin {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMemInputPin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMemInputPin_Impl, const OFFSET: isize>() -> IMemInputPin_Vtbl {
@@ -31704,6 +32418,7 @@ pub trait IMemoryData_Impl: Sized {
     fn GetInfo(&self, pdwlength: *mut u32, ppbdata: *mut *mut u8, pcbactualdata: *mut u32) -> ::windows::core::Result<()>;
     fn SetActual(&self, cbdatavalid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMemoryData {}
 impl IMemoryData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMemoryData_Impl, const OFFSET: isize>() -> IMemoryData_Vtbl {
         unsafe extern "system" fn SetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IMemoryData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsize: u32, pbdata: *const u8, dwflags: u32) -> ::windows::core::HRESULT {
@@ -31743,6 +32458,8 @@ pub trait IMixerOCX_Impl: Sized {
     fn Advise(&self, pmdns: &::core::option::Option<IMixerOCXNotify>) -> ::windows::core::Result<()>;
     fn UnAdvise(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IMixerOCX {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IMixerOCX_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMixerOCX_Impl, const OFFSET: isize>() -> IMixerOCX_Vtbl {
@@ -31815,6 +32532,8 @@ pub trait IMixerOCXNotify_Impl: Sized {
     fn OnDataChange(&self, uldataflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMixerOCXNotify {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMixerOCXNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMixerOCXNotify_Impl, const OFFSET: isize>() -> IMixerOCXNotify_Vtbl {
         unsafe extern "system" fn OnInvalidateRect<Identity: ::windows::core::IUnknownImpl, Impl: IMixerOCXNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpcrect: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -31858,6 +32577,8 @@ pub trait IMixerPinConfig_Impl: Sized {
     fn SetStreamTransparent(&self, bstreamtransparent: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetStreamTransparent(&self, pbstreamtransparent: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMixerPinConfig {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMixerPinConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMixerPinConfig_Impl, const OFFSET: isize>() -> IMixerPinConfig_Vtbl {
@@ -31947,6 +32668,8 @@ pub trait IMixerPinConfig2_Impl: Sized + IMixerPinConfig_Impl {
     fn GetOverlaySurfaceColorControls(&self, pcolorcontrol: *mut super::super::Graphics::DirectDraw::DDCOLORCONTROL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IMixerPinConfig2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IMixerPinConfig2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMixerPinConfig2_Impl, const OFFSET: isize>() -> IMixerPinConfig2_Vtbl {
         unsafe extern "system" fn SetOverlaySurfaceColorControls<Identity: ::windows::core::IUnknownImpl, Impl: IMixerPinConfig2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcolorcontrol: *mut super::super::Graphics::DirectDraw::DDCOLORCONTROL) -> ::windows::core::HRESULT {
@@ -31975,6 +32698,8 @@ pub trait IMpeg2Data_Impl: Sized {
     fn GetTable(&self, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, dwtimeout: u32) -> ::windows::core::Result<ISectionList>;
     fn GetStreamOfSections(&self, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, hdatareadyevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<IMpeg2Stream>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMpeg2Data {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMpeg2Data_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2Data_Impl, const OFFSET: isize>() -> IMpeg2Data_Vtbl {
@@ -32029,6 +32754,8 @@ pub trait IMpeg2Demultiplexer_Impl: Sized {
     fn DeleteOutputPin(&self, pszpinname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMpeg2Demultiplexer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMpeg2Demultiplexer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2Demultiplexer_Impl, const OFFSET: isize>() -> IMpeg2Demultiplexer_Vtbl {
         unsafe extern "system" fn CreateOutputPin<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2Demultiplexer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmediatype: *mut AM_MEDIA_TYPE, pszpinname: ::windows::core::PCWSTR, ppipin: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -32063,6 +32790,8 @@ pub trait IMpeg2Stream_Impl: Sized {
     fn SupplyDataBuffer(&self, pstreambuffer: *const MPEG_STREAM_BUFFER) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMpeg2Stream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMpeg2Stream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2Stream_Impl, const OFFSET: isize>() -> IMpeg2Stream_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2Stream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requesttype: MPEG_REQUEST_TYPE, pmpeg2data: ::windows::core::RawPtr, pcontext: *const MPEG_CONTEXT, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, hdatareadyevent: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -32093,6 +32822,7 @@ pub trait IMpeg2TableFilter_Impl: Sized {
     fn RemoveTable(&self, p: u16, t: u8) -> ::windows::core::Result<()>;
     fn RemoveExtension(&self, p: u16, t: u8, e: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMpeg2TableFilter {}
 impl IMpeg2TableFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2TableFilter_Impl, const OFFSET: isize>() -> IMpeg2TableFilter_Vtbl {
         unsafe extern "system" fn AddPID<Identity: ::windows::core::IUnknownImpl, Impl: IMpeg2TableFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, p: u16) -> ::windows::core::HRESULT {
@@ -32155,6 +32885,8 @@ pub trait IMpegAudioDecoder_Impl: Sized {
     fn SetDualMode(&self, intdecode: u32) -> ::windows::core::Result<()>;
     fn AudioFormat(&self) -> ::windows::core::Result<MPEG1WAVEFORMAT>;
 }
+#[cfg(feature = "Win32_Media_Audio")]
+impl ::windows::core::RuntimeName for IMpegAudioDecoder {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl IMpegAudioDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMpegAudioDecoder_Impl, const OFFSET: isize>() -> IMpegAudioDecoder_Vtbl {
@@ -32293,6 +33025,8 @@ pub trait IMultiMediaStream_Impl: Sized {
     fn GetEndOfStreamEventHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMultiMediaStream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMultiMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiMediaStream_Impl, const OFFSET: isize>() -> IMultiMediaStream_Vtbl {
         unsafe extern "system" fn GetInformation<Identity: ::windows::core::IUnknownImpl, Impl: IMultiMediaStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwflags: *mut MMSSF_GET_INFORMATION_FLAGS, pstreamtype: *mut STREAM_TYPE) -> ::windows::core::HRESULT {
@@ -32407,6 +33141,8 @@ pub trait IOverlay_Impl: Sized {
     fn Unadvise(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IOverlay {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IOverlay_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOverlay_Impl, const OFFSET: isize>() -> IOverlay_Vtbl {
         unsafe extern "system" fn GetPalette<Identity: ::windows::core::IUnknownImpl, Impl: IOverlay_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcolors: *mut u32, pppalette: *mut *mut super::super::Graphics::Gdi::PALETTEENTRY) -> ::windows::core::HRESULT {
@@ -32503,6 +33239,8 @@ pub trait IOverlayNotify_Impl: Sized {
     fn OnPositionChange(&self, psourcerect: *const super::super::Foundation::RECT, pdestinationrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IOverlayNotify {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IOverlayNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOverlayNotify_Impl, const OFFSET: isize>() -> IOverlayNotify_Vtbl {
         unsafe extern "system" fn OnPaletteChange<Identity: ::windows::core::IUnknownImpl, Impl: IOverlayNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcolors: u32, ppalette: *const super::super::Graphics::Gdi::PALETTEENTRY) -> ::windows::core::HRESULT {
@@ -32542,6 +33280,8 @@ pub trait IOverlayNotify2_Impl: Sized + IOverlayNotify_Impl {
     fn OnDisplayChange(&self, hmonitor: super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IOverlayNotify2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IOverlayNotify2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOverlayNotify2_Impl, const OFFSET: isize>() -> IOverlayNotify2_Vtbl {
         unsafe extern "system" fn OnDisplayChange<Identity: ::windows::core::IUnknownImpl, Impl: IOverlayNotify2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::HRESULT {
@@ -32569,6 +33309,8 @@ pub trait IPAT_Impl: Sized {
     fn RegisterForWhenCurrent(&self, hnexttableiscurrent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPAT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPAT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPAT_Impl, const OFFSET: isize>() -> IPAT_Vtbl {
@@ -32693,6 +33435,7 @@ pub trait IPBDAAttributesDescriptor_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u16>;
     fn GetAttributePayload(&self, ppbattributebuffer: *mut *mut u8, pdwattributelength: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPBDAAttributesDescriptor {}
 impl IPBDAAttributesDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPBDAAttributesDescriptor_Impl, const OFFSET: isize>() -> IPBDAAttributesDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IPBDAAttributesDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -32738,6 +33481,7 @@ pub trait IPBDAEntitlementDescriptor_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u16>;
     fn GetToken(&self, ppbtokenbuffer: *mut *mut u8, pdwtokenlength: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPBDAEntitlementDescriptor {}
 impl IPBDAEntitlementDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPBDAEntitlementDescriptor_Impl, const OFFSET: isize>() -> IPBDAEntitlementDescriptor_Vtbl {
         unsafe extern "system" fn GetTag<Identity: ::windows::core::IUnknownImpl, Impl: IPBDAEntitlementDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbval: *mut u8) -> ::windows::core::HRESULT {
@@ -32783,6 +33527,7 @@ pub trait IPBDASiParser_Impl: Sized {
     fn GetEIT(&self, dwsize: u32, pbuffer: *const u8) -> ::windows::core::Result<IPBDA_EIT>;
     fn GetServices(&self, dwsize: u32, pbuffer: *const u8) -> ::windows::core::Result<IPBDA_Services>;
 }
+impl ::windows::core::RuntimeName for IPBDASiParser {}
 impl IPBDASiParser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPBDASiParser_Impl, const OFFSET: isize>() -> IPBDASiParser_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IPBDASiParser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -32836,6 +33581,7 @@ pub trait IPBDA_EIT_Impl: Sized {
     fn GetRecordDescriptorByIndex(&self, dwrecordindex: u32, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetRecordDescriptorByTag(&self, dwrecordindex: u32, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPBDA_EIT {}
 impl IPBDA_EIT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPBDA_EIT_Impl, const OFFSET: isize>() -> IPBDA_EIT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IPBDA_EIT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, size: u32, pbuffer: *const u8) -> ::windows::core::HRESULT {
@@ -32971,6 +33717,7 @@ pub trait IPBDA_Services_Impl: Sized {
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u32>;
     fn GetRecordByIndex(&self, dwrecordindex: u32) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IPBDA_Services {}
 impl IPBDA_Services_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPBDA_Services_Impl, const OFFSET: isize>() -> IPBDA_Services_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IPBDA_Services_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, size: u32, pbuffer: *const u8) -> ::windows::core::HRESULT {
@@ -33033,6 +33780,8 @@ pub trait IPMT_Impl: Sized {
     fn RegisterForWhenCurrent(&self, hnexttableiscurrent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMT {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMT_Impl, const OFFSET: isize>() -> IPMT_Vtbl {
@@ -33227,6 +33976,7 @@ impl IPMT_Vtbl {
 pub trait IPSITables_Impl: Sized {
     fn GetTable(&self, dwtsid: u32, dwtid_pid: u32, dwhashedver: u32, dwpara4: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IPSITables {}
 impl IPSITables_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPSITables_Impl, const OFFSET: isize>() -> IPSITables_Vtbl {
         unsafe extern "system" fn GetTable<Identity: ::windows::core::IUnknownImpl, Impl: IPSITables_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtsid: u32, dwtid_pid: u32, dwhashedver: u32, dwpara4: u32, ppiunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -33251,6 +34001,8 @@ pub trait IPTFilterLicenseRenewal_Impl: Sized {
     fn RenewLicenses(&self, wszfilename: &::windows::core::PCWSTR, wszexpiredkid: &::windows::core::PCWSTR, dwcallersid: u32, bhighpriority: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn CancelLicenseRenewal(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPTFilterLicenseRenewal {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPTFilterLicenseRenewal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPTFilterLicenseRenewal_Impl, const OFFSET: isize>() -> IPTFilterLicenseRenewal_Vtbl {
@@ -33280,6 +34032,8 @@ pub trait IPersistMediaPropertyBag_Impl: Sized + super::super::System::Com::IPer
     fn Load(&self, ppropbag: &::core::option::Option<IMediaPropertyBag>, perrorlog: &::core::option::Option<super::super::System::Com::IErrorLog>) -> ::windows::core::Result<()>;
     fn Save(&self, ppropbag: &::core::option::Option<IMediaPropertyBag>, fcleardirty: super::super::Foundation::BOOL, fsaveallproperties: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPersistMediaPropertyBag {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPersistMediaPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistMediaPropertyBag_Impl, const OFFSET: isize>() -> IPersistMediaPropertyBag_Vtbl {
@@ -33315,6 +34069,8 @@ pub trait IPersistTuneXml_Impl: Sized + super::super::System::Com::IPersist_Impl
     fn Load(&self, varvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPersistTuneXml {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPersistTuneXml_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistTuneXml_Impl, const OFFSET: isize>() -> IPersistTuneXml_Vtbl {
@@ -33355,6 +34111,8 @@ pub trait IPersistTuneXmlUtility_Impl: Sized {
     fn Deserialize(&self, varvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPersistTuneXmlUtility {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPersistTuneXmlUtility_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistTuneXmlUtility_Impl, const OFFSET: isize>() -> IPersistTuneXmlUtility_Vtbl {
         unsafe extern "system" fn Deserialize<Identity: ::windows::core::IUnknownImpl, Impl: IPersistTuneXmlUtility_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, varvalue: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -33378,6 +34136,8 @@ impl IPersistTuneXmlUtility_Vtbl {
 pub trait IPersistTuneXmlUtility2_Impl: Sized + IPersistTuneXmlUtility_Impl {
     fn Serialize(&self, pitunerequest: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPersistTuneXmlUtility2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPersistTuneXmlUtility2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistTuneXmlUtility2_Impl, const OFFSET: isize>() -> IPersistTuneXmlUtility2_Vtbl {
@@ -33416,6 +34176,8 @@ pub trait IPin_Impl: Sized {
     fn EndFlush(&self) -> ::windows::core::Result<()>;
     fn NewSegment(&self, tstart: i64, tstop: i64, drate: f64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPin_Impl, const OFFSET: isize>() -> IPin_Vtbl {
@@ -33561,6 +34323,8 @@ pub trait IPinConnection_Impl: Sized {
     fn DynamicDisconnect(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPinConnection {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPinConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPinConnection_Impl, const OFFSET: isize>() -> IPinConnection_Vtbl {
         unsafe extern "system" fn DynamicQueryAccept<Identity: ::windows::core::IUnknownImpl, Impl: IPinConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmt: *const AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -33600,6 +34364,8 @@ pub trait IPinFlowControl_Impl: Sized {
     fn Block(&self, dwblockflags: u32, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPinFlowControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPinFlowControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPinFlowControl_Impl, const OFFSET: isize>() -> IPinFlowControl_Vtbl {
         unsafe extern "system" fn Block<Identity: ::windows::core::IUnknownImpl, Impl: IPinFlowControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwblockflags: u32, hevent: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -33629,6 +34395,8 @@ pub trait IPinInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Disconnect(&self) -> ::windows::core::Result<()>;
     fn Render(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPinInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPinInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPinInfo_Impl, const OFFSET: isize>() -> IPinInfo_Vtbl {
@@ -33774,6 +34542,7 @@ pub trait IQualProp_Impl: Sized {
     fn AvgSyncOffset(&self) -> ::windows::core::Result<i32>;
     fn DevSyncOffset(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IQualProp {}
 impl IQualProp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQualProp_Impl, const OFFSET: isize>() -> IQualProp_Vtbl {
         unsafe extern "system" fn FramesDroppedInRenderer<Identity: ::windows::core::IUnknownImpl, Impl: IQualProp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcframes: *mut i32) -> ::windows::core::HRESULT {
@@ -33862,6 +34631,8 @@ pub trait IQualityControl_Impl: Sized {
     fn SetSink(&self, piqc: &::core::option::Option<IQualityControl>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IQualityControl {}
+#[cfg(feature = "Win32_System_Com")]
 impl IQualityControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQualityControl_Impl, const OFFSET: isize>() -> IQualityControl_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IQualityControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pself: ::windows::core::RawPtr, q: Quality) -> ::windows::core::HRESULT {
@@ -33890,6 +34661,8 @@ pub trait IQueueCommand_Impl: Sized {
     fn InvokeAtPresentationTime(&self, pcmd: *mut ::core::option::Option<IDeferredCommand>, time: f64, iid: *const ::windows::core::GUID, dispidmethod: i32, wflags: i16, cargs: i32, pdispparams: *const super::super::System::Com::VARIANT, pvarresult: *mut super::super::System::Com::VARIANT, puargerr: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IQueueCommand {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IQueueCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueueCommand_Impl, const OFFSET: isize>() -> IQueueCommand_Vtbl {
         unsafe extern "system" fn InvokeAtStreamTime<Identity: ::windows::core::IUnknownImpl, Impl: IQueueCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcmd: *mut ::windows::core::RawPtr, time: f64, iid: *const ::windows::core::GUID, dispidmethod: i32, wflags: i16, cargs: i32, pdispparams: *const super::super::System::Com::VARIANT, pvarresult: *mut super::super::System::Com::VARIANT, puargerr: *mut i16) -> ::windows::core::HRESULT {
@@ -33917,6 +34690,8 @@ pub trait IRegFilterInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Filter(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRegFilterInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRegFilterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegFilterInfo_Impl, const OFFSET: isize>() -> IRegFilterInfo_Vtbl {
@@ -33955,6 +34730,7 @@ impl IRegFilterInfo_Vtbl {
 pub trait IRegisterServiceProvider_Impl: Sized {
     fn RegisterService(&self, guidservice: *const ::windows::core::GUID, punkobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRegisterServiceProvider {}
 impl IRegisterServiceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegisterServiceProvider_Impl, const OFFSET: isize>() -> IRegisterServiceProvider_Vtbl {
         unsafe extern "system" fn RegisterService<Identity: ::windows::core::IUnknownImpl, Impl: IRegisterServiceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidservice: *const ::windows::core::GUID, punkobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -33972,6 +34748,7 @@ pub trait IRegisterTuner_Impl: Sized {
     fn Register(&self, ptuner: &::core::option::Option<ITuner>, pgraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
     fn Unregister(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRegisterTuner {}
 impl IRegisterTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegisterTuner_Impl, const OFFSET: isize>() -> IRegisterTuner_Vtbl {
         unsafe extern "system" fn Register<Identity: ::windows::core::IUnknownImpl, Impl: IRegisterTuner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptuner: ::windows::core::RawPtr, pgraph: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -33998,6 +34775,7 @@ pub trait IResourceConsumer_Impl: Sized {
     fn AcquireResource(&self, idresource: i32) -> ::windows::core::Result<()>;
     fn ReleaseResource(&self, idresource: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IResourceConsumer {}
 impl IResourceConsumer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceConsumer_Impl, const OFFSET: isize>() -> IResourceConsumer_Vtbl {
         unsafe extern "system" fn AcquireResource<Identity: ::windows::core::IUnknownImpl, Impl: IResourceConsumer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, idresource: i32) -> ::windows::core::HRESULT {
@@ -34031,6 +34809,8 @@ pub trait IResourceManager_Impl: Sized {
     fn SetFocus(&self, pfocusobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn ReleaseFocus(&self, pfocusobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResourceManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IResourceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManager_Impl, const OFFSET: isize>() -> IResourceManager_Vtbl {
@@ -34108,6 +34888,7 @@ pub trait ISBE2Crossbar_Impl: Sized {
     fn SetOutputProfile(&self, pprofile: &::core::option::Option<ISBE2MediaTypeProfile>, pcoutputpins: *mut u32, ppoutputpins: *mut ::core::option::Option<IPin>) -> ::windows::core::Result<()>;
     fn EnumStreams(&self) -> ::windows::core::Result<ISBE2EnumStream>;
 }
+impl ::windows::core::RuntimeName for ISBE2Crossbar {}
 impl ISBE2Crossbar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2Crossbar_Impl, const OFFSET: isize>() -> ISBE2Crossbar_Vtbl {
         unsafe extern "system" fn EnableDefaultMode<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2Crossbar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, defaultflags: u32) -> ::windows::core::HRESULT {
@@ -34160,6 +34941,7 @@ pub trait ISBE2EnumStream_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<ISBE2EnumStream>;
 }
+impl ::windows::core::RuntimeName for ISBE2EnumStream {}
 impl ISBE2EnumStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2EnumStream_Impl, const OFFSET: isize>() -> ISBE2EnumStream_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2EnumStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32, pstreamdesc: *mut SBE2_STREAM_DESC, pcreceived: *mut u32) -> ::windows::core::HRESULT {
@@ -34203,6 +34985,7 @@ impl ISBE2EnumStream_Vtbl {
 pub trait ISBE2FileScan_Impl: Sized {
     fn RepairFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISBE2FileScan {}
 impl ISBE2FileScan_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2FileScan_Impl, const OFFSET: isize>() -> ISBE2FileScan_Vtbl {
         unsafe extern "system" fn RepairFile<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2FileScan_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -34221,6 +35004,8 @@ pub trait ISBE2GlobalEvent_Impl: Sized {
     fn GetEvent(&self, idevt: *const ::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32, pspanning: *mut super::super::Foundation::BOOL, pcb: *mut u32, pb: *mut u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISBE2GlobalEvent {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISBE2GlobalEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2GlobalEvent_Impl, const OFFSET: isize>() -> ISBE2GlobalEvent_Vtbl {
         unsafe extern "system" fn GetEvent<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2GlobalEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, idevt: *const ::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32, pspanning: *mut super::super::Foundation::BOOL, pcb: *mut u32, pb: *mut u8) -> ::windows::core::HRESULT {
@@ -34238,6 +35023,8 @@ impl ISBE2GlobalEvent_Vtbl {
 pub trait ISBE2GlobalEvent2_Impl: Sized + ISBE2GlobalEvent_Impl {
     fn GetEventEx(&self, idevt: *const ::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32, pspanning: *mut super::super::Foundation::BOOL, pcb: *mut u32, pb: *mut u8, pstreamtime: *mut i64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISBE2GlobalEvent2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISBE2GlobalEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2GlobalEvent2_Impl, const OFFSET: isize>() -> ISBE2GlobalEvent2_Vtbl {
@@ -34259,6 +35046,8 @@ pub trait ISBE2MediaTypeProfile_Impl: Sized {
     fn AddStream(&self, pmediatype: *const AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
     fn DeleteStream(&self, index: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISBE2MediaTypeProfile {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISBE2MediaTypeProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2MediaTypeProfile_Impl, const OFFSET: isize>() -> ISBE2MediaTypeProfile_Vtbl {
@@ -34309,6 +35098,7 @@ impl ISBE2MediaTypeProfile_Vtbl {
 pub trait ISBE2SpanningEvent_Impl: Sized {
     fn GetEvent(&self, idevt: *const ::windows::core::GUID, streamid: u32, pcb: *mut u32, pb: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISBE2SpanningEvent {}
 impl ISBE2SpanningEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2SpanningEvent_Impl, const OFFSET: isize>() -> ISBE2SpanningEvent_Vtbl {
         unsafe extern "system" fn GetEvent<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2SpanningEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, idevt: *const ::windows::core::GUID, streamid: u32, pcb: *mut u32, pb: *mut u8) -> ::windows::core::HRESULT {
@@ -34327,6 +35117,7 @@ pub trait ISBE2StreamMap_Impl: Sized {
     fn UnmapStream(&self, stream: u32) -> ::windows::core::Result<()>;
     fn EnumMappedStreams(&self) -> ::windows::core::Result<ISBE2EnumStream>;
 }
+impl ::windows::core::RuntimeName for ISBE2StreamMap {}
 impl ISBE2StreamMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2StreamMap_Impl, const OFFSET: isize>() -> ISBE2StreamMap_Vtbl {
         unsafe extern "system" fn MapStream<Identity: ::windows::core::IUnknownImpl, Impl: ISBE2StreamMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stream: u32) -> ::windows::core::HRESULT {
@@ -34393,6 +35184,8 @@ pub trait ISCTE_EAS_Impl: Sized {
     fn GetTableDescriptorByIndex(&self, dwindex: u32) -> ::windows::core::Result<IGenericDescriptor>;
     fn GetTableDescriptorByTag(&self, btag: u8, pdwcookie: *mut u32, ppdescriptor: *mut ::core::option::Option<IGenericDescriptor>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISCTE_EAS {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISCTE_EAS_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCTE_EAS_Impl, const OFFSET: isize>() -> ISCTE_EAS_Vtbl {
@@ -34735,6 +35528,8 @@ pub trait ISIInbandEPG_Impl: Sized {
     fn IsSIEPGScanRunning(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISIInbandEPG {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISIInbandEPG_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISIInbandEPG_Impl, const OFFSET: isize>() -> ISIInbandEPG_Vtbl {
         unsafe extern "system" fn StartSIEPGScan<Identity: ::windows::core::IUnknownImpl, Impl: ISIInbandEPG_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -34772,6 +35567,7 @@ impl ISIInbandEPG_Vtbl {
 pub trait ISIInbandEPGEvent_Impl: Sized {
     fn SIObjectEvent(&self, pidvb_eit: &::core::option::Option<IDVB_EIT2>, dwtable_id: u32, dwservice_id: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISIInbandEPGEvent {}
 impl ISIInbandEPGEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISIInbandEPGEvent_Impl, const OFFSET: isize>() -> ISIInbandEPGEvent_Vtbl {
         unsafe extern "system" fn SIObjectEvent<Identity: ::windows::core::IUnknownImpl, Impl: ISIInbandEPGEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidvb_eit: ::windows::core::RawPtr, dwtable_id: u32, dwservice_id: u32) -> ::windows::core::HRESULT {
@@ -34793,6 +35589,8 @@ pub trait IScanningTuner_Impl: Sized + ITuner_Impl {
     fn ScanDown(&self, millisecondspause: i32) -> ::windows::core::Result<()>;
     fn AutoProgram(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IScanningTuner {}
 #[cfg(feature = "Win32_System_Com")]
 impl IScanningTuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScanningTuner_Impl, const OFFSET: isize>() -> IScanningTuner_Vtbl {
@@ -34845,6 +35643,8 @@ pub trait IScanningTunerEx_Impl: Sized + ITuner_Impl + IScanningTuner_Impl {
     fn GetCurrentTunerStandardCapability(&self, currentbroadcaststandard: &::windows::core::GUID, settlingtime: *mut i32, tvstandardssupported: *mut i32) -> ::windows::core::Result<()>;
     fn SetScanSignalTypeFilter(&self, scanmodulationtypes: i32, analogvideostandard: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IScanningTunerEx {}
 #[cfg(feature = "Win32_System_Com")]
 impl IScanningTunerEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScanningTunerEx_Impl, const OFFSET: isize>() -> IScanningTunerEx_Vtbl {
@@ -34921,6 +35721,8 @@ pub trait ISectionList_Impl: Sized {
     fn GetTableIdentifier(&self, ptableid: *const u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISectionList {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISectionList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISectionList_Impl, const OFFSET: isize>() -> ISectionList_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ISectionList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requesttype: MPEG_REQUEST_TYPE, pmpeg2data: ::windows::core::RawPtr, pcontext: *const MPEG_CONTEXT, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, timeout: u32, hdoneevent: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -34984,6 +35786,8 @@ pub trait ISeekingPassThru_Impl: Sized {
     fn Init(&self, bsupportrendering: super::super::Foundation::BOOL, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISeekingPassThru {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISeekingPassThru_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISeekingPassThru_Impl, const OFFSET: isize>() -> ISeekingPassThru_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: ISeekingPassThru_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bsupportrendering: super::super::Foundation::BOOL, ppin: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -35002,6 +35806,7 @@ pub trait ISelector_Impl: Sized {
     fn SourceNodeId(&self) -> ::windows::core::Result<u32>;
     fn SetSourceNodeId(&self, dwpinid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISelector {}
 impl ISelector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISelector_Impl, const OFFSET: isize>() -> ISelector_Vtbl {
         unsafe extern "system" fn NumSources<Identity: ::windows::core::IUnknownImpl, Impl: ISelector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwnumsources: *mut u32) -> ::windows::core::HRESULT {
@@ -35049,6 +35854,7 @@ pub trait IServiceLocationDescriptor_Impl: Sized {
     fn GetElementPID(&self, bindex: u8) -> ::windows::core::Result<u16>;
     fn GetElementLanguageCode(&self, bindex: u8, langcode: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceLocationDescriptor {}
 impl IServiceLocationDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceLocationDescriptor_Impl, const OFFSET: isize>() -> IServiceLocationDescriptor_Vtbl {
         unsafe extern "system" fn GetPCR_PID<Identity: ::windows::core::IUnknownImpl, Impl: IServiceLocationDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwval: *mut u16) -> ::windows::core::HRESULT {
@@ -35118,6 +35924,8 @@ pub trait ISpecifyParticularPages_Impl: Sized {
     fn GetPages(&self, guidwhatpages: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::System::Ole::CAUUID>;
 }
 #[cfg(feature = "Win32_System_Ole")]
+impl ::windows::core::RuntimeName for ISpecifyParticularPages {}
+#[cfg(feature = "Win32_System_Ole")]
 impl ISpecifyParticularPages_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpecifyParticularPages_Impl, const OFFSET: isize>() -> ISpecifyParticularPages_Vtbl {
         unsafe extern "system" fn GetPages<Identity: ::windows::core::IUnknownImpl, Impl: ISpecifyParticularPages_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidwhatpages: *const ::windows::core::GUID, ppages: *mut super::super::System::Ole::CAUUID) -> ::windows::core::HRESULT {
@@ -35145,6 +35953,7 @@ pub trait IStreamBufferConfigure_Impl: Sized {
     fn SetBackingFileDuration(&self, dwseconds: u32) -> ::windows::core::Result<()>;
     fn GetBackingFileDuration(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferConfigure {}
 impl IStreamBufferConfigure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferConfigure_Impl, const OFFSET: isize>() -> IStreamBufferConfigure_Vtbl {
         unsafe extern "system" fn SetDirectory<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferConfigure_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdirectoryname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -35209,6 +36018,7 @@ pub trait IStreamBufferConfigure2_Impl: Sized + IStreamBufferConfigure_Impl {
     fn SetFFTransitionRates(&self, dwmaxfullframerate: u32, dwmaxnonskippingrate: u32) -> ::windows::core::Result<()>;
     fn GetFFTransitionRates(&self, pdwmaxfullframerate: *mut u32, pdwmaxnonskippingrate: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferConfigure2 {}
 impl IStreamBufferConfigure2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferConfigure2_Impl, const OFFSET: isize>() -> IStreamBufferConfigure2_Vtbl {
         unsafe extern "system" fn SetMultiplexedPacketSize<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferConfigure2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbbytesperpacket: u32) -> ::windows::core::HRESULT {
@@ -35256,6 +36066,8 @@ pub trait IStreamBufferConfigure3_Impl: Sized + IStreamBufferConfigure_Impl + IS
     fn SetNamespace(&self, psznamespace: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetNamespace(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStreamBufferConfigure3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IStreamBufferConfigure3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferConfigure3_Impl, const OFFSET: isize>() -> IStreamBufferConfigure3_Vtbl {
@@ -35307,6 +36119,7 @@ pub trait IStreamBufferDataCounters_Impl: Sized {
     fn GetData(&self) -> ::windows::core::Result<SBE_PIN_DATA>;
     fn ResetData(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferDataCounters {}
 impl IStreamBufferDataCounters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferDataCounters_Impl, const OFFSET: isize>() -> IStreamBufferDataCounters_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferDataCounters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppindata: *mut SBE_PIN_DATA) -> ::windows::core::HRESULT {
@@ -35341,6 +36154,8 @@ pub trait IStreamBufferInitialize_Impl: Sized {
     fn SetSIDs(&self, csids: u32, ppsid: *mut super::super::Foundation::PSID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IStreamBufferInitialize {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IStreamBufferInitialize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferInitialize_Impl, const OFFSET: isize>() -> IStreamBufferInitialize_Vtbl {
         unsafe extern "system" fn SetHKEY<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferInitialize_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hkeyroot: super::super::System::Registry::HKEY) -> ::windows::core::HRESULT {
@@ -35364,6 +36179,7 @@ impl IStreamBufferInitialize_Vtbl {
     }
 }
 pub trait IStreamBufferMediaSeeking_Impl: Sized + IMediaSeeking_Impl {}
+impl ::windows::core::RuntimeName for IStreamBufferMediaSeeking {}
 impl IStreamBufferMediaSeeking_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferMediaSeeking_Impl, const OFFSET: isize>() -> IStreamBufferMediaSeeking_Vtbl {
         Self { base__: IMediaSeeking_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -35375,6 +36191,7 @@ impl IStreamBufferMediaSeeking_Vtbl {
 pub trait IStreamBufferMediaSeeking2_Impl: Sized + IMediaSeeking_Impl + IStreamBufferMediaSeeking_Impl {
     fn SetRateEx(&self, drate: f64, dwframespersec: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferMediaSeeking2 {}
 impl IStreamBufferMediaSeeking2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferMediaSeeking2_Impl, const OFFSET: isize>() -> IStreamBufferMediaSeeking2_Vtbl {
         unsafe extern "system" fn SetRateEx<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferMediaSeeking2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, drate: f64, dwframespersec: u32) -> ::windows::core::HRESULT {
@@ -35396,6 +36213,7 @@ pub trait IStreamBufferRecComp_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferRecComp {}
 impl IStreamBufferRecComp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferRecComp_Impl, const OFFSET: isize>() -> IStreamBufferRecComp_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferRecComp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psztargetfilename: ::windows::core::PCWSTR, pszsbrecprofileref: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -35455,6 +36273,8 @@ pub trait IStreamBufferRecordControl_Impl: Sized {
     fn GetRecordingStatus(&self, phresult: *mut ::windows::core::HRESULT, pbstarted: *mut super::super::Foundation::BOOL, pbstopped: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStreamBufferRecordControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IStreamBufferRecordControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferRecordControl_Impl, const OFFSET: isize>() -> IStreamBufferRecordControl_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferRecordControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prtstart: *mut i64) -> ::windows::core::HRESULT {
@@ -35490,6 +36310,7 @@ pub trait IStreamBufferRecordingAttribute_Impl: Sized {
     fn GetAttributeByIndex(&self, windex: u16, pulreserved: *const u32, pszattributename: ::windows::core::PWSTR, pcchnamelength: *mut u16, pstreambufferattributetype: *mut STREAMBUFFER_ATTR_DATATYPE, pbattribute: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
     fn EnumAttributes(&self) -> ::windows::core::Result<IEnumStreamBufferRecordingAttrib>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferRecordingAttribute {}
 impl IStreamBufferRecordingAttribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferRecordingAttribute_Impl, const OFFSET: isize>() -> IStreamBufferRecordingAttribute_Vtbl {
         unsafe extern "system" fn SetAttribute<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferRecordingAttribute_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulreserved: u32, pszattributename: ::windows::core::PCWSTR, streambufferattributetype: STREAMBUFFER_ATTR_DATATYPE, pbattribute: *const u8, cbattributelength: u16) -> ::windows::core::HRESULT {
@@ -35547,6 +36368,7 @@ pub trait IStreamBufferSink_Impl: Sized {
     fn CreateRecorder(&self, pszfilename: &::windows::core::PCWSTR, dwrecordtype: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn IsProfileLocked(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferSink {}
 impl IStreamBufferSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSink_Impl, const OFFSET: isize>() -> IStreamBufferSink_Vtbl {
         unsafe extern "system" fn LockProfile<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszstreambufferfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -35584,6 +36406,7 @@ impl IStreamBufferSink_Vtbl {
 pub trait IStreamBufferSink2_Impl: Sized + IStreamBufferSink_Impl {
     fn UnlockProfile(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferSink2 {}
 impl IStreamBufferSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSink2_Impl, const OFFSET: isize>() -> IStreamBufferSink2_Vtbl {
         unsafe extern "system" fn UnlockProfile<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSink2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -35600,6 +36423,7 @@ impl IStreamBufferSink2_Vtbl {
 pub trait IStreamBufferSink3_Impl: Sized + IStreamBufferSink_Impl + IStreamBufferSink2_Impl {
     fn SetAvailableFilter(&self, prtmin: *mut i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferSink3 {}
 impl IStreamBufferSink3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSink3_Impl, const OFFSET: isize>() -> IStreamBufferSink3_Vtbl {
         unsafe extern "system" fn SetAvailableFilter<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSink3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prtmin: *mut i64) -> ::windows::core::HRESULT {
@@ -35616,6 +36440,7 @@ impl IStreamBufferSink3_Vtbl {
 pub trait IStreamBufferSource_Impl: Sized {
     fn SetStreamSink(&self, pistreambuffersink: &::core::option::Option<IStreamBufferSink>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBufferSource {}
 impl IStreamBufferSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSource_Impl, const OFFSET: isize>() -> IStreamBufferSource_Vtbl {
         unsafe extern "system" fn SetStreamSink<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBufferSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pistreambuffersink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -35633,6 +36458,7 @@ pub trait IStreamBuilder_Impl: Sized {
     fn Render(&self, ppinout: &::core::option::Option<IPin>, pgraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
     fn Backout(&self, ppinout: &::core::option::Option<IPin>, pgraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStreamBuilder {}
 impl IStreamBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBuilder_Impl, const OFFSET: isize>() -> IStreamBuilder_Vtbl {
         unsafe extern "system" fn Render<Identity: ::windows::core::IUnknownImpl, Impl: IStreamBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppinout: ::windows::core::RawPtr, pgraph: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -35663,6 +36489,8 @@ pub trait IStreamSample_Impl: Sized {
     fn Update(&self, dwflags: u32, hevent: super::super::Foundation::HANDLE, pfnapc: &super::super::Foundation::PAPCFUNC, dwapcdata: usize) -> ::windows::core::Result<()>;
     fn CompletionStatus(&self, dwflags: u32, dwmilliseconds: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStreamSample {}
 #[cfg(feature = "Win32_Foundation")]
 impl IStreamSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamSample_Impl, const OFFSET: isize>() -> IStreamSample_Vtbl {
@@ -35716,6 +36544,8 @@ pub trait ITSDT_Impl: Sized {
     fn RegisterForWhenCurrent(&self, hnexttableiscurrent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn ConvertNextToCurrent(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITSDT {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITSDT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSDT_Impl, const OFFSET: isize>() -> ITSDT_Vtbl {
@@ -35814,6 +36644,8 @@ pub trait ITuneRequest_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetLocator(&self, locator: &::core::option::Option<ILocator>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITuneRequest {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITuneRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuneRequest_Impl, const OFFSET: isize>() -> ITuneRequest_Vtbl {
         unsafe extern "system" fn TuningSpace<Identity: ::windows::core::IUnknownImpl, Impl: ITuneRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tuningspace: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -35888,6 +36720,8 @@ pub trait ITuneRequestInfo_Impl: Sized {
     fn GetNextLocator(&self, currentrequest: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<ITuneRequest>;
     fn GetPreviousLocator(&self, currentrequest: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<ITuneRequest>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITuneRequestInfo {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITuneRequestInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuneRequestInfo_Impl, const OFFSET: isize>() -> ITuneRequestInfo_Vtbl {
@@ -35970,6 +36804,8 @@ pub trait ITuneRequestInfoEx_Impl: Sized + ITuneRequestInfo_Impl {
     fn CreateComponentListEx(&self, currentrequest: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITuneRequestInfoEx {}
+#[cfg(feature = "Win32_System_Com")]
 impl ITuneRequestInfoEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuneRequestInfoEx_Impl, const OFFSET: isize>() -> ITuneRequestInfoEx_Vtbl {
         unsafe extern "system" fn CreateComponentListEx<Identity: ::windows::core::IUnknownImpl, Impl: ITuneRequestInfoEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, currentrequest: ::windows::core::RawPtr, ppcurpmt: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -36002,6 +36838,8 @@ pub trait ITuner_Impl: Sized {
     fn SignalStrength(&self) -> ::windows::core::Result<i32>;
     fn TriggerSignalEvents(&self, interval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITuner {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITuner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuner_Impl, const OFFSET: isize>() -> ITuner_Vtbl {
@@ -36108,6 +36946,7 @@ pub trait ITunerCap_Impl: Sized {
     fn get_SupportedVideoFormats(&self, pulamtunermodetype: *mut u32, pulanalogvideostandard: *mut u32) -> ::windows::core::Result<()>;
     fn get_AuxInputCount(&self, pulcompositecount: *mut u32, pulsvideocount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITunerCap {}
 impl ITunerCap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITunerCap_Impl, const OFFSET: isize>() -> ITunerCap_Vtbl {
         unsafe extern "system" fn get_SupportedNetworkTypes<Identity: ::windows::core::IUnknownImpl, Impl: ITunerCap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulcnetworktypesmax: u32, pulcnetworktypes: *mut u32, pguidnetworktypes: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -36139,6 +36978,7 @@ impl ITunerCap_Vtbl {
 pub trait ITunerCapEx_Impl: Sized {
     fn Has608_708Caption(&self) -> ::windows::core::Result<i16>;
 }
+impl ::windows::core::RuntimeName for ITunerCapEx {}
 impl ITunerCapEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITunerCapEx_Impl, const OFFSET: isize>() -> ITunerCapEx_Vtbl {
         unsafe extern "system" fn Has608_708Caption<Identity: ::windows::core::IUnknownImpl, Impl: ITunerCapEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbhascaption: *mut i16) -> ::windows::core::HRESULT {
@@ -36180,6 +37020,8 @@ pub trait ITuningSpace_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetDefaultLocator(&self, locatorval: &::core::option::Option<ILocator>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<ITuningSpace>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITuningSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITuningSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuningSpace_Impl, const OFFSET: isize>() -> ITuningSpace_Vtbl {
@@ -36394,6 +37236,8 @@ pub trait ITuningSpaceContainer_Impl: Sized + super::super::System::Com::IDispat
     fn SetMaxCount(&self, maxcount: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITuningSpaceContainer {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITuningSpaceContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuningSpaceContainer_Impl, const OFFSET: isize>() -> ITuningSpaceContainer_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ITuningSpaceContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -36550,6 +37394,8 @@ pub trait ITuningSpaces_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn EnumTuningSpaces(&self) -> ::windows::core::Result<IEnumTuningSpaces>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITuningSpaces {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITuningSpaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITuningSpaces_Impl, const OFFSET: isize>() -> ITuningSpaces_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ITuningSpaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -36612,6 +37458,7 @@ pub trait IVMRAspectRatioControl_Impl: Sized {
     fn GetAspectRatioMode(&self, lpdwarmode: *mut u32) -> ::windows::core::Result<()>;
     fn SetAspectRatioMode(&self, dwarmode: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVMRAspectRatioControl {}
 impl IVMRAspectRatioControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRAspectRatioControl_Impl, const OFFSET: isize>() -> IVMRAspectRatioControl_Vtbl {
         unsafe extern "system" fn GetAspectRatioMode<Identity: ::windows::core::IUnknownImpl, Impl: IVMRAspectRatioControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpdwarmode: *mut u32) -> ::windows::core::HRESULT {
@@ -36638,6 +37485,7 @@ pub trait IVMRAspectRatioControl9_Impl: Sized {
     fn GetAspectRatioMode(&self) -> ::windows::core::Result<u32>;
     fn SetAspectRatioMode(&self, dwarmode: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVMRAspectRatioControl9 {}
 impl IVMRAspectRatioControl9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRAspectRatioControl9_Impl, const OFFSET: isize>() -> IVMRAspectRatioControl9_Vtbl {
         unsafe extern "system" fn GetAspectRatioMode<Identity: ::windows::core::IUnknownImpl, Impl: IVMRAspectRatioControl9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpdwarmode: *mut u32) -> ::windows::core::HRESULT {
@@ -36676,6 +37524,8 @@ pub trait IVMRDeinterlaceControl_Impl: Sized {
     fn SetDeinterlacePrefs(&self, dwdeinterlaceprefs: u32) -> ::windows::core::Result<()>;
     fn GetActualDeinterlaceMode(&self, dwstreamid: u32, lpdeinterlacemode: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVMRDeinterlaceControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVMRDeinterlaceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRDeinterlaceControl_Impl, const OFFSET: isize>() -> IVMRDeinterlaceControl_Vtbl {
@@ -36738,6 +37588,7 @@ pub trait IVMRDeinterlaceControl9_Impl: Sized {
     fn SetDeinterlacePrefs(&self, dwdeinterlaceprefs: u32) -> ::windows::core::Result<()>;
     fn GetActualDeinterlaceMode(&self, dwstreamid: u32) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IVMRDeinterlaceControl9 {}
 impl IVMRDeinterlaceControl9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRDeinterlaceControl9_Impl, const OFFSET: isize>() -> IVMRDeinterlaceControl9_Vtbl {
         unsafe extern "system" fn GetNumberOfDeinterlaceModes<Identity: ::windows::core::IUnknownImpl, Impl: IVMRDeinterlaceControl9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpvideodescription: *const VMR9VideoDesc, lpdwnumdeinterlacemodes: *mut u32, lpdeinterlacemodes: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -36823,6 +37674,7 @@ pub trait IVMRFilterConfig_Impl: Sized {
     fn SetRenderingMode(&self, mode: u32) -> ::windows::core::Result<()>;
     fn GetRenderingMode(&self, pmode: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVMRFilterConfig {}
 impl IVMRFilterConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRFilterConfig_Impl, const OFFSET: isize>() -> IVMRFilterConfig_Vtbl {
         unsafe extern "system" fn SetImageCompositor<Identity: ::windows::core::IUnknownImpl, Impl: IVMRFilterConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpvmrimgcompositor: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -36884,6 +37736,7 @@ pub trait IVMRFilterConfig9_Impl: Sized {
     fn SetRenderingMode(&self, mode: u32) -> ::windows::core::Result<()>;
     fn GetRenderingMode(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IVMRFilterConfig9 {}
 impl IVMRFilterConfig9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRFilterConfig9_Impl, const OFFSET: isize>() -> IVMRFilterConfig9_Vtbl {
         unsafe extern "system" fn SetImageCompositor<Identity: ::windows::core::IUnknownImpl, Impl: IVMRFilterConfig9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpvmrimgcompositor: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -36962,6 +37815,8 @@ pub trait IVMRImageCompositor_Impl: Sized {
     fn CompositeImage(&self, pd3ddevice: &::core::option::Option<::windows::core::IUnknown>, pddsrendertarget: &::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface7>, pmtrendertarget: *mut AM_MEDIA_TYPE, rtstart: i64, rtend: i64, dwclrbkgnd: u32, pvideostreaminfo: *mut VMRVIDEOSTREAMINFO, cstreams: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IVMRImageCompositor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IVMRImageCompositor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImageCompositor_Impl, const OFFSET: isize>() -> IVMRImageCompositor_Vtbl {
         unsafe extern "system" fn InitCompositionTarget<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImageCompositor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pd3ddevice: *mut ::core::ffi::c_void, pddsrendertarget: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -37004,6 +37859,8 @@ pub trait IVMRImageCompositor9_Impl: Sized {
     fn CompositeImage(&self, pd3ddevice: &::core::option::Option<::windows::core::IUnknown>, pddsrendertarget: &::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, pmtrendertarget: *const AM_MEDIA_TYPE, rtstart: i64, rtend: i64, dwclrbkgnd: u32, pvideostreaminfo: *const VMR9VideoStreamInfo, cstreams: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IVMRImageCompositor9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IVMRImageCompositor9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImageCompositor9_Impl, const OFFSET: isize>() -> IVMRImageCompositor9_Vtbl {
         unsafe extern "system" fn InitCompositionDevice<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImageCompositor9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pd3ddevice: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -37045,6 +37902,8 @@ pub trait IVMRImagePresenter_Impl: Sized {
     fn PresentImage(&self, dwuserid: usize, lppresinfo: *mut VMRPRESENTATIONINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IVMRImagePresenter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IVMRImagePresenter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenter_Impl, const OFFSET: isize>() -> IVMRImagePresenter_Vtbl {
         unsafe extern "system" fn StartPresenting<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwuserid: usize) -> ::windows::core::HRESULT {
@@ -37080,6 +37939,8 @@ pub trait IVMRImagePresenter9_Impl: Sized {
     fn PresentImage(&self, dwuserid: usize, lppresinfo: *const VMR9PresentationInfo) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IVMRImagePresenter9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IVMRImagePresenter9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenter9_Impl, const OFFSET: isize>() -> IVMRImagePresenter9_Vtbl {
         unsafe extern "system" fn StartPresenting<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenter9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwuserid: usize) -> ::windows::core::HRESULT {
@@ -37112,6 +37973,7 @@ pub trait IVMRImagePresenterConfig_Impl: Sized {
     fn SetRenderingPrefs(&self, dwrenderflags: u32) -> ::windows::core::Result<()>;
     fn GetRenderingPrefs(&self, dwrenderflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVMRImagePresenterConfig {}
 impl IVMRImagePresenterConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenterConfig_Impl, const OFFSET: isize>() -> IVMRImagePresenterConfig_Vtbl {
         unsafe extern "system" fn SetRenderingPrefs<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenterConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwrenderflags: u32) -> ::windows::core::HRESULT {
@@ -37138,6 +38000,7 @@ pub trait IVMRImagePresenterConfig9_Impl: Sized {
     fn SetRenderingPrefs(&self, dwrenderflags: u32) -> ::windows::core::Result<()>;
     fn GetRenderingPrefs(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IVMRImagePresenterConfig9 {}
 impl IVMRImagePresenterConfig9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenterConfig9_Impl, const OFFSET: isize>() -> IVMRImagePresenterConfig9_Vtbl {
         unsafe extern "system" fn SetRenderingPrefs<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenterConfig9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwrenderflags: u32) -> ::windows::core::HRESULT {
@@ -37172,6 +38035,8 @@ pub trait IVMRImagePresenterExclModeConfig_Impl: Sized + IVMRImagePresenterConfi
     fn GetXlcModeDDObjAndPrimarySurface(&self, lpddobj: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDraw7>, lpprimarysurf: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface7>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
+impl ::windows::core::RuntimeName for IVMRImagePresenterExclModeConfig {}
+#[cfg(feature = "Win32_Graphics_DirectDraw")]
 impl IVMRImagePresenterExclModeConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenterExclModeConfig_Impl, const OFFSET: isize>() -> IVMRImagePresenterExclModeConfig_Vtbl {
         unsafe extern "system" fn SetXlcModeDDObjAndPrimarySurface<Identity: ::windows::core::IUnknownImpl, Impl: IVMRImagePresenterExclModeConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpddobj: ::windows::core::RawPtr, lpprimarysurf: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -37200,6 +38065,8 @@ pub trait IVMRMixerBitmap_Impl: Sized {
     fn UpdateAlphaBitmapParameters(&self, pbmpparms: *mut VMRALPHABITMAP) -> ::windows::core::Result<()>;
     fn GetAlphaBitmapParameters(&self, pbmpparms: *mut VMRALPHABITMAP) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRMixerBitmap {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 impl IVMRMixerBitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMixerBitmap_Impl, const OFFSET: isize>() -> IVMRMixerBitmap_Vtbl {
@@ -37235,6 +38102,8 @@ pub trait IVMRMixerBitmap9_Impl: Sized {
     fn UpdateAlphaBitmapParameters(&self, pbmpparms: *const VMR9AlphaBitmap) -> ::windows::core::Result<()>;
     fn GetAlphaBitmapParameters(&self) -> ::windows::core::Result<VMR9AlphaBitmap>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRMixerBitmap9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 impl IVMRMixerBitmap9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMixerBitmap9_Impl, const OFFSET: isize>() -> IVMRMixerBitmap9_Vtbl {
@@ -37282,6 +38151,7 @@ pub trait IVMRMixerControl_Impl: Sized {
     fn SetMixingPrefs(&self, dwmixerprefs: u32) -> ::windows::core::Result<()>;
     fn GetMixingPrefs(&self, pdwmixerprefs: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVMRMixerControl {}
 impl IVMRMixerControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMixerControl_Impl, const OFFSET: isize>() -> IVMRMixerControl_Vtbl {
         unsafe extern "system" fn SetAlpha<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMixerControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamid: u32, alpha: f32) -> ::windows::core::HRESULT {
@@ -37367,6 +38237,7 @@ pub trait IVMRMixerControl9_Impl: Sized {
     fn GetProcAmpControl(&self, dwstreamid: u32, lpclrcontrol: *mut VMR9ProcAmpControl) -> ::windows::core::Result<()>;
     fn GetProcAmpControlRange(&self, dwstreamid: u32, lpclrcontrol: *mut VMR9ProcAmpControlRange) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVMRMixerControl9 {}
 impl IVMRMixerControl9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMixerControl9_Impl, const OFFSET: isize>() -> IVMRMixerControl9_Vtbl {
         unsafe extern "system" fn SetAlpha<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMixerControl9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamid: u32, alpha: f32) -> ::windows::core::HRESULT {
@@ -37488,6 +38359,8 @@ pub trait IVMRMonitorConfig_Impl: Sized {
     fn GetAvailableMonitors(&self, pinfo: *mut VMRMONITORINFO, dwmaxinfoarraysize: u32, pdwnumdevices: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRMonitorConfig {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IVMRMonitorConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMonitorConfig_Impl, const OFFSET: isize>() -> IVMRMonitorConfig_Vtbl {
         unsafe extern "system" fn SetMonitor<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMonitorConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguid: *const VMRGUID) -> ::windows::core::HRESULT {
@@ -37536,6 +38409,8 @@ pub trait IVMRMonitorConfig9_Impl: Sized {
     fn GetDefaultMonitor(&self) -> ::windows::core::Result<u32>;
     fn GetAvailableMonitors(&self, pinfo: *mut VMR9MonitorInfo, dwmaxinfoarraysize: u32, pdwnumdevices: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRMonitorConfig9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IVMRMonitorConfig9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRMonitorConfig9_Impl, const OFFSET: isize>() -> IVMRMonitorConfig9_Vtbl {
@@ -37597,6 +38472,8 @@ pub trait IVMRSurface_Impl: Sized {
     fn GetSurface(&self) -> ::windows::core::Result<super::super::Graphics::DirectDraw::IDirectDrawSurface7>;
 }
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
+impl ::windows::core::RuntimeName for IVMRSurface {}
+#[cfg(feature = "Win32_Graphics_DirectDraw")]
 impl IVMRSurface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurface_Impl, const OFFSET: isize>() -> IVMRSurface_Vtbl {
         unsafe extern "system" fn IsSurfaceLocked<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -37644,6 +38521,8 @@ pub trait IVMRSurface9_Impl: Sized {
     fn UnlockSurface(&self) -> ::windows::core::Result<()>;
     fn GetSurface(&self) -> ::windows::core::Result<super::super::Graphics::Direct3D9::IDirect3DSurface9>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D9")]
+impl ::windows::core::RuntimeName for IVMRSurface9 {}
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl IVMRSurface9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurface9_Impl, const OFFSET: isize>() -> IVMRSurface9_Vtbl {
@@ -37699,6 +38578,8 @@ pub trait IVMRSurfaceAllocator_Impl: Sized {
     fn AdviseNotify(&self, lpivmrsurfallocnotify: &::core::option::Option<IVMRSurfaceAllocatorNotify>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRSurfaceAllocator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 impl IVMRSurfaceAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocator_Impl, const OFFSET: isize>() -> IVMRSurfaceAllocator_Vtbl {
         unsafe extern "system" fn AllocateSurface<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwuserid: usize, lpallocinfo: *mut VMRALLOCATIONINFO, lpdwactualbuffers: *mut u32, lplpsurface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -37740,6 +38621,8 @@ pub trait IVMRSurfaceAllocator9_Impl: Sized {
     fn GetSurface(&self, dwuserid: usize, surfaceindex: u32, surfaceflags: u32) -> ::windows::core::Result<super::super::Graphics::Direct3D9::IDirect3DSurface9>;
     fn AdviseNotify(&self, lpivmrsurfallocnotify: &::core::option::Option<IVMRSurfaceAllocatorNotify9>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IVMRSurfaceAllocator9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IVMRSurfaceAllocator9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocator9_Impl, const OFFSET: isize>() -> IVMRSurfaceAllocator9_Vtbl {
@@ -37786,6 +38669,8 @@ pub trait IVMRSurfaceAllocatorEx9_Impl: Sized + IVMRSurfaceAllocator9_Impl {
     fn GetSurfaceEx(&self, dwuserid: usize, surfaceindex: u32, surfaceflags: u32, lplpsurface: *mut ::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, lprcdst: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IVMRSurfaceAllocatorEx9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IVMRSurfaceAllocatorEx9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocatorEx9_Impl, const OFFSET: isize>() -> IVMRSurfaceAllocatorEx9_Vtbl {
         unsafe extern "system" fn GetSurfaceEx<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocatorEx9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwuserid: usize, surfaceindex: u32, surfaceflags: u32, lplpsurface: *mut ::windows::core::RawPtr, lprcdst: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -37808,6 +38693,8 @@ pub trait IVMRSurfaceAllocatorNotify_Impl: Sized {
     fn NotifyEvent(&self, eventcode: i32, param1: isize, param2: isize) -> ::windows::core::Result<()>;
     fn SetBorderColor(&self, clrborder: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRSurfaceAllocatorNotify {}
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 impl IVMRSurfaceAllocatorNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocatorNotify_Impl, const OFFSET: isize>() -> IVMRSurfaceAllocatorNotify_Vtbl {
@@ -37864,6 +38751,8 @@ pub trait IVMRSurfaceAllocatorNotify9_Impl: Sized {
     fn NotifyEvent(&self, eventcode: i32, param1: isize, param2: isize) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRSurfaceAllocatorNotify9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 impl IVMRSurfaceAllocatorNotify9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocatorNotify9_Impl, const OFFSET: isize>() -> IVMRSurfaceAllocatorNotify9_Vtbl {
         unsafe extern "system" fn AdviseSurfaceAllocator<Identity: ::windows::core::IUnknownImpl, Impl: IVMRSurfaceAllocatorNotify9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwuserid: usize, lpivrmsurfaceallocator: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -37912,6 +38801,8 @@ pub trait IVMRVideoStreamControl_Impl: Sized {
     fn GetStreamActiveState(&self, lpfactive: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IVMRVideoStreamControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IVMRVideoStreamControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRVideoStreamControl_Impl, const OFFSET: isize>() -> IVMRVideoStreamControl_Vtbl {
         unsafe extern "system" fn SetColorKey<Identity: ::windows::core::IUnknownImpl, Impl: IVMRVideoStreamControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpclrkey: *mut super::super::Graphics::DirectDraw::DDCOLORKEY) -> ::windows::core::HRESULT {
@@ -37951,6 +38842,8 @@ pub trait IVMRVideoStreamControl9_Impl: Sized {
     fn SetStreamActiveState(&self, factive: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetStreamActiveState(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVMRVideoStreamControl9 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVMRVideoStreamControl9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRVideoStreamControl9_Impl, const OFFSET: isize>() -> IVMRVideoStreamControl9_Vtbl {
@@ -37998,6 +38891,8 @@ pub trait IVMRWindowlessControl_Impl: Sized {
     fn SetColorKey(&self, clr: u32) -> ::windows::core::Result<()>;
     fn GetColorKey(&self, lpclr: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRWindowlessControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IVMRWindowlessControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRWindowlessControl_Impl, const OFFSET: isize>() -> IVMRWindowlessControl_Vtbl {
@@ -38115,6 +39010,8 @@ pub trait IVMRWindowlessControl9_Impl: Sized {
     fn SetBorderColor(&self, clr: u32) -> ::windows::core::Result<()>;
     fn GetBorderColor(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVMRWindowlessControl9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IVMRWindowlessControl9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVMRWindowlessControl9_Impl, const OFFSET: isize>() -> IVMRWindowlessControl9_Vtbl {
@@ -38239,6 +39136,8 @@ pub trait IVPBaseConfig_Impl: Sized {
     fn SetSurfaceParameters(&self, dwpitch: u32, dwxorigin: u32, dwyorigin: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IVPBaseConfig {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IVPBaseConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPBaseConfig_Impl, const OFFSET: isize>() -> IVPBaseConfig_Vtbl {
         unsafe extern "system" fn GetConnectInfo<Identity: ::windows::core::IUnknownImpl, Impl: IVPBaseConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwnumconnectinfo: *mut u32, pddvpconnectinfo: *mut super::super::Graphics::DirectDraw::DDVIDEOPORTCONNECT) -> ::windows::core::HRESULT {
@@ -38336,6 +39235,7 @@ impl IVPBaseConfig_Vtbl {
 pub trait IVPBaseNotify_Impl: Sized {
     fn RenegotiateVPParameters(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVPBaseNotify {}
 impl IVPBaseNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPBaseNotify_Impl, const OFFSET: isize>() -> IVPBaseNotify_Vtbl {
         unsafe extern "system" fn RenegotiateVPParameters<Identity: ::windows::core::IUnknownImpl, Impl: IVPBaseNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -38354,6 +39254,8 @@ pub trait IVPConfig_Impl: Sized + IVPBaseConfig_Impl {
     fn IsVPDecimationAllowed(&self, pbisdecimationallowed: *mut i32) -> ::windows::core::Result<()>;
     fn SetScalingFactors(&self, pamvpsize: *mut AMVPSIZE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IVPConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IVPConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPConfig_Impl, const OFFSET: isize>() -> IVPConfig_Vtbl {
@@ -38381,6 +39283,7 @@ pub trait IVPManager_Impl: Sized {
     fn SetVideoPortIndex(&self, dwvideoportindex: u32) -> ::windows::core::Result<()>;
     fn GetVideoPortIndex(&self, pdwvideoportindex: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVPManager {}
 impl IVPManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPManager_Impl, const OFFSET: isize>() -> IVPManager_Vtbl {
         unsafe extern "system" fn SetVideoPortIndex<Identity: ::windows::core::IUnknownImpl, Impl: IVPManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwvideoportindex: u32) -> ::windows::core::HRESULT {
@@ -38407,6 +39310,7 @@ pub trait IVPNotify_Impl: Sized + IVPBaseNotify_Impl {
     fn SetDeinterlaceMode(&self, mode: AMVP_MODE) -> ::windows::core::Result<()>;
     fn GetDeinterlaceMode(&self, pmode: *mut AMVP_MODE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVPNotify {}
 impl IVPNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPNotify_Impl, const OFFSET: isize>() -> IVPNotify_Vtbl {
         unsafe extern "system" fn SetDeinterlaceMode<Identity: ::windows::core::IUnknownImpl, Impl: IVPNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: AMVP_MODE) -> ::windows::core::HRESULT {
@@ -38435,6 +39339,8 @@ pub trait IVPNotify2_Impl: Sized + IVPBaseNotify_Impl + IVPNotify_Impl {
     fn GetVPSyncMaster(&self, pbvpsyncmaster: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVPNotify2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVPNotify2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPNotify2_Impl, const OFFSET: isize>() -> IVPNotify2_Vtbl {
         unsafe extern "system" fn SetVPSyncMaster<Identity: ::windows::core::IUnknownImpl, Impl: IVPNotify2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bvpsyncmaster: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -38460,6 +39366,8 @@ impl IVPNotify2_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IVPVBIConfig_Impl: Sized + IVPBaseConfig_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
+impl ::windows::core::RuntimeName for IVPVBIConfig {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 impl IVPVBIConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPVBIConfig_Impl, const OFFSET: isize>() -> IVPVBIConfig_Vtbl {
         Self { base__: IVPBaseConfig_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -38469,6 +39377,7 @@ impl IVPVBIConfig_Vtbl {
     }
 }
 pub trait IVPVBINotify_Impl: Sized + IVPBaseNotify_Impl {}
+impl ::windows::core::RuntimeName for IVPVBINotify {}
 impl IVPVBINotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVPVBINotify_Impl, const OFFSET: isize>() -> IVPVBINotify_Vtbl {
         Self { base__: IVPBaseNotify_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -38479,6 +39388,8 @@ impl IVPVBINotify_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVideoEncoder_Impl: Sized + IEncoderAPI_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVideoEncoder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVideoEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVideoEncoder_Impl, const OFFSET: isize>() -> IVideoEncoder_Vtbl {
@@ -38493,6 +39404,7 @@ pub trait IVideoFrameStep_Impl: Sized {
     fn CanStep(&self, bmultiple: i32, pstepobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn CancelStep(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVideoFrameStep {}
 impl IVideoFrameStep_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVideoFrameStep_Impl, const OFFSET: isize>() -> IVideoFrameStep_Vtbl {
         unsafe extern "system" fn Step<Identity: ::windows::core::IUnknownImpl, Impl: IVideoFrameStep_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwframes: u32, pstepobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -38562,6 +39474,7 @@ pub trait IVideoProcAmp_Impl: Sized {
     fn put_WhiteBalanceComponent(&self, value1: i32, value2: i32, flags: i32) -> ::windows::core::Result<()>;
     fn getRange_WhiteBalanceComponent(&self, pmin: *mut i32, pmax: *mut i32, psteppingdelta: *mut i32, pdefault: *mut i32, pcapsflag: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVideoProcAmp {}
 impl IVideoProcAmp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVideoProcAmp_Impl, const OFFSET: isize>() -> IVideoProcAmp_Vtbl {
         unsafe extern "system" fn get_BacklightCompensation<Identity: ::windows::core::IUnknownImpl, Impl: IVideoProcAmp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut i32, pflags: *mut i32) -> ::windows::core::HRESULT {
@@ -38848,6 +39761,8 @@ pub trait IVideoWindow_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn HideCursor(&self, hidecursor: OA_BOOL) -> ::windows::core::Result<()>;
     fn IsCursorHidden(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVideoWindow {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVideoWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVideoWindow_Impl, const OFFSET: isize>() -> IVideoWindow_Vtbl {
@@ -39200,6 +40115,8 @@ pub trait IXDSCodec_Impl: Sized {
     fn GetLastErrorCode(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXDSCodec {}
+#[cfg(feature = "Win32_Foundation")]
 impl IXDSCodec_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXDSCodec_Impl, const OFFSET: isize>() -> IXDSCodec_Vtbl {
         unsafe extern "system" fn XDSToRatObjOK<Identity: ::windows::core::IUnknownImpl, Impl: IXDSCodec_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phrcocreateretval: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -39274,6 +40191,7 @@ pub trait IXDSCodecConfig_Impl: Sized {
     fn GetSecureChannelObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetPauseBufferTime(&self, dwpausebuffertime: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXDSCodecConfig {}
 impl IXDSCodecConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXDSCodecConfig_Impl, const OFFSET: isize>() -> IXDSCodecConfig_Vtbl {
         unsafe extern "system" fn GetSecureChannelObject<Identity: ::windows::core::IUnknownImpl, Impl: IXDSCodecConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunkdrmsecurechannel: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -39305,6 +40223,8 @@ impl IXDSCodecConfig_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXDSCodecEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXDSCodecEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXDSCodecEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXDSCodecEvents_Impl, const OFFSET: isize>() -> IXDSCodecEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -39318,6 +40238,8 @@ pub trait IXDSToRat_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Init(&self) -> ::windows::core::Result<()>;
     fn ParseXDSBytePair(&self, byte1: u8, byte2: u8, pensystem: *mut EnTvRat_System, penlevel: *mut EnTvRat_GenericLevel, plbfenattributes: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IXDSToRat {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IXDSToRat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXDSToRat_Impl, const OFFSET: isize>() -> IXDSToRat_Vtbl {
@@ -39343,6 +40265,8 @@ impl IXDSToRat_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IMSVidCtlEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IMSVidCtlEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IMSVidCtlEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IMSVidCtlEvents_Impl, const OFFSET: isize>() -> _IMSVidCtlEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
@@ -3,6 +3,7 @@ pub trait IDMOQualityControl_Impl: Sized {
     fn SetStatus(&self, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetStatus(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IDMOQualityControl {}
 impl IDMOQualityControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMOQualityControl_Impl, const OFFSET: isize>() -> IDMOQualityControl_Vtbl {
         unsafe extern "system" fn SetNow<Identity: ::windows::core::IUnknownImpl, Impl: IDMOQualityControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rtnow: i64) -> ::windows::core::HRESULT {
@@ -43,6 +44,7 @@ pub trait IDMOVideoOutputOptimizations_Impl: Sized {
     fn GetCurrentOperationMode(&self, uloutputstreamindex: u32) -> ::windows::core::Result<u32>;
     fn GetCurrentSampleRequirements(&self, uloutputstreamindex: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IDMOVideoOutputOptimizations {}
 impl IDMOVideoOutputOptimizations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDMOVideoOutputOptimizations_Impl, const OFFSET: isize>() -> IDMOVideoOutputOptimizations_Vtbl {
         unsafe extern "system" fn QueryOperationModePreferences<Identity: ::windows::core::IUnknownImpl, Impl: IDMOVideoOutputOptimizations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uloutputstreamindex: u32, pdwrequestedcapabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -101,6 +103,7 @@ pub trait IEnumDMO_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDMO>;
 }
+impl ::windows::core::RuntimeName for IEnumDMO {}
 impl IEnumDMO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDMO_Impl, const OFFSET: isize>() -> IEnumDMO_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDMO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, citemstofetch: u32, pclsid: *mut ::windows::core::GUID, names: *mut ::windows::core::PWSTR, pcitemsfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -146,6 +149,7 @@ pub trait IMediaBuffer_Impl: Sized {
     fn GetMaxLength(&self) -> ::windows::core::Result<u32>;
     fn GetBufferAndLength(&self, ppbuffer: *mut *mut u8, pcblength: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMediaBuffer {}
 impl IMediaBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaBuffer_Impl, const OFFSET: isize>() -> IMediaBuffer_Vtbl {
         unsafe extern "system" fn SetLength<Identity: ::windows::core::IUnknownImpl, Impl: IMediaBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cblength: u32) -> ::windows::core::HRESULT {
@@ -204,6 +208,8 @@ pub trait IMediaObject_Impl: Sized {
     fn ProcessOutput(&self, dwflags: u32, coutputbuffercount: u32, poutputbuffers: *mut DMO_OUTPUT_DATA_BUFFER, pdwstatus: *mut u32) -> ::windows::core::Result<()>;
     fn Lock(&self, block: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMediaObject {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMediaObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaObject_Impl, const OFFSET: isize>() -> IMediaObject_Vtbl {
@@ -394,6 +400,7 @@ pub trait IMediaObjectInPlace_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IMediaObjectInPlace>;
     fn GetLatency(&self) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IMediaObjectInPlace {}
 impl IMediaObjectInPlace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMediaObjectInPlace_Impl, const OFFSET: isize>() -> IMediaObjectInPlace_Vtbl {
         unsafe extern "system" fn Process<Identity: ::windows::core::IUnknownImpl, Impl: IMediaObjectInPlace_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulsize: u32, pdata: *mut u8, reftimestart: i64, dwflags: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
@@ -2,6 +2,7 @@ pub trait IKsAggregateControl_Impl: Sized {
     fn KsAddAggregate(&self, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn KsRemoveAggregate(&self, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IKsAggregateControl {}
 impl IKsAggregateControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsAggregateControl_Impl, const OFFSET: isize>() -> IKsAggregateControl_Vtbl {
         unsafe extern "system" fn KsAddAggregate<Identity: ::windows::core::IUnknownImpl, Impl: IKsAggregateControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -29,6 +30,7 @@ pub trait IKsControl_Impl: Sized {
     fn KsMethod(&self, method: *const KSIDENTIFIER, methodlength: u32, methoddata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
     fn KsEvent(&self, event: *const KSIDENTIFIER, eventlength: u32, eventdata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IKsControl {}
 impl IKsControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsControl_Impl, const OFFSET: isize>() -> IKsControl_Vtbl {
         unsafe extern "system" fn KsProperty<Identity: ::windows::core::IUnknownImpl, Impl: IKsControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, property: *const KSIDENTIFIER, propertylength: u32, propertydata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT {
@@ -63,6 +65,8 @@ pub trait IKsFormatSupport_Impl: Sized {
     fn GetDevicePreferredFormat(&self) -> ::windows::core::Result<*mut KSDATAFORMAT>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IKsFormatSupport {}
+#[cfg(feature = "Win32_Foundation")]
 impl IKsFormatSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsFormatSupport_Impl, const OFFSET: isize>() -> IKsFormatSupport_Vtbl {
         unsafe extern "system" fn IsFormatSupported<Identity: ::windows::core::IUnknownImpl, Impl: IKsFormatSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pksformat: *mut KSDATAFORMAT, cbformat: u32, pbsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -94,6 +98,7 @@ impl IKsFormatSupport_Vtbl {
 pub trait IKsJackContainerId_Impl: Sized {
     fn GetJackContainerId(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IKsJackContainerId {}
 impl IKsJackContainerId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackContainerId_Impl, const OFFSET: isize>() -> IKsJackContainerId_Vtbl {
         unsafe extern "system" fn GetJackContainerId<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackContainerId_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pjackcontainerid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -118,6 +123,8 @@ pub trait IKsJackDescription_Impl: Sized {
     fn GetJackCount(&self) -> ::windows::core::Result<u32>;
     fn GetJackDescription(&self, njack: u32) -> ::windows::core::Result<KSJACK_DESCRIPTION>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IKsJackDescription {}
 #[cfg(feature = "Win32_Foundation")]
 impl IKsJackDescription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackDescription_Impl, const OFFSET: isize>() -> IKsJackDescription_Vtbl {
@@ -157,6 +164,7 @@ pub trait IKsJackDescription2_Impl: Sized {
     fn GetJackCount(&self) -> ::windows::core::Result<u32>;
     fn GetJackDescription2(&self, njack: u32) -> ::windows::core::Result<KSJACK_DESCRIPTION2>;
 }
+impl ::windows::core::RuntimeName for IKsJackDescription2 {}
 impl IKsJackDescription2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackDescription2_Impl, const OFFSET: isize>() -> IKsJackDescription2_Vtbl {
         unsafe extern "system" fn GetJackCount<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackDescription2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcjacks: *mut u32) -> ::windows::core::HRESULT {
@@ -196,6 +204,8 @@ pub trait IKsJackSinkInformation_Impl: Sized {
     fn GetJackSinkInformation(&self) -> ::windows::core::Result<KSJACK_SINK_INFORMATION>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IKsJackSinkInformation {}
+#[cfg(feature = "Win32_Foundation")]
 impl IKsJackSinkInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackSinkInformation_Impl, const OFFSET: isize>() -> IKsJackSinkInformation_Vtbl {
         unsafe extern "system" fn GetJackSinkInformation<Identity: ::windows::core::IUnknownImpl, Impl: IKsJackSinkInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pjacksinkinformation: *mut KSJACK_SINK_INFORMATION) -> ::windows::core::HRESULT {
@@ -220,6 +230,7 @@ pub trait IKsPropertySet_Impl: Sized {
     fn Get(&self, propset: *const ::windows::core::GUID, id: u32, instancedata: *const ::core::ffi::c_void, instancelength: u32, propertydata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
     fn QuerySupported(&self, propset: *const ::windows::core::GUID, id: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IKsPropertySet {}
 impl IKsPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsPropertySet_Impl, const OFFSET: isize>() -> IKsPropertySet_Vtbl {
         unsafe extern "system" fn Set<Identity: ::windows::core::IUnknownImpl, Impl: IKsPropertySet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propset: *const ::windows::core::GUID, id: u32, instancedata: *const ::core::ffi::c_void, instancelength: u32, propertydata: *const ::core::ffi::c_void, datalength: u32) -> ::windows::core::HRESULT {
@@ -257,6 +268,7 @@ impl IKsPropertySet_Vtbl {
 pub trait IKsTopology_Impl: Sized {
     fn CreateNodeInstance(&self, nodeid: u32, flags: u32, desiredaccess: u32, unkouter: &::core::option::Option<::windows::core::IUnknown>, interfaceid: *const ::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IKsTopology {}
 impl IKsTopology_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKsTopology_Impl, const OFFSET: isize>() -> IKsTopology_Vtbl {
         unsafe extern "system" fn CreateNodeInstance<Identity: ::windows::core::IUnknownImpl, Impl: IKsTopology_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nodeid: u32, flags: u32, desiredaccess: u32, unkouter: *mut ::core::ffi::c_void, interfaceid: *const ::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/impl.rs
@@ -6,6 +6,8 @@ pub trait IWindowsMediaLibrarySharingDevice_Impl: Sized + super::super::System::
     fn Properties(&self) -> ::windows::core::Result<IWindowsMediaLibrarySharingDeviceProperties>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsMediaLibrarySharingDevice {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsMediaLibrarySharingDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDevice_Impl, const OFFSET: isize>() -> IWindowsMediaLibrarySharingDevice_Vtbl {
         unsafe extern "system" fn DeviceID<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, deviceid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -65,6 +67,8 @@ pub trait IWindowsMediaLibrarySharingDeviceProperties_Impl: Sized + super::super
     fn GetProperty(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWindowsMediaLibrarySharingDeviceProperty>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsMediaLibrarySharingDeviceProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsMediaLibrarySharingDeviceProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDeviceProperties_Impl, const OFFSET: isize>() -> IWindowsMediaLibrarySharingDeviceProperties_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDeviceProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, property: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -117,6 +121,8 @@ pub trait IWindowsMediaLibrarySharingDeviceProperty_Impl: Sized + super::super::
     fn Value(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsMediaLibrarySharingDeviceProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsMediaLibrarySharingDeviceProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDeviceProperty_Impl, const OFFSET: isize>() -> IWindowsMediaLibrarySharingDeviceProperty_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDeviceProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -157,6 +163,8 @@ pub trait IWindowsMediaLibrarySharingDevices_Impl: Sized + super::super::System:
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn GetDevice(&self, deviceid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWindowsMediaLibrarySharingDevice>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsMediaLibrarySharingDevices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsMediaLibrarySharingDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingDevices_Impl, const OFFSET: isize>() -> IWindowsMediaLibrarySharingDevices_Vtbl {
@@ -226,6 +234,8 @@ pub trait IWindowsMediaLibrarySharingServices_Impl: Sized + super::super::System
     fn getAllDevices(&self) -> ::windows::core::Result<IWindowsMediaLibrarySharingDevices>;
     fn customSettingsApplied(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsMediaLibrarySharingServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsMediaLibrarySharingServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsMediaLibrarySharingServices_Impl, const OFFSET: isize>() -> IWindowsMediaLibrarySharingServices_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
@@ -1,6 +1,7 @@
 pub trait IAdvancedMediaCapture_Impl: Sized {
     fn GetAdvancedMediaCaptureSettings(&self) -> ::windows::core::Result<IAdvancedMediaCaptureSettings>;
 }
+impl ::windows::core::RuntimeName for IAdvancedMediaCapture {}
 impl IAdvancedMediaCapture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAdvancedMediaCapture_Impl, const OFFSET: isize>() -> IAdvancedMediaCapture_Vtbl {
         unsafe extern "system" fn GetAdvancedMediaCaptureSettings<Identity: ::windows::core::IUnknownImpl, Impl: IAdvancedMediaCapture_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -26,6 +27,7 @@ impl IAdvancedMediaCapture_Vtbl {
 pub trait IAdvancedMediaCaptureInitializationSettings_Impl: Sized {
     fn SetDirectxDeviceManager(&self, value: &::core::option::Option<IMFDXGIDeviceManager>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAdvancedMediaCaptureInitializationSettings {}
 impl IAdvancedMediaCaptureInitializationSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAdvancedMediaCaptureInitializationSettings_Impl, const OFFSET: isize>() -> IAdvancedMediaCaptureInitializationSettings_Vtbl {
         unsafe extern "system" fn SetDirectxDeviceManager<Identity: ::windows::core::IUnknownImpl, Impl: IAdvancedMediaCaptureInitializationSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -42,6 +44,7 @@ impl IAdvancedMediaCaptureInitializationSettings_Vtbl {
 pub trait IAdvancedMediaCaptureSettings_Impl: Sized {
     fn GetDirectxDeviceManager(&self) -> ::windows::core::Result<IMFDXGIDeviceManager>;
 }
+impl ::windows::core::RuntimeName for IAdvancedMediaCaptureSettings {}
 impl IAdvancedMediaCaptureSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAdvancedMediaCaptureSettings_Impl, const OFFSET: isize>() -> IAdvancedMediaCaptureSettings_Vtbl {
         unsafe extern "system" fn GetDirectxDeviceManager<Identity: ::windows::core::IUnknownImpl, Impl: IAdvancedMediaCaptureSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -64,6 +67,7 @@ impl IAdvancedMediaCaptureSettings_Vtbl {
 pub trait IAudioSourceProvider_Impl: Sized {
     fn ProvideInput(&self, dwsamplecount: u32, pdwchannelcount: *mut u32, pinterleavedaudiodata: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioSourceProvider {}
 impl IAudioSourceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSourceProvider_Impl, const OFFSET: isize>() -> IAudioSourceProvider_Vtbl {
         unsafe extern "system" fn ProvideInput<Identity: ::windows::core::IUnknownImpl, Impl: IAudioSourceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsamplecount: u32, pdwchannelcount: *mut u32, pinterleavedaudiodata: *mut f32) -> ::windows::core::HRESULT {
@@ -81,6 +85,7 @@ pub trait IClusterDetector_Impl: Sized {
     fn Initialize(&self, wbaseentrylevel: u16, wclusterentrylevel: u16) -> ::windows::core::Result<()>;
     fn Detect(&self, dwmaxnumclusters: u32, fminclusterduration: f32, fmaxclusterduration: f32, psrctoc: &::core::option::Option<IToc>) -> ::windows::core::Result<IToc>;
 }
+impl ::windows::core::RuntimeName for IClusterDetector {}
 impl IClusterDetector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClusterDetector_Impl, const OFFSET: isize>() -> IClusterDetector_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IClusterDetector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wbaseentrylevel: u16, wclusterentrylevel: u16) -> ::windows::core::HRESULT {
@@ -127,6 +132,8 @@ pub trait ICodecAPI_Impl: Sized {
     fn SetAllSettings(&self, __midl__icodecapi0001: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
     fn SetAllSettingsWithNotify(&self, __midl__icodecapi0002: &::core::option::Option<super::super::System::Com::IStream>, changedparam: *mut *mut ::windows::core::GUID, changedparamcount: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICodecAPI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICodecAPI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICodecAPI_Impl, const OFFSET: isize>() -> ICodecAPI_Vtbl {
@@ -258,6 +265,8 @@ pub trait ID3D12VideoDecodeCommandList_Impl: Sized + super::super::Graphics::Dir
     fn WriteBufferImmediate(&self, count: u32, pparams: *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_MODE);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDecodeCommandList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDecodeCommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecodeCommandList_Impl, const OFFSET: isize>() -> ID3D12VideoDecodeCommandList_Vtbl {
         unsafe extern "system" fn Close<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecodeCommandList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -357,6 +366,8 @@ pub trait ID3D12VideoDecodeCommandList1_Impl: Sized + super::super::Graphics::Di
     fn DecodeFrame1(&self, pdecoder: &::core::option::Option<ID3D12VideoDecoder>, poutputarguments: *const D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS1, pinputarguments: *const D3D12_VIDEO_DECODE_INPUT_STREAM_ARGUMENTS);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDecodeCommandList1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDecodeCommandList1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecodeCommandList1_Impl, const OFFSET: isize>() -> ID3D12VideoDecodeCommandList1_Vtbl {
         unsafe extern "system" fn DecodeFrame1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecodeCommandList1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdecoder: ::windows::core::RawPtr, poutputarguments: *const D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS1, pinputarguments: *const D3D12_VIDEO_DECODE_INPUT_STREAM_ARGUMENTS) {
@@ -376,6 +387,8 @@ pub trait ID3D12VideoDecodeCommandList2_Impl: Sized + super::super::Graphics::Di
     fn InitializeExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pinitializationparameters: *const ::core::ffi::c_void, initializationparameterssizeinbytes: usize);
     fn ExecuteExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pexecutionparameters: *const ::core::ffi::c_void, executionparameterssizeinbytes: usize);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDecodeCommandList2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDecodeCommandList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecodeCommandList2_Impl, const OFFSET: isize>() -> ID3D12VideoDecodeCommandList2_Vtbl {
@@ -410,6 +423,8 @@ pub trait ID3D12VideoDecoder_Impl: Sized + super::super::Graphics::Direct3D12::I
     fn GetDesc(&self) -> D3D12_VIDEO_DECODER_DESC;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ID3D12VideoDecoder {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ID3D12VideoDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecoder_Impl, const OFFSET: isize>() -> ID3D12VideoDecoder_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecoder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_VIDEO_DECODER_DESC) {
@@ -427,6 +442,8 @@ impl ID3D12VideoDecoder_Vtbl {
 pub trait ID3D12VideoDecoder1_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Object_Impl + super::super::Graphics::Direct3D12::ID3D12DeviceChild_Impl + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl + ID3D12VideoDecoder_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ID3D12VideoDecoder1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ID3D12VideoDecoder1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecoder1_Impl, const OFFSET: isize>() -> ID3D12VideoDecoder1_Vtbl {
@@ -449,6 +466,8 @@ pub trait ID3D12VideoDecoderHeap_Impl: Sized + super::super::Graphics::Direct3D1
     fn GetDesc(&self) -> D3D12_VIDEO_DECODER_HEAP_DESC;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDecoderHeap {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDecoderHeap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecoderHeap_Impl, const OFFSET: isize>() -> ID3D12VideoDecoderHeap_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecoderHeap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_VIDEO_DECODER_HEAP_DESC) {
@@ -466,6 +485,8 @@ impl ID3D12VideoDecoderHeap_Vtbl {
 pub trait ID3D12VideoDecoderHeap1_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Object_Impl + super::super::Graphics::Direct3D12::ID3D12DeviceChild_Impl + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl + ID3D12VideoDecoderHeap_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDecoderHeap1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDecoderHeap1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDecoderHeap1_Impl, const OFFSET: isize>() -> ID3D12VideoDecoderHeap1_Vtbl {
@@ -490,6 +511,8 @@ pub trait ID3D12VideoDevice_Impl: Sized {
     fn CreateVideoDecoderHeap(&self, pvideodecoderheapdesc: *const D3D12_VIDEO_DECODER_HEAP_DESC, riid: *const ::windows::core::GUID, ppvideodecoderheap: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateVideoProcessor(&self, nodemask: u32, poutputstreamdesc: *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC, numinputstreamdescs: u32, pinputstreamdescs: *const D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC, riid: *const ::windows::core::GUID, ppvideoprocessor: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDevice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDevice_Impl, const OFFSET: isize>() -> ID3D12VideoDevice_Vtbl {
@@ -531,6 +554,8 @@ pub trait ID3D12VideoDevice1_Impl: Sized + ID3D12VideoDevice_Impl {
     fn CreateVideoMotionVectorHeap(&self, pdesc: *const D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>, riid: *const ::windows::core::GUID, ppvideomotionvectorheap: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDevice1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDevice1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDevice1_Impl, const OFFSET: isize>() -> ID3D12VideoDevice1_Vtbl {
         unsafe extern "system" fn CreateVideoMotionEstimator<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDevice1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *const D3D12_VIDEO_MOTION_ESTIMATOR_DESC, pprotectedresourcesession: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppvideomotionestimator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -561,6 +586,8 @@ pub trait ID3D12VideoDevice2_Impl: Sized + ID3D12VideoDevice_Impl + ID3D12VideoD
     fn CreateVideoExtensionCommand(&self, pdesc: *const D3D12_VIDEO_EXTENSION_COMMAND_DESC, pcreationparameters: *const ::core::ffi::c_void, creationparametersdatasizeinbytes: usize, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>, riid: *const ::windows::core::GUID, ppvideoextensioncommand: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn ExecuteExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pexecutionparameters: *const ::core::ffi::c_void, executionparameterssizeinbytes: usize, poutputdata: *mut ::core::ffi::c_void, outputdatasizeinbytes: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDevice2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDevice2_Impl, const OFFSET: isize>() -> ID3D12VideoDevice2_Vtbl {
@@ -608,6 +635,8 @@ pub trait ID3D12VideoDevice3_Impl: Sized + ID3D12VideoDevice_Impl + ID3D12VideoD
     fn CreateVideoEncoderHeap(&self, pdesc: *const D3D12_VIDEO_ENCODER_HEAP_DESC, riid: *const ::windows::core::GUID, ppvideoencoderheap: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoDevice3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoDevice3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDevice3_Impl, const OFFSET: isize>() -> ID3D12VideoDevice3_Vtbl {
         unsafe extern "system" fn CreateVideoEncoder<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoDevice3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *const D3D12_VIDEO_ENCODER_DESC, riid: *const ::windows::core::GUID, ppvideoencoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -649,6 +678,8 @@ pub trait ID3D12VideoEncodeCommandList_Impl: Sized + super::super::Graphics::Dir
     fn WriteBufferImmediate(&self, count: u32, pparams: *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_MODE);
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D12VideoEncodeCommandList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D12VideoEncodeCommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncodeCommandList_Impl, const OFFSET: isize>() -> ID3D12VideoEncodeCommandList_Vtbl {
@@ -762,6 +793,8 @@ pub trait ID3D12VideoEncodeCommandList1_Impl: Sized + super::super::Graphics::Di
     fn ExecuteExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pexecutionparameters: *const ::core::ffi::c_void, executionparameterssizeinbytes: usize);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D12VideoEncodeCommandList1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D12VideoEncodeCommandList1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncodeCommandList1_Impl, const OFFSET: isize>() -> ID3D12VideoEncodeCommandList1_Vtbl {
         unsafe extern "system" fn InitializeExtensionCommand<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncodeCommandList1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pextensioncommand: ::windows::core::RawPtr, pinitializationparameters: *const ::core::ffi::c_void, initializationparameterssizeinbytes: usize) {
@@ -789,6 +822,8 @@ pub trait ID3D12VideoEncodeCommandList2_Impl: Sized + super::super::Graphics::Di
     fn EncodeFrame(&self, pencoder: &::core::option::Option<ID3D12VideoEncoder>, pheap: &::core::option::Option<ID3D12VideoEncoderHeap>, pinputarguments: *const D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS, poutputarguments: *const D3D12_VIDEO_ENCODER_ENCODEFRAME_OUTPUT_ARGUMENTS);
     fn ResolveEncoderOutputMetadata(&self, pinputarguments: *const D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS, poutputarguments: *const D3D12_VIDEO_ENCODER_RESOLVE_METADATA_OUTPUT_ARGUMENTS);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoEncodeCommandList2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoEncodeCommandList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncodeCommandList2_Impl, const OFFSET: isize>() -> ID3D12VideoEncodeCommandList2_Vtbl {
@@ -822,6 +857,8 @@ pub trait ID3D12VideoEncoder_Impl: Sized + super::super::Graphics::Direct3D12::I
     fn GetInputFormat(&self) -> super::super::Graphics::Dxgi::Common::DXGI_FORMAT;
     fn GetMaxMotionEstimationPrecision(&self) -> D3D12_VIDEO_ENCODER_MOTION_ESTIMATION_PRECISION_MODE;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoEncoder {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoEncoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncoder_Impl, const OFFSET: isize>() -> ID3D12VideoEncoder_Vtbl {
@@ -886,6 +923,8 @@ pub trait ID3D12VideoEncoderHeap_Impl: Sized + super::super::Graphics::Direct3D1
     fn GetResolutionList(&self, resolutionslistcount: u32, presolutionlist: *mut D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ID3D12VideoEncoderHeap {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ID3D12VideoEncoderHeap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncoderHeap_Impl, const OFFSET: isize>() -> ID3D12VideoEncoderHeap_Vtbl {
         unsafe extern "system" fn GetNodeMask<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoEncoderHeap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -944,6 +983,8 @@ pub trait ID3D12VideoExtensionCommand_Impl: Sized + super::super::Graphics::Dire
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ID3D12VideoExtensionCommand {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ID3D12VideoExtensionCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoExtensionCommand_Impl, const OFFSET: isize>() -> ID3D12VideoExtensionCommand_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoExtensionCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_VIDEO_EXTENSION_COMMAND_DESC) {
@@ -972,6 +1013,8 @@ pub trait ID3D12VideoMotionEstimator_Impl: Sized + super::super::Graphics::Direc
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoMotionEstimator {}
+#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoMotionEstimator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoMotionEstimator_Impl, const OFFSET: isize>() -> ID3D12VideoMotionEstimator_Vtbl {
         unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoMotionEstimator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut D3D12_VIDEO_MOTION_ESTIMATOR_DESC) {
@@ -999,6 +1042,8 @@ pub trait ID3D12VideoMotionVectorHeap_Impl: Sized + super::super::Graphics::Dire
     fn GetDesc(&self) -> D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC;
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoMotionVectorHeap {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoMotionVectorHeap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoMotionVectorHeap_Impl, const OFFSET: isize>() -> ID3D12VideoMotionVectorHeap_Vtbl {
@@ -1039,6 +1084,8 @@ pub trait ID3D12VideoProcessCommandList_Impl: Sized + super::super::Graphics::Di
     fn ProcessFrames(&self, pvideoprocessor: &::core::option::Option<ID3D12VideoProcessor>, poutputarguments: *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, numinputstreams: u32, pinputarguments: *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS);
     fn WriteBufferImmediate(&self, count: u32, pparams: *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_MODE);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D12VideoProcessCommandList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D12VideoProcessCommandList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessCommandList_Impl, const OFFSET: isize>() -> ID3D12VideoProcessCommandList_Vtbl {
@@ -1139,6 +1186,8 @@ pub trait ID3D12VideoProcessCommandList1_Impl: Sized + super::super::Graphics::D
     fn ProcessFrames1(&self, pvideoprocessor: &::core::option::Option<ID3D12VideoProcessor>, poutputarguments: *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, numinputstreams: u32, pinputarguments: *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D12VideoProcessCommandList1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D12VideoProcessCommandList1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessCommandList1_Impl, const OFFSET: isize>() -> ID3D12VideoProcessCommandList1_Vtbl {
         unsafe extern "system" fn ProcessFrames1<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessCommandList1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvideoprocessor: ::windows::core::RawPtr, poutputarguments: *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, numinputstreams: u32, pinputarguments: *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1) {
@@ -1158,6 +1207,8 @@ pub trait ID3D12VideoProcessCommandList2_Impl: Sized + super::super::Graphics::D
     fn InitializeExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pinitializationparameters: *const ::core::ffi::c_void, initializationparameterssizeinbytes: usize);
     fn ExecuteExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pexecutionparameters: *const ::core::ffi::c_void, executionparameterssizeinbytes: usize);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for ID3D12VideoProcessCommandList2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl ID3D12VideoProcessCommandList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessCommandList2_Impl, const OFFSET: isize>() -> ID3D12VideoProcessCommandList2_Vtbl {
@@ -1194,6 +1245,8 @@ pub trait ID3D12VideoProcessor_Impl: Sized + super::super::Graphics::Direct3D12:
     fn GetInputStreamDescs(&self, numinputstreamdescs: u32, pinputstreamdescs: *mut D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC) -> ::windows::core::Result<()>;
     fn GetOutputStreamDesc(&self) -> D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoProcessor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessor_Impl, const OFFSET: isize>() -> ID3D12VideoProcessor_Vtbl {
@@ -1234,6 +1287,8 @@ pub trait ID3D12VideoProcessor1_Impl: Sized + super::super::Graphics::Direct3D12
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
+impl ::windows::core::RuntimeName for ID3D12VideoProcessor1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl ID3D12VideoProcessor1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessor1_Impl, const OFFSET: isize>() -> ID3D12VideoProcessor1_Vtbl {
         unsafe extern "system" fn GetProtectedResourceSession<Identity: ::windows::core::IUnknownImpl, Impl: ID3D12VideoProcessor1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1261,6 +1316,8 @@ pub trait IDXVAHD_Device_Impl: Sized {
     fn GetVideoProcessorFilterRange(&self, filter: DXVAHD_FILTER) -> ::windows::core::Result<DXVAHD_FILTER_RANGE_DATA>;
     fn CreateVideoProcessor(&self, pvpguid: *const ::windows::core::GUID) -> ::windows::core::Result<IDXVAHD_VideoProcessor>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDXVAHD_Device {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDXVAHD_Device_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXVAHD_Device_Impl, const OFFSET: isize>() -> IDXVAHD_Device_Vtbl {
@@ -1347,6 +1404,8 @@ pub trait IDXVAHD_VideoProcessor_Impl: Sized {
     fn VideoProcessBltHD(&self, poutputsurface: &::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, outputframe: u32, streamcount: u32, pstreams: *const DXVAHD_STREAM_DATA) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDXVAHD_VideoProcessor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDXVAHD_VideoProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDXVAHD_VideoProcessor_Impl, const OFFSET: isize>() -> IDXVAHD_VideoProcessor_Vtbl {
         unsafe extern "system" fn SetVideoProcessBltState<Identity: ::windows::core::IUnknownImpl, Impl: IDXVAHD_VideoProcessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, state: DXVAHD_BLT_STATE, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1392,6 +1451,8 @@ pub trait IDirect3D9ExOverlayExtension_Impl: Sized {
     fn CheckDeviceOverlayType(&self, adapter: u32, devtype: super::super::Graphics::Direct3D9::D3DDEVTYPE, overlaywidth: u32, overlayheight: u32, overlayformat: super::super::Graphics::Direct3D9::D3DFORMAT, pdisplaymode: *mut super::super::Graphics::Direct3D9::D3DDISPLAYMODEEX, displayrotation: super::super::Graphics::Direct3D9::D3DDISPLAYROTATION, poverlaycaps: *mut D3DOVERLAYCAPS) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
+impl ::windows::core::RuntimeName for IDirect3D9ExOverlayExtension {}
+#[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl IDirect3D9ExOverlayExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3D9ExOverlayExtension_Impl, const OFFSET: isize>() -> IDirect3D9ExOverlayExtension_Vtbl {
         unsafe extern "system" fn CheckDeviceOverlayType<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3D9ExOverlayExtension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, adapter: u32, devtype: super::super::Graphics::Direct3D9::D3DDEVTYPE, overlaywidth: u32, overlayheight: u32, overlayformat: super::super::Graphics::Direct3D9::D3DFORMAT, pdisplaymode: *mut super::super::Graphics::Direct3D9::D3DDISPLAYMODEEX, displayrotation: super::super::Graphics::Direct3D9::D3DDISPLAYROTATION, poverlaycaps: *mut D3DOVERLAYCAPS) -> ::windows::core::HRESULT {
@@ -1413,6 +1474,8 @@ pub trait IDirect3DAuthenticatedChannel9_Impl: Sized {
     fn Query(&self, inputsize: u32, pinput: *const ::core::ffi::c_void, outputsize: u32, poutput: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Configure(&self, inputsize: u32, pinput: *const ::core::ffi::c_void, poutput: *mut super::super::Graphics::Direct3D9::D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirect3DAuthenticatedChannel9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirect3DAuthenticatedChannel9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DAuthenticatedChannel9_Impl, const OFFSET: isize>() -> IDirect3DAuthenticatedChannel9_Vtbl {
@@ -1466,6 +1529,8 @@ pub trait IDirect3DCryptoSession9_Impl: Sized {
     fn FinishSessionKeyRefresh(&self) -> ::windows::core::Result<()>;
     fn GetEncryptionBltKey(&self, preadbackkey: *mut ::core::ffi::c_void, keysize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D9")]
+impl ::windows::core::RuntimeName for IDirect3DCryptoSession9 {}
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl IDirect3DCryptoSession9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DCryptoSession9_Impl, const OFFSET: isize>() -> IDirect3DCryptoSession9_Vtbl {
@@ -1538,6 +1603,8 @@ pub trait IDirect3DDevice9Video_Impl: Sized {
     fn CreateCryptoSession(&self, pcryptotype: *const ::windows::core::GUID, pdecodeprofile: *const ::windows::core::GUID, ppcryptosession: *mut ::core::option::Option<IDirect3DCryptoSession9>, pcryptohandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirect3DDevice9Video {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirect3DDevice9Video_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9Video_Impl, const OFFSET: isize>() -> IDirect3DDevice9Video_Vtbl {
         unsafe extern "system" fn GetContentProtectionCaps<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDevice9Video_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcryptotype: *const ::windows::core::GUID, pdecodeprofile: *const ::windows::core::GUID, pcaps: *mut D3DCONTENTPROTECTIONCAPS) -> ::windows::core::HRESULT {
@@ -1576,6 +1643,8 @@ pub trait IDirect3DDeviceManager9_Impl: Sized {
     fn UnlockDevice(&self, hdevice: super::super::Foundation::HANDLE, fsavestate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetVideoService(&self, hdevice: super::super::Foundation::HANDLE, riid: *const ::windows::core::GUID, ppservice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirect3DDeviceManager9 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirect3DDeviceManager9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDeviceManager9_Impl, const OFFSET: isize>() -> IDirect3DDeviceManager9_Vtbl {
@@ -1640,6 +1709,8 @@ pub trait IDirectXVideoAccelerationService_Impl: Sized {
     fn CreateSurface(&self, width: u32, height: u32, backbuffers: u32, format: super::super::Graphics::Direct3D9::D3DFORMAT, pool: super::super::Graphics::Direct3D9::D3DPOOL, usage: u32, dxvatype: DXVA2_VideoRenderTargetType, ppsurface: *mut ::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirectXVideoAccelerationService {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirectXVideoAccelerationService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoAccelerationService_Impl, const OFFSET: isize>() -> IDirectXVideoAccelerationService_Vtbl {
         unsafe extern "system" fn CreateSurface<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoAccelerationService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, width: u32, height: u32, backbuffers: u32, format: super::super::Graphics::Direct3D9::D3DFORMAT, pool: super::super::Graphics::Direct3D9::D3DPOOL, usage: u32, dxvatype: DXVA2_VideoRenderTargetType, ppsurface: *mut ::windows::core::RawPtr, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -1663,6 +1734,8 @@ pub trait IDirectXVideoDecoder_Impl: Sized {
     fn EndFrame(&self, phandlecomplete: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn Execute(&self, pexecuteparams: *const DXVA2_DecodeExecuteParams) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirectXVideoDecoder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirectXVideoDecoder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoDecoder_Impl, const OFFSET: isize>() -> IDirectXVideoDecoder_Vtbl {
@@ -1730,6 +1803,8 @@ pub trait IDirectXVideoDecoderService_Impl: Sized + IDirectXVideoAccelerationSer
     fn CreateVideoDecoder(&self, guid: *const ::windows::core::GUID, pvideodesc: *const DXVA2_VideoDesc, pconfig: *const DXVA2_ConfigPictureDecode, ppdecoderrendertargets: *const ::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, numrendertargets: u32) -> ::windows::core::Result<IDirectXVideoDecoder>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirectXVideoDecoderService {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirectXVideoDecoderService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoDecoderService_Impl, const OFFSET: isize>() -> IDirectXVideoDecoderService_Vtbl {
         unsafe extern "system" fn GetDecoderDeviceGuids<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoDecoderService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32, pguids: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1774,6 +1849,7 @@ pub trait IDirectXVideoMemoryConfiguration_Impl: Sized {
     fn GetAvailableSurfaceTypeByIndex(&self, dwtypeindex: u32) -> ::windows::core::Result<DXVA2_SurfaceType>;
     fn SetSurfaceType(&self, dwtype: DXVA2_SurfaceType) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectXVideoMemoryConfiguration {}
 impl IDirectXVideoMemoryConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoMemoryConfiguration_Impl, const OFFSET: isize>() -> IDirectXVideoMemoryConfiguration_Vtbl {
         unsafe extern "system" fn GetAvailableSurfaceTypeByIndex<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoMemoryConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtypeindex: u32, pdwtype: *mut DXVA2_SurfaceType) -> ::windows::core::HRESULT {
@@ -1811,6 +1887,8 @@ pub trait IDirectXVideoProcessor_Impl: Sized {
     fn GetFilterPropertyRange(&self, filtersetting: u32) -> ::windows::core::Result<DXVA2_ValueRange>;
     fn VideoProcessBlt(&self, prendertarget: &::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, pbltparams: *const DXVA2_VideoProcessBltParams, psamples: *const DXVA2_VideoSample, numsamples: u32, phandlecomplete: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirectXVideoProcessor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirectXVideoProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoProcessor_Impl, const OFFSET: isize>() -> IDirectXVideoProcessor_Vtbl {
@@ -1893,6 +1971,8 @@ pub trait IDirectXVideoProcessorService_Impl: Sized + IDirectXVideoAccelerationS
     fn GetFilterPropertyRange(&self, videoprocdeviceguid: *const ::windows::core::GUID, pvideodesc: *const DXVA2_VideoDesc, rendertargetformat: super::super::Graphics::Direct3D9::D3DFORMAT, filtersetting: u32) -> ::windows::core::Result<DXVA2_ValueRange>;
     fn CreateVideoProcessor(&self, videoprocdeviceguid: *const ::windows::core::GUID, pvideodesc: *const DXVA2_VideoDesc, rendertargetformat: super::super::Graphics::Direct3D9::D3DFORMAT, maxnumsubstreams: u32) -> ::windows::core::Result<IDirectXVideoProcessor>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
+impl ::windows::core::RuntimeName for IDirectXVideoProcessorService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 impl IDirectXVideoProcessorService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectXVideoProcessorService_Impl, const OFFSET: isize>() -> IDirectXVideoProcessorService_Vtbl {
@@ -1980,6 +2060,7 @@ pub trait IEVRFilterConfig_Impl: Sized {
     fn SetNumberOfStreams(&self, dwmaxstreams: u32) -> ::windows::core::Result<()>;
     fn GetNumberOfStreams(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEVRFilterConfig {}
 impl IEVRFilterConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEVRFilterConfig_Impl, const OFFSET: isize>() -> IEVRFilterConfig_Vtbl {
         unsafe extern "system" fn SetNumberOfStreams<Identity: ::windows::core::IUnknownImpl, Impl: IEVRFilterConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmaxstreams: u32) -> ::windows::core::HRESULT {
@@ -2012,6 +2093,7 @@ pub trait IEVRFilterConfigEx_Impl: Sized + IEVRFilterConfig_Impl {
     fn SetConfigPrefs(&self, dwconfigflags: u32) -> ::windows::core::Result<()>;
     fn GetConfigPrefs(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEVRFilterConfigEx {}
 impl IEVRFilterConfigEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEVRFilterConfigEx_Impl, const OFFSET: isize>() -> IEVRFilterConfigEx_Vtbl {
         unsafe extern "system" fn SetConfigPrefs<Identity: ::windows::core::IUnknownImpl, Impl: IEVRFilterConfigEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwconfigflags: u32) -> ::windows::core::HRESULT {
@@ -2047,6 +2129,8 @@ pub trait IEVRTrustedVideoPlugin_Impl: Sized {
     fn SetConstriction(&self, dwkpix: u32) -> ::windows::core::Result<()>;
     fn DisableImageExport(&self, bdisable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEVRTrustedVideoPlugin {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEVRTrustedVideoPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEVRTrustedVideoPlugin_Impl, const OFFSET: isize>() -> IEVRTrustedVideoPlugin_Vtbl {
@@ -2100,6 +2184,8 @@ pub trait IEVRVideoStreamControl_Impl: Sized {
     fn GetStreamActiveState(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEVRVideoStreamControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEVRVideoStreamControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEVRVideoStreamControl_Impl, const OFFSET: isize>() -> IEVRVideoStreamControl_Vtbl {
         unsafe extern "system" fn SetStreamActiveState<Identity: ::windows::core::IUnknownImpl, Impl: IEVRVideoStreamControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, factive: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2133,6 +2219,7 @@ pub trait IFileClient_Impl: Sized {
     fn Write(&self, pfio: &::core::option::Option<IFileIo>) -> ::windows::core::Result<()>;
     fn Read(&self, pfio: &::core::option::Option<IFileIo>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFileClient {}
 impl IFileClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileClient_Impl, const OFFSET: isize>() -> IFileClient_Vtbl {
         unsafe extern "system" fn GetObjectDiskSize<Identity: ::windows::core::IUnknownImpl, Impl: IFileClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pqwsize: *mut u64) -> ::windows::core::HRESULT {
@@ -2174,6 +2261,8 @@ pub trait IFileIo_Impl: Sized {
     fn Seek(&self, eseekorigin: SEEK_ORIGIN, qwseekoffset: u64, dwseekflags: u32, pqwcurrentposition: *mut u64) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileIo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFileIo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileIo_Impl, const OFFSET: isize>() -> IFileIo_Vtbl {
@@ -2256,6 +2345,8 @@ pub trait IMF2DBuffer_Impl: Sized {
     fn ContiguousCopyFrom(&self, pbsrcbuffer: *const u8, cbsrcbuffer: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMF2DBuffer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMF2DBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMF2DBuffer_Impl, const OFFSET: isize>() -> IMF2DBuffer_Vtbl {
         unsafe extern "system" fn Lock2D<Identity: ::windows::core::IUnknownImpl, Impl: IMF2DBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbscanline0: *mut *mut u8, plpitch: *mut i32) -> ::windows::core::HRESULT {
@@ -2326,6 +2417,8 @@ pub trait IMF2DBuffer2_Impl: Sized + IMF2DBuffer_Impl {
     fn Copy2DTo(&self, pdestbuffer: &::core::option::Option<IMF2DBuffer2>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMF2DBuffer2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMF2DBuffer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMF2DBuffer2_Impl, const OFFSET: isize>() -> IMF2DBuffer2_Vtbl {
         unsafe extern "system" fn Lock2DSize<Identity: ::windows::core::IUnknownImpl, Impl: IMF2DBuffer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lockflags: MF2DBuffer_LockFlags, ppbscanline0: *mut *mut u8, plpitch: *mut i32, ppbbufferstart: *mut *mut u8, pcbbufferlength: *mut u32) -> ::windows::core::HRESULT {
@@ -2358,6 +2451,8 @@ pub trait IMFASFContentInfo_Impl: Sized {
     fn GeneratePresentationDescriptor(&self) -> ::windows::core::Result<IMFPresentationDescriptor>;
     fn GetEncodingConfigurationPropertyStore(&self, wstreamnumber: u16) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMFASFContentInfo {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMFASFContentInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFContentInfo_Impl, const OFFSET: isize>() -> IMFASFContentInfo_Vtbl {
@@ -2457,6 +2552,8 @@ pub trait IMFASFIndexer_Impl: Sized {
     fn GetIndexWriteSpace(&self) -> ::windows::core::Result<u64>;
     fn GetCompletedIndex(&self, piindexbuffer: &::core::option::Option<IMFMediaBuffer>, cboffsetwithinindex: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFASFIndexer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFASFIndexer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFIndexer_Impl, const OFFSET: isize>() -> IMFASFIndexer_Vtbl {
@@ -2581,6 +2678,7 @@ pub trait IMFASFMultiplexer_Impl: Sized {
     fn GetStatistics(&self, wstreamnumber: u16) -> ::windows::core::Result<ASF_MUX_STATISTICS>;
     fn SetSyncTolerance(&self, mssynctolerance: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFASFMultiplexer {}
 impl IMFASFMultiplexer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFMultiplexer_Impl, const OFFSET: isize>() -> IMFASFMultiplexer_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFMultiplexer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, picontentinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2668,6 +2766,7 @@ pub trait IMFASFMutualExclusion_Impl: Sized {
     fn AddRecord(&self) -> ::windows::core::Result<u32>;
     fn Clone(&self) -> ::windows::core::Result<IMFASFMutualExclusion>;
 }
+impl ::windows::core::RuntimeName for IMFASFMutualExclusion {}
 impl IMFASFMutualExclusion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFMutualExclusion_Impl, const OFFSET: isize>() -> IMFASFMutualExclusion_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFMutualExclusion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2775,6 +2874,8 @@ pub trait IMFASFProfile_Impl: Sized + IMFAttributes_Impl {
     fn CreateStreamPrioritization(&self) -> ::windows::core::Result<IMFASFStreamPrioritization>;
     fn Clone(&self) -> ::windows::core::Result<IMFASFProfile>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFASFProfile {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFASFProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFProfile_Impl, const OFFSET: isize>() -> IMFASFProfile_Vtbl {
@@ -2947,6 +3048,7 @@ pub trait IMFASFSplitter_Impl: Sized {
     fn Flush(&self) -> ::windows::core::Result<()>;
     fn GetLastSendTime(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFASFSplitter {}
 impl IMFASFSplitter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFSplitter_Impl, const OFFSET: isize>() -> IMFASFSplitter_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFSplitter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, picontentinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3036,6 +3138,8 @@ pub trait IMFASFStreamConfig_Impl: Sized + IMFAttributes_Impl {
     fn RemoveAllPayloadExtensions(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IMFASFStreamConfig>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFASFStreamConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFASFStreamConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFStreamConfig_Impl, const OFFSET: isize>() -> IMFASFStreamConfig_Vtbl {
@@ -3138,6 +3242,7 @@ pub trait IMFASFStreamPrioritization_Impl: Sized {
     fn RemoveStream(&self, dwstreamindex: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IMFASFStreamPrioritization>;
 }
+impl ::windows::core::RuntimeName for IMFASFStreamPrioritization {}
 impl IMFASFStreamPrioritization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFStreamPrioritization_Impl, const OFFSET: isize>() -> IMFASFStreamPrioritization_Vtbl {
         unsafe extern "system" fn GetStreamCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFStreamPrioritization_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwstreamcount: *mut u32) -> ::windows::core::HRESULT {
@@ -3206,6 +3311,7 @@ pub trait IMFASFStreamSelector_Impl: Sized {
     fn BitrateToStepNumber(&self, dwbitrate: u32) -> ::windows::core::Result<u32>;
     fn SetStreamSelectorFlags(&self, dwstreamselectorflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFASFStreamSelector {}
 impl IMFASFStreamSelector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFStreamSelector_Impl, const OFFSET: isize>() -> IMFASFStreamSelector_Vtbl {
         unsafe extern "system" fn GetStreamCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFASFStreamSelector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcstreams: *mut u32) -> ::windows::core::HRESULT {
@@ -3367,6 +3473,8 @@ pub trait IMFActivate_Impl: Sized + IMFAttributes_Impl {
     fn DetachObject(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFActivate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFActivate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFActivate_Impl, const OFFSET: isize>() -> IMFActivate_Vtbl {
         unsafe extern "system" fn ActivateObject<Identity: ::windows::core::IUnknownImpl, Impl: IMFActivate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3399,6 +3507,7 @@ pub trait IMFAsyncCallback_Impl: Sized {
     fn GetParameters(&self, pdwflags: *mut u32, pdwqueue: *mut u32) -> ::windows::core::Result<()>;
     fn Invoke(&self, pasyncresult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFAsyncCallback {}
 impl IMFAsyncCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAsyncCallback_Impl, const OFFSET: isize>() -> IMFAsyncCallback_Vtbl {
         unsafe extern "system" fn GetParameters<Identity: ::windows::core::IUnknownImpl, Impl: IMFAsyncCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwflags: *mut u32, pdwqueue: *mut u32) -> ::windows::core::HRESULT {
@@ -3425,6 +3534,7 @@ pub trait IMFAsyncCallbackLogging_Impl: Sized + IMFAsyncCallback_Impl {
     fn GetObjectPointer(&self) -> *mut ::core::ffi::c_void;
     fn GetObjectTag(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for IMFAsyncCallbackLogging {}
 impl IMFAsyncCallbackLogging_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAsyncCallbackLogging_Impl, const OFFSET: isize>() -> IMFAsyncCallbackLogging_Vtbl {
         unsafe extern "system" fn GetObjectPointer<Identity: ::windows::core::IUnknownImpl, Impl: IMFAsyncCallbackLogging_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut ::core::ffi::c_void {
@@ -3454,6 +3564,7 @@ pub trait IMFAsyncResult_Impl: Sized {
     fn GetObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetStateNoAddRef(&self) -> ::core::option::Option<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IMFAsyncResult {}
 impl IMFAsyncResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAsyncResult_Impl, const OFFSET: isize>() -> IMFAsyncResult_Vtbl {
         unsafe extern "system" fn GetState<Identity: ::windows::core::IUnknownImpl, Impl: IMFAsyncResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunkstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3539,6 +3650,8 @@ pub trait IMFAttributes_Impl: Sized {
     fn GetItemByIndex(&self, unindex: u32, pguidkey: *mut ::windows::core::GUID, pvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
     fn CopyAllItems(&self, pdest: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFAttributes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAttributes_Impl, const OFFSET: isize>() -> IMFAttributes_Vtbl {
@@ -3795,6 +3908,8 @@ pub trait IMFAudioMediaType_Impl: Sized + IMFAttributes_Impl + IMFMediaType_Impl
     fn GetAudioFormat(&self) -> *mut super::Audio::WAVEFORMATEX;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFAudioMediaType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFAudioMediaType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAudioMediaType_Impl, const OFFSET: isize>() -> IMFAudioMediaType_Vtbl {
         unsafe extern "system" fn GetAudioFormat<Identity: ::windows::core::IUnknownImpl, Impl: IMFAudioMediaType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut super::Audio::WAVEFORMATEX {
@@ -3816,6 +3931,7 @@ pub trait IMFAudioPolicy_Impl: Sized {
     fn SetIconPath(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetIconPath(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IMFAudioPolicy {}
 impl IMFAudioPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAudioPolicy_Impl, const OFFSET: isize>() -> IMFAudioPolicy_Vtbl {
         unsafe extern "system" fn SetGroupingParam<Identity: ::windows::core::IUnknownImpl, Impl: IMFAudioPolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rguidclass: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -3887,6 +4003,7 @@ pub trait IMFAudioStreamVolume_Impl: Sized {
     fn SetAllVolumes(&self, dwcount: u32, pfvolumes: *const f32) -> ::windows::core::Result<()>;
     fn GetAllVolumes(&self, dwcount: u32, pfvolumes: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFAudioStreamVolume {}
 impl IMFAudioStreamVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFAudioStreamVolume_Impl, const OFFSET: isize>() -> IMFAudioStreamVolume_Vtbl {
         unsafe extern "system" fn GetChannelCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFAudioStreamVolume_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -3943,6 +4060,7 @@ pub trait IMFBufferListNotify_Impl: Sized {
     fn OnAddSourceBuffer(&self);
     fn OnRemoveSourceBuffer(&self);
 }
+impl ::windows::core::RuntimeName for IMFBufferListNotify {}
 impl IMFBufferListNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFBufferListNotify_Impl, const OFFSET: isize>() -> IMFBufferListNotify_Vtbl {
         unsafe extern "system" fn OnAddSourceBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IMFBufferListNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -3983,6 +4101,8 @@ pub trait IMFByteStream_Impl: Sized {
     fn Flush(&self) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFByteStream {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFByteStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStream_Impl, const OFFSET: isize>() -> IMFByteStream_Vtbl {
@@ -4139,6 +4259,8 @@ pub trait IMFByteStreamBuffering_Impl: Sized {
     fn StopBuffering(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFByteStreamBuffering {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFByteStreamBuffering_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamBuffering_Impl, const OFFSET: isize>() -> IMFByteStreamBuffering_Vtbl {
         unsafe extern "system" fn SetBufferingParams<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamBuffering_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparams: *const MFBYTESTREAM_BUFFERING_PARAMS) -> ::windows::core::HRESULT {
@@ -4170,6 +4292,7 @@ impl IMFByteStreamBuffering_Vtbl {
 pub trait IMFByteStreamCacheControl_Impl: Sized {
     fn StopBackgroundTransfer(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFByteStreamCacheControl {}
 impl IMFByteStreamCacheControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamCacheControl_Impl, const OFFSET: isize>() -> IMFByteStreamCacheControl_Vtbl {
         unsafe extern "system" fn StopBackgroundTransfer<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamCacheControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4189,6 +4312,8 @@ pub trait IMFByteStreamCacheControl2_Impl: Sized + IMFByteStreamCacheControl_Imp
     fn SetCacheLimit(&self, qwbytes: u64) -> ::windows::core::Result<()>;
     fn IsBackgroundTransferActive(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFByteStreamCacheControl2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFByteStreamCacheControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamCacheControl2_Impl, const OFFSET: isize>() -> IMFByteStreamCacheControl2_Vtbl {
@@ -4231,6 +4356,8 @@ pub trait IMFByteStreamHandler_Impl: Sized {
     fn CancelObjectCreation(&self, piunknowncancelcookie: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetMaxNumberOfBytesRequiredForResolution(&self) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMFByteStreamHandler {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMFByteStreamHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamHandler_Impl, const OFFSET: isize>() -> IMFByteStreamHandler_Vtbl {
@@ -4275,6 +4402,7 @@ impl IMFByteStreamHandler_Vtbl {
 pub trait IMFByteStreamProxyClassFactory_Impl: Sized {
     fn CreateByteStreamProxy(&self, pbytestream: &::core::option::Option<IMFByteStream>, pattributes: &::core::option::Option<IMFAttributes>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFByteStreamProxyClassFactory {}
 impl IMFByteStreamProxyClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamProxyClassFactory_Impl, const OFFSET: isize>() -> IMFByteStreamProxyClassFactory_Vtbl {
         unsafe extern "system" fn CreateByteStreamProxy<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamProxyClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbytestream: ::windows::core::RawPtr, pattributes: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4294,6 +4422,8 @@ pub trait IMFByteStreamTimeSeek_Impl: Sized {
     fn TimeSeek(&self, qwtimeposition: u64) -> ::windows::core::Result<()>;
     fn GetTimeSeekResult(&self, pqwstarttime: *mut u64, pqwstoptime: *mut u64, pqwduration: *mut u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFByteStreamTimeSeek {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFByteStreamTimeSeek_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFByteStreamTimeSeek_Impl, const OFFSET: isize>() -> IMFByteStreamTimeSeek_Vtbl {
@@ -4334,6 +4464,7 @@ pub trait IMFCameraOcclusionStateMonitor_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn GetSupportedStates(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for IMFCameraOcclusionStateMonitor {}
 impl IMFCameraOcclusionStateMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraOcclusionStateMonitor_Impl, const OFFSET: isize>() -> IMFCameraOcclusionStateMonitor_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraOcclusionStateMonitor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4365,6 +4496,7 @@ impl IMFCameraOcclusionStateMonitor_Vtbl {
 pub trait IMFCameraOcclusionStateReport_Impl: Sized {
     fn GetOcclusionState(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFCameraOcclusionStateReport {}
 impl IMFCameraOcclusionStateReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraOcclusionStateReport_Impl, const OFFSET: isize>() -> IMFCameraOcclusionStateReport_Vtbl {
         unsafe extern "system" fn GetOcclusionState<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraOcclusionStateReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, occlusionstate: *mut u32) -> ::windows::core::HRESULT {
@@ -4387,6 +4519,7 @@ impl IMFCameraOcclusionStateReport_Vtbl {
 pub trait IMFCameraOcclusionStateReportCallback_Impl: Sized {
     fn OnOcclusionStateReport(&self, occlusionstatereport: &::core::option::Option<IMFCameraOcclusionStateReport>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCameraOcclusionStateReportCallback {}
 impl IMFCameraOcclusionStateReportCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraOcclusionStateReportCallback_Impl, const OFFSET: isize>() -> IMFCameraOcclusionStateReportCallback_Vtbl {
         unsafe extern "system" fn OnOcclusionStateReport<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraOcclusionStateReportCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, occlusionstatereport: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4404,6 +4537,7 @@ pub trait IMFCameraSyncObject_Impl: Sized {
     fn WaitOnSignal(&self, timeoutinms: u32) -> ::windows::core::Result<()>;
     fn Shutdown(&self);
 }
+impl ::windows::core::RuntimeName for IMFCameraSyncObject {}
 impl IMFCameraSyncObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraSyncObject_Impl, const OFFSET: isize>() -> IMFCameraSyncObject_Vtbl {
         unsafe extern "system" fn WaitOnSignal<Identity: ::windows::core::IUnknownImpl, Impl: IMFCameraSyncObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timeoutinms: u32) -> ::windows::core::HRESULT {
@@ -4437,6 +4571,8 @@ pub trait IMFCaptureEngine_Impl: Sized {
     fn GetSink(&self, mfcaptureenginesinktype: MF_CAPTURE_ENGINE_SINK_TYPE) -> ::windows::core::Result<IMFCaptureSink>;
     fn GetSource(&self) -> ::windows::core::Result<IMFCaptureSource>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFCaptureEngine {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFCaptureEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngine_Impl, const OFFSET: isize>() -> IMFCaptureEngine_Vtbl {
@@ -4511,6 +4647,7 @@ impl IMFCaptureEngine_Vtbl {
 pub trait IMFCaptureEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureEngineClassFactory {}
 impl IMFCaptureEngineClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineClassFactory_Impl, const OFFSET: isize>() -> IMFCaptureEngineClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4527,6 +4664,7 @@ impl IMFCaptureEngineClassFactory_Vtbl {
 pub trait IMFCaptureEngineOnEventCallback_Impl: Sized {
     fn OnEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureEngineOnEventCallback {}
 impl IMFCaptureEngineOnEventCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineOnEventCallback_Impl, const OFFSET: isize>() -> IMFCaptureEngineOnEventCallback_Vtbl {
         unsafe extern "system" fn OnEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineOnEventCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4543,6 +4681,7 @@ impl IMFCaptureEngineOnEventCallback_Vtbl {
 pub trait IMFCaptureEngineOnSampleCallback_Impl: Sized {
     fn OnSample(&self, psample: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureEngineOnSampleCallback {}
 impl IMFCaptureEngineOnSampleCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineOnSampleCallback_Impl, const OFFSET: isize>() -> IMFCaptureEngineOnSampleCallback_Vtbl {
         unsafe extern "system" fn OnSample<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineOnSampleCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psample: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4559,6 +4698,7 @@ impl IMFCaptureEngineOnSampleCallback_Vtbl {
 pub trait IMFCaptureEngineOnSampleCallback2_Impl: Sized + IMFCaptureEngineOnSampleCallback_Impl {
     fn OnSynchronizedEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureEngineOnSampleCallback2 {}
 impl IMFCaptureEngineOnSampleCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineOnSampleCallback2_Impl, const OFFSET: isize>() -> IMFCaptureEngineOnSampleCallback2_Vtbl {
         unsafe extern "system" fn OnSynchronizedEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureEngineOnSampleCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4580,6 +4720,7 @@ pub trait IMFCapturePhotoConfirmation_Impl: Sized {
     fn SetPixelFormat(&self, subtype: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetPixelFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IMFCapturePhotoConfirmation {}
 impl IMFCapturePhotoConfirmation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCapturePhotoConfirmation_Impl, const OFFSET: isize>() -> IMFCapturePhotoConfirmation_Vtbl {
         unsafe extern "system" fn SetPhotoConfirmationCallback<Identity: ::windows::core::IUnknownImpl, Impl: IMFCapturePhotoConfirmation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnotificationcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4619,6 +4760,7 @@ pub trait IMFCapturePhotoSink_Impl: Sized + IMFCaptureSink_Impl {
     fn SetSampleCallback(&self, pcallback: &::core::option::Option<IMFCaptureEngineOnSampleCallback>) -> ::windows::core::Result<()>;
     fn SetOutputByteStream(&self, pbytestream: &::core::option::Option<IMFByteStream>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCapturePhotoSink {}
 impl IMFCapturePhotoSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCapturePhotoSink_Impl, const OFFSET: isize>() -> IMFCapturePhotoSink_Vtbl {
         unsafe extern "system" fn SetOutputFileName<Identity: ::windows::core::IUnknownImpl, Impl: IMFCapturePhotoSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -4659,6 +4801,8 @@ pub trait IMFCapturePreviewSink_Impl: Sized + IMFCaptureSink_Impl {
     fn SetRotation(&self, dwstreamindex: u32, dwrotationvalue: u32) -> ::windows::core::Result<()>;
     fn SetCustomSink(&self, pmediasink: &::core::option::Option<IMFMediaSink>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFCapturePreviewSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFCapturePreviewSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCapturePreviewSink_Impl, const OFFSET: isize>() -> IMFCapturePreviewSink_Vtbl {
@@ -4744,6 +4888,7 @@ pub trait IMFCaptureRecordSink_Impl: Sized + IMFCaptureSink_Impl {
     fn GetRotation(&self, dwstreamindex: u32) -> ::windows::core::Result<u32>;
     fn SetRotation(&self, dwstreamindex: u32, dwrotationvalue: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureRecordSink {}
 impl IMFCaptureRecordSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureRecordSink_Impl, const OFFSET: isize>() -> IMFCaptureRecordSink_Vtbl {
         unsafe extern "system" fn SetOutputByteStream<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureRecordSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbytestream: ::windows::core::RawPtr, guidcontainertype: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -4803,6 +4948,7 @@ pub trait IMFCaptureSink_Impl: Sized {
     fn Prepare(&self) -> ::windows::core::Result<()>;
     fn RemoveAllStreams(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureSink {}
 impl IMFCaptureSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureSink_Impl, const OFFSET: isize>() -> IMFCaptureSink_Vtbl {
         unsafe extern "system" fn GetOutputMediaType<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsinkstreamindex: u32, ppmediatype: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4864,6 +5010,7 @@ impl IMFCaptureSink_Vtbl {
 pub trait IMFCaptureSink2_Impl: Sized + IMFCaptureSink_Impl {
     fn SetOutputMediaType(&self, dwstreamindex: u32, pmediatype: &::core::option::Option<IMFMediaType>, pencodingattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCaptureSink2 {}
 impl IMFCaptureSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureSink2_Impl, const OFFSET: isize>() -> IMFCaptureSink2_Vtbl {
         unsafe extern "system" fn SetOutputMediaType<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureSink2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pmediatype: ::windows::core::RawPtr, pencodingattributes: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4894,6 +5041,8 @@ pub trait IMFCaptureSource_Impl: Sized {
     fn SetMirrorState(&self, dwstreamindex: u32, fmirrorstate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetStreamIndexFromFriendlyName(&self, uifriendlyname: u32) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFCaptureSource {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFCaptureSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCaptureSource_Impl, const OFFSET: isize>() -> IMFCaptureSource_Vtbl {
@@ -5047,6 +5196,7 @@ pub trait IMFCdmSuspendNotify_Impl: Sized {
     fn Begin(&self) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCdmSuspendNotify {}
 impl IMFCdmSuspendNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCdmSuspendNotify_Impl, const OFFSET: isize>() -> IMFCdmSuspendNotify_Vtbl {
         unsafe extern "system" fn Begin<Identity: ::windows::core::IUnknownImpl, Impl: IMFCdmSuspendNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5072,6 +5222,7 @@ pub trait IMFClock_Impl: Sized {
     fn GetState(&self, dwreserved: u32) -> ::windows::core::Result<MFCLOCK_STATE>;
     fn GetProperties(&self) -> ::windows::core::Result<MFCLOCK_PROPERTIES>;
 }
+impl ::windows::core::RuntimeName for IMFClock {}
 impl IMFClock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFClock_Impl, const OFFSET: isize>() -> IMFClock_Vtbl {
         unsafe extern "system" fn GetClockCharacteristics<Identity: ::windows::core::IUnknownImpl, Impl: IMFClock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcharacteristics: *mut u32) -> ::windows::core::HRESULT {
@@ -5140,6 +5291,7 @@ pub trait IMFClockConsumer_Impl: Sized {
     fn SetPresentationClock(&self, ppresentationclock: &::core::option::Option<IMFPresentationClock>) -> ::windows::core::Result<()>;
     fn GetPresentationClock(&self) -> ::windows::core::Result<IMFPresentationClock>;
 }
+impl ::windows::core::RuntimeName for IMFClockConsumer {}
 impl IMFClockConsumer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFClockConsumer_Impl, const OFFSET: isize>() -> IMFClockConsumer_Vtbl {
         unsafe extern "system" fn SetPresentationClock<Identity: ::windows::core::IUnknownImpl, Impl: IMFClockConsumer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresentationclock: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5175,6 +5327,7 @@ pub trait IMFClockStateSink_Impl: Sized {
     fn OnClockRestart(&self, hnssystemtime: i64) -> ::windows::core::Result<()>;
     fn OnClockSetRate(&self, hnssystemtime: i64, flrate: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFClockStateSink {}
 impl IMFClockStateSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFClockStateSink_Impl, const OFFSET: isize>() -> IMFClockStateSink_Vtbl {
         unsafe extern "system" fn OnClockStart<Identity: ::windows::core::IUnknownImpl, Impl: IMFClockStateSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hnssystemtime: i64, llclockstartoffset: i64) -> ::windows::core::HRESULT {
@@ -5223,6 +5376,7 @@ pub trait IMFCollection_Impl: Sized {
     fn InsertElementAt(&self, dwindex: u32, punknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn RemoveAllElements(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFCollection {}
 impl IMFCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFCollection_Impl, const OFFSET: isize>() -> IMFCollection_Vtbl {
         unsafe extern "system" fn GetElementCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcelements: *mut u32) -> ::windows::core::HRESULT {
@@ -5296,6 +5450,7 @@ pub trait IMFContentDecryptionModule_Impl: Sized {
     fn CreateTrustedInput(&self, contentinitdata: *const u8, contentinitdatasize: u32) -> ::windows::core::Result<IMFTrustedInput>;
     fn GetProtectionSystemIds(&self, systemids: *mut *mut ::windows::core::GUID, count: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFContentDecryptionModule {}
 impl IMFContentDecryptionModule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModule_Impl, const OFFSET: isize>() -> IMFContentDecryptionModule_Vtbl {
         unsafe extern "system" fn SetContentEnabler<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModule_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contentenabler: ::windows::core::RawPtr, result: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5373,6 +5528,8 @@ pub trait IMFContentDecryptionModuleAccess_Impl: Sized {
     fn GetKeySystem(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMFContentDecryptionModuleAccess {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMFContentDecryptionModuleAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleAccess_Impl, const OFFSET: isize>() -> IMFContentDecryptionModuleAccess_Vtbl {
         unsafe extern "system" fn CreateContentDecryptionModule<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contentdecryptionmoduleproperties: ::windows::core::RawPtr, contentdecryptionmodule: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5425,6 +5582,8 @@ pub trait IMFContentDecryptionModuleFactory_Impl: Sized {
     fn CreateContentDecryptionModuleAccess(&self, keysystem: &::windows::core::PCWSTR, configurations: *const ::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>, numconfigurations: u32) -> ::windows::core::Result<IMFContentDecryptionModuleAccess>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IMFContentDecryptionModuleFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IMFContentDecryptionModuleFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleFactory_Impl, const OFFSET: isize>() -> IMFContentDecryptionModuleFactory_Vtbl {
         unsafe extern "system" fn IsTypeSupported<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keysystem: ::windows::core::PCWSTR, contenttype: ::windows::core::PCWSTR) -> super::super::Foundation::BOOL {
@@ -5464,6 +5623,8 @@ pub trait IMFContentDecryptionModuleSession_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn Remove(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFContentDecryptionModuleSession {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFContentDecryptionModuleSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleSession_Impl, const OFFSET: isize>() -> IMFContentDecryptionModuleSession_Vtbl {
@@ -5545,6 +5706,7 @@ pub trait IMFContentDecryptionModuleSessionCallbacks_Impl: Sized {
     fn KeyMessage(&self, messagetype: MF_MEDIAKEYSESSION_MESSAGETYPE, message: *const u8, messagesize: u32, destinationurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn KeyStatusChanged(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFContentDecryptionModuleSessionCallbacks {}
 impl IMFContentDecryptionModuleSessionCallbacks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleSessionCallbacks_Impl, const OFFSET: isize>() -> IMFContentDecryptionModuleSessionCallbacks_Vtbl {
         unsafe extern "system" fn KeyMessage<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptionModuleSessionCallbacks_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, messagetype: MF_MEDIAKEYSESSION_MESSAGETYPE, message: *const u8, messagesize: u32, destinationurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -5570,6 +5732,7 @@ impl IMFContentDecryptionModuleSessionCallbacks_Vtbl {
 pub trait IMFContentDecryptorContext_Impl: Sized {
     fn InitializeHardwareKey(&self, inputprivatedatabytecount: u32, inputprivatedata: *const ::core::ffi::c_void) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IMFContentDecryptorContext {}
 impl IMFContentDecryptorContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptorContext_Impl, const OFFSET: isize>() -> IMFContentDecryptorContext_Vtbl {
         unsafe extern "system" fn InitializeHardwareKey<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentDecryptorContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputprivatedatabytecount: u32, inputprivatedata: *const ::core::ffi::c_void, outputprivatedata: *mut u64) -> ::windows::core::HRESULT {
@@ -5599,6 +5762,8 @@ pub trait IMFContentEnabler_Impl: Sized {
     fn MonitorEnable(&self) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFContentEnabler {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFContentEnabler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentEnabler_Impl, const OFFSET: isize>() -> IMFContentEnabler_Vtbl {
@@ -5668,6 +5833,7 @@ pub trait IMFContentProtectionDevice_Impl: Sized {
     fn InvokeFunction(&self, functionid: u32, inputbufferbytecount: u32, inputbuffer: *const u8, outputbufferbytecount: *mut u32, outputbuffer: *mut u8) -> ::windows::core::Result<()>;
     fn GetPrivateDataByteCount(&self, privateinputbytecount: *mut u32, privateoutputbytecount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFContentProtectionDevice {}
 impl IMFContentProtectionDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentProtectionDevice_Impl, const OFFSET: isize>() -> IMFContentProtectionDevice_Vtbl {
         unsafe extern "system" fn InvokeFunction<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentProtectionDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, functionid: u32, inputbufferbytecount: u32, inputbuffer: *const u8, outputbufferbytecount: *mut u32, outputbuffer: *mut u8) -> ::windows::core::HRESULT {
@@ -5694,6 +5860,7 @@ pub trait IMFContentProtectionManager_Impl: Sized {
     fn BeginEnableContent(&self, penableractivate: &::core::option::Option<IMFActivate>, ptopo: &::core::option::Option<IMFTopology>, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndEnableContent(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFContentProtectionManager {}
 impl IMFContentProtectionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentProtectionManager_Impl, const OFFSET: isize>() -> IMFContentProtectionManager_Vtbl {
         unsafe extern "system" fn BeginEnableContent<Identity: ::windows::core::IUnknownImpl, Impl: IMFContentProtectionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, penableractivate: ::windows::core::RawPtr, ptopo: ::windows::core::RawPtr, pcallback: ::windows::core::RawPtr, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5721,6 +5888,8 @@ pub trait IMFD3D12SynchronizationObject_Impl: Sized {
     fn SignalEventOnFinalResourceRelease(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFD3D12SynchronizationObject {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFD3D12SynchronizationObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFD3D12SynchronizationObject_Impl, const OFFSET: isize>() -> IMFD3D12SynchronizationObject_Vtbl {
@@ -5751,6 +5920,8 @@ pub trait IMFD3D12SynchronizationObjectCommands_Impl: Sized {
     fn SignalEventOnResourceReady(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn EnqueueResourceRelease(&self, pconsumercommandqueue: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12CommandQueue>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
+impl ::windows::core::RuntimeName for IMFD3D12SynchronizationObjectCommands {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 impl IMFD3D12SynchronizationObjectCommands_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFD3D12SynchronizationObjectCommands_Impl, const OFFSET: isize>() -> IMFD3D12SynchronizationObjectCommands_Vtbl {
@@ -5791,6 +5962,8 @@ pub trait IMFDLNASinkInit_Impl: Sized {
     fn Initialize(&self, pbytestream: &::core::option::Option<IMFByteStream>, fpal: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFDLNASinkInit {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFDLNASinkInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDLNASinkInit_Impl, const OFFSET: isize>() -> IMFDLNASinkInit_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IMFDLNASinkInit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbytestream: ::windows::core::RawPtr, fpal: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5809,6 +5982,8 @@ pub trait IMFDRMNetHelper_Impl: Sized {
     fn ProcessLicenseRequest(&self, plicenserequest: *const u8, cblicenserequest: u32, pplicenseresponse: *mut *mut u8, pcblicenseresponse: *mut u32, pbstrkid: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetChainedLicenseResponse(&self, pplicenseresponse: *mut *mut u8, pcblicenseresponse: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFDRMNetHelper {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFDRMNetHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDRMNetHelper_Impl, const OFFSET: isize>() -> IMFDRMNetHelper_Vtbl {
@@ -5838,6 +6013,7 @@ pub trait IMFDXGIBuffer_Impl: Sized {
     fn GetUnknown(&self, guid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetUnknown(&self, guid: *const ::windows::core::GUID, punkdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFDXGIBuffer {}
 impl IMFDXGIBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDXGIBuffer_Impl, const OFFSET: isize>() -> IMFDXGIBuffer_Vtbl {
         unsafe extern "system" fn GetResource<Identity: ::windows::core::IUnknownImpl, Impl: IMFDXGIBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5888,6 +6064,8 @@ pub trait IMFDXGIDeviceManager_Impl: Sized {
     fn TestDevice(&self, hdevice: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn UnlockDevice(&self, hdevice: super::super::Foundation::HANDLE, fsavestate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFDXGIDeviceManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFDXGIDeviceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDXGIDeviceManager_Impl, const OFFSET: isize>() -> IMFDXGIDeviceManager_Vtbl {
@@ -5950,6 +6128,7 @@ impl IMFDXGIDeviceManager_Vtbl {
 pub trait IMFDXGIDeviceManagerSource_Impl: Sized {
     fn GetManager(&self) -> ::windows::core::Result<IMFDXGIDeviceManager>;
 }
+impl ::windows::core::RuntimeName for IMFDXGIDeviceManagerSource {}
 impl IMFDXGIDeviceManagerSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDXGIDeviceManagerSource_Impl, const OFFSET: isize>() -> IMFDXGIDeviceManagerSource_Vtbl {
         unsafe extern "system" fn GetManager<Identity: ::windows::core::IUnknownImpl, Impl: IMFDXGIDeviceManagerSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmanager: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5974,6 +6153,7 @@ pub trait IMFDesiredSample_Impl: Sized {
     fn SetDesiredSampleTimeAndDuration(&self, hnssampletime: i64, hnssampleduration: i64);
     fn Clear(&self);
 }
+impl ::windows::core::RuntimeName for IMFDesiredSample {}
 impl IMFDesiredSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDesiredSample_Impl, const OFFSET: isize>() -> IMFDesiredSample_Vtbl {
         unsafe extern "system" fn GetDesiredSampleTimeAndDuration<Identity: ::windows::core::IUnknownImpl, Impl: IMFDesiredSample_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phnssampletime: *mut i64, phnssampleduration: *mut i64) -> ::windows::core::HRESULT {
@@ -6010,6 +6190,7 @@ pub trait IMFExtendedCameraControl_Impl: Sized {
     fn UnlockPayload(&self) -> ::windows::core::Result<()>;
     fn CommitSettings(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFExtendedCameraControl {}
 impl IMFExtendedCameraControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraControl_Impl, const OFFSET: isize>() -> IMFExtendedCameraControl_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u64 {
@@ -6059,6 +6240,7 @@ impl IMFExtendedCameraControl_Vtbl {
 pub trait IMFExtendedCameraController_Impl: Sized {
     fn GetExtendedCameraControl(&self, dwstreamindex: u32, ulpropertyid: u32) -> ::windows::core::Result<IMFExtendedCameraControl>;
 }
+impl ::windows::core::RuntimeName for IMFExtendedCameraController {}
 impl IMFExtendedCameraController_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraController_Impl, const OFFSET: isize>() -> IMFExtendedCameraController_Vtbl {
         unsafe extern "system" fn GetExtendedCameraControl<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraController_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamindex: u32, ulpropertyid: u32, ppcontrol: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6083,6 +6265,7 @@ pub trait IMFExtendedCameraIntrinsicModel_Impl: Sized {
     fn SetModel(&self, pintrinsicmodel: *const MFExtendedCameraIntrinsic_IntrinsicModel) -> ::windows::core::Result<()>;
     fn GetDistortionModelType(&self) -> ::windows::core::Result<MFCameraIntrinsic_DistortionModelType>;
 }
+impl ::windows::core::RuntimeName for IMFExtendedCameraIntrinsicModel {}
 impl IMFExtendedCameraIntrinsicModel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsicModel_Impl, const OFFSET: isize>() -> IMFExtendedCameraIntrinsicModel_Vtbl {
         unsafe extern "system" fn GetModel<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsicModel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pintrinsicmodel: *mut MFExtendedCameraIntrinsic_IntrinsicModel) -> ::windows::core::HRESULT {
@@ -6131,6 +6314,7 @@ pub trait IMFExtendedCameraIntrinsics_Impl: Sized {
     fn GetIntrinsicModelByIndex(&self, dwindex: u32) -> ::windows::core::Result<IMFExtendedCameraIntrinsicModel>;
     fn AddIntrinsicModel(&self, pintrinsicmodel: &::core::option::Option<IMFExtendedCameraIntrinsicModel>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFExtendedCameraIntrinsics {}
 impl IMFExtendedCameraIntrinsics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsics_Impl, const OFFSET: isize>() -> IMFExtendedCameraIntrinsics_Vtbl {
         unsafe extern "system" fn InitializeFromBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsics_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbbuffer: *const u8, dwbuffersize: u32) -> ::windows::core::HRESULT {
@@ -6199,6 +6383,7 @@ pub trait IMFExtendedCameraIntrinsicsDistortionModel6KT_Impl: Sized {
     fn GetDistortionModel(&self) -> ::windows::core::Result<MFCameraIntrinsic_DistortionModel6KT>;
     fn SetDistortionModel(&self, pdistortionmodel: *const MFCameraIntrinsic_DistortionModel6KT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFExtendedCameraIntrinsicsDistortionModel6KT {}
 impl IMFExtendedCameraIntrinsicsDistortionModel6KT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsicsDistortionModel6KT_Impl, const OFFSET: isize>() -> IMFExtendedCameraIntrinsicsDistortionModel6KT_Vtbl {
         unsafe extern "system" fn GetDistortionModel<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsicsDistortionModel6KT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdistortionmodel: *mut MFCameraIntrinsic_DistortionModel6KT) -> ::windows::core::HRESULT {
@@ -6231,6 +6416,7 @@ pub trait IMFExtendedCameraIntrinsicsDistortionModelArcTan_Impl: Sized {
     fn GetDistortionModel(&self) -> ::windows::core::Result<MFCameraIntrinsic_DistortionModelArcTan>;
     fn SetDistortionModel(&self, pdistortionmodel: *const MFCameraIntrinsic_DistortionModelArcTan) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFExtendedCameraIntrinsicsDistortionModelArcTan {}
 impl IMFExtendedCameraIntrinsicsDistortionModelArcTan_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsicsDistortionModelArcTan_Impl, const OFFSET: isize>() -> IMFExtendedCameraIntrinsicsDistortionModelArcTan_Vtbl {
         unsafe extern "system" fn GetDistortionModel<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedCameraIntrinsicsDistortionModelArcTan_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdistortionmodel: *mut MFCameraIntrinsic_DistortionModelArcTan) -> ::windows::core::HRESULT {
@@ -6264,6 +6450,8 @@ pub trait IMFExtendedDRMTypeSupport_Impl: Sized {
     fn IsTypeSupportedEx(&self, r#type: &super::super::Foundation::BSTR, keysystem: &super::super::Foundation::BSTR) -> ::windows::core::Result<MF_MEDIA_ENGINE_CANPLAY>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFExtendedDRMTypeSupport {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFExtendedDRMTypeSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedDRMTypeSupport_Impl, const OFFSET: isize>() -> IMFExtendedDRMTypeSupport_Vtbl {
         unsafe extern "system" fn IsTypeSupportedEx<Identity: ::windows::core::IUnknownImpl, Impl: IMFExtendedDRMTypeSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, keysystem: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, panswer: *mut MF_MEDIA_ENGINE_CANPLAY) -> ::windows::core::HRESULT {
@@ -6286,6 +6474,7 @@ impl IMFExtendedDRMTypeSupport_Vtbl {
 pub trait IMFFieldOfUseMFTUnlock_Impl: Sized {
     fn Unlock(&self, punkmft: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFFieldOfUseMFTUnlock {}
 impl IMFFieldOfUseMFTUnlock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFFieldOfUseMFTUnlock_Impl, const OFFSET: isize>() -> IMFFieldOfUseMFTUnlock_Vtbl {
         unsafe extern "system" fn Unlock<Identity: ::windows::core::IUnknownImpl, Impl: IMFFieldOfUseMFTUnlock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkmft: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6303,6 +6492,7 @@ pub trait IMFFinalizableMediaSink_Impl: Sized + IMFMediaSink_Impl {
     fn BeginFinalize(&self, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndFinalize(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFFinalizableMediaSink {}
 impl IMFFinalizableMediaSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFFinalizableMediaSink_Impl, const OFFSET: isize>() -> IMFFinalizableMediaSink_Vtbl {
         unsafe extern "system" fn BeginFinalize<Identity: ::windows::core::IUnknownImpl, Impl: IMFFinalizableMediaSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6328,6 +6518,7 @@ impl IMFFinalizableMediaSink_Vtbl {
 pub trait IMFGetService_Impl: Sized {
     fn GetService(&self, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFGetService {}
 impl IMFGetService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFGetService_Impl, const OFFSET: isize>() -> IMFGetService_Vtbl {
         unsafe extern "system" fn GetService<Identity: ::windows::core::IUnknownImpl, Impl: IMFGetService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6346,6 +6537,8 @@ pub trait IMFHDCPStatus_Impl: Sized {
     fn Query(&self, pstatus: *mut MF_HDCP_STATUS, pfstatus: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn Set(&self, status: MF_HDCP_STATUS) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFHDCPStatus {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFHDCPStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFHDCPStatus_Impl, const OFFSET: isize>() -> IMFHDCPStatus_Vtbl {
@@ -6384,6 +6577,8 @@ pub trait IMFHttpDownloadRequest_Impl: Sized {
     fn GetRangeEndOffset(&self) -> ::windows::core::Result<u64>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFHttpDownloadRequest {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFHttpDownloadRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFHttpDownloadRequest_Impl, const OFFSET: isize>() -> IMFHttpDownloadRequest_Vtbl {
@@ -6540,6 +6735,8 @@ pub trait IMFHttpDownloadSession_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFHttpDownloadSession {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFHttpDownloadSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFHttpDownloadSession_Impl, const OFFSET: isize>() -> IMFHttpDownloadSession_Vtbl {
         unsafe extern "system" fn SetServer<Identity: ::windows::core::IUnknownImpl, Impl: IMFHttpDownloadSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szservername: ::windows::core::PCWSTR, nport: u32) -> ::windows::core::HRESULT {
@@ -6577,6 +6774,7 @@ impl IMFHttpDownloadSession_Vtbl {
 pub trait IMFHttpDownloadSessionProvider_Impl: Sized {
     fn CreateHttpDownloadSession(&self, wszscheme: &::windows::core::PCWSTR) -> ::windows::core::Result<IMFHttpDownloadSession>;
 }
+impl ::windows::core::RuntimeName for IMFHttpDownloadSessionProvider {}
 impl IMFHttpDownloadSessionProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFHttpDownloadSessionProvider_Impl, const OFFSET: isize>() -> IMFHttpDownloadSessionProvider_Vtbl {
         unsafe extern "system" fn CreateHttpDownloadSession<Identity: ::windows::core::IUnknownImpl, Impl: IMFHttpDownloadSessionProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszscheme: ::windows::core::PCWSTR, ppdownloadsession: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6602,6 +6800,8 @@ pub trait IMFImageSharingEngine_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<DEVICE_INFO>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFImageSharingEngine {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFImageSharingEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFImageSharingEngine_Impl, const OFFSET: isize>() -> IMFImageSharingEngine_Vtbl {
@@ -6642,6 +6842,8 @@ pub trait IMFImageSharingEngineClassFactory_Impl: Sized {
     fn CreateInstanceFromUDN(&self, puniquedevicename: &super::super::Foundation::BSTR) -> ::windows::core::Result<IMFImageSharingEngine>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFImageSharingEngineClassFactory {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFImageSharingEngineClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFImageSharingEngineClassFactory_Impl, const OFFSET: isize>() -> IMFImageSharingEngineClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstanceFromUDN<Identity: ::windows::core::IUnknownImpl, Impl: IMFImageSharingEngineClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puniquedevicename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppengine: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6669,6 +6871,7 @@ pub trait IMFInputTrustAuthority_Impl: Sized {
     fn UpdateAccess(&self, pparam: *const MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFInputTrustAuthority {}
 impl IMFInputTrustAuthority_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFInputTrustAuthority_Impl, const OFFSET: isize>() -> IMFInputTrustAuthority_Vtbl {
         unsafe extern "system" fn GetDecrypter<Identity: ::windows::core::IUnknownImpl, Impl: IMFInputTrustAuthority_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6730,6 +6933,7 @@ impl IMFInputTrustAuthority_Vtbl {
 pub trait IMFLocalMFTRegistration_Impl: Sized {
     fn RegisterMFTs(&self, pmfts: *const MFT_REGISTRATION_INFO, cmfts: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFLocalMFTRegistration {}
 impl IMFLocalMFTRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFLocalMFTRegistration_Impl, const OFFSET: isize>() -> IMFLocalMFTRegistration_Vtbl {
         unsafe extern "system" fn RegisterMFTs<Identity: ::windows::core::IUnknownImpl, Impl: IMFLocalMFTRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmfts: *const MFT_REGISTRATION_INFO, cmfts: u32) -> ::windows::core::HRESULT {
@@ -6750,6 +6954,7 @@ pub trait IMFMediaBuffer_Impl: Sized {
     fn SetCurrentLength(&self, cbcurrentlength: u32) -> ::windows::core::Result<()>;
     fn GetMaxLength(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFMediaBuffer {}
 impl IMFMediaBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaBuffer_Impl, const OFFSET: isize>() -> IMFMediaBuffer_Vtbl {
         unsafe extern "system" fn Lock<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbbuffer: *mut *mut u8, pcbmaxlength: *mut u32, pcbcurrentlength: *mut u32) -> ::windows::core::HRESULT {
@@ -6847,6 +7052,8 @@ pub trait IMFMediaEngine_Impl: Sized {
     fn TransferVideoFrame(&self, pdstsurf: &::core::option::Option<::windows::core::IUnknown>, psrc: *const MFVideoNormalizedRect, pdst: *const super::super::Foundation::RECT, pborderclr: *const MFARGB) -> ::windows::core::Result<()>;
     fn OnVideoStreamTick(&self) -> ::windows::core::Result<i64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngine {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngine_Impl, const OFFSET: isize>() -> IMFMediaEngine_Vtbl {
@@ -7156,6 +7363,7 @@ pub trait IMFMediaEngineAudioEndpointId_Impl: Sized {
     fn SetAudioEndpointId(&self, pszendpointid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetAudioEndpointId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineAudioEndpointId {}
 impl IMFMediaEngineAudioEndpointId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineAudioEndpointId_Impl, const OFFSET: isize>() -> IMFMediaEngineAudioEndpointId_Vtbl {
         unsafe extern "system" fn SetAudioEndpointId<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineAudioEndpointId_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszendpointid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -7189,6 +7397,7 @@ pub trait IMFMediaEngineClassFactory_Impl: Sized {
     fn CreateTimeRange(&self) -> ::windows::core::Result<IMFMediaTimeRange>;
     fn CreateError(&self) -> ::windows::core::Result<IMFMediaError>;
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineClassFactory {}
 impl IMFMediaEngineClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory_Impl, const OFFSET: isize>() -> IMFMediaEngineClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pattr: ::windows::core::RawPtr, ppplayer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7240,6 +7449,8 @@ pub trait IMFMediaEngineClassFactory2_Impl: Sized {
     fn CreateMediaKeys2(&self, keysystem: &super::super::Foundation::BSTR, defaultcdmstorepath: &super::super::Foundation::BSTR, inprivatecdmstorepath: &super::super::Foundation::BSTR) -> ::windows::core::Result<IMFMediaKeys>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineClassFactory2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineClassFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory2_Impl, const OFFSET: isize>() -> IMFMediaEngineClassFactory2_Vtbl {
         unsafe extern "system" fn CreateMediaKeys2<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keysystem: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, defaultcdmstorepath: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, inprivatecdmstorepath: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppkeys: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7263,6 +7474,8 @@ impl IMFMediaEngineClassFactory2_Vtbl {
 pub trait IMFMediaEngineClassFactory3_Impl: Sized {
     fn CreateMediaKeySystemAccess(&self, keysystem: &super::super::Foundation::BSTR, ppsupportedconfigurationsarray: *const ::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>, usize: u32) -> ::windows::core::Result<IMFMediaKeySystemAccess>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IMFMediaEngineClassFactory3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IMFMediaEngineClassFactory3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory3_Impl, const OFFSET: isize>() -> IMFMediaEngineClassFactory3_Vtbl {
@@ -7289,6 +7502,7 @@ impl IMFMediaEngineClassFactory3_Vtbl {
 pub trait IMFMediaEngineClassFactory4_Impl: Sized {
     fn CreateContentDecryptionModuleFactory(&self, keysystem: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineClassFactory4 {}
 impl IMFMediaEngineClassFactory4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory4_Impl, const OFFSET: isize>() -> IMFMediaEngineClassFactory4_Vtbl {
         unsafe extern "system" fn CreateContentDecryptionModuleFactory<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactory4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keysystem: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7311,6 +7525,8 @@ pub trait IMFMediaEngineClassFactoryEx_Impl: Sized + IMFMediaEngineClassFactory_
     fn CreateMediaKeys(&self, keysystem: &super::super::Foundation::BSTR, cdmstorepath: &super::super::Foundation::BSTR) -> ::windows::core::Result<IMFMediaKeys>;
     fn IsTypeSupported(&self, r#type: &super::super::Foundation::BSTR, keysystem: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineClassFactoryEx {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineClassFactoryEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineClassFactoryEx_Impl, const OFFSET: isize>() -> IMFMediaEngineClassFactoryEx_Vtbl {
@@ -7362,6 +7578,7 @@ pub trait IMFMediaEngineEME_Impl: Sized {
     fn Keys(&self) -> ::windows::core::Result<IMFMediaKeys>;
     fn SetMediaKeys(&self, keys: &::core::option::Option<IMFMediaKeys>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineEME {}
 impl IMFMediaEngineEME_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineEME_Impl, const OFFSET: isize>() -> IMFMediaEngineEME_Vtbl {
         unsafe extern "system" fn Keys<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineEME_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keys: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7395,6 +7612,8 @@ pub trait IMFMediaEngineEMENotify_Impl: Sized {
     fn Encrypted(&self, pbinitdata: *const u8, cb: u32, bstrinitdatatype: &super::super::Foundation::BSTR);
     fn WaitingForKey(&self);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineEMENotify {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineEMENotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineEMENotify_Impl, const OFFSET: isize>() -> IMFMediaEngineEMENotify_Vtbl {
@@ -7458,6 +7677,8 @@ pub trait IMFMediaEngineEx_Impl: Sized + IMFMediaEngine_Impl {
     fn SetCurrentTimeEx(&self, seektime: f64, seekmode: MF_MEDIA_ENGINE_SEEK_MODE) -> ::windows::core::Result<()>;
     fn EnableTimeUpdateTimer(&self, fenabletimer: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaEngineEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaEngineEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineEx_Impl, const OFFSET: isize>() -> IMFMediaEngineEx_Vtbl {
@@ -7783,6 +8004,8 @@ pub trait IMFMediaEngineExtension_Impl: Sized {
     fn EndCreateObject(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineExtension {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineExtension_Impl, const OFFSET: isize>() -> IMFMediaEngineExtension_Vtbl {
         unsafe extern "system" fn CanPlayType<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineExtension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, audioonly: super::super::Foundation::BOOL, mimetype: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, panswer: *mut MF_MEDIA_ENGINE_CANPLAY) -> ::windows::core::HRESULT {
@@ -7832,6 +8055,7 @@ impl IMFMediaEngineExtension_Vtbl {
 pub trait IMFMediaEngineNeedKeyNotify_Impl: Sized {
     fn NeedKey(&self, initdata: *const u8, cb: u32);
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineNeedKeyNotify {}
 impl IMFMediaEngineNeedKeyNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineNeedKeyNotify_Impl, const OFFSET: isize>() -> IMFMediaEngineNeedKeyNotify_Vtbl {
         unsafe extern "system" fn NeedKey<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineNeedKeyNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, initdata: *const u8, cb: u32) {
@@ -7848,6 +8072,7 @@ impl IMFMediaEngineNeedKeyNotify_Vtbl {
 pub trait IMFMediaEngineNotify_Impl: Sized {
     fn EventNotify(&self, event: u32, param1: usize, param2: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineNotify {}
 impl IMFMediaEngineNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineNotify_Impl, const OFFSET: isize>() -> IMFMediaEngineNotify_Vtbl {
         unsafe extern "system" fn EventNotify<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, event: u32, param1: usize, param2: u32) -> ::windows::core::HRESULT {
@@ -7865,6 +8090,8 @@ impl IMFMediaEngineNotify_Vtbl {
 pub trait IMFMediaEngineOPMInfo_Impl: Sized {
     fn GetOPMInfo(&self, pstatus: *mut MF_MEDIA_ENGINE_OPM_STATUS, pconstricted: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineOPMInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineOPMInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineOPMInfo_Impl, const OFFSET: isize>() -> IMFMediaEngineOPMInfo_Vtbl {
@@ -7888,6 +8115,8 @@ pub trait IMFMediaEngineProtectedContent_Impl: Sized {
     fn SetContentProtectionManager(&self, pcpm: &::core::option::Option<IMFContentProtectionManager>) -> ::windows::core::Result<()>;
     fn SetApplicationCertificate(&self, pbblob: *const u8, cbblob: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineProtectedContent {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineProtectedContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineProtectedContent_Impl, const OFFSET: isize>() -> IMFMediaEngineProtectedContent_Vtbl {
@@ -7956,6 +8185,8 @@ pub trait IMFMediaEngineSrcElements_Impl: Sized {
     fn AddElement(&self, purl: &super::super::Foundation::BSTR, ptype: &super::super::Foundation::BSTR, pmedia: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn RemoveAllElements(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineSrcElements {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineSrcElements_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineSrcElements_Impl, const OFFSET: isize>() -> IMFMediaEngineSrcElements_Vtbl {
@@ -8027,6 +8258,8 @@ pub trait IMFMediaEngineSrcElementsEx_Impl: Sized + IMFMediaEngineSrcElements_Im
     fn GetKeySystem(&self, index: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineSrcElementsEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineSrcElementsEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineSrcElementsEx_Impl, const OFFSET: isize>() -> IMFMediaEngineSrcElementsEx_Vtbl {
         unsafe extern "system" fn AddElementEx<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineSrcElementsEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, purl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ptype: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pmedia: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, keysystem: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -8061,6 +8294,8 @@ pub trait IMFMediaEngineSupportsSourceTransfer_Impl: Sized {
     fn DetachMediaSource(&self, ppbytestream: *mut ::core::option::Option<IMFByteStream>, ppmediasource: *mut ::core::option::Option<IMFMediaSource>, ppmse: *mut ::core::option::Option<IMFMediaSourceExtension>) -> ::windows::core::Result<()>;
     fn AttachMediaSource(&self, pbytestream: &::core::option::Option<IMFByteStream>, pmediasource: &::core::option::Option<IMFMediaSource>, pmse: &::core::option::Option<IMFMediaSourceExtension>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineSupportsSourceTransfer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineSupportsSourceTransfer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineSupportsSourceTransfer_Impl, const OFFSET: isize>() -> IMFMediaEngineSupportsSourceTransfer_Vtbl {
@@ -8099,6 +8334,7 @@ impl IMFMediaEngineSupportsSourceTransfer_Vtbl {
 pub trait IMFMediaEngineTransferSource_Impl: Sized {
     fn TransferSourceToMediaEngine(&self, destination: &::core::option::Option<IMFMediaEngine>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaEngineTransferSource {}
 impl IMFMediaEngineTransferSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineTransferSource_Impl, const OFFSET: isize>() -> IMFMediaEngineTransferSource_Vtbl {
         unsafe extern "system" fn TransferSourceToMediaEngine<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineTransferSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, destination: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8121,6 +8357,8 @@ pub trait IMFMediaEngineWebSupport_Impl: Sized {
     fn ConnectWebAudio(&self, dwsamplerate: u32) -> ::windows::core::Result<IAudioSourceProvider>;
     fn DisconnectWebAudio(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaEngineWebSupport {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaEngineWebSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEngineWebSupport_Impl, const OFFSET: isize>() -> IMFMediaEngineWebSupport_Vtbl {
@@ -8162,6 +8400,7 @@ pub trait IMFMediaError_Impl: Sized {
     fn SetErrorCode(&self, error: MF_MEDIA_ENGINE_ERR) -> ::windows::core::Result<()>;
     fn SetExtendedErrorCode(&self, error: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaError {}
 impl IMFMediaError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaError_Impl, const OFFSET: isize>() -> IMFMediaError_Vtbl {
         unsafe extern "system" fn GetErrorCode<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u16 {
@@ -8203,6 +8442,8 @@ pub trait IMFMediaEvent_Impl: Sized + IMFAttributes_Impl {
     fn GetStatus(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
     fn GetValue(&self) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEvent_Impl, const OFFSET: isize>() -> IMFMediaEvent_Vtbl {
@@ -8270,6 +8511,8 @@ pub trait IMFMediaEventGenerator_Impl: Sized {
     fn QueueEvent(&self, met: u32, guidextendedtype: *const ::windows::core::GUID, hrstatus: ::windows::core::HRESULT, pvvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaEventGenerator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaEventGenerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEventGenerator_Impl, const OFFSET: isize>() -> IMFMediaEventGenerator_Vtbl {
         unsafe extern "system" fn GetEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEventGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: MEDIA_EVENT_GENERATOR_GET_EVENT_FLAGS, ppevent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8326,6 +8569,8 @@ pub trait IMFMediaEventQueue_Impl: Sized {
     fn QueueEventParamUnk(&self, met: u32, guidextendedtype: *const ::windows::core::GUID, hrstatus: ::windows::core::HRESULT, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaEventQueue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaEventQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaEventQueue_Impl, const OFFSET: isize>() -> IMFMediaEventQueue_Vtbl {
@@ -8400,6 +8645,8 @@ pub trait IMFMediaKeySession_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaKeySession {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaKeySession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySession_Impl, const OFFSET: isize>() -> IMFMediaKeySession_Vtbl {
         unsafe extern "system" fn GetError<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, code: *mut u16, systemcode: *mut u32) -> ::windows::core::HRESULT {
@@ -8461,6 +8708,8 @@ pub trait IMFMediaKeySession2_Impl: Sized + IMFMediaKeySession_Impl {
     fn Remove(&self) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaKeySession2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaKeySession2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySession2_Impl, const OFFSET: isize>() -> IMFMediaKeySession2_Vtbl {
@@ -8527,6 +8776,8 @@ pub trait IMFMediaKeySessionNotify_Impl: Sized {
     fn KeyError(&self, code: u16, systemcode: u32);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaKeySessionNotify {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaKeySessionNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySessionNotify_Impl, const OFFSET: isize>() -> IMFMediaKeySessionNotify_Vtbl {
         unsafe extern "system" fn KeyMessage<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySessionNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, destinationurl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, message: *const u8, cb: u32) {
@@ -8561,6 +8812,8 @@ pub trait IMFMediaKeySessionNotify2_Impl: Sized + IMFMediaKeySessionNotify_Impl 
     fn KeyStatusChange(&self);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaKeySessionNotify2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaKeySessionNotify2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySessionNotify2_Impl, const OFFSET: isize>() -> IMFMediaKeySessionNotify2_Vtbl {
         unsafe extern "system" fn KeyMessage2<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySessionNotify2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, emessagetype: MF_MEDIAKEYSESSION_MESSAGETYPE, destinationurl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbmessage: *const u8, cbmessage: u32) {
@@ -8589,6 +8842,8 @@ pub trait IMFMediaKeySystemAccess_Impl: Sized {
     fn SupportedConfiguration(&self) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
     fn KeySystem(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IMFMediaKeySystemAccess {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IMFMediaKeySystemAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeySystemAccess_Impl, const OFFSET: isize>() -> IMFMediaKeySystemAccess_Vtbl {
@@ -8643,6 +8898,8 @@ pub trait IMFMediaKeys_Impl: Sized {
     fn Shutdown(&self) -> ::windows::core::Result<()>;
     fn GetSuspendNotify(&self) -> ::windows::core::Result<IMFCdmSuspendNotify>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaKeys {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaKeys_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeys_Impl, const OFFSET: isize>() -> IMFMediaKeys_Vtbl {
@@ -8703,6 +8960,8 @@ pub trait IMFMediaKeys2_Impl: Sized + IMFMediaKeys_Impl {
     fn GetDOMException(&self, systemcode: ::windows::core::HRESULT) -> ::windows::core::Result<::windows::core::HRESULT>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaKeys2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaKeys2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeys2_Impl, const OFFSET: isize>() -> IMFMediaKeys2_Vtbl {
         unsafe extern "system" fn CreateSession2<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaKeys2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, esessiontype: MF_MEDIAKEYSESSION_TYPE, pmfmediakeysessionnotify2: ::windows::core::RawPtr, ppsession: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8756,6 +9015,8 @@ pub trait IMFMediaSession_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn GetSessionCapabilities(&self) -> ::windows::core::Result<u32>;
     fn GetFullTopology(&self, dwgetfulltopologyflags: u32, topoid: u64) -> ::windows::core::Result<IMFTopology>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSession_Impl, const OFFSET: isize>() -> IMFMediaSession_Vtbl {
@@ -8850,6 +9111,8 @@ pub trait IMFMediaSharingEngine_Impl: Sized + IMFMediaEngine_Impl {
     fn GetDevice(&self) -> ::windows::core::Result<DEVICE_INFO>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaSharingEngine {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFMediaSharingEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSharingEngine_Impl, const OFFSET: isize>() -> IMFMediaSharingEngine_Vtbl {
         unsafe extern "system" fn GetDevice<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSharingEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevice: *mut DEVICE_INFO) -> ::windows::core::HRESULT {
@@ -8872,6 +9135,7 @@ impl IMFMediaSharingEngine_Vtbl {
 pub trait IMFMediaSharingEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pattr: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<IMFMediaSharingEngine>;
 }
+impl ::windows::core::RuntimeName for IMFMediaSharingEngineClassFactory {}
 impl IMFMediaSharingEngineClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSharingEngineClassFactory_Impl, const OFFSET: isize>() -> IMFMediaSharingEngineClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSharingEngineClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pattr: ::windows::core::RawPtr, ppengine: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8902,6 +9166,7 @@ pub trait IMFMediaSink_Impl: Sized {
     fn GetPresentationClock(&self) -> ::windows::core::Result<IMFPresentationClock>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaSink {}
 impl IMFMediaSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSink_Impl, const OFFSET: isize>() -> IMFMediaSink_Vtbl {
         unsafe extern "system" fn GetCharacteristics<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcharacteristics: *mut u32) -> ::windows::core::HRESULT {
@@ -9005,6 +9270,7 @@ impl IMFMediaSink_Vtbl {
 pub trait IMFMediaSinkPreroll_Impl: Sized {
     fn NotifyPreroll(&self, hnsupcomingstarttime: i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaSinkPreroll {}
 impl IMFMediaSinkPreroll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSinkPreroll_Impl, const OFFSET: isize>() -> IMFMediaSinkPreroll_Vtbl {
         unsafe extern "system" fn NotifyPreroll<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSinkPreroll_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hnsupcomingstarttime: i64) -> ::windows::core::HRESULT {
@@ -9027,6 +9293,8 @@ pub trait IMFMediaSource_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn Pause(&self) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaSource {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSource_Impl, const OFFSET: isize>() -> IMFMediaSource_Vtbl {
@@ -9091,6 +9359,8 @@ pub trait IMFMediaSource2_Impl: Sized + IMFMediaEventGenerator_Impl + IMFMediaSo
     fn SetMediaType(&self, dwstreamid: u32, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaSource2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaSource2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSource2_Impl, const OFFSET: isize>() -> IMFMediaSource2_Vtbl {
         unsafe extern "system" fn SetMediaType<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSource2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamid: u32, pmediatype: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9110,6 +9380,8 @@ pub trait IMFMediaSourceEx_Impl: Sized + IMFMediaEventGenerator_Impl + IMFMediaS
     fn GetStreamAttributes(&self, dwstreamidentifier: u32) -> ::windows::core::Result<IMFAttributes>;
     fn SetD3DManager(&self, pmanager: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaSourceEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaSourceEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceEx_Impl, const OFFSET: isize>() -> IMFMediaSourceEx_Vtbl {
@@ -9164,6 +9436,8 @@ pub trait IMFMediaSourceExtension_Impl: Sized {
     fn IsTypeSupported(&self, r#type: &super::super::Foundation::BSTR) -> super::super::Foundation::BOOL;
     fn GetSourceBuffer(&self, dwstreamindex: u32) -> ::core::option::Option<IMFSourceBuffer>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaSourceExtension {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaSourceExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceExtension_Impl, const OFFSET: isize>() -> IMFMediaSourceExtension_Vtbl {
@@ -9245,6 +9519,7 @@ pub trait IMFMediaSourceExtensionLiveSeekableRange_Impl: Sized {
     fn SetLiveSeekableRange(&self, start: f64, end: f64) -> ::windows::core::Result<()>;
     fn ClearLiveSeekableRange(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaSourceExtensionLiveSeekableRange {}
 impl IMFMediaSourceExtensionLiveSeekableRange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceExtensionLiveSeekableRange_Impl, const OFFSET: isize>() -> IMFMediaSourceExtensionLiveSeekableRange_Vtbl {
         unsafe extern "system" fn SetLiveSeekableRange<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceExtensionLiveSeekableRange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, start: f64, end: f64) -> ::windows::core::HRESULT {
@@ -9272,6 +9547,7 @@ pub trait IMFMediaSourceExtensionNotify_Impl: Sized {
     fn OnSourceEnded(&self);
     fn OnSourceClose(&self);
 }
+impl ::windows::core::RuntimeName for IMFMediaSourceExtensionNotify {}
 impl IMFMediaSourceExtensionNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceExtensionNotify_Impl, const OFFSET: isize>() -> IMFMediaSourceExtensionNotify_Vtbl {
         unsafe extern "system" fn OnSourceOpen<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceExtensionNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -9303,6 +9579,7 @@ impl IMFMediaSourceExtensionNotify_Vtbl {
 pub trait IMFMediaSourcePresentationProvider_Impl: Sized {
     fn ForceEndOfPresentation(&self, ppresentationdescriptor: &::core::option::Option<IMFPresentationDescriptor>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaSourcePresentationProvider {}
 impl IMFMediaSourcePresentationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourcePresentationProvider_Impl, const OFFSET: isize>() -> IMFMediaSourcePresentationProvider_Vtbl {
         unsafe extern "system" fn ForceEndOfPresentation<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourcePresentationProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresentationdescriptor: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9319,6 +9596,7 @@ impl IMFMediaSourcePresentationProvider_Vtbl {
 pub trait IMFMediaSourceTopologyProvider_Impl: Sized {
     fn GetMediaSourceTopology(&self, ppresentationdescriptor: &::core::option::Option<IMFPresentationDescriptor>) -> ::windows::core::Result<IMFTopology>;
 }
+impl ::windows::core::RuntimeName for IMFMediaSourceTopologyProvider {}
 impl IMFMediaSourceTopologyProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceTopologyProvider_Impl, const OFFSET: isize>() -> IMFMediaSourceTopologyProvider_Vtbl {
         unsafe extern "system" fn GetMediaSourceTopology<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaSourceTopologyProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresentationdescriptor: ::windows::core::RawPtr, pptopology: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9344,6 +9622,8 @@ pub trait IMFMediaStream_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn GetStreamDescriptor(&self) -> ::windows::core::Result<IMFStreamDescriptor>;
     fn RequestSample(&self, ptoken: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaStream_Impl, const OFFSET: isize>() -> IMFMediaStream_Vtbl {
@@ -9391,6 +9671,8 @@ pub trait IMFMediaStream2_Impl: Sized + IMFMediaEventGenerator_Impl + IMFMediaSt
     fn GetStreamState(&self) -> ::windows::core::Result<MF_STREAM_STATE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaStream2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaStream2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaStream2_Impl, const OFFSET: isize>() -> IMFMediaStream2_Vtbl {
         unsafe extern "system" fn SetStreamState<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaStream2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: MF_STREAM_STATE) -> ::windows::core::HRESULT {
@@ -9422,6 +9704,7 @@ impl IMFMediaStream2_Vtbl {
 pub trait IMFMediaStreamSourceSampleRequest_Impl: Sized {
     fn SetSample(&self, value: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFMediaStreamSourceSampleRequest {}
 impl IMFMediaStreamSourceSampleRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaStreamSourceSampleRequest_Impl, const OFFSET: isize>() -> IMFMediaStreamSourceSampleRequest_Vtbl {
         unsafe extern "system" fn SetSample<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaStreamSourceSampleRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9444,6 +9727,8 @@ pub trait IMFMediaTimeRange_Impl: Sized {
     fn AddRange(&self, starttime: f64, endtime: f64) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFMediaTimeRange {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFMediaTimeRange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaTimeRange_Impl, const OFFSET: isize>() -> IMFMediaTimeRange_Vtbl {
@@ -9512,6 +9797,8 @@ pub trait IMFMediaType_Impl: Sized + IMFAttributes_Impl {
     fn FreeRepresentation(&self, guidrepresentation: &::windows::core::GUID, pvrepresentation: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMediaType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMediaType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaType_Impl, const OFFSET: isize>() -> IMFMediaType_Vtbl {
         unsafe extern "system" fn GetMajorType<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidmajortype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -9578,6 +9865,7 @@ pub trait IMFMediaTypeHandler_Impl: Sized {
     fn GetCurrentMediaType(&self) -> ::windows::core::Result<IMFMediaType>;
     fn GetMajorType(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IMFMediaTypeHandler {}
 impl IMFMediaTypeHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaTypeHandler_Impl, const OFFSET: isize>() -> IMFMediaTypeHandler_Vtbl {
         unsafe extern "system" fn IsMediaTypeSupported<Identity: ::windows::core::IUnknownImpl, Impl: IMFMediaTypeHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmediatype: ::windows::core::RawPtr, ppmediatype: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9665,6 +9953,8 @@ pub trait IMFMetadata_Impl: Sized {
     fn GetAllPropertyNames(&self) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFMetadata {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFMetadata_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMetadata_Impl, const OFFSET: isize>() -> IMFMetadata_Vtbl {
         unsafe extern "system" fn SetLanguage<Identity: ::windows::core::IUnknownImpl, Impl: IMFMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszrfc1766: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -9744,6 +10034,7 @@ impl IMFMetadata_Vtbl {
 pub trait IMFMetadataProvider_Impl: Sized {
     fn GetMFMetadata(&self, ppresentationdescriptor: &::core::option::Option<IMFPresentationDescriptor>, dwstreamidentifier: u32, dwflags: u32) -> ::windows::core::Result<IMFMetadata>;
 }
+impl ::windows::core::RuntimeName for IMFMetadataProvider {}
 impl IMFMetadataProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMetadataProvider_Impl, const OFFSET: isize>() -> IMFMetadataProvider_Vtbl {
         unsafe extern "system" fn GetMFMetadata<Identity: ::windows::core::IUnknownImpl, Impl: IMFMetadataProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresentationdescriptor: ::windows::core::RawPtr, dwstreamidentifier: u32, dwflags: u32, ppmfmetadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9767,6 +10058,7 @@ pub trait IMFMuxStreamAttributesManager_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
     fn GetAttributes(&self, dwmuxstreamindex: u32) -> ::windows::core::Result<IMFAttributes>;
 }
+impl ::windows::core::RuntimeName for IMFMuxStreamAttributesManager {}
 impl IMFMuxStreamAttributesManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMuxStreamAttributesManager_Impl, const OFFSET: isize>() -> IMFMuxStreamAttributesManager_Vtbl {
         unsafe extern "system" fn GetStreamCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFMuxStreamAttributesManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwmuxstreamcount: *mut u32) -> ::windows::core::HRESULT {
@@ -9809,6 +10101,7 @@ pub trait IMFMuxStreamMediaTypeManager_Impl: Sized {
     fn RemoveStreamConfiguration(&self, ullstreammask: u64) -> ::windows::core::Result<()>;
     fn GetStreamConfiguration(&self, ulindex: u32) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IMFMuxStreamMediaTypeManager {}
 impl IMFMuxStreamMediaTypeManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMuxStreamMediaTypeManager_Impl, const OFFSET: isize>() -> IMFMuxStreamMediaTypeManager_Vtbl {
         unsafe extern "system" fn GetStreamCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFMuxStreamMediaTypeManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwmuxstreamcount: *mut u32) -> ::windows::core::HRESULT {
@@ -9884,6 +10177,7 @@ pub trait IMFMuxStreamSampleManager_Impl: Sized {
     fn GetSample(&self, dwmuxstreamindex: u32) -> ::windows::core::Result<IMFSample>;
     fn GetStreamConfiguration(&self) -> u64;
 }
+impl ::windows::core::RuntimeName for IMFMuxStreamSampleManager {}
 impl IMFMuxStreamSampleManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFMuxStreamSampleManager_Impl, const OFFSET: isize>() -> IMFMuxStreamSampleManager_Vtbl {
         unsafe extern "system" fn GetStreamCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFMuxStreamSampleManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwmuxstreamcount: *mut u32) -> ::windows::core::HRESULT {
@@ -9932,6 +10226,8 @@ pub trait IMFNetCredential_Impl: Sized {
     fn GetPassword(&self, pbdata: *mut u8, pcbdata: *mut u32, fencryptdata: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn LoggedOnUser(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFNetCredential {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFNetCredential_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetCredential_Impl, const OFFSET: isize>() -> IMFNetCredential_Vtbl {
@@ -9986,6 +10282,8 @@ pub trait IMFNetCredentialCache_Impl: Sized {
     fn SetUserOptions(&self, pcred: &::core::option::Option<IMFNetCredential>, dwoptionsflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFNetCredentialCache {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFNetCredentialCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetCredentialCache_Impl, const OFFSET: isize>() -> IMFNetCredentialCache_Vtbl {
         unsafe extern "system" fn GetCredential<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetCredentialCache_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pszrealm: ::windows::core::PCWSTR, dwauthenticationflags: u32, ppcred: *mut ::windows::core::RawPtr, pdwrequirementsflags: *mut u32) -> ::windows::core::HRESULT {
@@ -10020,6 +10318,8 @@ pub trait IMFNetCredentialManager_Impl: Sized {
     fn EndGetCredentials(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<IMFNetCredential>;
     fn SetGood(&self, pcred: &::core::option::Option<IMFNetCredential>, fgood: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFNetCredentialManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFNetCredentialManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetCredentialManager_Impl, const OFFSET: isize>() -> IMFNetCredentialManager_Vtbl {
@@ -10061,6 +10361,8 @@ pub trait IMFNetCrossOriginSupport_Impl: Sized {
     fn GetSourceOrigin(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn IsSameOrigin(&self, wszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFNetCrossOriginSupport {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFNetCrossOriginSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetCrossOriginSupport_Impl, const OFFSET: isize>() -> IMFNetCrossOriginSupport_Vtbl {
@@ -10117,6 +10419,8 @@ pub trait IMFNetProxyLocator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IMFNetProxyLocator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFNetProxyLocator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFNetProxyLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetProxyLocator_Impl, const OFFSET: isize>() -> IMFNetProxyLocator_Vtbl {
         unsafe extern "system" fn FindFirstProxy<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetProxyLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszhost: ::windows::core::PCWSTR, pszurl: ::windows::core::PCWSTR, freserved: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -10166,6 +10470,7 @@ impl IMFNetProxyLocator_Vtbl {
 pub trait IMFNetProxyLocatorFactory_Impl: Sized {
     fn CreateProxyLocator(&self, pszprotocol: &::windows::core::PCWSTR) -> ::windows::core::Result<IMFNetProxyLocator>;
 }
+impl ::windows::core::RuntimeName for IMFNetProxyLocatorFactory {}
 impl IMFNetProxyLocatorFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetProxyLocatorFactory_Impl, const OFFSET: isize>() -> IMFNetProxyLocatorFactory_Vtbl {
         unsafe extern "system" fn CreateProxyLocator<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetProxyLocatorFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszprotocol: ::windows::core::PCWSTR, ppproxylocator: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -10189,6 +10494,7 @@ pub trait IMFNetResourceFilter_Impl: Sized {
     fn OnRedirect(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<i16>;
     fn OnSendingRequest(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFNetResourceFilter {}
 impl IMFNetResourceFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetResourceFilter_Impl, const OFFSET: isize>() -> IMFNetResourceFilter_Vtbl {
         unsafe extern "system" fn OnRedirect<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetResourceFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pvbcancel: *mut i16) -> ::windows::core::HRESULT {
@@ -10222,6 +10528,7 @@ pub trait IMFNetSchemeHandlerConfig_Impl: Sized {
     fn GetSupportedProtocolType(&self, nprotocolindex: u32) -> ::windows::core::Result<MFNETSOURCE_PROTOCOL_TYPE>;
     fn ResetProtocolRolloverSettings(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFNetSchemeHandlerConfig {}
 impl IMFNetSchemeHandlerConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetSchemeHandlerConfig_Impl, const OFFSET: isize>() -> IMFNetSchemeHandlerConfig_Vtbl {
         unsafe extern "system" fn GetNumberOfSupportedProtocols<Identity: ::windows::core::IUnknownImpl, Impl: IMFNetSchemeHandlerConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcprotocols: *mut u32) -> ::windows::core::HRESULT {
@@ -10266,6 +10573,7 @@ pub trait IMFObjectReferenceStream_Impl: Sized {
     fn SaveReference(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn LoadReference(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFObjectReferenceStream {}
 impl IMFObjectReferenceStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFObjectReferenceStream_Impl, const OFFSET: isize>() -> IMFObjectReferenceStream_Vtbl {
         unsafe extern "system" fn SaveReference<Identity: ::windows::core::IUnknownImpl, Impl: IMFObjectReferenceStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10294,6 +10602,8 @@ pub trait IMFOutputPolicy_Impl: Sized + IMFAttributes_Impl {
     fn GetOriginatorID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetMinimumGRLVersion(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFOutputPolicy {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFOutputPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFOutputPolicy_Impl, const OFFSET: isize>() -> IMFOutputPolicy_Vtbl {
@@ -10348,6 +10658,8 @@ pub trait IMFOutputSchema_Impl: Sized + IMFAttributes_Impl {
     fn GetOriginatorID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFOutputSchema {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFOutputSchema_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFOutputSchema_Impl, const OFFSET: isize>() -> IMFOutputSchema_Vtbl {
         unsafe extern "system" fn GetSchemaType<Identity: ::windows::core::IUnknownImpl, Impl: IMFOutputSchema_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidschematype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -10398,6 +10710,7 @@ pub trait IMFOutputTrustAuthority_Impl: Sized {
     fn GetAction(&self) -> ::windows::core::Result<MFPOLICYMANAGER_ACTION>;
     fn SetPolicy(&self, pppolicy: *const ::core::option::Option<IMFOutputPolicy>, npolicy: u32, ppbticket: *mut *mut u8, pcbticket: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFOutputTrustAuthority {}
 impl IMFOutputTrustAuthority_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFOutputTrustAuthority_Impl, const OFFSET: isize>() -> IMFOutputTrustAuthority_Vtbl {
         unsafe extern "system" fn GetAction<Identity: ::windows::core::IUnknownImpl, Impl: IMFOutputTrustAuthority_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, paction: *mut MFPOLICYMANAGER_ACTION) -> ::windows::core::HRESULT {
@@ -10429,6 +10742,7 @@ impl IMFOutputTrustAuthority_Vtbl {
 pub trait IMFPMPClient_Impl: Sized {
     fn SetPMPHost(&self, ppmphost: &::core::option::Option<IMFPMPHost>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFPMPClient {}
 impl IMFPMPClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPClient_Impl, const OFFSET: isize>() -> IMFPMPClient_Vtbl {
         unsafe extern "system" fn SetPMPHost<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmphost: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -10445,6 +10759,7 @@ impl IMFPMPClient_Vtbl {
 pub trait IMFPMPClientApp_Impl: Sized {
     fn SetPMPHost(&self, ppmphost: &::core::option::Option<IMFPMPHostApp>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFPMPClientApp {}
 impl IMFPMPClientApp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPClientApp_Impl, const OFFSET: isize>() -> IMFPMPClientApp_Vtbl {
         unsafe extern "system" fn SetPMPHost<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPClientApp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmphost: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -10464,6 +10779,8 @@ pub trait IMFPMPHost_Impl: Sized {
     fn UnlockProcess(&self) -> ::windows::core::Result<()>;
     fn CreateObjectByCLSID(&self, clsid: *const ::windows::core::GUID, pstream: &::core::option::Option<super::super::System::Com::IStream>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMFPMPHost {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMFPMPHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPHost_Impl, const OFFSET: isize>() -> IMFPMPHost_Vtbl {
@@ -10500,6 +10817,8 @@ pub trait IMFPMPHostApp_Impl: Sized {
     fn ActivateClassById(&self, id: &::windows::core::PCWSTR, pstream: &::core::option::Option<super::super::System::Com::IStream>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMFPMPHostApp {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMFPMPHostApp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPHostApp_Impl, const OFFSET: isize>() -> IMFPMPHostApp_Vtbl {
         unsafe extern "system" fn LockProcess<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPHostApp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10533,6 +10852,7 @@ pub trait IMFPMPServer_Impl: Sized {
     fn UnlockProcess(&self) -> ::windows::core::Result<()>;
     fn CreateObjectByCLSID(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFPMPServer {}
 impl IMFPMPServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPServer_Impl, const OFFSET: isize>() -> IMFPMPServer_Vtbl {
         unsafe extern "system" fn LockProcess<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMPServer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10583,6 +10903,8 @@ pub trait IMFPMediaItem_Impl: Sized {
     fn SetStreamSink(&self, dwstreamindex: u32, pmediasink: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetMetadata(&self) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IMFPMediaItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IMFPMediaItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMediaItem_Impl, const OFFSET: isize>() -> IMFPMediaItem_Vtbl {
@@ -10819,6 +11141,8 @@ pub trait IMFPMediaPlayer_Impl: Sized {
     fn RemoveAllEffects(&self) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFPMediaPlayer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFPMediaPlayer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMediaPlayer_Impl, const OFFSET: isize>() -> IMFPMediaPlayer_Vtbl {
@@ -11135,6 +11459,8 @@ pub trait IMFPMediaPlayerCallback_Impl: Sized {
     fn OnMediaPlayerEvent(&self, peventheader: *const MFP_EVENT_HEADER);
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMFPMediaPlayerCallback {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMFPMediaPlayerCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMediaPlayerCallback_Impl, const OFFSET: isize>() -> IMFPMediaPlayerCallback_Vtbl {
         unsafe extern "system" fn OnMediaPlayerEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMFPMediaPlayerCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventheader: *const MFP_EVENT_HEADER) {
@@ -11157,6 +11483,8 @@ pub trait IMFPluginControl_Impl: Sized {
     fn GetDisabledByIndex(&self, plugintype: u32, index: u32) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetDisabled(&self, plugintype: u32, clsid: *const ::windows::core::GUID, disabled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFPluginControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFPluginControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPluginControl_Impl, const OFFSET: isize>() -> IMFPluginControl_Vtbl {
@@ -11221,6 +11549,8 @@ pub trait IMFPluginControl2_Impl: Sized + IMFPluginControl_Impl {
     fn SetPolicy(&self, policy: MF_PLUGIN_CONTROL_POLICY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFPluginControl2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFPluginControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPluginControl2_Impl, const OFFSET: isize>() -> IMFPluginControl2_Vtbl {
         unsafe extern "system" fn SetPolicy<Identity: ::windows::core::IUnknownImpl, Impl: IMFPluginControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, policy: MF_PLUGIN_CONTROL_POLICY) -> ::windows::core::HRESULT {
@@ -11244,6 +11574,7 @@ pub trait IMFPresentationClock_Impl: Sized + IMFClock_Impl {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn Pause(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFPresentationClock {}
 impl IMFPresentationClock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPresentationClock_Impl, const OFFSET: isize>() -> IMFPresentationClock_Vtbl {
         unsafe extern "system" fn SetTimeSource<Identity: ::windows::core::IUnknownImpl, Impl: IMFPresentationClock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptimesource: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11323,6 +11654,8 @@ pub trait IMFPresentationDescriptor_Impl: Sized + IMFAttributes_Impl {
     fn Clone(&self) -> ::windows::core::Result<IMFPresentationDescriptor>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFPresentationDescriptor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFPresentationDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPresentationDescriptor_Impl, const OFFSET: isize>() -> IMFPresentationDescriptor_Vtbl {
         unsafe extern "system" fn GetStreamDescriptorCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFPresentationDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwdescriptorcount: *mut u32) -> ::windows::core::HRESULT {
@@ -11378,6 +11711,7 @@ impl IMFPresentationDescriptor_Vtbl {
 pub trait IMFPresentationTimeSource_Impl: Sized + IMFClock_Impl {
     fn GetUnderlyingClock(&self) -> ::windows::core::Result<IMFClock>;
 }
+impl ::windows::core::RuntimeName for IMFPresentationTimeSource {}
 impl IMFPresentationTimeSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFPresentationTimeSource_Impl, const OFFSET: isize>() -> IMFPresentationTimeSource_Vtbl {
         unsafe extern "system" fn GetUnderlyingClock<Identity: ::windows::core::IUnknownImpl, Impl: IMFPresentationTimeSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppclock: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11401,6 +11735,7 @@ pub trait IMFProtectedEnvironmentAccess_Impl: Sized {
     fn Call(&self, inputlength: u32, input: *const u8, outputlength: u32) -> ::windows::core::Result<u8>;
     fn ReadGRL(&self, outputlength: *mut u32, output: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFProtectedEnvironmentAccess {}
 impl IMFProtectedEnvironmentAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFProtectedEnvironmentAccess_Impl, const OFFSET: isize>() -> IMFProtectedEnvironmentAccess_Vtbl {
         unsafe extern "system" fn Call<Identity: ::windows::core::IUnknownImpl, Impl: IMFProtectedEnvironmentAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputlength: u32, input: *const u8, outputlength: u32, output: *mut u8) -> ::windows::core::HRESULT {
@@ -11436,6 +11771,7 @@ pub trait IMFQualityAdvise_Impl: Sized {
     fn GetQualityLevel(&self) -> ::windows::core::Result<MF_QUALITY_LEVEL>;
     fn DropTime(&self, hnsamounttodrop: i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFQualityAdvise {}
 impl IMFQualityAdvise_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityAdvise_Impl, const OFFSET: isize>() -> IMFQualityAdvise_Vtbl {
         unsafe extern "system" fn SetDropMode<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityAdvise_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, edropmode: MF_QUALITY_DROP_MODE) -> ::windows::core::HRESULT {
@@ -11491,6 +11827,7 @@ impl IMFQualityAdvise_Vtbl {
 pub trait IMFQualityAdvise2_Impl: Sized + IMFQualityAdvise_Impl {
     fn NotifyQualityEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFQualityAdvise2 {}
 impl IMFQualityAdvise2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityAdvise2_Impl, const OFFSET: isize>() -> IMFQualityAdvise2_Vtbl {
         unsafe extern "system" fn NotifyQualityEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityAdvise2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pevent: ::windows::core::RawPtr, pdwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -11514,6 +11851,7 @@ pub trait IMFQualityAdviseLimits_Impl: Sized {
     fn GetMaximumDropMode(&self) -> ::windows::core::Result<MF_QUALITY_DROP_MODE>;
     fn GetMinimumQualityLevel(&self) -> ::windows::core::Result<MF_QUALITY_LEVEL>;
 }
+impl ::windows::core::RuntimeName for IMFQualityAdviseLimits {}
 impl IMFQualityAdviseLimits_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityAdviseLimits_Impl, const OFFSET: isize>() -> IMFQualityAdviseLimits_Vtbl {
         unsafe extern "system" fn GetMaximumDropMode<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityAdviseLimits_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pedropmode: *mut MF_QUALITY_DROP_MODE) -> ::windows::core::HRESULT {
@@ -11556,6 +11894,7 @@ pub trait IMFQualityManager_Impl: Sized {
     fn NotifyQualityEvent(&self, pobject: &::core::option::Option<::windows::core::IUnknown>, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFQualityManager {}
 impl IMFQualityManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityManager_Impl, const OFFSET: isize>() -> IMFQualityManager_Vtbl {
         unsafe extern "system" fn NotifyTopology<Identity: ::windows::core::IUnknownImpl, Impl: IMFQualityManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptopology: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11608,6 +11947,8 @@ pub trait IMFRateControl_Impl: Sized {
     fn GetRate(&self, pfthin: *mut super::super::Foundation::BOOL, pflrate: *mut f32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFRateControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFRateControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRateControl_Impl, const OFFSET: isize>() -> IMFRateControl_Vtbl {
         unsafe extern "system" fn SetRate<Identity: ::windows::core::IUnknownImpl, Impl: IMFRateControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fthin: super::super::Foundation::BOOL, flrate: f32) -> ::windows::core::HRESULT {
@@ -11636,6 +11977,8 @@ pub trait IMFRateSupport_Impl: Sized {
     fn GetFastestRate(&self, edirection: MFRATE_DIRECTION, fthin: super::super::Foundation::BOOL) -> ::windows::core::Result<f32>;
     fn IsRateSupported(&self, fthin: super::super::Foundation::BOOL, flrate: f32, pflnearestsupportedrate: *mut f32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFRateSupport {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFRateSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRateSupport_Impl, const OFFSET: isize>() -> IMFRateSupport_Vtbl {
@@ -11681,6 +12024,7 @@ pub trait IMFReadWriteClassFactory_Impl: Sized {
     fn CreateInstanceFromURL(&self, clsid: *const ::windows::core::GUID, pwszurl: &::windows::core::PCWSTR, pattributes: &::core::option::Option<IMFAttributes>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateInstanceFromObject(&self, clsid: *const ::windows::core::GUID, punkobject: &::core::option::Option<::windows::core::IUnknown>, pattributes: &::core::option::Option<IMFAttributes>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFReadWriteClassFactory {}
 impl IMFReadWriteClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFReadWriteClassFactory_Impl, const OFFSET: isize>() -> IMFReadWriteClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstanceFromURL<Identity: ::windows::core::IUnknownImpl, Impl: IMFReadWriteClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, pwszurl: ::windows::core::PCWSTR, pattributes: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11708,6 +12052,7 @@ pub trait IMFRealTimeClient_Impl: Sized {
     fn UnregisterThreads(&self) -> ::windows::core::Result<()>;
     fn SetWorkQueue(&self, dwworkqueueid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFRealTimeClient {}
 impl IMFRealTimeClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRealTimeClient_Impl, const OFFSET: isize>() -> IMFRealTimeClient_Vtbl {
         unsafe extern "system" fn RegisterThreads<Identity: ::windows::core::IUnknownImpl, Impl: IMFRealTimeClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtaskindex: u32, wszclass: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -11741,6 +12086,7 @@ pub trait IMFRealTimeClientEx_Impl: Sized {
     fn UnregisterThreads(&self) -> ::windows::core::Result<()>;
     fn SetWorkQueueEx(&self, dwmultithreadedworkqueueid: u32, lworkitembasepriority: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFRealTimeClientEx {}
 impl IMFRealTimeClientEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRealTimeClientEx_Impl, const OFFSET: isize>() -> IMFRealTimeClientEx_Vtbl {
         unsafe extern "system" fn RegisterThreadsEx<Identity: ::windows::core::IUnknownImpl, Impl: IMFRealTimeClientEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwtaskindex: *mut u32, wszclassname: ::windows::core::PCWSTR, lbasepriority: i32) -> ::windows::core::HRESULT {
@@ -11772,6 +12118,7 @@ impl IMFRealTimeClientEx_Vtbl {
 pub trait IMFRelativePanelReport_Impl: Sized {
     fn GetRelativePanel(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFRelativePanelReport {}
 impl IMFRelativePanelReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRelativePanelReport_Impl, const OFFSET: isize>() -> IMFRelativePanelReport_Vtbl {
         unsafe extern "system" fn GetRelativePanel<Identity: ::windows::core::IUnknownImpl, Impl: IMFRelativePanelReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, panel: *mut u32) -> ::windows::core::HRESULT {
@@ -11796,6 +12143,7 @@ pub trait IMFRelativePanelWatcher_Impl: Sized + IMFShutdown_Impl {
     fn EndGetReport(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<IMFRelativePanelReport>;
     fn GetReport(&self) -> ::windows::core::Result<IMFRelativePanelReport>;
 }
+impl ::windows::core::RuntimeName for IMFRelativePanelWatcher {}
 impl IMFRelativePanelWatcher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRelativePanelWatcher_Impl, const OFFSET: isize>() -> IMFRelativePanelWatcher_Vtbl {
         unsafe extern "system" fn BeginGetReport<Identity: ::windows::core::IUnknownImpl, Impl: IMFRelativePanelWatcher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11839,6 +12187,7 @@ impl IMFRelativePanelWatcher_Vtbl {
 pub trait IMFRemoteAsyncCallback_Impl: Sized {
     fn Invoke(&self, hr: ::windows::core::HRESULT, premoteresult: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFRemoteAsyncCallback {}
 impl IMFRemoteAsyncCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRemoteAsyncCallback_Impl, const OFFSET: isize>() -> IMFRemoteAsyncCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IMFRemoteAsyncCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, premoteresult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11855,6 +12204,7 @@ impl IMFRemoteAsyncCallback_Vtbl {
 pub trait IMFRemoteDesktopPlugin_Impl: Sized {
     fn UpdateTopology(&self, ptopology: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFRemoteDesktopPlugin {}
 impl IMFRemoteDesktopPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRemoteDesktopPlugin_Impl, const OFFSET: isize>() -> IMFRemoteDesktopPlugin_Vtbl {
         unsafe extern "system" fn UpdateTopology<Identity: ::windows::core::IUnknownImpl, Impl: IMFRemoteDesktopPlugin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptopology: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11872,6 +12222,7 @@ pub trait IMFRemoteProxy_Impl: Sized {
     fn GetRemoteObject(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetRemoteHost(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFRemoteProxy {}
 impl IMFRemoteProxy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFRemoteProxy_Impl, const OFFSET: isize>() -> IMFRemoteProxy_Vtbl {
         unsafe extern "system" fn GetRemoteObject<Identity: ::windows::core::IUnknownImpl, Impl: IMFRemoteProxy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11901,6 +12252,8 @@ pub trait IMFSAMIStyle_Impl: Sized {
     fn SetSelectedStyle(&self, pwszstyle: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetSelectedStyle(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSAMIStyle {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSAMIStyle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSAMIStyle_Impl, const OFFSET: isize>() -> IMFSAMIStyle_Vtbl {
@@ -11962,6 +12315,8 @@ pub trait IMFSSLCertificateManager_Impl: Sized {
     fn GetCertificatePolicy(&self, pszurl: &::windows::core::PCWSTR, pfoverrideautomaticcheck: *mut super::super::Foundation::BOOL, pfclientcertificateavailable: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn OnServerCertificate(&self, pszurl: &::windows::core::PCWSTR, pbdata: *const u8, cbdata: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFSSLCertificateManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFSSLCertificateManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSSLCertificateManager_Impl, const OFFSET: isize>() -> IMFSSLCertificateManager_Vtbl {
@@ -12026,6 +12381,8 @@ pub trait IMFSample_Impl: Sized + IMFAttributes_Impl {
     fn GetTotalLength(&self) -> ::windows::core::Result<u32>;
     fn CopyToBuffer(&self, pbuffer: &::core::option::Option<IMFMediaBuffer>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSample {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSample_Impl, const OFFSET: isize>() -> IMFSample_Vtbl {
@@ -12167,6 +12524,7 @@ pub trait IMFSampleAllocatorControl_Impl: Sized {
     fn SetDefaultAllocator(&self, dwoutputstreamid: u32, pallocator: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetAllocatorUsage(&self, dwoutputstreamid: u32, pdwinputstreamid: *mut u32, peusage: *mut MFSampleAllocatorUsage) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSampleAllocatorControl {}
 impl IMFSampleAllocatorControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleAllocatorControl_Impl, const OFFSET: isize>() -> IMFSampleAllocatorControl_Vtbl {
         unsafe extern "system" fn SetDefaultAllocator<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleAllocatorControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoutputstreamid: u32, pallocator: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12194,6 +12552,7 @@ pub trait IMFSampleGrabberSinkCallback_Impl: Sized + IMFClockStateSink_Impl {
     fn OnProcessSample(&self, guidmajormediatype: *const ::windows::core::GUID, dwsampleflags: u32, llsampletime: i64, llsampleduration: i64, psamplebuffer: *const u8, dwsamplesize: u32) -> ::windows::core::Result<()>;
     fn OnShutdown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSampleGrabberSinkCallback {}
 impl IMFSampleGrabberSinkCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleGrabberSinkCallback_Impl, const OFFSET: isize>() -> IMFSampleGrabberSinkCallback_Vtbl {
         unsafe extern "system" fn OnSetPresentationClock<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleGrabberSinkCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresentationclock: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12225,6 +12584,7 @@ impl IMFSampleGrabberSinkCallback_Vtbl {
 pub trait IMFSampleGrabberSinkCallback2_Impl: Sized + IMFClockStateSink_Impl + IMFSampleGrabberSinkCallback_Impl {
     fn OnProcessSampleEx(&self, guidmajormediatype: *const ::windows::core::GUID, dwsampleflags: u32, llsampletime: i64, llsampleduration: i64, psamplebuffer: *const u8, dwsamplesize: u32, pattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSampleGrabberSinkCallback2 {}
 impl IMFSampleGrabberSinkCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleGrabberSinkCallback2_Impl, const OFFSET: isize>() -> IMFSampleGrabberSinkCallback2_Vtbl {
         unsafe extern "system" fn OnProcessSampleEx<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleGrabberSinkCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidmajormediatype: *const ::windows::core::GUID, dwsampleflags: u32, llsampletime: i64, llsampleduration: i64, psamplebuffer: *const u8, dwsamplesize: u32, pattributes: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12243,6 +12603,7 @@ pub trait IMFSampleOutputStream_Impl: Sized {
     fn EndWriteSample(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSampleOutputStream {}
 impl IMFSampleOutputStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleOutputStream_Impl, const OFFSET: isize>() -> IMFSampleOutputStream_Vtbl {
         unsafe extern "system" fn BeginWriteSample<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleOutputStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psample: ::windows::core::RawPtr, pcallback: ::windows::core::RawPtr, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12278,6 +12639,7 @@ pub trait IMFSampleProtection_Impl: Sized {
     fn InitOutputProtection(&self, dwversion: u32, dwoutputid: u32, pbcert: *const u8, cbcert: u32, ppbseed: *mut *mut u8, pcbseed: *mut u32) -> ::windows::core::Result<()>;
     fn InitInputProtection(&self, dwversion: u32, dwinputid: u32, pbseed: *const u8, cbseed: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSampleProtection {}
 impl IMFSampleProtection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleProtection_Impl, const OFFSET: isize>() -> IMFSampleProtection_Vtbl {
         unsafe extern "system" fn GetInputProtectionVersion<Identity: ::windows::core::IUnknownImpl, Impl: IMFSampleProtection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwversion: *mut u32) -> ::windows::core::HRESULT {
@@ -12336,6 +12698,7 @@ pub trait IMFSaveJob_Impl: Sized {
     fn CancelSave(&self) -> ::windows::core::Result<()>;
     fn GetProgress(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFSaveJob {}
 impl IMFSaveJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSaveJob_Impl, const OFFSET: isize>() -> IMFSaveJob_Vtbl {
         unsafe extern "system" fn BeginSave<Identity: ::windows::core::IUnknownImpl, Impl: IMFSaveJob_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstream: ::windows::core::RawPtr, pcallback: ::windows::core::RawPtr, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12383,6 +12746,8 @@ pub trait IMFSchemeHandler_Impl: Sized {
     fn CancelObjectCreation(&self, piunknowncancelcookie: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMFSchemeHandler {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMFSchemeHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSchemeHandler_Impl, const OFFSET: isize>() -> IMFSchemeHandler_Vtbl {
         unsafe extern "system" fn BeginCreateObject<Identity: ::windows::core::IUnknownImpl, Impl: IMFSchemeHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwflags: u32, pprops: ::windows::core::RawPtr, ppiunknowncancelcookie: *mut *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12414,6 +12779,7 @@ impl IMFSchemeHandler_Vtbl {
 pub trait IMFSecureBuffer_Impl: Sized {
     fn GetIdentifier(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IMFSecureBuffer {}
 impl IMFSecureBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSecureBuffer_Impl, const OFFSET: isize>() -> IMFSecureBuffer_Vtbl {
         unsafe extern "system" fn GetIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: IMFSecureBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguididentifier: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -12437,6 +12803,7 @@ pub trait IMFSecureChannel_Impl: Sized {
     fn GetCertificate(&self, ppcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::Result<()>;
     fn SetupSession(&self, pbencryptedsessionkey: *const u8, cbsessionkey: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSecureChannel {}
 impl IMFSecureChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSecureChannel_Impl, const OFFSET: isize>() -> IMFSecureChannel_Vtbl {
         unsafe extern "system" fn GetCertificate<Identity: ::windows::core::IUnknownImpl, Impl: IMFSecureChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::HRESULT {
@@ -12464,6 +12831,8 @@ pub trait IMFSeekInfo_Impl: Sized {
     fn GetNearestKeyFrames(&self, pguidtimeformat: *const ::windows::core::GUID, pvarstartposition: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarpreviouskeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pvarnextkeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSeekInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSeekInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSeekInfo_Impl, const OFFSET: isize>() -> IMFSeekInfo_Vtbl {
         unsafe extern "system" fn GetNearestKeyFrames<Identity: ::windows::core::IUnknownImpl, Impl: IMFSeekInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidtimeformat: *const ::windows::core::GUID, pvarstartposition: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarpreviouskeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pvarnextkeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -12482,6 +12851,7 @@ pub trait IMFSensorActivitiesReport_Impl: Sized {
     fn GetActivityReport(&self, index: u32) -> ::windows::core::Result<IMFSensorActivityReport>;
     fn GetActivityReportByDeviceName(&self, symbolicname: &::windows::core::PCWSTR) -> ::windows::core::Result<IMFSensorActivityReport>;
 }
+impl ::windows::core::RuntimeName for IMFSensorActivitiesReport {}
 impl IMFSensorActivitiesReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivitiesReport_Impl, const OFFSET: isize>() -> IMFSensorActivitiesReport_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivitiesReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pccount: *mut u32) -> ::windows::core::HRESULT {
@@ -12531,6 +12901,7 @@ impl IMFSensorActivitiesReport_Vtbl {
 pub trait IMFSensorActivitiesReportCallback_Impl: Sized {
     fn OnActivitiesReport(&self, sensoractivitiesreport: &::core::option::Option<IMFSensorActivitiesReport>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSensorActivitiesReportCallback {}
 impl IMFSensorActivitiesReportCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivitiesReportCallback_Impl, const OFFSET: isize>() -> IMFSensorActivitiesReportCallback_Vtbl {
         unsafe extern "system" fn OnActivitiesReport<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivitiesReportCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sensoractivitiesreport: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12548,6 +12919,7 @@ pub trait IMFSensorActivityMonitor_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSensorActivityMonitor {}
 impl IMFSensorActivityMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivityMonitor_Impl, const OFFSET: isize>() -> IMFSensorActivityMonitor_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivityMonitor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12572,6 +12944,7 @@ pub trait IMFSensorActivityReport_Impl: Sized {
     fn GetProcessCount(&self) -> ::windows::core::Result<u32>;
     fn GetProcessActivity(&self, index: u32) -> ::windows::core::Result<IMFSensorProcessActivity>;
 }
+impl ::windows::core::RuntimeName for IMFSensorActivityReport {}
 impl IMFSensorActivityReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivityReport_Impl, const OFFSET: isize>() -> IMFSensorActivityReport_Vtbl {
         unsafe extern "system" fn GetFriendlyName<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorActivityReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, friendlyname: ::windows::core::PWSTR, cchfriendlyname: u32, pcchwritten: *mut u32) -> ::windows::core::HRESULT {
@@ -12629,6 +13002,7 @@ pub trait IMFSensorDevice_Impl: Sized {
     fn SetSensorDeviceMode(&self, emode: MFSensorDeviceMode) -> ::windows::core::Result<()>;
     fn GetSensorDeviceMode(&self) -> ::windows::core::Result<MFSensorDeviceMode>;
 }
+impl ::windows::core::RuntimeName for IMFSensorDevice {}
 impl IMFSensorDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorDevice_Impl, const OFFSET: isize>() -> IMFSensorDevice_Vtbl {
         unsafe extern "system" fn GetDeviceId<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdeviceid: *mut u64) -> ::windows::core::HRESULT {
@@ -12745,6 +13119,7 @@ pub trait IMFSensorGroup_Impl: Sized {
     fn GetDefaultSensorDeviceIndex(&self) -> ::windows::core::Result<u32>;
     fn CreateMediaSource(&self) -> ::windows::core::Result<IMFMediaSource>;
 }
+impl ::windows::core::RuntimeName for IMFSensorGroup {}
 impl IMFSensorGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorGroup_Impl, const OFFSET: isize>() -> IMFSensorGroup_Vtbl {
         unsafe extern "system" fn GetSymbolicLink<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, symboliclink: ::windows::core::PWSTR, cchsymboliclink: i32, pcchwritten: *mut i32) -> ::windows::core::HRESULT {
@@ -12847,6 +13222,8 @@ pub trait IMFSensorProcessActivity_Impl: Sized {
     fn GetReportTime(&self) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFSensorProcessActivity {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFSensorProcessActivity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorProcessActivity_Impl, const OFFSET: isize>() -> IMFSensorProcessActivity_Vtbl {
         unsafe extern "system" fn GetProcessId<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorProcessActivity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppid: *mut u32) -> ::windows::core::HRESULT {
@@ -12913,6 +13290,8 @@ pub trait IMFSensorProfile_Impl: Sized {
     fn AddBlockedControl(&self, wzblockedcontrol: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFSensorProfile {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFSensorProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorProfile_Impl, const OFFSET: isize>() -> IMFSensorProfile_Vtbl {
         unsafe extern "system" fn GetProfileId<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorProfile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pid: *mut SENSORPROFILEID) -> ::windows::core::HRESULT {
@@ -12967,6 +13346,7 @@ pub trait IMFSensorProfileCollection_Impl: Sized {
     fn RemoveProfileByIndex(&self, index: u32);
     fn RemoveProfile(&self, profileid: *const SENSORPROFILEID);
 }
+impl ::windows::core::RuntimeName for IMFSensorProfileCollection {}
 impl IMFSensorProfileCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorProfileCollection_Impl, const OFFSET: isize>() -> IMFSensorProfileCollection_Vtbl {
         unsafe extern "system" fn GetProfileCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorProfileCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -13032,6 +13412,8 @@ pub trait IMFSensorStream_Impl: Sized + IMFAttributes_Impl {
     fn CloneSensorStream(&self) -> ::windows::core::Result<IMFSensorStream>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSensorStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSensorStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorStream_Impl, const OFFSET: isize>() -> IMFSensorStream_Vtbl {
         unsafe extern "system" fn GetMediaTypeCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -13086,6 +13468,8 @@ pub trait IMFSensorTransformFactory_Impl: Sized {
     fn GetTransformInformation(&self, transformindex: u32, pguidtransformid: *mut ::windows::core::GUID, ppattributes: *mut ::core::option::Option<IMFAttributes>, ppstreaminformation: *mut ::core::option::Option<IMFCollection>) -> ::windows::core::Result<()>;
     fn CreateTransform(&self, guidsensortransformid: *const ::windows::core::GUID, pattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<super::Streaming::IMFDeviceTransform>;
 }
+#[cfg(feature = "Win32_Media_Streaming")]
+impl ::windows::core::RuntimeName for IMFSensorTransformFactory {}
 #[cfg(feature = "Win32_Media_Streaming")]
 impl IMFSensorTransformFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSensorTransformFactory_Impl, const OFFSET: isize>() -> IMFSensorTransformFactory_Vtbl {
@@ -13152,6 +13536,7 @@ pub trait IMFSequencerSource_Impl: Sized {
     fn UpdateTopology(&self, dwid: u32, ptopology: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
     fn UpdateTopologyFlags(&self, dwid: u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSequencerSource {}
 impl IMFSequencerSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSequencerSource_Impl, const OFFSET: isize>() -> IMFSequencerSource_Vtbl {
         unsafe extern "system" fn AppendTopology<Identity: ::windows::core::IUnknownImpl, Impl: IMFSequencerSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptopology: ::windows::core::RawPtr, dwflags: u32, pdwid: *mut u32) -> ::windows::core::HRESULT {
@@ -13201,6 +13586,7 @@ impl IMFSequencerSource_Vtbl {
 pub trait IMFSharingEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pattr: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IMFSharingEngineClassFactory {}
 impl IMFSharingEngineClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSharingEngineClassFactory_Impl, const OFFSET: isize>() -> IMFSharingEngineClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IMFSharingEngineClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pattr: ::windows::core::RawPtr, ppengine: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13224,6 +13610,7 @@ pub trait IMFShutdown_Impl: Sized {
     fn Shutdown(&self) -> ::windows::core::Result<()>;
     fn GetShutdownStatus(&self) -> ::windows::core::Result<MFSHUTDOWN_STATUS>;
 }
+impl ::windows::core::RuntimeName for IMFShutdown {}
 impl IMFShutdown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFShutdown_Impl, const OFFSET: isize>() -> IMFShutdown_Vtbl {
         unsafe extern "system" fn Shutdown<Identity: ::windows::core::IUnknownImpl, Impl: IMFShutdown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13255,6 +13642,7 @@ impl IMFShutdown_Vtbl {
 pub trait IMFSignedLibrary_Impl: Sized {
     fn GetProcedureAddress(&self, name: &::windows::core::PCSTR, address: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSignedLibrary {}
 impl IMFSignedLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSignedLibrary_Impl, const OFFSET: isize>() -> IMFSignedLibrary_Vtbl {
         unsafe extern "system" fn GetProcedureAddress<Identity: ::windows::core::IUnknownImpl, Impl: IMFSignedLibrary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, address: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13275,6 +13663,8 @@ pub trait IMFSimpleAudioVolume_Impl: Sized {
     fn SetMute(&self, bmute: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetMute(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFSimpleAudioVolume {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFSimpleAudioVolume_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSimpleAudioVolume_Impl, const OFFSET: isize>() -> IMFSimpleAudioVolume_Vtbl {
@@ -13335,6 +13725,7 @@ pub trait IMFSinkWriter_Impl: Sized {
     fn GetServiceForStream(&self, dwstreamindex: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetStatistics(&self, dwstreamindex: u32) -> ::windows::core::Result<MF_SINK_WRITER_STATISTICS>;
 }
+impl ::windows::core::RuntimeName for IMFSinkWriter {}
 impl IMFSinkWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriter_Impl, const OFFSET: isize>() -> IMFSinkWriter_Vtbl {
         unsafe extern "system" fn AddStream<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptargetmediatype: ::windows::core::RawPtr, pdwstreamindex: *mut u32) -> ::windows::core::HRESULT {
@@ -13427,6 +13818,7 @@ pub trait IMFSinkWriterCallback_Impl: Sized {
     fn OnFinalize(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnMarker(&self, dwstreamindex: u32, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSinkWriterCallback {}
 impl IMFSinkWriterCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterCallback_Impl, const OFFSET: isize>() -> IMFSinkWriterCallback_Vtbl {
         unsafe extern "system" fn OnFinalize<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -13453,6 +13845,7 @@ pub trait IMFSinkWriterCallback2_Impl: Sized + IMFSinkWriterCallback_Impl {
     fn OnTransformChange(&self) -> ::windows::core::Result<()>;
     fn OnStreamError(&self, dwstreamindex: u32, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSinkWriterCallback2 {}
 impl IMFSinkWriterCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterCallback2_Impl, const OFFSET: isize>() -> IMFSinkWriterCallback2_Vtbl {
         unsafe extern "system" fn OnTransformChange<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13479,6 +13872,7 @@ pub trait IMFSinkWriterEncoderConfig_Impl: Sized {
     fn SetTargetMediaType(&self, dwstreamindex: u32, ptargetmediatype: &::core::option::Option<IMFMediaType>, pencodingparameters: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
     fn PlaceEncodingParameters(&self, dwstreamindex: u32, pencodingparameters: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSinkWriterEncoderConfig {}
 impl IMFSinkWriterEncoderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterEncoderConfig_Impl, const OFFSET: isize>() -> IMFSinkWriterEncoderConfig_Vtbl {
         unsafe extern "system" fn SetTargetMediaType<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterEncoderConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamindex: u32, ptargetmediatype: ::windows::core::RawPtr, pencodingparameters: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13504,6 +13898,7 @@ impl IMFSinkWriterEncoderConfig_Vtbl {
 pub trait IMFSinkWriterEx_Impl: Sized + IMFSinkWriter_Impl {
     fn GetTransformForStream(&self, dwstreamindex: u32, dwtransformindex: u32, pguidcategory: *mut ::windows::core::GUID, pptransform: *mut ::core::option::Option<IMFTransform>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSinkWriterEx {}
 impl IMFSinkWriterEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterEx_Impl, const OFFSET: isize>() -> IMFSinkWriterEx_Vtbl {
         unsafe extern "system" fn GetTransformForStream<Identity: ::windows::core::IUnknownImpl, Impl: IMFSinkWriterEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamindex: u32, dwtransformindex: u32, pguidcategory: *mut ::windows::core::GUID, pptransform: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13532,6 +13927,8 @@ pub trait IMFSourceBuffer_Impl: Sized {
     fn Abort(&self) -> ::windows::core::Result<()>;
     fn Remove(&self, start: f64, end: f64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFSourceBuffer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFSourceBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBuffer_Impl, const OFFSET: isize>() -> IMFSourceBuffer_Vtbl {
@@ -13625,6 +14022,7 @@ pub trait IMFSourceBufferAppendMode_Impl: Sized {
     fn GetAppendMode(&self) -> MF_MSE_APPEND_MODE;
     fn SetAppendMode(&self, mode: MF_MSE_APPEND_MODE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSourceBufferAppendMode {}
 impl IMFSourceBufferAppendMode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBufferAppendMode_Impl, const OFFSET: isize>() -> IMFSourceBufferAppendMode_Vtbl {
         unsafe extern "system" fn GetAppendMode<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBufferAppendMode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> MF_MSE_APPEND_MODE {
@@ -13651,6 +14049,7 @@ pub trait IMFSourceBufferList_Impl: Sized {
     fn GetLength(&self) -> u32;
     fn GetSourceBuffer(&self, index: u32) -> ::core::option::Option<IMFSourceBuffer>;
 }
+impl ::windows::core::RuntimeName for IMFSourceBufferList {}
 impl IMFSourceBufferList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBufferList_Impl, const OFFSET: isize>() -> IMFSourceBufferList_Vtbl {
         unsafe extern "system" fn GetLength<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBufferList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -13680,6 +14079,7 @@ pub trait IMFSourceBufferNotify_Impl: Sized {
     fn OnUpdate(&self);
     fn OnUpdateEnd(&self);
 }
+impl ::windows::core::RuntimeName for IMFSourceBufferNotify {}
 impl IMFSourceBufferNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBufferNotify_Impl, const OFFSET: isize>() -> IMFSourceBufferNotify_Vtbl {
         unsafe extern "system" fn OnUpdateStart<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceBufferNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -13723,6 +14123,7 @@ impl IMFSourceBufferNotify_Vtbl {
 pub trait IMFSourceOpenMonitor_Impl: Sized {
     fn OnSourceEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSourceOpenMonitor {}
 impl IMFSourceOpenMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceOpenMonitor_Impl, const OFFSET: isize>() -> IMFSourceOpenMonitor_Vtbl {
         unsafe extern "system" fn OnSourceEvent<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceOpenMonitor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13749,6 +14150,8 @@ pub trait IMFSourceReader_Impl: Sized {
     fn GetServiceForStream(&self, dwstreamindex: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetPresentationAttribute(&self, dwstreamindex: u32, guidattribute: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSourceReader {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSourceReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceReader_Impl, const OFFSET: isize>() -> IMFSourceReader_Vtbl {
@@ -13849,6 +14252,7 @@ pub trait IMFSourceReaderCallback_Impl: Sized {
     fn OnFlush(&self, dwstreamindex: u32) -> ::windows::core::Result<()>;
     fn OnEvent(&self, dwstreamindex: u32, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSourceReaderCallback {}
 impl IMFSourceReaderCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceReaderCallback_Impl, const OFFSET: isize>() -> IMFSourceReaderCallback_Vtbl {
         unsafe extern "system" fn OnReadSample<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceReaderCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT, dwstreamindex: u32, dwstreamflags: u32, lltimestamp: i64, psample: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -13881,6 +14285,7 @@ pub trait IMFSourceReaderCallback2_Impl: Sized + IMFSourceReaderCallback_Impl {
     fn OnTransformChange(&self) -> ::windows::core::Result<()>;
     fn OnStreamError(&self, dwstreamindex: u32, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSourceReaderCallback2 {}
 impl IMFSourceReaderCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceReaderCallback2_Impl, const OFFSET: isize>() -> IMFSourceReaderCallback2_Vtbl {
         unsafe extern "system" fn OnTransformChange<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceReaderCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13910,6 +14315,8 @@ pub trait IMFSourceReaderEx_Impl: Sized + IMFSourceReader_Impl {
     fn RemoveAllTransformsForStream(&self, dwstreamindex: u32) -> ::windows::core::Result<()>;
     fn GetTransformForStream(&self, dwstreamindex: u32, dwtransformindex: u32, pguidcategory: *mut ::windows::core::GUID, pptransform: *mut ::core::option::Option<IMFTransform>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSourceReaderEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSourceReaderEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceReaderEx_Impl, const OFFSET: isize>() -> IMFSourceReaderEx_Vtbl {
@@ -13961,6 +14368,8 @@ pub trait IMFSourceResolver_Impl: Sized {
     fn EndCreateObjectFromByteStream(&self, presult: &::core::option::Option<IMFAsyncResult>, pobjecttype: *mut MF_OBJECT_TYPE, ppobject: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn CancelObjectCreation(&self, piunknowncancelcookie: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IMFSourceResolver {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IMFSourceResolver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSourceResolver_Impl, const OFFSET: isize>() -> IMFSourceResolver_Vtbl {
@@ -14022,6 +14431,8 @@ pub trait IMFSpatialAudioObjectBuffer_Impl: Sized + IMFMediaBuffer_Impl {
     fn GetType(&self) -> ::windows::core::Result<super::Audio::AudioObjectType>;
     fn GetMetadataItems(&self) -> ::windows::core::Result<super::Audio::ISpatialAudioMetadataItems>;
 }
+#[cfg(feature = "Win32_Media_Audio")]
+impl ::windows::core::RuntimeName for IMFSpatialAudioObjectBuffer {}
 #[cfg(feature = "Win32_Media_Audio")]
 impl IMFSpatialAudioObjectBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSpatialAudioObjectBuffer_Impl, const OFFSET: isize>() -> IMFSpatialAudioObjectBuffer_Vtbl {
@@ -14088,6 +14499,8 @@ pub trait IMFSpatialAudioSample_Impl: Sized + IMFAttributes_Impl + IMFSample_Imp
     fn GetSpatialAudioObjectByIndex(&self, dwindex: u32) -> ::windows::core::Result<IMFSpatialAudioObjectBuffer>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFSpatialAudioSample {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFSpatialAudioSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSpatialAudioSample_Impl, const OFFSET: isize>() -> IMFSpatialAudioSample_Vtbl {
         unsafe extern "system" fn GetObjectCount<Identity: ::windows::core::IUnknownImpl, Impl: IMFSpatialAudioSample_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwobjectcount: *mut u32) -> ::windows::core::HRESULT {
@@ -14134,6 +14547,8 @@ pub trait IMFStreamDescriptor_Impl: Sized + IMFAttributes_Impl {
     fn GetMediaTypeHandler(&self) -> ::windows::core::Result<IMFMediaTypeHandler>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFStreamDescriptor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFStreamDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFStreamDescriptor_Impl, const OFFSET: isize>() -> IMFStreamDescriptor_Vtbl {
         unsafe extern "system" fn GetStreamIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: IMFStreamDescriptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwstreamidentifier: *mut u32) -> ::windows::core::HRESULT {
@@ -14177,6 +14592,8 @@ pub trait IMFStreamSink_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn PlaceMarker(&self, emarkertype: MFSTREAMSINK_MARKER_TYPE, pvarmarkervalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarcontextvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFStreamSink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFStreamSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFStreamSink_Impl, const OFFSET: isize>() -> IMFStreamSink_Vtbl {
@@ -14247,6 +14664,8 @@ pub trait IMFStreamingSinkConfig_Impl: Sized {
     fn StartStreaming(&self, fseekoffsetisbyteoffset: super::super::Foundation::BOOL, qwseekoffset: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFStreamingSinkConfig {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFStreamingSinkConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFStreamingSinkConfig_Impl, const OFFSET: isize>() -> IMFStreamingSinkConfig_Vtbl {
         unsafe extern "system" fn StartStreaming<Identity: ::windows::core::IUnknownImpl, Impl: IMFStreamingSinkConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fseekoffsetisbyteoffset: super::super::Foundation::BOOL, qwseekoffset: u64) -> ::windows::core::HRESULT {
@@ -14264,6 +14683,7 @@ pub trait IMFSystemId_Impl: Sized {
     fn GetData(&self, size: *mut u32, data: *mut *mut u8) -> ::windows::core::Result<()>;
     fn Setup(&self, stage: u32, cbin: u32, pbin: *const u8, pcbout: *mut u32, ppbout: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFSystemId {}
 impl IMFSystemId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFSystemId_Impl, const OFFSET: isize>() -> IMFSystemId_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IMFSystemId_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, size: *mut u32, data: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -14293,6 +14713,8 @@ pub trait IMFTimecodeTranslate_Impl: Sized {
     fn BeginConvertHNSToTimecode(&self, hnstime: i64, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndConvertHNSToTimecode(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFTimecodeTranslate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFTimecodeTranslate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimecodeTranslate_Impl, const OFFSET: isize>() -> IMFTimecodeTranslate_Vtbl {
@@ -14357,6 +14779,8 @@ pub trait IMFTimedText_Impl: Sized {
     fn SetInBandEnabled(&self, enabled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn IsInBandEnabled(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTimedText {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFTimedText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedText_Impl, const OFFSET: isize>() -> IMFTimedText_Vtbl {
@@ -14503,6 +14927,7 @@ impl IMFTimedText_Vtbl {
 pub trait IMFTimedTextBinary_Impl: Sized {
     fn GetData(&self, data: *mut *mut u8, length: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextBinary {}
 impl IMFTimedTextBinary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextBinary_Impl, const OFFSET: isize>() -> IMFTimedTextBinary_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextBinary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, data: *mut *mut u8, length: *mut u32) -> ::windows::core::HRESULT {
@@ -14521,6 +14946,7 @@ pub trait IMFTimedTextBouten_Impl: Sized {
     fn GetBoutenColor(&self) -> ::windows::core::Result<MFARGB>;
     fn GetBoutenPosition(&self) -> ::windows::core::Result<MF_TIMED_TEXT_BOUTEN_POSITION>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextBouten {}
 impl IMFTimedTextBouten_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextBouten_Impl, const OFFSET: isize>() -> IMFTimedTextBouten_Vtbl {
         unsafe extern "system" fn GetBoutenType<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextBouten_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut MF_TIMED_TEXT_BOUTEN_TYPE) -> ::windows::core::HRESULT {
@@ -14580,6 +15006,7 @@ pub trait IMFTimedTextCue_Impl: Sized {
     fn GetLineCount(&self) -> u32;
     fn GetLine(&self, index: u32) -> ::windows::core::Result<IMFTimedTextFormattedText>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextCue {}
 impl IMFTimedTextCue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextCue_Impl, const OFFSET: isize>() -> IMFTimedTextCue_Vtbl {
         unsafe extern "system" fn GetId<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextCue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -14695,6 +15122,7 @@ pub trait IMFTimedTextCueList_Impl: Sized {
     fn AddDataCue(&self, start: f64, duration: f64, data: *const u8, datasize: u32) -> ::windows::core::Result<IMFTimedTextCue>;
     fn RemoveCue(&self, cue: &::core::option::Option<IMFTimedTextCue>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextCueList {}
 impl IMFTimedTextCueList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextCueList_Impl, const OFFSET: isize>() -> IMFTimedTextCueList_Vtbl {
         unsafe extern "system" fn GetLength<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextCueList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -14782,6 +15210,7 @@ pub trait IMFTimedTextFormattedText_Impl: Sized {
     fn GetSubformattingCount(&self) -> u32;
     fn GetSubformatting(&self, index: u32, firstchar: *mut u32, charlength: *mut u32, style: *mut ::core::option::Option<IMFTimedTextStyle>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextFormattedText {}
 impl IMFTimedTextFormattedText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextFormattedText_Impl, const OFFSET: isize>() -> IMFTimedTextFormattedText_Vtbl {
         unsafe extern "system" fn GetText<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextFormattedText_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, text: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -14826,6 +15255,8 @@ pub trait IMFTimedTextNotify_Impl: Sized {
     fn Cue(&self, cueevent: MF_TIMED_TEXT_CUE_EVENT, currenttime: f64, cue: &::core::option::Option<IMFTimedTextCue>);
     fn Reset(&self);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTimedTextNotify {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFTimedTextNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextNotify_Impl, const OFFSET: isize>() -> IMFTimedTextNotify_Vtbl {
@@ -14894,6 +15325,8 @@ pub trait IMFTimedTextRegion_Impl: Sized {
     fn GetZIndex(&self) -> ::windows::core::Result<i32>;
     fn GetScrollMode(&self) -> ::windows::core::Result<MF_TIMED_TEXT_SCROLL_MODE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTimedTextRegion {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFTimedTextRegion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextRegion_Impl, const OFFSET: isize>() -> IMFTimedTextRegion_Vtbl {
@@ -15031,6 +15464,7 @@ pub trait IMFTimedTextRuby_Impl: Sized {
     fn GetRubyAlign(&self) -> ::windows::core::Result<MF_TIMED_TEXT_RUBY_ALIGN>;
     fn GetRubyReserve(&self) -> ::windows::core::Result<MF_TIMED_TEXT_RUBY_RESERVE>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextRuby {}
 impl IMFTimedTextRuby_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextRuby_Impl, const OFFSET: isize>() -> IMFTimedTextRuby_Vtbl {
         unsafe extern "system" fn GetRubyText<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextRuby_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rubytext: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -15105,6 +15539,8 @@ pub trait IMFTimedTextStyle_Impl: Sized {
     fn GetTextDecoration(&self) -> ::windows::core::Result<u32>;
     fn GetTextOutline(&self, color: *mut MFARGB, thickness: *mut f64, blurradius: *mut f64, unittype: *mut MF_TIMED_TEXT_UNIT_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTimedTextStyle {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFTimedTextStyle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextStyle_Impl, const OFFSET: isize>() -> IMFTimedTextStyle_Vtbl {
@@ -15262,6 +15698,8 @@ pub trait IMFTimedTextStyle2_Impl: Sized {
     fn GetFontAngleInDegrees(&self) -> ::windows::core::Result<f64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTimedTextStyle2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFTimedTextStyle2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextStyle2_Impl, const OFFSET: isize>() -> IMFTimedTextStyle2_Vtbl {
         unsafe extern "system" fn GetRuby<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextStyle2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ruby: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -15336,6 +15774,8 @@ pub trait IMFTimedTextTrack_Impl: Sized {
     fn GetReadyState(&self) -> MF_TIMED_TEXT_TRACK_READY_STATE;
     fn GetCueList(&self) -> ::windows::core::Result<IMFTimedTextCueList>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTimedTextTrack {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFTimedTextTrack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextTrack_Impl, const OFFSET: isize>() -> IMFTimedTextTrack_Vtbl {
@@ -15460,6 +15900,7 @@ pub trait IMFTimedTextTrackList_Impl: Sized {
     fn GetTrack(&self, index: u32) -> ::windows::core::Result<IMFTimedTextTrack>;
     fn GetTrackById(&self, trackid: u32) -> ::windows::core::Result<IMFTimedTextTrack>;
 }
+impl ::windows::core::RuntimeName for IMFTimedTextTrackList {}
 impl IMFTimedTextTrackList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextTrackList_Impl, const OFFSET: isize>() -> IMFTimedTextTrackList_Vtbl {
         unsafe extern "system" fn GetLength<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimedTextTrackList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -15504,6 +15945,7 @@ pub trait IMFTimer_Impl: Sized {
     fn SetTimer(&self, dwflags: u32, llclocktime: i64, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn CancelTimer(&self, punkkey: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTimer {}
 impl IMFTimer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimer_Impl, const OFFSET: isize>() -> IMFTimer_Vtbl {
         unsafe extern "system" fn SetTimer<Identity: ::windows::core::IUnknownImpl, Impl: IMFTimer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, llclocktime: i64, pcallback: ::windows::core::RawPtr, punkstate: *mut ::core::ffi::c_void, ppunkkey: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -15535,6 +15977,7 @@ impl IMFTimer_Vtbl {
 pub trait IMFTopoLoader_Impl: Sized {
     fn Load(&self, pinputtopo: &::core::option::Option<IMFTopology>, ppoutputtopo: *mut ::core::option::Option<IMFTopology>, pcurrenttopo: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTopoLoader {}
 impl IMFTopoLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopoLoader_Impl, const OFFSET: isize>() -> IMFTopoLoader_Vtbl {
         unsafe extern "system" fn Load<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopoLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinputtopo: ::windows::core::RawPtr, ppoutputtopo: *mut ::windows::core::RawPtr, pcurrenttopo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -15561,6 +16004,8 @@ pub trait IMFTopology_Impl: Sized + IMFAttributes_Impl {
     fn GetSourceNodeCollection(&self) -> ::windows::core::Result<IMFCollection>;
     fn GetOutputNodeCollection(&self) -> ::windows::core::Result<IMFCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFTopology {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFTopology_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopology_Impl, const OFFSET: isize>() -> IMFTopology_Vtbl {
@@ -15687,6 +16132,8 @@ pub trait IMFTopologyNode_Impl: Sized + IMFAttributes_Impl {
     fn GetInputPrefType(&self, dwinputindex: u32) -> ::windows::core::Result<IMFMediaType>;
     fn CloneFrom(&self, pnode: &::core::option::Option<IMFTopologyNode>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFTopologyNode {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFTopologyNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyNode_Impl, const OFFSET: isize>() -> IMFTopologyNode_Vtbl {
@@ -15839,6 +16286,7 @@ impl IMFTopologyNode_Vtbl {
 pub trait IMFTopologyNodeAttributeEditor_Impl: Sized {
     fn UpdateNodeAttributes(&self, topoid: u64, cupdates: u32, pupdates: *const MFTOPONODE_ATTRIBUTE_UPDATE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTopologyNodeAttributeEditor {}
 impl IMFTopologyNodeAttributeEditor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyNodeAttributeEditor_Impl, const OFFSET: isize>() -> IMFTopologyNodeAttributeEditor_Vtbl {
         unsafe extern "system" fn UpdateNodeAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyNodeAttributeEditor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, topoid: u64, cupdates: u32, pupdates: *const MFTOPONODE_ATTRIBUTE_UPDATE) -> ::windows::core::HRESULT {
@@ -15855,6 +16303,7 @@ impl IMFTopologyNodeAttributeEditor_Vtbl {
 pub trait IMFTopologyServiceLookup_Impl: Sized {
     fn LookupService(&self, r#type: MF_SERVICE_LOOKUP_TYPE, dwindex: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobjects: *mut *mut ::core::ffi::c_void, pnobjects: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTopologyServiceLookup {}
 impl IMFTopologyServiceLookup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyServiceLookup_Impl, const OFFSET: isize>() -> IMFTopologyServiceLookup_Vtbl {
         unsafe extern "system" fn LookupService<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyServiceLookup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: MF_SERVICE_LOOKUP_TYPE, dwindex: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobjects: *mut *mut ::core::ffi::c_void, pnobjects: *mut u32) -> ::windows::core::HRESULT {
@@ -15872,6 +16321,7 @@ pub trait IMFTopologyServiceLookupClient_Impl: Sized {
     fn InitServicePointers(&self, plookup: &::core::option::Option<IMFTopologyServiceLookup>) -> ::windows::core::Result<()>;
     fn ReleaseServicePointers(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTopologyServiceLookupClient {}
 impl IMFTopologyServiceLookupClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyServiceLookupClient_Impl, const OFFSET: isize>() -> IMFTopologyServiceLookupClient_Vtbl {
         unsafe extern "system" fn InitServicePointers<Identity: ::windows::core::IUnknownImpl, Impl: IMFTopologyServiceLookupClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plookup: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -15897,6 +16347,7 @@ impl IMFTopologyServiceLookupClient_Vtbl {
 pub trait IMFTrackedSample_Impl: Sized {
     fn SetAllocator(&self, psampleallocator: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTrackedSample {}
 impl IMFTrackedSample_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTrackedSample_Impl, const OFFSET: isize>() -> IMFTrackedSample_Vtbl {
         unsafe extern "system" fn SetAllocator<Identity: ::windows::core::IUnknownImpl, Impl: IMFTrackedSample_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psampleallocator: ::windows::core::RawPtr, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -15918,6 +16369,7 @@ pub trait IMFTranscodeProfile_Impl: Sized {
     fn SetContainerAttributes(&self, pattrs: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
     fn GetContainerAttributes(&self) -> ::windows::core::Result<IMFAttributes>;
 }
+impl ::windows::core::RuntimeName for IMFTranscodeProfile {}
 impl IMFTranscodeProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTranscodeProfile_Impl, const OFFSET: isize>() -> IMFTranscodeProfile_Vtbl {
         unsafe extern "system" fn SetAudioAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IMFTranscodeProfile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pattrs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -15988,6 +16440,7 @@ pub trait IMFTranscodeSinkInfoProvider_Impl: Sized {
     fn SetProfile(&self, pprofile: &::core::option::Option<IMFTranscodeProfile>) -> ::windows::core::Result<()>;
     fn GetSinkInfo(&self) -> ::windows::core::Result<MF_TRANSCODE_SINK_INFO>;
 }
+impl ::windows::core::RuntimeName for IMFTranscodeSinkInfoProvider {}
 impl IMFTranscodeSinkInfoProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTranscodeSinkInfoProvider_Impl, const OFFSET: isize>() -> IMFTranscodeSinkInfoProvider_Vtbl {
         unsafe extern "system" fn SetOutputFile<Identity: ::windows::core::IUnknownImpl, Impl: IMFTranscodeSinkInfoProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -16053,6 +16506,7 @@ pub trait IMFTransform_Impl: Sized {
     fn ProcessInput(&self, dwinputstreamid: u32, psample: &::core::option::Option<IMFSample>, dwflags: u32) -> ::windows::core::Result<()>;
     fn ProcessOutput(&self, dwflags: u32, coutputbuffercount: u32, poutputsamples: *mut MFT_OUTPUT_DATA_BUFFER, pdwstatus: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFTransform {}
 impl IMFTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTransform_Impl, const OFFSET: isize>() -> IMFTransform_Vtbl {
         unsafe extern "system" fn GetStreamLimits<Identity: ::windows::core::IUnknownImpl, Impl: IMFTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwinputminimum: *mut u32, pdwinputmaximum: *mut u32, pdwoutputminimum: *mut u32, pdwoutputmaximum: *mut u32) -> ::windows::core::HRESULT {
@@ -16270,6 +16724,7 @@ impl IMFTransform_Vtbl {
 pub trait IMFTrustedInput_Impl: Sized {
     fn GetInputTrustAuthority(&self, dwstreamid: u32, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IMFTrustedInput {}
 impl IMFTrustedInput_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTrustedInput_Impl, const OFFSET: isize>() -> IMFTrustedInput_Vtbl {
         unsafe extern "system" fn GetInputTrustAuthority<Identity: ::windows::core::IUnknownImpl, Impl: IMFTrustedInput_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamid: u32, riid: *const ::windows::core::GUID, ppunkobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -16295,6 +16750,8 @@ pub trait IMFTrustedOutput_Impl: Sized {
     fn GetOutputTrustAuthorityByIndex(&self, dwindex: u32) -> ::windows::core::Result<IMFOutputTrustAuthority>;
     fn IsFinal(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFTrustedOutput {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFTrustedOutput_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFTrustedOutput_Impl, const OFFSET: isize>() -> IMFTrustedOutput_Vtbl {
@@ -16345,6 +16802,7 @@ impl IMFTrustedOutput_Vtbl {
 pub trait IMFVideoCaptureSampleAllocator_Impl: Sized + IMFVideoSampleAllocator_Impl {
     fn InitializeCaptureSampleAllocator(&self, cbsamplesize: u32, cbcapturemetadatasize: u32, cbalignment: u32, cminimumsamples: u32, pattributes: &::core::option::Option<IMFAttributes>, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoCaptureSampleAllocator {}
 impl IMFVideoCaptureSampleAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoCaptureSampleAllocator_Impl, const OFFSET: isize>() -> IMFVideoCaptureSampleAllocator_Vtbl {
         unsafe extern "system" fn InitializeCaptureSampleAllocator<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoCaptureSampleAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsamplesize: u32, cbcapturemetadatasize: u32, cbalignment: u32, cminimumsamples: u32, pattributes: ::windows::core::RawPtr, pmediatype: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -16364,6 +16822,7 @@ impl IMFVideoCaptureSampleAllocator_Vtbl {
 pub trait IMFVideoDeviceID_Impl: Sized {
     fn GetDeviceID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IMFVideoDeviceID {}
 impl IMFVideoDeviceID_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoDeviceID_Impl, const OFFSET: isize>() -> IMFVideoDeviceID_Vtbl {
         unsafe extern "system" fn GetDeviceID<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoDeviceID_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdeviceid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -16402,6 +16861,8 @@ pub trait IMFVideoDisplayControl_Impl: Sized {
     fn SetFullscreen(&self, ffullscreen: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetFullscreen(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IMFVideoDisplayControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IMFVideoDisplayControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoDisplayControl_Impl, const OFFSET: isize>() -> IMFVideoDisplayControl_Vtbl {
@@ -16545,6 +17006,8 @@ pub trait IMFVideoMediaType_Impl: Sized + IMFAttributes_Impl + IMFMediaType_Impl
     fn GetVideoRepresentation(&self, guidrepresentation: &::windows::core::GUID, ppvrepresentation: *mut *mut ::core::ffi::c_void, lstride: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFVideoMediaType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFVideoMediaType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMediaType_Impl, const OFFSET: isize>() -> IMFVideoMediaType_Vtbl {
         unsafe extern "system" fn GetVideoFormat<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMediaType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> *mut MFVIDEOFORMAT {
@@ -16574,6 +17037,8 @@ pub trait IMFVideoMixerBitmap_Impl: Sized {
     fn UpdateAlphaBitmapParameters(&self, pbmpparms: *const MFVideoAlphaBitmapParams) -> ::windows::core::Result<()>;
     fn GetAlphaBitmapParameters(&self) -> ::windows::core::Result<MFVideoAlphaBitmapParams>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IMFVideoMixerBitmap {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 impl IMFVideoMixerBitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMixerBitmap_Impl, const OFFSET: isize>() -> IMFVideoMixerBitmap_Vtbl {
@@ -16621,6 +17086,7 @@ pub trait IMFVideoMixerControl_Impl: Sized {
     fn SetStreamOutputRect(&self, dwstreamid: u32, pnrcoutput: *const MFVideoNormalizedRect) -> ::windows::core::Result<()>;
     fn GetStreamOutputRect(&self, dwstreamid: u32) -> ::windows::core::Result<MFVideoNormalizedRect>;
 }
+impl ::windows::core::RuntimeName for IMFVideoMixerControl {}
 impl IMFVideoMixerControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMixerControl_Impl, const OFFSET: isize>() -> IMFVideoMixerControl_Vtbl {
         unsafe extern "system" fn SetStreamZOrder<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMixerControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwstreamid: u32, dwz: u32) -> ::windows::core::HRESULT {
@@ -16671,6 +17137,7 @@ pub trait IMFVideoMixerControl2_Impl: Sized + IMFVideoMixerControl_Impl {
     fn SetMixingPrefs(&self, dwmixflags: u32) -> ::windows::core::Result<()>;
     fn GetMixingPrefs(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFVideoMixerControl2 {}
 impl IMFVideoMixerControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMixerControl2_Impl, const OFFSET: isize>() -> IMFVideoMixerControl2_Vtbl {
         unsafe extern "system" fn SetMixingPrefs<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoMixerControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmixflags: u32) -> ::windows::core::HRESULT {
@@ -16702,6 +17169,7 @@ impl IMFVideoMixerControl2_Vtbl {
 pub trait IMFVideoPositionMapper_Impl: Sized {
     fn MapOutputCoordinateToInputStream(&self, xout: f32, yout: f32, dwoutputstreamindex: u32, dwinputstreamindex: u32, pxin: *mut f32, pyin: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoPositionMapper {}
 impl IMFVideoPositionMapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoPositionMapper_Impl, const OFFSET: isize>() -> IMFVideoPositionMapper_Vtbl {
         unsafe extern "system" fn MapOutputCoordinateToInputStream<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoPositionMapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xout: f32, yout: f32, dwoutputstreamindex: u32, dwinputstreamindex: u32, pxin: *mut f32, pyin: *mut f32) -> ::windows::core::HRESULT {
@@ -16722,6 +17190,7 @@ pub trait IMFVideoPresenter_Impl: Sized + IMFClockStateSink_Impl {
     fn ProcessMessage(&self, emessage: MFVP_MESSAGE_TYPE, ulparam: usize) -> ::windows::core::Result<()>;
     fn GetCurrentMediaType(&self) -> ::windows::core::Result<IMFVideoMediaType>;
 }
+impl ::windows::core::RuntimeName for IMFVideoPresenter {}
 impl IMFVideoPresenter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoPresenter_Impl, const OFFSET: isize>() -> IMFVideoPresenter_Vtbl {
         unsafe extern "system" fn ProcessMessage<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoPresenter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, emessage: MFVP_MESSAGE_TYPE, ulparam: usize) -> ::windows::core::HRESULT {
@@ -16765,6 +17234,8 @@ pub trait IMFVideoProcessor_Impl: Sized {
     fn GetBackgroundColor(&self) -> ::windows::core::Result<u32>;
     fn SetBackgroundColor(&self, clrbkg: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D9")]
+impl ::windows::core::RuntimeName for IMFVideoProcessor {}
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 impl IMFVideoProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoProcessor_Impl, const OFFSET: isize>() -> IMFVideoProcessor_Vtbl {
@@ -16900,6 +17371,8 @@ pub trait IMFVideoProcessorControl_Impl: Sized {
     fn SetConstrictionSize(&self, pconstrictionsize: *const super::super::Foundation::SIZE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFVideoProcessorControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFVideoProcessorControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoProcessorControl_Impl, const OFFSET: isize>() -> IMFVideoProcessorControl_Vtbl {
         unsafe extern "system" fn SetBorderColor<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoProcessorControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbordercolor: *const MFARGB) -> ::windows::core::HRESULT {
@@ -16953,6 +17426,8 @@ pub trait IMFVideoProcessorControl2_Impl: Sized + IMFVideoProcessorControl_Impl 
     fn GetSupportedHardwareEffects(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFVideoProcessorControl2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMFVideoProcessorControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoProcessorControl2_Impl, const OFFSET: isize>() -> IMFVideoProcessorControl2_Vtbl {
         unsafe extern "system" fn SetRotationOverride<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoProcessorControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uirotation: u32) -> ::windows::core::HRESULT {
@@ -16994,6 +17469,8 @@ pub trait IMFVideoProcessorControl3_Impl: Sized + IMFVideoProcessorControl_Impl 
     fn SetSphericalVideoProperties(&self, x: f32, y: f32, z: f32, w: f32, fieldofview: f32) -> ::windows::core::Result<()>;
     fn SetOutputDevice(&self, poutputdevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMFVideoProcessorControl3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMFVideoProcessorControl3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoProcessorControl3_Impl, const OFFSET: isize>() -> IMFVideoProcessorControl3_Vtbl {
@@ -17038,6 +17515,7 @@ impl IMFVideoProcessorControl3_Vtbl {
 pub trait IMFVideoRenderer_Impl: Sized {
     fn InitializeRenderer(&self, pvideomixer: &::core::option::Option<IMFTransform>, pvideopresenter: &::core::option::Option<IMFVideoPresenter>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoRenderer {}
 impl IMFVideoRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoRenderer_Impl, const OFFSET: isize>() -> IMFVideoRenderer_Vtbl {
         unsafe extern "system" fn InitializeRenderer<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoRenderer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvideomixer: ::windows::core::RawPtr, pvideopresenter: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -17054,6 +17532,7 @@ impl IMFVideoRenderer_Vtbl {
 pub trait IMFVideoRendererEffectControl_Impl: Sized {
     fn OnAppServiceConnectionEstablished(&self, pappserviceconnection: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoRendererEffectControl {}
 impl IMFVideoRendererEffectControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoRendererEffectControl_Impl, const OFFSET: isize>() -> IMFVideoRendererEffectControl_Vtbl {
         unsafe extern "system" fn OnAppServiceConnectionEstablished<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoRendererEffectControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pappserviceconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17076,6 +17555,7 @@ pub trait IMFVideoSampleAllocator_Impl: Sized {
     fn InitializeSampleAllocator(&self, crequestedframes: u32, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
     fn AllocateSample(&self) -> ::windows::core::Result<IMFSample>;
 }
+impl ::windows::core::RuntimeName for IMFVideoSampleAllocator {}
 impl IMFVideoSampleAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocator_Impl, const OFFSET: isize>() -> IMFVideoSampleAllocator_Vtbl {
         unsafe extern "system" fn SetDirectXManager<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17120,6 +17600,7 @@ pub trait IMFVideoSampleAllocatorCallback_Impl: Sized {
     fn SetCallback(&self, pnotify: &::core::option::Option<IMFVideoSampleAllocatorNotify>) -> ::windows::core::Result<()>;
     fn GetFreeSampleCount(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IMFVideoSampleAllocatorCallback {}
 impl IMFVideoSampleAllocatorCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorCallback_Impl, const OFFSET: isize>() -> IMFVideoSampleAllocatorCallback_Vtbl {
         unsafe extern "system" fn SetCallback<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnotify: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -17151,6 +17632,7 @@ impl IMFVideoSampleAllocatorCallback_Vtbl {
 pub trait IMFVideoSampleAllocatorEx_Impl: Sized + IMFVideoSampleAllocator_Impl {
     fn InitializeSampleAllocatorEx(&self, cinitialsamples: u32, cmaximumsamples: u32, pattributes: &::core::option::Option<IMFAttributes>, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoSampleAllocatorEx {}
 impl IMFVideoSampleAllocatorEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorEx_Impl, const OFFSET: isize>() -> IMFVideoSampleAllocatorEx_Vtbl {
         unsafe extern "system" fn InitializeSampleAllocatorEx<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cinitialsamples: u32, cmaximumsamples: u32, pattributes: ::windows::core::RawPtr, pmediatype: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -17170,6 +17652,7 @@ impl IMFVideoSampleAllocatorEx_Vtbl {
 pub trait IMFVideoSampleAllocatorNotify_Impl: Sized {
     fn NotifyRelease(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoSampleAllocatorNotify {}
 impl IMFVideoSampleAllocatorNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorNotify_Impl, const OFFSET: isize>() -> IMFVideoSampleAllocatorNotify_Vtbl {
         unsafe extern "system" fn NotifyRelease<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17186,6 +17669,7 @@ impl IMFVideoSampleAllocatorNotify_Vtbl {
 pub trait IMFVideoSampleAllocatorNotifyEx_Impl: Sized + IMFVideoSampleAllocatorNotify_Impl {
     fn NotifyPrune(&self, __midl__imfvideosampleallocatornotifyex0000: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMFVideoSampleAllocatorNotifyEx {}
 impl IMFVideoSampleAllocatorNotifyEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorNotifyEx_Impl, const OFFSET: isize>() -> IMFVideoSampleAllocatorNotifyEx_Vtbl {
         unsafe extern "system" fn NotifyPrune<Identity: ::windows::core::IUnknownImpl, Impl: IMFVideoSampleAllocatorNotifyEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, __midl__imfvideosampleallocatornotifyex0000: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -17213,6 +17697,8 @@ pub trait IMFVirtualCamera_Impl: Sized + IMFAttributes_Impl {
     fn CreateSyncSemaphore(&self, kseventset: *const ::windows::core::GUID, kseventid: u32, kseventflags: u32, semaphorehandle: super::super::Foundation::HANDLE, semaphoreadjustment: i32) -> ::windows::core::Result<IMFCameraSyncObject>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Devices_Properties", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMFVirtualCamera {}
 #[cfg(all(feature = "Win32_Devices_Properties", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMFVirtualCamera_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFVirtualCamera_Impl, const OFFSET: isize>() -> IMFVirtualCamera_Vtbl {
@@ -17322,6 +17808,7 @@ pub trait IMFWorkQueueServices_Impl: Sized {
     fn GetPlaftormWorkQueueMMCSSClass(&self, dwplatformworkqueueid: u32, pwszclass: ::windows::core::PWSTR, pcchclass: *mut u32) -> ::windows::core::Result<()>;
     fn GetPlatformWorkQueueMMCSSTaskId(&self, dwplatformworkqueueid: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMFWorkQueueServices {}
 impl IMFWorkQueueServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFWorkQueueServices_Impl, const OFFSET: isize>() -> IMFWorkQueueServices_Vtbl {
         unsafe extern "system" fn BeginRegisterTopologyWorkQueuesWithMMCSS<Identity: ::windows::core::IUnknownImpl, Impl: IMFWorkQueueServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17427,6 +17914,7 @@ pub trait IMFWorkQueueServicesEx_Impl: Sized + IMFWorkQueueServices_Impl {
     fn BeginRegisterPlatformWorkQueueWithMMCSSEx(&self, dwplatformworkqueue: u32, wszclass: &::windows::core::PCWSTR, dwtaskid: u32, lpriority: i32, pcallback: &::core::option::Option<IMFAsyncCallback>, pstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetPlatformWorkQueueMMCSSPriority(&self, dwplatformworkqueueid: u32) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IMFWorkQueueServicesEx {}
 impl IMFWorkQueueServicesEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFWorkQueueServicesEx_Impl, const OFFSET: isize>() -> IMFWorkQueueServicesEx_Vtbl {
         unsafe extern "system" fn GetTopologyWorkQueueMMCSSPriority<Identity: ::windows::core::IUnknownImpl, Impl: IMFWorkQueueServicesEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtopologyworkqueueid: u32, plpriority: *mut i32) -> ::windows::core::HRESULT {
@@ -17474,6 +17962,7 @@ pub trait IOPMVideoOutput_Impl: Sized {
     fn COPPCompatibleGetInformation(&self, pparameters: *const OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS) -> ::windows::core::Result<OPM_REQUESTED_INFORMATION>;
     fn Configure(&self, pparameters: *const OPM_CONFIGURE_PARAMETERS, uladditionalparameterssize: u32, pbadditionalparameters: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOPMVideoOutput {}
 impl IOPMVideoOutput_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOPMVideoOutput_Impl, const OFFSET: isize>() -> IOPMVideoOutput_Vtbl {
         unsafe extern "system" fn StartInitialization<Identity: ::windows::core::IUnknownImpl, Impl: IOPMVideoOutput_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prnrandomnumber: *mut OPM_RANDOM_NUMBER, ppbcertificate: *mut *mut u8, pulcertificatelength: *mut u32) -> ::windows::core::HRESULT {
@@ -17530,6 +18019,7 @@ pub trait IPlayToControl_Impl: Sized {
     fn Connect(&self, pfactory: &::core::option::Option<IMFSharingEngineClassFactory>) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPlayToControl {}
 impl IPlayToControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToControl_Impl, const OFFSET: isize>() -> IPlayToControl_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfactory: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -17555,6 +18045,7 @@ impl IPlayToControl_Vtbl {
 pub trait IPlayToControlWithCapabilities_Impl: Sized + IPlayToControl_Impl {
     fn GetCapabilities(&self) -> ::windows::core::Result<PLAYTO_SOURCE_CREATEFLAGS>;
 }
+impl ::windows::core::RuntimeName for IPlayToControlWithCapabilities {}
 impl IPlayToControlWithCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToControlWithCapabilities_Impl, const OFFSET: isize>() -> IPlayToControlWithCapabilities_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToControlWithCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcapabilities: *mut PLAYTO_SOURCE_CREATEFLAGS) -> ::windows::core::HRESULT {
@@ -17577,6 +18068,7 @@ impl IPlayToControlWithCapabilities_Vtbl {
 pub trait IPlayToSourceClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pcontrol: &::core::option::Option<IPlayToControl>) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
+impl ::windows::core::RuntimeName for IPlayToSourceClassFactory {}
 impl IPlayToSourceClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToSourceClassFactory_Impl, const OFFSET: isize>() -> IPlayToSourceClassFactory_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToSourceClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pcontrol: ::windows::core::RawPtr, ppsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17609,6 +18101,7 @@ pub trait IToc_Impl: Sized {
     fn AddEntryListByIndex(&self, wentrylistindex: u16, pentrylist: &::core::option::Option<ITocEntryList>) -> ::windows::core::Result<()>;
     fn RemoveEntryListByIndex(&self, wentrylistindex: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IToc {}
 impl IToc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IToc_Impl, const OFFSET: isize>() -> IToc_Vtbl {
         unsafe extern "system" fn SetDescriptor<Identity: ::windows::core::IUnknownImpl, Impl: IToc_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdescriptor: *mut TOC_DESCRIPTOR) -> ::windows::core::HRESULT {
@@ -17698,6 +18191,7 @@ pub trait ITocCollection_Impl: Sized {
     fn AddEntryByIndex(&self, dwentryindex: u32, ptoc: &::core::option::Option<IToc>) -> ::windows::core::Result<()>;
     fn RemoveEntryByIndex(&self, dwentryindex: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITocCollection {}
 impl ITocCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITocCollection_Impl, const OFFSET: isize>() -> ITocCollection_Vtbl {
         unsafe extern "system" fn GetEntryCount<Identity: ::windows::core::IUnknownImpl, Impl: ITocCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwentrycount: *mut u32) -> ::windows::core::HRESULT {
@@ -17754,6 +18248,7 @@ pub trait ITocEntry_Impl: Sized {
     fn SetDescriptionData(&self, dwdescriptiondatasize: u32, pbtdescriptiondata: *mut u8, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetDescriptionData(&self, pdwdescriptiondatasize: *mut u32, pbtdescriptiondata: *mut u8, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITocEntry {}
 impl ITocEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITocEntry_Impl, const OFFSET: isize>() -> ITocEntry_Vtbl {
         unsafe extern "system" fn SetTitle<Identity: ::windows::core::IUnknownImpl, Impl: ITocEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwsztitle: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -17819,6 +18314,7 @@ pub trait ITocEntryList_Impl: Sized {
     fn AddEntryByIndex(&self, dwentryindex: u32, pentry: &::core::option::Option<ITocEntry>) -> ::windows::core::Result<()>;
     fn RemoveEntryByIndex(&self, dwentryindex: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITocEntryList {}
 impl ITocEntryList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITocEntryList_Impl, const OFFSET: isize>() -> ITocEntryList_Vtbl {
         unsafe extern "system" fn GetEntryCount<Identity: ::windows::core::IUnknownImpl, Impl: ITocEntryList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwentrycount: *mut u32) -> ::windows::core::HRESULT {
@@ -17875,6 +18371,7 @@ pub trait ITocParser_Impl: Sized {
     fn RemoveTocByType(&self, enumtocpostype: TOC_POS_TYPE, guidtoctype: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITocParser {}
 impl ITocParser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITocParser_Impl, const OFFSET: isize>() -> ITocParser_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: ITocParser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -17948,6 +18445,7 @@ impl ITocParser_Vtbl {
 pub trait IValidateBinding_Impl: Sized {
     fn GetIdentifier(&self, guidlicensorid: &::windows::core::GUID, pbephemeron: *const u8, cbephemeron: u32, ppbblobvalidationid: *mut *mut u8, pcbblobsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IValidateBinding {}
 impl IValidateBinding_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IValidateBinding_Impl, const OFFSET: isize>() -> IValidateBinding_Vtbl {
         unsafe extern "system" fn GetIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: IValidateBinding_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidlicensorid: ::windows::core::GUID, pbephemeron: *const u8, cbephemeron: u32, ppbblobvalidationid: *mut *mut u8, pcbblobsize: *mut u32) -> ::windows::core::HRESULT {
@@ -17967,6 +18465,7 @@ pub trait IWMCodecLeakyBucket_Impl: Sized {
     fn SetBufferFullnessBits(&self, ulbufferfullness: u32) -> ::windows::core::Result<()>;
     fn GetBufferFullnessBits(&self, pulbufferfullness: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMCodecLeakyBucket {}
 impl IWMCodecLeakyBucket_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecLeakyBucket_Impl, const OFFSET: isize>() -> IWMCodecLeakyBucket_Vtbl {
         unsafe extern "system" fn SetBufferSizeBits<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecLeakyBucket_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulbuffersize: u32) -> ::windows::core::HRESULT {
@@ -18004,6 +18503,7 @@ impl IWMCodecLeakyBucket_Vtbl {
 pub trait IWMCodecOutputTimestamp_Impl: Sized {
     fn GetNextOutputTime(&self, prttime: *mut i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMCodecOutputTimestamp {}
 impl IWMCodecOutputTimestamp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecOutputTimestamp_Impl, const OFFSET: isize>() -> IWMCodecOutputTimestamp_Vtbl {
         unsafe extern "system" fn GetNextOutputTime<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecOutputTimestamp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prttime: *mut i64) -> ::windows::core::HRESULT {
@@ -18022,6 +18522,8 @@ pub trait IWMCodecPrivateData_Impl: Sized {
     fn SetPartialOutputType(&self, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE) -> ::windows::core::Result<()>;
     fn GetPrivateData(&self, pbdata: *mut u8, pcbdata: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
+impl ::windows::core::RuntimeName for IWMCodecPrivateData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
 impl IWMCodecPrivateData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecPrivateData_Impl, const OFFSET: isize>() -> IWMCodecPrivateData_Vtbl {
@@ -18051,6 +18553,8 @@ pub trait IWMCodecProps_Impl: Sized {
     fn GetCodecProp(&self, dwformat: u32, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_PROP_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
+impl ::windows::core::RuntimeName for IWMCodecProps {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
 impl IWMCodecProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecProps_Impl, const OFFSET: isize>() -> IWMCodecProps_Vtbl {
         unsafe extern "system" fn GetFormatProp<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_PROP_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT {
@@ -18079,6 +18583,8 @@ pub trait IWMCodecStrings_Impl: Sized {
     fn GetDescription(&self, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, cchlength: u32, szdescription: ::windows::core::PWSTR, pcchlength: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
+impl ::windows::core::RuntimeName for IWMCodecStrings {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
 impl IWMCodecStrings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecStrings_Impl, const OFFSET: isize>() -> IWMCodecStrings_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecStrings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, cchlength: u32, szname: ::windows::core::PWSTR, pcchlength: *mut u32) -> ::windows::core::HRESULT {
@@ -18105,6 +18611,7 @@ pub trait IWMColorConvProps_Impl: Sized {
     fn SetMode(&self, lmode: i32) -> ::windows::core::Result<()>;
     fn SetFullCroppingParam(&self, lsrccropleft: i32, lsrccroptop: i32, ldstcropleft: i32, ldstcroptop: i32, lcropwidth: i32, lcropheight: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMColorConvProps {}
 impl IWMColorConvProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMColorConvProps_Impl, const OFFSET: isize>() -> IWMColorConvProps_Vtbl {
         unsafe extern "system" fn SetMode<Identity: ::windows::core::IUnknownImpl, Impl: IWMColorConvProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lmode: i32) -> ::windows::core::HRESULT {
@@ -18130,6 +18637,7 @@ impl IWMColorConvProps_Vtbl {
 pub trait IWMColorLegalizerProps_Impl: Sized {
     fn SetColorLegalizerQuality(&self, lquality: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMColorLegalizerProps {}
 impl IWMColorLegalizerProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMColorLegalizerProps_Impl, const OFFSET: isize>() -> IWMColorLegalizerProps_Vtbl {
         unsafe extern "system" fn SetColorLegalizerQuality<Identity: ::windows::core::IUnknownImpl, Impl: IWMColorLegalizerProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lquality: i32) -> ::windows::core::HRESULT {
@@ -18150,6 +18658,8 @@ pub trait IWMFrameInterpProps_Impl: Sized {
     fn SetFrameInterpEnabled(&self, bfienabled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SetComplexityLevel(&self, icomplexity: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMFrameInterpProps {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMFrameInterpProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMFrameInterpProps_Impl, const OFFSET: isize>() -> IWMFrameInterpProps_Vtbl {
@@ -18190,6 +18700,7 @@ pub trait IWMInterlaceProps_Impl: Sized {
     fn SetInitInverseTeleCinePattern(&self, iinitpattern: i32) -> ::windows::core::Result<()>;
     fn SetLastFrame(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMInterlaceProps {}
 impl IWMInterlaceProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMInterlaceProps_Impl, const OFFSET: isize>() -> IWMInterlaceProps_Vtbl {
         unsafe extern "system" fn SetProcessType<Identity: ::windows::core::IUnknownImpl, Impl: IWMInterlaceProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iprocesstype: i32) -> ::windows::core::HRESULT {
@@ -18222,6 +18733,7 @@ pub trait IWMResamplerProps_Impl: Sized {
     fn SetHalfFilterLength(&self, lhalffilterlen: i32) -> ::windows::core::Result<()>;
     fn SetUserChannelMtx(&self, userchannelmtx: *mut f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMResamplerProps {}
 impl IWMResamplerProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMResamplerProps_Impl, const OFFSET: isize>() -> IWMResamplerProps_Vtbl {
         unsafe extern "system" fn SetHalfFilterLength<Identity: ::windows::core::IUnknownImpl, Impl: IWMResamplerProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lhalffilterlen: i32) -> ::windows::core::HRESULT {
@@ -18251,6 +18763,7 @@ pub trait IWMResizerProps_Impl: Sized {
     fn SetFullCropRegion(&self, lcliporixsrc: i32, lcliporiysrc: i32, lclipwidthsrc: i32, lclipheightsrc: i32, lcliporixdst: i32, lcliporiydst: i32, lclipwidthdst: i32, lclipheightdst: i32) -> ::windows::core::Result<()>;
     fn GetFullCropRegion(&self, lcliporixsrc: *mut i32, lcliporiysrc: *mut i32, lclipwidthsrc: *mut i32, lclipheightsrc: *mut i32, lcliporixdst: *mut i32, lcliporiydst: *mut i32, lclipwidthdst: *mut i32, lclipheightdst: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMResizerProps {}
 impl IWMResizerProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMResizerProps_Impl, const OFFSET: isize>() -> IWMResizerProps_Vtbl {
         unsafe extern "system" fn SetResizerQuality<Identity: ::windows::core::IUnknownImpl, Impl: IWMResizerProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lquality: i32) -> ::windows::core::HRESULT {
@@ -18296,6 +18809,8 @@ pub trait IWMSampleExtensionSupport_Impl: Sized {
     fn SetUseSampleExtensions(&self, fuseextensions: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMSampleExtensionSupport {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMSampleExtensionSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSampleExtensionSupport_Impl, const OFFSET: isize>() -> IWMSampleExtensionSupport_Vtbl {
         unsafe extern "system" fn SetUseSampleExtensions<Identity: ::windows::core::IUnknownImpl, Impl: IWMSampleExtensionSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fuseextensions: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -18312,6 +18827,7 @@ impl IWMSampleExtensionSupport_Vtbl {
 pub trait IWMValidate_Impl: Sized {
     fn SetIdentifier(&self, guidvalidationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMValidate {}
 impl IWMValidate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMValidate_Impl, const OFFSET: isize>() -> IWMValidate_Vtbl {
         unsafe extern "system" fn SetIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: IWMValidate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidvalidationid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -18329,6 +18845,7 @@ pub trait IWMVideoDecoderHurryup_Impl: Sized {
     fn SetHurryup(&self, lhurryup: i32) -> ::windows::core::Result<()>;
     fn GetHurryup(&self, plhurryup: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMVideoDecoderHurryup {}
 impl IWMVideoDecoderHurryup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoDecoderHurryup_Impl, const OFFSET: isize>() -> IWMVideoDecoderHurryup_Vtbl {
         unsafe extern "system" fn SetHurryup<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoDecoderHurryup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lhurryup: i32) -> ::windows::core::HRESULT {
@@ -18357,6 +18874,8 @@ pub trait IWMVideoDecoderReconBuffer_Impl: Sized {
     fn GetReconstructedVideoFrame(&self, pbuf: &::core::option::Option<super::DxMediaObjects::IMediaBuffer>) -> ::windows::core::Result<()>;
     fn SetReconstructedVideoFrame(&self, pbuf: &::core::option::Option<super::DxMediaObjects::IMediaBuffer>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Media_DxMediaObjects")]
+impl ::windows::core::RuntimeName for IWMVideoDecoderReconBuffer {}
 #[cfg(feature = "Win32_Media_DxMediaObjects")]
 impl IWMVideoDecoderReconBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoDecoderReconBuffer_Impl, const OFFSET: isize>() -> IWMVideoDecoderReconBuffer_Vtbl {
@@ -18389,6 +18908,7 @@ impl IWMVideoDecoderReconBuffer_Vtbl {
 pub trait IWMVideoForceKeyFrame_Impl: Sized {
     fn SetKeyFrame(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMVideoForceKeyFrame {}
 impl IWMVideoForceKeyFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoForceKeyFrame_Impl, const OFFSET: isize>() -> IWMVideoForceKeyFrame_Vtbl {
         unsafe extern "system" fn SetKeyFrame<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoForceKeyFrame_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -18403,6 +18923,7 @@ impl IWMVideoForceKeyFrame_Vtbl {
     }
 }
 pub trait MFASYNCRESULT_Impl: Sized + IMFAsyncResult_Impl {}
+impl ::windows::core::RuntimeName for MFASYNCRESULT {}
 impl MFASYNCRESULT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: MFASYNCRESULT_Impl, const OFFSET: isize>() -> MFASYNCRESULT_Vtbl {
         Self { base__: IMFAsyncResult_Vtbl::new::<Identity, Impl, OFFSET>() }

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
@@ -46,6 +46,8 @@ pub trait IFeed_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ItemCount(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeed {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeed_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeed_Impl, const OFFSET: isize>() -> IFeed_Vtbl {
         unsafe extern "system" fn Xml<Identity: ::windows::core::IUnknownImpl, Impl: IFeed_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: i32, sortproperty: FEEDS_XML_SORT_PROPERTY, sortorder: FEEDS_XML_SORT_ORDER, filterflags: FEEDS_XML_FILTER_FLAGS, includeflags: FEEDS_XML_INCLUDE_FLAGS, xml: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -516,6 +518,8 @@ pub trait IFeed2_Impl: Sized + super::super::System::Com::IDispatch_Impl + IFeed
     fn ClearCredentials(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeed2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeed2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeed2_Impl, const OFFSET: isize>() -> IFeed2_Vtbl {
         unsafe extern "system" fn GetItemByEffectiveId<Identity: ::windows::core::IUnknownImpl, Impl: IFeed2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, itemeffectiveid: i32, disp: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -602,6 +606,8 @@ pub trait IFeedEnclosure_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn RemoveFile(&self) -> ::windows::core::Result<()>;
     fn SetFile(&self, downloadurl: &super::super::Foundation::BSTR, downloadfilepath: &super::super::Foundation::BSTR, downloadmimetype: &super::super::Foundation::BSTR, enclosurefilename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedEnclosure {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedEnclosure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedEnclosure_Impl, const OFFSET: isize>() -> IFeedEnclosure_Vtbl {
@@ -757,6 +763,8 @@ pub trait IFeedEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FeedItemCountChanged(&self, path: &super::super::Foundation::BSTR, itemcounttype: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedEvents_Impl, const OFFSET: isize>() -> IFeedEvents_Vtbl {
         unsafe extern "system" fn Error<Identity: ::windows::core::IUnknownImpl, Impl: IFeedEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -836,6 +844,8 @@ pub trait IFeedFolder_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TotalItemCount(&self) -> ::windows::core::Result<i32>;
     fn GetWatcher(&self, scope: FEEDS_EVENTS_SCOPE, mask: FEEDS_EVENTS_MASK) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedFolder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedFolder_Impl, const OFFSET: isize>() -> IFeedFolder_Vtbl {
@@ -1065,6 +1075,8 @@ pub trait IFeedFolderEvents_Impl: Sized + super::super::System::Com::IDispatch_I
     fn FeedItemCountChanged(&self, path: &super::super::Foundation::BSTR, itemcounttype: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedFolderEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedFolderEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedFolderEvents_Impl, const OFFSET: isize>() -> IFeedFolderEvents_Vtbl {
         unsafe extern "system" fn Error<Identity: ::windows::core::IUnknownImpl, Impl: IFeedFolderEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1191,6 +1203,8 @@ pub trait IFeedItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LastDownloadTime(&self) -> ::windows::core::Result<f64>;
     fn Modified(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedItem_Impl, const OFFSET: isize>() -> IFeedItem_Vtbl {
@@ -1399,6 +1413,8 @@ pub trait IFeedItem2_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn EffectiveId(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedItem2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedItem2_Impl, const OFFSET: isize>() -> IFeedItem2_Vtbl {
         unsafe extern "system" fn EffectiveId<Identity: ::windows::core::IUnknownImpl, Impl: IFeedItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectiveid: *mut i32) -> ::windows::core::HRESULT {
@@ -1424,6 +1440,8 @@ pub trait IFeedsEnum_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedsEnum {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedsEnum_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedsEnum_Impl, const OFFSET: isize>() -> IFeedsEnum_Vtbl {
@@ -1490,6 +1508,8 @@ pub trait IFeedsManager_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Normalize(&self, feedxmlin: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ItemCountLimit(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFeedsManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFeedsManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedsManager_Impl, const OFFSET: isize>() -> IFeedsManager_Vtbl {
@@ -1669,6 +1689,8 @@ pub trait IWMPAudioRenderConfig_Impl: Sized {
     fn SetaudioOutputDevice(&self, bstroutputdevice: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPAudioRenderConfig {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPAudioRenderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPAudioRenderConfig_Impl, const OFFSET: isize>() -> IWMPAudioRenderConfig_Vtbl {
         unsafe extern "system" fn audioOutputDevice<Identity: ::windows::core::IUnknownImpl, Impl: IWMPAudioRenderConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstroutputdevice: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1697,6 +1719,8 @@ pub trait IWMPCdrom_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn playlist(&self) -> ::windows::core::Result<IWMPPlaylist>;
     fn eject(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPCdrom {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPCdrom_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCdrom_Impl, const OFFSET: isize>() -> IWMPCdrom_Vtbl {
@@ -1749,6 +1773,8 @@ pub trait IWMPCdromBurn_Impl: Sized {
     fn stopBurn(&self) -> ::windows::core::Result<()>;
     fn erase(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPCdromBurn {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPCdromBurn_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCdromBurn_Impl, const OFFSET: isize>() -> IWMPCdromBurn_Vtbl {
@@ -1857,6 +1883,8 @@ pub trait IWMPCdromCollection_Impl: Sized + super::super::System::Com::IDispatch
     fn getByDriveSpecifier(&self, bstrdrivespecifier: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWMPCdrom>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPCdromCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPCdromCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCdromCollection_Impl, const OFFSET: isize>() -> IWMPCdromCollection_Vtbl {
         unsafe extern "system" fn count<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCdromCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1903,6 +1931,7 @@ pub trait IWMPCdromRip_Impl: Sized {
     fn startRip(&self) -> ::windows::core::Result<()>;
     fn stopRip(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPCdromRip {}
 impl IWMPCdromRip_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCdromRip_Impl, const OFFSET: isize>() -> IWMPCdromRip_Vtbl {
         unsafe extern "system" fn ripState<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCdromRip_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwmprs: *mut WMPRipState) -> ::windows::core::HRESULT {
@@ -1948,6 +1977,8 @@ pub trait IWMPClosedCaption_Impl: Sized + super::super::System::Com::IDispatch_I
     fn captioningId(&self, pbstrcaptioningid: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetcaptioningId(&self, bstrcaptioningid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPClosedCaption {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPClosedCaption_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPClosedCaption_Impl, const OFFSET: isize>() -> IWMPClosedCaption_Vtbl {
@@ -2016,6 +2047,8 @@ pub trait IWMPClosedCaption2_Impl: Sized + super::super::System::Com::IDispatch_
     fn getSAMIStyleName(&self, nindex: i32, pbstrname: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPClosedCaption2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPClosedCaption2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPClosedCaption2_Impl, const OFFSET: isize>() -> IWMPClosedCaption2_Vtbl {
         unsafe extern "system" fn SAMILangCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMPClosedCaption2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2065,6 +2098,8 @@ pub trait IWMPContentContainer_Impl: Sized {
     fn GetContentPrice(&self, idxcontent: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetContentID(&self, idxcontent: u32) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPContentContainer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMPContentContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPContentContainer_Impl, const OFFSET: isize>() -> IWMPContentContainer_Vtbl {
@@ -2153,6 +2188,7 @@ pub trait IWMPContentContainerList_Impl: Sized {
     fn GetContainerCount(&self) -> ::windows::core::Result<u32>;
     fn GetContainer(&self, idxcontainer: u32) -> ::windows::core::Result<IWMPContentContainer>;
 }
+impl ::windows::core::RuntimeName for IWMPContentContainerList {}
 impl IWMPContentContainerList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPContentContainerList_Impl, const OFFSET: isize>() -> IWMPContentContainerList_Vtbl {
         unsafe extern "system" fn GetTransactionType<Identity: ::windows::core::IUnknownImpl, Impl: IWMPContentContainerList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwmptt: *mut WMPTransactionType) -> ::windows::core::HRESULT {
@@ -2225,6 +2261,8 @@ pub trait IWMPContentPartner_Impl: Sized {
     fn CompareContainerListPrices(&self, plistbase: &::core::option::Option<IWMPContentContainerList>, plistcompare: &::core::option::Option<IWMPContentContainerList>) -> ::windows::core::Result<i32>;
     fn VerifyPermission(&self, bstrpermission: &super::super::Foundation::BSTR, pcontext: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPContentPartner {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPContentPartner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPContentPartner_Impl, const OFFSET: isize>() -> IWMPContentPartner_Vtbl {
@@ -2415,6 +2453,8 @@ pub trait IWMPContentPartnerCallback_Impl: Sized {
     fn VerifyPermissionComplete(&self, bstrpermission: &super::super::Foundation::BSTR, pcontext: *const super::super::System::Com::VARIANT, hrpermission: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPContentPartnerCallback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPContentPartnerCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPContentPartnerCallback_Impl, const OFFSET: isize>() -> IWMPContentPartnerCallback_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IWMPContentPartnerCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: WMPCallbackNotification, pcontext: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2522,6 +2562,8 @@ pub trait IWMPControls_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetcurrentMarker(&self, lmarker: i32) -> ::windows::core::Result<()>;
     fn playItem(&self, piwmpmedia: &::core::option::Option<IWMPMedia>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPControls {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPControls_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPControls_Impl, const OFFSET: isize>() -> IWMPControls_Vtbl {
@@ -2640,6 +2682,8 @@ pub trait IWMPControls2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn step(&self, lstep: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPControls2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPControls2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPControls2_Impl, const OFFSET: isize>() -> IWMPControls2_Vtbl {
         unsafe extern "system" fn step<Identity: ::windows::core::IUnknownImpl, Impl: IWMPControls2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lstep: i32) -> ::windows::core::HRESULT {
@@ -2666,6 +2710,8 @@ pub trait IWMPControls3_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn currentPositionTimecode(&self, bstrtimecode: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetcurrentPositionTimecode(&self, bstrtimecode: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPControls3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPControls3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPControls3_Impl, const OFFSET: isize>() -> IWMPControls3_Vtbl {
@@ -2743,6 +2789,8 @@ pub trait IWMPConvert_Impl: Sized {
     fn GetErrorURL(&self, pbstrurl: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPConvert {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPConvert_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPConvert_Impl, const OFFSET: isize>() -> IWMPConvert_Vtbl {
         unsafe extern "system" fn ConvertFile<Identity: ::windows::core::IUnknownImpl, Impl: IWMPConvert_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrinputfile: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrdestinationfolder: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbstroutputfile: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2789,6 +2837,8 @@ pub trait IWMPCore_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn error(&self) -> ::windows::core::Result<IWMPError>;
     fn status(&self, pbstrstatus: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPCore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPCore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCore_Impl, const OFFSET: isize>() -> IWMPCore_Vtbl {
@@ -2991,6 +3041,8 @@ pub trait IWMPCore2_Impl: Sized + super::super::System::Com::IDispatch_Impl + IW
     fn dvd(&self) -> ::windows::core::Result<IWMPDVD>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPCore2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPCore2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCore2_Impl, const OFFSET: isize>() -> IWMPCore2_Vtbl {
         unsafe extern "system" fn dvd<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCore2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdvd: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3015,6 +3067,8 @@ pub trait IWMPCore3_Impl: Sized + super::super::System::Com::IDispatch_Impl + IW
     fn newPlaylist(&self, bstrname: &super::super::Foundation::BSTR, bstrurl: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWMPPlaylist>;
     fn newMedia(&self, bstrurl: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWMPMedia>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPCore3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPCore3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPCore3_Impl, const OFFSET: isize>() -> IWMPCore3_Vtbl {
@@ -3059,6 +3113,8 @@ pub trait IWMPDVD_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn back(&self) -> ::windows::core::Result<()>;
     fn resume(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPDVD {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPDVD_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDVD_Impl, const OFFSET: isize>() -> IWMPDVD_Vtbl {
@@ -3115,6 +3171,8 @@ pub trait IWMPDownloadCollection_Impl: Sized + super::super::System::Com::IDispa
     fn removeItem(&self, litem: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPDownloadCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPDownloadCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDownloadCollection_Impl, const OFFSET: isize>() -> IWMPDownloadCollection_Vtbl {
@@ -3186,6 +3244,8 @@ pub trait IWMPDownloadItem_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn cancel(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPDownloadItem {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPDownloadItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDownloadItem_Impl, const OFFSET: isize>() -> IWMPDownloadItem_Vtbl {
         unsafe extern "system" fn sourceURL<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDownloadItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrurl: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3249,6 +3309,8 @@ pub trait IWMPDownloadItem2_Impl: Sized + super::super::System::Com::IDispatch_I
     fn getItemInfo(&self, bstritemname: &super::super::Foundation::BSTR, pbstrval: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPDownloadItem2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPDownloadItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDownloadItem2_Impl, const OFFSET: isize>() -> IWMPDownloadItem2_Vtbl {
         unsafe extern "system" fn getItemInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDownloadItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstritemname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbstrval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3267,6 +3329,8 @@ pub trait IWMPDownloadManager_Impl: Sized + super::super::System::Com::IDispatch
     fn getDownloadCollection(&self, lcollectionid: i32) -> ::windows::core::Result<IWMPDownloadCollection>;
     fn createDownloadCollection(&self) -> ::windows::core::Result<IWMPDownloadCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPDownloadManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPDownloadManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPDownloadManager_Impl, const OFFSET: isize>() -> IWMPDownloadManager_Vtbl {
@@ -3316,6 +3380,8 @@ pub trait IWMPEffects_Impl: Sized {
     fn GoFullscreen(&self, ffullscreen: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn RenderFullScreen(&self, plevels: *mut TimedLevel) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IWMPEffects {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IWMPEffects_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEffects_Impl, const OFFSET: isize>() -> IWMPEffects_Vtbl {
@@ -3403,6 +3469,8 @@ pub trait IWMPEffects2_Impl: Sized + IWMPEffects_Impl {
     fn RenderWindowed(&self, pdata: *mut TimedLevel, frequiredrender: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPEffects2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IWMPEffects2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEffects2_Impl, const OFFSET: isize>() -> IWMPEffects2_Vtbl {
         unsafe extern "system" fn SetCore<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEffects2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pplayer: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3457,6 +3525,8 @@ pub trait IWMPError_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn webHelp(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPError {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPError_Impl, const OFFSET: isize>() -> IWMPError_Vtbl {
         unsafe extern "system" fn clearErrorQueue<Identity: ::windows::core::IUnknownImpl, Impl: IWMPError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3506,6 +3576,8 @@ pub trait IWMPErrorItem_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn customUrl(&self, pbstrcustomurl: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPErrorItem {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPErrorItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPErrorItem_Impl, const OFFSET: isize>() -> IWMPErrorItem_Vtbl {
         unsafe extern "system" fn errorCode<Identity: ::windows::core::IUnknownImpl, Impl: IWMPErrorItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phr: *mut i32) -> ::windows::core::HRESULT {
@@ -3550,6 +3622,8 @@ impl IWMPErrorItem_Vtbl {
 pub trait IWMPErrorItem2_Impl: Sized + super::super::System::Com::IDispatch_Impl + IWMPErrorItem_Impl {
     fn condition(&self, plcondition: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPErrorItem2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPErrorItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPErrorItem2_Impl, const OFFSET: isize>() -> IWMPErrorItem2_Vtbl {
@@ -3612,6 +3686,8 @@ pub trait IWMPEvents_Impl: Sized {
     fn MouseMove(&self, nbutton: i16, nshiftstate: i16, fx: i32, fy: i32);
     fn MouseUp(&self, nbutton: i16, nshiftstate: i16, fx: i32, fy: i32);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEvents_Impl, const OFFSET: isize>() -> IWMPEvents_Vtbl {
@@ -3903,6 +3979,8 @@ pub trait IWMPEvents2_Impl: Sized + IWMPEvents_Impl {
     fn CreatePartnershipComplete(&self, pdevice: &::core::option::Option<IWMPSyncDevice>, hrresult: ::windows::core::HRESULT);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPEvents2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPEvents2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEvents2_Impl, const OFFSET: isize>() -> IWMPEvents2_Vtbl {
         unsafe extern "system" fn DeviceConnect<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEvents2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevice: ::windows::core::RawPtr) {
@@ -3963,6 +4041,8 @@ pub trait IWMPEvents3_Impl: Sized + IWMPEvents_Impl + IWMPEvents2_Impl {
     fn MediaCollectionMediaAdded(&self, pdispmedia: &::core::option::Option<super::super::System::Com::IDispatch>);
     fn MediaCollectionMediaRemoved(&self, pdispmedia: &::core::option::Option<super::super::System::Com::IDispatch>);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPEvents3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPEvents3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEvents3_Impl, const OFFSET: isize>() -> IWMPEvents3_Vtbl {
@@ -4045,6 +4125,8 @@ pub trait IWMPEvents4_Impl: Sized + IWMPEvents_Impl + IWMPEvents2_Impl + IWMPEve
     fn DeviceEstimation(&self, pdevice: &::core::option::Option<IWMPSyncDevice>, hrresult: ::windows::core::HRESULT, qwestimatedusedspace: i64, qwestimatedspace: i64);
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPEvents4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPEvents4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEvents4_Impl, const OFFSET: isize>() -> IWMPEvents4_Vtbl {
         unsafe extern "system" fn DeviceEstimation<Identity: ::windows::core::IUnknownImpl, Impl: IWMPEvents4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdevice: ::windows::core::RawPtr, hrresult: ::windows::core::HRESULT, qwestimatedusedspace: i64, qwestimatedspace: i64) {
@@ -4072,6 +4154,8 @@ pub trait IWMPFolderMonitorServices_Impl: Sized {
     fn startScan(&self) -> ::windows::core::Result<()>;
     fn stopScan(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPFolderMonitorServices {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMPFolderMonitorServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPFolderMonitorServices_Impl, const OFFSET: isize>() -> IWMPFolderMonitorServices_Vtbl {
@@ -4154,6 +4238,7 @@ pub trait IWMPGraphCreation_Impl: Sized {
     fn GraphCreationPostRender(&self, pfiltergraph: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetGraphCreationFlags(&self, pdwflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPGraphCreation {}
 impl IWMPGraphCreation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPGraphCreation_Impl, const OFFSET: isize>() -> IWMPGraphCreation_Vtbl {
         unsafe extern "system" fn GraphCreationPreRender<Identity: ::windows::core::IUnknownImpl, Impl: IWMPGraphCreation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfiltergraph: *mut ::core::ffi::c_void, preserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4189,6 +4274,8 @@ pub trait IWMPLibrary_Impl: Sized {
     fn mediaCollection(&self) -> ::windows::core::Result<IWMPMediaCollection>;
     fn isIdentical(&self, piwmplibrary: &::core::option::Option<IWMPLibrary>, pvbool: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPLibrary {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibrary_Impl, const OFFSET: isize>() -> IWMPLibrary_Vtbl {
@@ -4235,6 +4322,8 @@ pub trait IWMPLibrary2_Impl: Sized + IWMPLibrary_Impl {
     fn getItemInfo(&self, bstritemname: &super::super::Foundation::BSTR, pbstrval: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPLibrary2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPLibrary2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibrary2_Impl, const OFFSET: isize>() -> IWMPLibrary2_Vtbl {
         unsafe extern "system" fn getItemInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibrary2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstritemname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbstrval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4252,6 +4341,7 @@ pub trait IWMPLibraryServices_Impl: Sized {
     fn getCountByType(&self, wmplt: WMPLibraryType, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn getLibraryByType(&self, wmplt: WMPLibraryType, lindex: i32) -> ::windows::core::Result<IWMPLibrary>;
 }
+impl ::windows::core::RuntimeName for IWMPLibraryServices {}
 impl IWMPLibraryServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibraryServices_Impl, const OFFSET: isize>() -> IWMPLibraryServices_Vtbl {
         unsafe extern "system" fn getCountByType<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibraryServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wmplt: WMPLibraryType, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -4285,6 +4375,7 @@ pub trait IWMPLibrarySharingServices_Impl: Sized {
     fn isLibrarySharingEnabled(&self, pvbenabled: *mut i16) -> ::windows::core::Result<()>;
     fn showLibrarySharing(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPLibrarySharingServices {}
 impl IWMPLibrarySharingServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibrarySharingServices_Impl, const OFFSET: isize>() -> IWMPLibrarySharingServices_Vtbl {
         unsafe extern "system" fn isLibraryShared<Identity: ::windows::core::IUnknownImpl, Impl: IWMPLibrarySharingServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvbshared: *mut i16) -> ::windows::core::HRESULT {
@@ -4334,6 +4425,8 @@ pub trait IWMPMedia_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn isMemberOf(&self, pplaylist: &::core::option::Option<IWMPPlaylist>, pvarfismemberof: *mut i16) -> ::windows::core::Result<()>;
     fn isReadOnlyItem(&self, bstritemname: &super::super::Foundation::BSTR, pvarfisreadonly: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMedia {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMedia_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMedia_Impl, const OFFSET: isize>() -> IWMPMedia_Vtbl {
@@ -4458,6 +4551,8 @@ pub trait IWMPMedia2_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn error(&self) -> ::windows::core::Result<IWMPErrorItem>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMedia2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMedia2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMedia2_Impl, const OFFSET: isize>() -> IWMPMedia2_Vtbl {
         unsafe extern "system" fn error<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMedia2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppiwmperroritem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4482,6 +4577,8 @@ pub trait IWMPMedia3_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn getAttributeCountByType(&self, bstrtype: &super::super::Foundation::BSTR, bstrlanguage: &super::super::Foundation::BSTR, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn getItemInfoByType(&self, bstrtype: &super::super::Foundation::BSTR, bstrlanguage: &super::super::Foundation::BSTR, lindex: i32, pvarvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMedia3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMedia3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMedia3_Impl, const OFFSET: isize>() -> IWMPMedia3_Vtbl {
@@ -4520,6 +4617,8 @@ pub trait IWMPMediaCollection_Impl: Sized + super::super::System::Com::IDispatch
     fn setDeleted(&self, pitem: &::core::option::Option<IWMPMedia>, varfisdeleted: i16) -> ::windows::core::Result<()>;
     fn isDeleted(&self, pitem: &::core::option::Option<IWMPMedia>, pvarfisdeleted: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMediaCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMediaCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMediaCollection_Impl, const OFFSET: isize>() -> IWMPMediaCollection_Vtbl {
@@ -4659,6 +4758,8 @@ pub trait IWMPMediaCollection2_Impl: Sized + super::super::System::Com::IDispatc
     fn getByAttributeAndMediaType(&self, bstrattribute: &super::super::Foundation::BSTR, bstrvalue: &super::super::Foundation::BSTR, bstrmediatype: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWMPPlaylist>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMediaCollection2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMediaCollection2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMediaCollection2_Impl, const OFFSET: isize>() -> IWMPMediaCollection2_Vtbl {
         unsafe extern "system" fn createQuery<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMediaCollection2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppquery: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4721,6 +4822,7 @@ pub trait IWMPMediaPluginRegistrar_Impl: Sized {
     fn WMPRegisterPlayerPlugin(&self, pwszfriendlyname: &::windows::core::PCWSTR, pwszdescription: &::windows::core::PCWSTR, pwszuninstallstring: &::windows::core::PCWSTR, dwpriority: u32, guidplugintype: &::windows::core::GUID, clsid: &::windows::core::GUID, cmediatypes: u32, pmediatypes: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn WMPUnRegisterPlayerPlugin(&self, guidplugintype: &::windows::core::GUID, clsid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPMediaPluginRegistrar {}
 impl IWMPMediaPluginRegistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMediaPluginRegistrar_Impl, const OFFSET: isize>() -> IWMPMediaPluginRegistrar_Vtbl {
         unsafe extern "system" fn WMPRegisterPlayerPlugin<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMediaPluginRegistrar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfriendlyname: ::windows::core::PCWSTR, pwszdescription: ::windows::core::PCWSTR, pwszuninstallstring: ::windows::core::PCWSTR, dwpriority: u32, guidplugintype: ::windows::core::GUID, clsid: ::windows::core::GUID, cmediatypes: u32, pmediatypes: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4750,6 +4852,8 @@ pub trait IWMPMetadataPicture_Impl: Sized + super::super::System::Com::IDispatch
     fn description(&self, pbstrdescription: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn URL(&self, pbstrurl: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMetadataPicture {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMetadataPicture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMetadataPicture_Impl, const OFFSET: isize>() -> IWMPMetadataPicture_Vtbl {
@@ -4790,6 +4894,8 @@ pub trait IWMPMetadataText_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn description(&self, pbstrdescription: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn text(&self, pbstrtext: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPMetadataText {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPMetadataText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPMetadataText_Impl, const OFFSET: isize>() -> IWMPMetadataText_Vtbl {
@@ -4844,6 +4950,8 @@ pub trait IWMPNetwork_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn encodedFrameRate(&self, plframerate: *mut i32) -> ::windows::core::Result<()>;
     fn framesSkipped(&self, plframes: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPNetwork {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPNetwork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNetwork_Impl, const OFFSET: isize>() -> IWMPNetwork_Vtbl {
@@ -5034,6 +5142,8 @@ pub trait IWMPNodeRealEstate_Impl: Sized {
     fn GetFullScreen(&self, pffullscreen: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPNodeRealEstate {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPNodeRealEstate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeRealEstate_Impl, const OFFSET: isize>() -> IWMPNodeRealEstate_Vtbl {
         unsafe extern "system" fn GetDesiredSize<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeRealEstate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psize: *mut super::super::Foundation::SIZE) -> ::windows::core::HRESULT {
@@ -5092,6 +5202,8 @@ pub trait IWMPNodeRealEstateHost_Impl: Sized {
     fn OnFullScreenTransition(&self, ffullscreen: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPNodeRealEstateHost {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPNodeRealEstateHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeRealEstateHost_Impl, const OFFSET: isize>() -> IWMPNodeRealEstateHost_Vtbl {
         unsafe extern "system" fn OnDesiredSizeChange<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeRealEstateHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psize: *mut super::super::Foundation::SIZE) -> ::windows::core::HRESULT {
@@ -5118,6 +5230,7 @@ pub trait IWMPNodeWindowed_Impl: Sized {
     fn SetOwnerWindow(&self, hwnd: isize) -> ::windows::core::Result<()>;
     fn GetOwnerWindow(&self, phwnd: *mut isize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPNodeWindowed {}
 impl IWMPNodeWindowed_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowed_Impl, const OFFSET: isize>() -> IWMPNodeWindowed_Vtbl {
         unsafe extern "system" fn SetOwnerWindow<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowed_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: isize) -> ::windows::core::HRESULT {
@@ -5145,6 +5258,8 @@ pub trait IWMPNodeWindowedHost_Impl: Sized {
     fn OnWindowMessageFromRenderer(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPNodeWindowedHost {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPNodeWindowedHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowedHost_Impl, const OFFSET: isize>() -> IWMPNodeWindowedHost_Vtbl {
         unsafe extern "system" fn OnWindowMessageFromRenderer<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowedHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5166,6 +5281,8 @@ pub trait IWMPNodeWindowless_Impl: Sized + IWMPWindowMessageSink_Impl {
     fn OnDraw(&self, hdc: isize, prcdraw: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPNodeWindowless {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPNodeWindowless_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowless_Impl, const OFFSET: isize>() -> IWMPNodeWindowless_Vtbl {
         unsafe extern "system" fn OnDraw<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowless_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hdc: isize, prcdraw: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -5183,6 +5300,8 @@ impl IWMPNodeWindowless_Vtbl {
 pub trait IWMPNodeWindowlessHost_Impl: Sized {
     fn InvalidateRect(&self, prc: *const super::super::Foundation::RECT, ferase: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPNodeWindowlessHost {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMPNodeWindowlessHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPNodeWindowlessHost_Impl, const OFFSET: isize>() -> IWMPNodeWindowlessHost_Vtbl {
@@ -5208,6 +5327,8 @@ pub trait IWMPPlayer_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn SetuiMode(&self, bstrmode: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn uiMode(&self, pbstrmode: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlayer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlayer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayer_Impl, const OFFSET: isize>() -> IWMPPlayer_Vtbl {
@@ -5282,6 +5403,8 @@ pub trait IWMPPlayer2_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn windowlessVideo(&self, pbenabled: *mut i16) -> ::windows::core::Result<()>;
     fn SetwindowlessVideo(&self, benabled: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlayer2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlayer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayer2_Impl, const OFFSET: isize>() -> IWMPPlayer2_Vtbl {
@@ -5380,6 +5503,8 @@ pub trait IWMPPlayer3_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn windowlessVideo(&self, pbenabled: *mut i16) -> ::windows::core::Result<()>;
     fn SetwindowlessVideo(&self, benabled: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlayer3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlayer3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayer3_Impl, const OFFSET: isize>() -> IWMPPlayer3_Vtbl {
@@ -5481,6 +5606,8 @@ pub trait IWMPPlayer4_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn playerApplication(&self) -> ::windows::core::Result<IWMPPlayerApplication>;
     fn openPlayer(&self, bstrurl: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlayer4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlayer4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayer4_Impl, const OFFSET: isize>() -> IWMPPlayer4_Vtbl {
@@ -5596,6 +5723,8 @@ pub trait IWMPPlayerApplication_Impl: Sized + super::super::System::Com::IDispat
     fn hasDisplay(&self, pbhasdisplay: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlayerApplication {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlayerApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayerApplication_Impl, const OFFSET: isize>() -> IWMPPlayerApplication_Vtbl {
         unsafe extern "system" fn switchToPlayerApplication<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayerApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5637,6 +5766,8 @@ pub trait IWMPPlayerServices_Impl: Sized {
     fn setTaskPaneURL(&self, bstrtaskpane: &super::super::Foundation::BSTR, bstrurl: &super::super::Foundation::BSTR, bstrfriendlyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPPlayerServices {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPPlayerServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayerServices_Impl, const OFFSET: isize>() -> IWMPPlayerServices_Vtbl {
         unsafe extern "system" fn activateUIPlugin<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayerServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrplugin: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -5669,6 +5800,8 @@ impl IWMPPlayerServices_Vtbl {
 pub trait IWMPPlayerServices2_Impl: Sized + IWMPPlayerServices_Impl {
     fn setBackgroundProcessingPriority(&self, bstrpriority: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPPlayerServices2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMPPlayerServices2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlayerServices2_Impl, const OFFSET: isize>() -> IWMPPlayerServices2_Vtbl {
@@ -5703,6 +5836,8 @@ pub trait IWMPPlaylist_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn removeItem(&self, piwmpmedia: &::core::option::Option<IWMPMedia>) -> ::windows::core::Result<()>;
     fn moveItem(&self, lindexold: i32, lindexnew: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlaylist {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlaylist_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlaylist_Impl, const OFFSET: isize>() -> IWMPPlaylist_Vtbl {
@@ -5810,6 +5945,8 @@ pub trait IWMPPlaylistArray_Impl: Sized + super::super::System::Com::IDispatch_I
     fn item(&self, lindex: i32) -> ::windows::core::Result<IWMPPlaylist>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlaylistArray {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlaylistArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlaylistArray_Impl, const OFFSET: isize>() -> IWMPPlaylistArray_Vtbl {
         unsafe extern "system" fn count<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlaylistArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -5848,6 +5985,8 @@ pub trait IWMPPlaylistCollection_Impl: Sized + super::super::System::Com::IDispa
     fn isDeleted(&self, pitem: &::core::option::Option<IWMPPlaylist>, pvarfisdeleted: *mut i16) -> ::windows::core::Result<()>;
     fn importPlaylist(&self, pitem: &::core::option::Option<IWMPPlaylist>) -> ::windows::core::Result<IWMPPlaylist>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPPlaylistCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPPlaylistCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlaylistCollection_Impl, const OFFSET: isize>() -> IWMPPlaylistCollection_Vtbl {
@@ -5933,6 +6072,7 @@ pub trait IWMPPlugin_Impl: Sized {
     fn AdviseWMPServices(&self, pwmpservices: &::core::option::Option<IWMPServices>) -> ::windows::core::Result<()>;
     fn UnAdviseWMPServices(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPPlugin {}
 impl IWMPPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlugin_Impl, const OFFSET: isize>() -> IWMPPlugin_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPlugin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwplaybackcontext: usize) -> ::windows::core::HRESULT {
@@ -5985,6 +6125,8 @@ pub trait IWMPPluginEnable_Impl: Sized {
     fn GetEnable(&self, pfenable: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPPluginEnable {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPPluginEnable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPluginEnable_Impl, const OFFSET: isize>() -> IWMPPluginEnable_Vtbl {
         unsafe extern "system" fn SetEnable<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPluginEnable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fenable: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -6017,6 +6159,8 @@ pub trait IWMPPluginUI_Impl: Sized {
     fn SetProperty(&self, pwszname: &::windows::core::PCWSTR, pvarproperty: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn TranslateAccelerator(&self, lpmsg: *mut super::super::UI::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IWMPPluginUI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IWMPPluginUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPPluginUI_Impl, const OFFSET: isize>() -> IWMPPluginUI_Vtbl {
@@ -6076,6 +6220,8 @@ pub trait IWMPQuery_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn beginNextGroup(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPQuery {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPQuery_Impl, const OFFSET: isize>() -> IWMPQuery_Vtbl {
         unsafe extern "system" fn addCondition<Identity: ::windows::core::IUnknownImpl, Impl: IWMPQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrattribute: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstroperator: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrvalue: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6105,6 +6251,8 @@ pub trait IWMPRemoteMediaServices_Impl: Sized {
     fn GetScriptableObject(&self, pbstrname: *mut super::super::Foundation::BSTR, ppdispatch: *mut ::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
     fn GetCustomUIMode(&self, pbstrfile: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPRemoteMediaServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPRemoteMediaServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPRemoteMediaServices_Impl, const OFFSET: isize>() -> IWMPRemoteMediaServices_Vtbl {
@@ -6146,6 +6294,8 @@ pub trait IWMPRenderConfig_Impl: Sized {
     fn inProcOnly(&self, pfinproc: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPRenderConfig {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPRenderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPRenderConfig_Impl, const OFFSET: isize>() -> IWMPRenderConfig_Vtbl {
         unsafe extern "system" fn SetinProcOnly<Identity: ::windows::core::IUnknownImpl, Impl: IWMPRenderConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, finproc: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -6172,6 +6322,7 @@ pub trait IWMPServices_Impl: Sized {
     fn GetStreamTime(&self, prt: *mut i64) -> ::windows::core::Result<()>;
     fn GetStreamState(&self, pstate: *mut WMPServices_StreamState) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPServices {}
 impl IWMPServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPServices_Impl, const OFFSET: isize>() -> IWMPServices_Vtbl {
         unsafe extern "system" fn GetStreamTime<Identity: ::windows::core::IUnknownImpl, Impl: IWMPServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prt: *mut i64) -> ::windows::core::HRESULT {
@@ -6220,6 +6371,8 @@ pub trait IWMPSettings_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn enableErrorDialogs(&self, pfenableerrordialogs: *mut i16) -> ::windows::core::Result<()>;
     fn SetenableErrorDialogs(&self, fenableerrordialogs: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSettings_Impl, const OFFSET: isize>() -> IWMPSettings_Vtbl {
@@ -6376,6 +6529,8 @@ pub trait IWMPSettings2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn requestMediaAccessRights(&self, bstrdesiredaccess: &super::super::Foundation::BSTR, pvbaccepted: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPSettings2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPSettings2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSettings2_Impl, const OFFSET: isize>() -> IWMPSettings2_Vtbl {
         unsafe extern "system" fn defaultAudioLanguage<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSettings2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pllangid: *mut i32) -> ::windows::core::HRESULT {
@@ -6409,6 +6564,8 @@ pub trait IWMPSkinManager_Impl: Sized {
     fn SetVisualStyle(&self, bstrpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPSkinManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPSkinManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSkinManager_Impl, const OFFSET: isize>() -> IWMPSkinManager_Vtbl {
         unsafe extern "system" fn SetVisualStyle<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSkinManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrpath: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6427,6 +6584,8 @@ pub trait IWMPStringCollection_Impl: Sized + super::super::System::Com::IDispatc
     fn count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn item(&self, lindex: i32, pbstrstring: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPStringCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPStringCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPStringCollection_Impl, const OFFSET: isize>() -> IWMPStringCollection_Vtbl {
@@ -6457,6 +6616,8 @@ pub trait IWMPStringCollection2_Impl: Sized + super::super::System::Com::IDispat
     fn getAttributeCountByType(&self, lcollectionindex: i32, bstrtype: &super::super::Foundation::BSTR, bstrlanguage: &super::super::Foundation::BSTR, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn getItemInfoByType(&self, lcollectionindex: i32, bstrtype: &super::super::Foundation::BSTR, bstrlanguage: &super::super::Foundation::BSTR, lattributeindex: i32, pvarvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMPStringCollection2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMPStringCollection2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPStringCollection2_Impl, const OFFSET: isize>() -> IWMPStringCollection2_Vtbl {
@@ -6500,6 +6661,8 @@ pub trait IWMPSubscriptionService_Impl: Sized {
     fn startBackgroundProcessing(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPSubscriptionService {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPSubscriptionService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSubscriptionService_Impl, const OFFSET: isize>() -> IWMPSubscriptionService_Vtbl {
         unsafe extern "system" fn allowPlay<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSubscriptionService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pmedia: ::windows::core::RawPtr, pfallowplay: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -6542,6 +6705,8 @@ pub trait IWMPSubscriptionService2_Impl: Sized + IWMPSubscriptionService_Impl {
     fn prepareForSync(&self, bstrfilename: &super::super::Foundation::BSTR, bstrdevicename: &super::super::Foundation::BSTR, pcb: &::core::option::Option<IWMPSubscriptionServiceCallback>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPSubscriptionService2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPSubscriptionService2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSubscriptionService2_Impl, const OFFSET: isize>() -> IWMPSubscriptionService2_Vtbl {
         unsafe extern "system" fn stopBackgroundProcessing<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSubscriptionService2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6579,6 +6744,7 @@ impl IWMPSubscriptionService2_Vtbl {
 pub trait IWMPSubscriptionServiceCallback_Impl: Sized {
     fn onComplete(&self, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPSubscriptionServiceCallback {}
 impl IWMPSubscriptionServiceCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSubscriptionServiceCallback_Impl, const OFFSET: isize>() -> IWMPSubscriptionServiceCallback_Vtbl {
         unsafe extern "system" fn onComplete<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSubscriptionServiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -6611,6 +6777,8 @@ pub trait IWMPSyncDevice_Impl: Sized {
     fn showSettings(&self) -> ::windows::core::Result<()>;
     fn isIdentical(&self, pdevice: &::core::option::Option<IWMPSyncDevice>, pvbool: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPSyncDevice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMPSyncDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSyncDevice_Impl, const OFFSET: isize>() -> IWMPSyncDevice_Vtbl {
@@ -6723,6 +6891,8 @@ pub trait IWMPSyncDevice2_Impl: Sized + IWMPSyncDevice_Impl {
     fn setItemInfo(&self, bstritemname: &super::super::Foundation::BSTR, bstrval: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPSyncDevice2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMPSyncDevice2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSyncDevice2_Impl, const OFFSET: isize>() -> IWMPSyncDevice2_Vtbl {
         unsafe extern "system" fn setItemInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSyncDevice2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstritemname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrval: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6741,6 +6911,8 @@ pub trait IWMPSyncDevice3_Impl: Sized + IWMPSyncDevice_Impl + IWMPSyncDevice2_Im
     fn estimateSyncSize(&self, pnonruleplaylist: &::core::option::Option<IWMPPlaylist>, prulesplaylist: &::core::option::Option<IWMPPlaylist>) -> ::windows::core::Result<()>;
     fn cancelEstimation(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMPSyncDevice3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMPSyncDevice3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSyncDevice3_Impl, const OFFSET: isize>() -> IWMPSyncDevice3_Vtbl {
@@ -6768,6 +6940,7 @@ pub trait IWMPSyncServices_Impl: Sized {
     fn deviceCount(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn getDevice(&self, lindex: i32) -> ::windows::core::Result<IWMPSyncDevice>;
 }
+impl ::windows::core::RuntimeName for IWMPSyncServices {}
 impl IWMPSyncServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSyncServices_Impl, const OFFSET: isize>() -> IWMPSyncServices_Vtbl {
         unsafe extern "system" fn deviceCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMPSyncServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -6799,6 +6972,7 @@ impl IWMPSyncServices_Vtbl {
 pub trait IWMPTranscodePolicy_Impl: Sized {
     fn allowTranscode(&self, pvballow: *mut i16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPTranscodePolicy {}
 impl IWMPTranscodePolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPTranscodePolicy_Impl, const OFFSET: isize>() -> IWMPTranscodePolicy_Vtbl {
         unsafe extern "system" fn allowTranscode<Identity: ::windows::core::IUnknownImpl, Impl: IWMPTranscodePolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvballow: *mut i16) -> ::windows::core::HRESULT {
@@ -6815,6 +6989,7 @@ impl IWMPTranscodePolicy_Vtbl {
 pub trait IWMPUserEventSink_Impl: Sized {
     fn NotifyUserEvent(&self, eventcode: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPUserEventSink {}
 impl IWMPUserEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPUserEventSink_Impl, const OFFSET: isize>() -> IWMPUserEventSink_Vtbl {
         unsafe extern "system" fn NotifyUserEvent<Identity: ::windows::core::IUnknownImpl, Impl: IWMPUserEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventcode: i32) -> ::windows::core::HRESULT {
@@ -6833,6 +7008,8 @@ pub trait IWMPVideoRenderConfig_Impl: Sized {
     fn SetpresenterActivate(&self, pactivate: &::core::option::Option<super::MediaFoundation::IMFActivate>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Media_MediaFoundation")]
+impl ::windows::core::RuntimeName for IWMPVideoRenderConfig {}
+#[cfg(feature = "Win32_Media_MediaFoundation")]
 impl IWMPVideoRenderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPVideoRenderConfig_Impl, const OFFSET: isize>() -> IWMPVideoRenderConfig_Vtbl {
         unsafe extern "system" fn SetpresenterActivate<Identity: ::windows::core::IUnknownImpl, Impl: IWMPVideoRenderConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pactivate: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6850,6 +7027,8 @@ impl IWMPVideoRenderConfig_Vtbl {
 pub trait IWMPWindowMessageSink_Impl: Sized {
     fn OnWindowMessage(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMPWindowMessageSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMPWindowMessageSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPWindowMessageSink_Impl, const OFFSET: isize>() -> IWMPWindowMessageSink_Vtbl {
@@ -6911,6 +7090,8 @@ pub trait IXFeed_Impl: Sized {
     fn UnreadItemCount(&self) -> ::windows::core::Result<u32>;
     fn ItemCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXFeed {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXFeed_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeed_Impl, const OFFSET: isize>() -> IXFeed_Vtbl {
@@ -7364,6 +7545,8 @@ pub trait IXFeed2_Impl: Sized + IXFeed_Impl {
     fn ClearCredentials(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXFeed2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXFeed2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeed2_Impl, const OFFSET: isize>() -> IXFeed2_Vtbl {
         unsafe extern "system" fn GetItemByEffectiveId<Identity: ::windows::core::IUnknownImpl, Impl: IXFeed2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uieffectiveid: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7443,6 +7626,7 @@ pub trait IXFeedEnclosure_Impl: Sized {
     fn RemoveFile(&self) -> ::windows::core::Result<()>;
     fn SetFile(&self, pszdownloadurl: &::windows::core::PCWSTR, pszdownloadfilepath: &::windows::core::PCWSTR, pszdownloadmimetype: &::windows::core::PCWSTR, pszenclosurefilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXFeedEnclosure {}
 impl IXFeedEnclosure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedEnclosure_Impl, const OFFSET: isize>() -> IXFeedEnclosure_Vtbl {
         unsafe extern "system" fn Url<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedEnclosure_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -7589,6 +7773,7 @@ pub trait IXFeedEvents_Impl: Sized {
     fn FeedDownloadCompleted(&self, pszpath: &::windows::core::PCWSTR, fde: FEEDS_DOWNLOAD_ERROR) -> ::windows::core::Result<()>;
     fn FeedItemCountChanged(&self, pszpath: &::windows::core::PCWSTR, feicfflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXFeedEvents {}
 impl IXFeedEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedEvents_Impl, const OFFSET: isize>() -> IXFeedEvents_Vtbl {
         unsafe extern "system" fn Error<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7668,6 +7853,8 @@ pub trait IXFeedFolder_Impl: Sized {
     fn TotalUnreadItemCount(&self) -> ::windows::core::Result<u32>;
     fn TotalItemCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXFeedFolder {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXFeedFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedFolder_Impl, const OFFSET: isize>() -> IXFeedFolder_Vtbl {
@@ -7847,6 +8034,7 @@ pub trait IXFeedFolderEvents_Impl: Sized {
     fn FeedDownloadCompleted(&self, pszpath: &::windows::core::PCWSTR, fde: FEEDS_DOWNLOAD_ERROR) -> ::windows::core::Result<()>;
     fn FeedItemCountChanged(&self, pszpath: &::windows::core::PCWSTR, feicfflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXFeedFolderEvents {}
 impl IXFeedFolderEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedFolderEvents_Impl, const OFFSET: isize>() -> IXFeedFolderEvents_Vtbl {
         unsafe extern "system" fn Error<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedFolderEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7973,6 +8161,8 @@ pub trait IXFeedItem_Impl: Sized {
     fn LastDownloadTime(&self) -> ::windows::core::Result<super::super::Foundation::SYSTEMTIME>;
     fn Modified(&self) -> ::windows::core::Result<super::super::Foundation::SYSTEMTIME>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXFeedItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXFeedItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedItem_Impl, const OFFSET: isize>() -> IXFeedItem_Vtbl {
@@ -8169,6 +8359,8 @@ pub trait IXFeedItem2_Impl: Sized + IXFeedItem_Impl {
     fn EffectiveId(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXFeedItem2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXFeedItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedItem2_Impl, const OFFSET: isize>() -> IXFeedItem2_Vtbl {
         unsafe extern "system" fn EffectiveId<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puieffectiveid: *mut u32) -> ::windows::core::HRESULT {
@@ -8192,6 +8384,7 @@ pub trait IXFeedsEnum_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<u32>;
     fn Item(&self, uiindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXFeedsEnum {}
 impl IXFeedsEnum_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedsEnum_Impl, const OFFSET: isize>() -> IXFeedsEnum_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedsEnum_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puicount: *mut u32) -> ::windows::core::HRESULT {
@@ -8235,6 +8428,8 @@ pub trait IXFeedsManager_Impl: Sized {
     fn Normalize(&self, pstreamin: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<super::super::System::Com::IStream>;
     fn ItemCountLimit(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXFeedsManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXFeedsManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXFeedsManager_Impl, const OFFSET: isize>() -> IXFeedsManager_Vtbl {
@@ -8386,6 +8581,8 @@ impl IXFeedsManager_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _WMPOCXEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _WMPOCXEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _WMPOCXEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _WMPOCXEvents_Impl, const OFFSET: isize>() -> _WMPOCXEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
@@ -7,6 +7,8 @@ pub trait IAVIEditStream_Impl: Sized {
     fn SetInfo(&self, lpinfo: *const AVISTREAMINFOW, cbinfo: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAVIEditStream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAVIEditStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAVIEditStream_Impl, const OFFSET: isize>() -> IAVIEditStream_Vtbl {
         unsafe extern "system" fn Cut<Identity: ::windows::core::IUnknownImpl, Impl: IAVIEditStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plstart: *mut i32, pllength: *mut i32, ppresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -63,6 +65,8 @@ pub trait IAVIFile_Impl: Sized {
     fn EndRecord(&self) -> ::windows::core::Result<()>;
     fn DeleteStream(&self, fcctype: u32, lparam: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAVIFile {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAVIFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAVIFile_Impl, const OFFSET: isize>() -> IAVIFile_Vtbl {
@@ -121,6 +125,8 @@ pub trait IAVIPersistFile_Impl: Sized + super::super::System::Com::IPersist_Impl
     fn Reserved1(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAVIPersistFile {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAVIPersistFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAVIPersistFile_Impl, const OFFSET: isize>() -> IAVIPersistFile_Vtbl {
         unsafe extern "system" fn Reserved1<Identity: ::windows::core::IUnknownImpl, Impl: IAVIPersistFile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -148,6 +154,8 @@ pub trait IAVIStream_Impl: Sized {
     fn WriteData(&self, fcc: u32, lp: *const ::core::ffi::c_void, cb: i32) -> ::windows::core::Result<()>;
     fn SetInfo(&self, lpinfo: *const AVISTREAMINFOW, cbinfo: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAVIStream {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAVIStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAVIStream_Impl, const OFFSET: isize>() -> IAVIStream_Vtbl {
@@ -229,6 +237,7 @@ pub trait IAVIStreaming_Impl: Sized {
     fn Begin(&self, lstart: i32, lend: i32, lrate: i32) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAVIStreaming {}
 impl IAVIStreaming_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAVIStreaming_Impl, const OFFSET: isize>() -> IAVIStreaming_Vtbl {
         unsafe extern "system" fn Begin<Identity: ::windows::core::IUnknownImpl, Impl: IAVIStreaming_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lstart: i32, lend: i32, lrate: i32) -> ::windows::core::HRESULT {
@@ -254,6 +263,8 @@ pub trait IGetFrame_Impl: Sized {
     fn End(&self) -> ::windows::core::Result<()>;
     fn SetFormat(&self, lpbi: *const super::super::Graphics::Gdi::BITMAPINFOHEADER, lpbits: *const ::core::ffi::c_void, x: i32, y: i32, dx: i32, dy: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IGetFrame {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl IGetFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetFrame_Impl, const OFFSET: isize>() -> IGetFrame_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
@@ -5,6 +5,8 @@ pub trait IPhotoAcquire_Impl: Sized {
     fn EnumResults(&self) -> ::windows::core::Result<super::super::System::Com::IEnumString>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPhotoAcquire {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPhotoAcquire_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquire_Impl, const OFFSET: isize>() -> IPhotoAcquire_Vtbl {
         unsafe extern "system" fn CreatePhotoSource<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquire_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdevice: ::windows::core::PCWSTR, ppphotoacquiresource: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -52,6 +54,8 @@ pub trait IPhotoAcquireDeviceSelectionDialog_Impl: Sized {
     fn DoModal(&self, hwndparent: super::super::Foundation::HWND, dwdeviceflags: u32, pbstrdeviceid: *mut super::super::Foundation::BSTR, pndevicetype: *mut DEVICE_SELECTION_DEVICE_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPhotoAcquireDeviceSelectionDialog {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPhotoAcquireDeviceSelectionDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireDeviceSelectionDialog_Impl, const OFFSET: isize>() -> IPhotoAcquireDeviceSelectionDialog_Vtbl {
         unsafe extern "system" fn SetTitle<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireDeviceSelectionDialog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psztitle: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -92,6 +96,8 @@ pub trait IPhotoAcquireItem_Impl: Sized {
     fn GetSubItemCount(&self) -> ::windows::core::Result<u32>;
     fn GetSubItemAt(&self, nitemindex: u32) -> ::windows::core::Result<IPhotoAcquireItem>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IPhotoAcquireItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IPhotoAcquireItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireItem_Impl, const OFFSET: isize>() -> IPhotoAcquireItem_Vtbl {
@@ -208,6 +214,8 @@ pub trait IPhotoAcquireOptionsDialog_Impl: Sized {
     fn SaveData(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPhotoAcquireOptionsDialog {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPhotoAcquireOptionsDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireOptionsDialog_Impl, const OFFSET: isize>() -> IPhotoAcquireOptionsDialog_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireOptionsDialog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszregistryroot: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -261,6 +269,8 @@ pub trait IPhotoAcquirePlugin_Impl: Sized {
     fn TransferComplete(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn DisplayConfigureDialog(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IPhotoAcquirePlugin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IPhotoAcquirePlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquirePlugin_Impl, const OFFSET: isize>() -> IPhotoAcquirePlugin_Vtbl {
@@ -318,6 +328,8 @@ pub trait IPhotoAcquireProgressCB_Impl: Sized {
     fn ErrorAdvise(&self, hr: ::windows::core::HRESULT, pszerrormessage: &::windows::core::PCWSTR, nmessagetype: ERROR_ADVISE_MESSAGE_TYPE) -> ::windows::core::Result<ERROR_ADVISE_RESULT>;
     fn GetUserInput(&self, riidtype: *const ::windows::core::GUID, punknown: &::core::option::Option<::windows::core::IUnknown>, ppropvarresult: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, ppropvardefault: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPhotoAcquireProgressCB {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPhotoAcquireProgressCB_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireProgressCB_Impl, const OFFSET: isize>() -> IPhotoAcquireProgressCB_Vtbl {
@@ -478,6 +490,8 @@ pub trait IPhotoAcquireSettings_Impl: Sized {
     fn GetAcquisitionTime(&self) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPhotoAcquireSettings {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPhotoAcquireSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireSettings_Impl, const OFFSET: isize>() -> IPhotoAcquireSettings_Vtbl {
         unsafe extern "system" fn InitializeFromRegistry<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszregistrykey: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -614,6 +628,8 @@ pub trait IPhotoAcquireSource_Impl: Sized {
     fn BindToObject(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPhotoAcquireSource {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPhotoAcquireSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireSource_Impl, const OFFSET: isize>() -> IPhotoAcquireSource_Vtbl {
         unsafe extern "system" fn GetFriendlyName<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoAcquireSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrfriendlyname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -707,6 +723,8 @@ pub trait IPhotoProgressActionCB_Impl: Sized {
     fn DoAction(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPhotoProgressActionCB {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPhotoProgressActionCB_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoProgressActionCB_Impl, const OFFSET: isize>() -> IPhotoProgressActionCB_Vtbl {
         unsafe extern "system" fn DoAction<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoProgressActionCB_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -741,6 +759,8 @@ pub trait IPhotoProgressDialog_Impl: Sized {
     fn IsCancelled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetUserInput(&self, riidtype: *const ::windows::core::GUID, punknown: &::core::option::Option<::windows::core::IUnknown>, ppropvarresult: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, ppropvardefault: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPhotoProgressDialog {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPhotoProgressDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhotoProgressDialog_Impl, const OFFSET: isize>() -> IPhotoProgressDialog_Vtbl {
@@ -891,6 +911,8 @@ pub trait IUserInputString_Impl: Sized {
     fn GetMruEntryAt(&self, nindex: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetImage(&self, nsize: u32, phbitmap: *mut super::super::Graphics::Gdi::HBITMAP, phicon: *mut super::super::UI::WindowsAndMessaging::HICON) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IUserInputString {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IUserInputString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserInputString_Impl, const OFFSET: isize>() -> IUserInputString_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
@@ -6,6 +6,7 @@ pub trait IEnumSpObjectTokens_Impl: Sized {
     fn Item(&self, index: u32) -> ::windows::core::Result<ISpObjectToken>;
     fn GetCount(&self, pcount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumSpObjectTokens {}
 impl IEnumSpObjectTokens_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSpObjectTokens_Impl, const OFFSET: isize>() -> IEnumSpObjectTokens_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSpObjectTokens_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -78,6 +79,8 @@ pub trait ISpAudio_Impl: Sized + super::super::System::Com::ISequentialStream_Im
     fn GetBufferNotifySize(&self, pcbsize: *mut u32) -> ::windows::core::Result<()>;
     fn SetBufferNotifySize(&self, cbsize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpAudio {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpAudio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpAudio_Impl, const OFFSET: isize>() -> ISpAudio_Vtbl {
@@ -158,6 +161,7 @@ impl ISpAudio_Vtbl {
 pub trait ISpContainerLexicon_Impl: Sized + ISpLexicon_Impl {
     fn AddLexicon(&self, paddlexicon: &::core::option::Option<ISpLexicon>, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpContainerLexicon {}
 impl ISpContainerLexicon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpContainerLexicon_Impl, const OFFSET: isize>() -> ISpContainerLexicon_Vtbl {
         unsafe extern "system" fn AddLexicon<Identity: ::windows::core::IUnknownImpl, Impl: ISpContainerLexicon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, paddlexicon: ::windows::core::RawPtr, dwflags: u32) -> ::windows::core::HRESULT {
@@ -185,6 +189,7 @@ pub trait ISpDataKey_Impl: Sized {
     fn EnumKeys(&self, index: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn EnumValues(&self, index: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISpDataKey {}
 impl ISpDataKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpDataKey_Impl, const OFFSET: isize>() -> ISpDataKey_Vtbl {
         unsafe extern "system" fn SetData<Identity: ::windows::core::IUnknownImpl, Impl: ISpDataKey_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszvaluename: ::windows::core::PCWSTR, cbdata: u32, pdata: *const u8) -> ::windows::core::HRESULT {
@@ -301,6 +306,7 @@ pub trait ISpDisplayAlternates_Impl: Sized {
     fn GetDisplayAlternates(&self, pphrase: *const SPDISPLAYPHRASE, crequestcount: u32, ppcomemphrases: *mut *mut SPDISPLAYPHRASE, pcphrasesreturned: *mut u32) -> ::windows::core::Result<()>;
     fn SetFullStopTrailSpace(&self, ultrailspace: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpDisplayAlternates {}
 impl ISpDisplayAlternates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpDisplayAlternates_Impl, const OFFSET: isize>() -> ISpDisplayAlternates_Vtbl {
         unsafe extern "system" fn GetDisplayAlternates<Identity: ::windows::core::IUnknownImpl, Impl: ISpDisplayAlternates_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pphrase: *const SPDISPLAYPHRASE, crequestcount: u32, ppcomemphrases: *mut *mut SPDISPLAYPHRASE, pcphrasesreturned: *mut u32) -> ::windows::core::HRESULT {
@@ -327,6 +333,7 @@ pub trait ISpEnginePronunciation_Impl: Sized {
     fn Normalize(&self, pszword: &::windows::core::PCWSTR, pszleftcontext: &::windows::core::PCWSTR, pszrightcontext: &::windows::core::PCWSTR, langid: u16, pnormalizationlist: *mut SPNORMALIZATIONLIST) -> ::windows::core::Result<()>;
     fn GetPronunciations(&self, pszword: &::windows::core::PCWSTR, pszleftcontext: &::windows::core::PCWSTR, pszrightcontext: &::windows::core::PCWSTR, langid: u16, penginepronunciationlist: *mut SPWORDPRONUNCIATIONLIST) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpEnginePronunciation {}
 impl ISpEnginePronunciation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpEnginePronunciation_Impl, const OFFSET: isize>() -> ISpEnginePronunciation_Vtbl {
         unsafe extern "system" fn Normalize<Identity: ::windows::core::IUnknownImpl, Impl: ISpEnginePronunciation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, pszleftcontext: ::windows::core::PCWSTR, pszrightcontext: ::windows::core::PCWSTR, langid: u16, pnormalizationlist: *mut SPNORMALIZATIONLIST) -> ::windows::core::HRESULT {
@@ -354,6 +361,8 @@ pub trait ISpEventSink_Impl: Sized {
     fn AddEvents(&self, peventarray: *const SPEVENT, ulcount: u32) -> ::windows::core::Result<()>;
     fn GetEventInterest(&self, pulleventinterest: *mut u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpEventSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpEventSink_Impl, const OFFSET: isize>() -> ISpEventSink_Vtbl {
@@ -383,6 +392,8 @@ pub trait ISpEventSource_Impl: Sized + ISpNotifySource_Impl {
     fn GetEvents(&self, ulcount: u32, peventarray: *mut SPEVENT, pulfetched: *mut u32) -> ::windows::core::Result<()>;
     fn GetInfo(&self, pinfo: *mut SPEVENTSOURCEINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpEventSource {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpEventSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpEventSource_Impl, const OFFSET: isize>() -> ISpEventSource_Vtbl {
@@ -417,6 +428,8 @@ pub trait ISpEventSource2_Impl: Sized + ISpNotifySource_Impl + ISpEventSource_Im
     fn GetEventsEx(&self, ulcount: u32, peventarray: *mut SPEVENTEX, pulfetched: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpEventSource2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpEventSource2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpEventSource2_Impl, const OFFSET: isize>() -> ISpEventSource2_Vtbl {
         unsafe extern "system" fn GetEventsEx<Identity: ::windows::core::IUnknownImpl, Impl: ISpEventSource2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulcount: u32, peventarray: *mut SPEVENTEX, pulfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -441,6 +454,8 @@ pub trait ISpGrammarBuilder_Impl: Sized {
     fn AddResource(&self, hrulestate: *mut SPSTATEHANDLE__, pszresourcename: &::windows::core::PCWSTR, pszresourcevalue: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Commit(&self, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpGrammarBuilder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpGrammarBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpGrammarBuilder_Impl, const OFFSET: isize>() -> ISpGrammarBuilder_Vtbl {
@@ -504,6 +519,7 @@ pub trait ISpGrammarBuilder2_Impl: Sized {
     fn AddTextSubset(&self, hfromstate: *mut SPSTATEHANDLE__, htostate: *mut SPSTATEHANDLE__, psz: &::windows::core::PCWSTR, ematchmode: SPMATCHINGMODE) -> ::windows::core::Result<()>;
     fn SetPhoneticAlphabet(&self, phoneticalphabet: PHONETICALPHABET) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpGrammarBuilder2 {}
 impl ISpGrammarBuilder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpGrammarBuilder2_Impl, const OFFSET: isize>() -> ISpGrammarBuilder2_Vtbl {
         unsafe extern "system" fn AddTextSubset<Identity: ::windows::core::IUnknownImpl, Impl: ISpGrammarBuilder2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hfromstate: *mut SPSTATEHANDLE__, htostate: *mut SPSTATEHANDLE__, psz: ::windows::core::PCWSTR, ematchmode: SPMATCHINGMODE) -> ::windows::core::HRESULT {
@@ -534,6 +550,7 @@ pub trait ISpLexicon_Impl: Sized {
     fn GetGenerationChange(&self, dwflags: u32, pdwgeneration: *mut u32, pwordlist: *mut SPWORDLIST) -> ::windows::core::Result<()>;
     fn GetWords(&self, dwflags: u32, pdwgeneration: *mut u32, pdwcookie: *mut u32, pwordlist: *mut SPWORDLIST) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpLexicon {}
 impl ISpLexicon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpLexicon_Impl, const OFFSET: isize>() -> ISpLexicon_Vtbl {
         unsafe extern "system" fn GetPronunciations<Identity: ::windows::core::IUnknownImpl, Impl: ISpLexicon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, langid: u16, dwflags: u32, pwordpronunciationlist: *mut SPWORDPRONUNCIATIONLIST) -> ::windows::core::HRESULT {
@@ -589,6 +606,8 @@ pub trait ISpMMSysAudio_Impl: Sized + super::super::System::Com::ISequentialStre
     fn SetLineId(&self, ulineid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpMMSysAudio {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpMMSysAudio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpMMSysAudio_Impl, const OFFSET: isize>() -> ISpMMSysAudio_Vtbl {
         unsafe extern "system" fn GetDeviceId<Identity: ::windows::core::IUnknownImpl, Impl: ISpMMSysAudio_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pudeviceid: *mut u32) -> ::windows::core::HRESULT {
@@ -634,6 +653,8 @@ pub trait ISpNotifyCallback_Impl: Sized {
     fn NotifyCallback(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpNotifyCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpNotifyCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifyCallback_Impl, const OFFSET: isize>() -> ISpNotifyCallback_Vtbl {
         unsafe extern "system" fn NotifyCallback<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifyCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -650,6 +671,7 @@ impl ISpNotifyCallback_Vtbl {
 pub trait ISpNotifySink_Impl: Sized {
     fn Notify(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpNotifySink {}
 impl ISpNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifySink_Impl, const OFFSET: isize>() -> ISpNotifySink_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -673,6 +695,8 @@ pub trait ISpNotifySource_Impl: Sized {
     fn WaitForNotifyEvent(&self, dwmilliseconds: u32) -> ::windows::core::Result<()>;
     fn GetNotifyEventHandle(&self) -> super::super::Foundation::HANDLE;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpNotifySource {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpNotifySource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifySource_Impl, const OFFSET: isize>() -> ISpNotifySource_Vtbl {
@@ -736,6 +760,8 @@ pub trait ISpNotifyTranslator_Impl: Sized + ISpNotifySink_Impl {
     fn GetEventHandle(&self) -> super::super::Foundation::HANDLE;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpNotifyTranslator {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpNotifyTranslator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifyTranslator_Impl, const OFFSET: isize>() -> ISpNotifyTranslator_Vtbl {
         unsafe extern "system" fn InitWindowMessage<Identity: ::windows::core::IUnknownImpl, Impl: ISpNotifyTranslator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, msg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -795,6 +821,8 @@ pub trait ISpObjectToken_Impl: Sized + ISpDataKey_Impl {
     fn DisplayUI(&self, hwndparent: super::super::Foundation::HWND, psztitle: &::windows::core::PCWSTR, psztypeofui: &::windows::core::PCWSTR, pvextradata: *mut ::core::ffi::c_void, cbextradata: u32, punkobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn MatchesAttributes(&self, pszattributes: &::windows::core::PCWSTR, pfmatches: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpObjectToken {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpObjectToken_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectToken_Impl, const OFFSET: isize>() -> ISpObjectToken_Vtbl {
@@ -894,6 +922,8 @@ pub trait ISpObjectTokenCategory_Impl: Sized + ISpDataKey_Impl {
     fn GetDefaultTokenId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpObjectTokenCategory {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpObjectTokenCategory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectTokenCategory_Impl, const OFFSET: isize>() -> ISpObjectTokenCategory_Vtbl {
         unsafe extern "system" fn SetId<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectTokenCategory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcategoryid: ::windows::core::PCWSTR, fcreateifnotexist: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -969,6 +999,8 @@ pub trait ISpObjectTokenInit_Impl: Sized + ISpDataKey_Impl + ISpObjectToken_Impl
     fn InitFromDataKey(&self, pszcategoryid: &::windows::core::PCWSTR, psztokenid: &::windows::core::PCWSTR, pdatakey: &::core::option::Option<ISpDataKey>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpObjectTokenInit {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpObjectTokenInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectTokenInit_Impl, const OFFSET: isize>() -> ISpObjectTokenInit_Vtbl {
         unsafe extern "system" fn InitFromDataKey<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectTokenInit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcategoryid: ::windows::core::PCWSTR, psztokenid: ::windows::core::PCWSTR, pdatakey: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -986,6 +1018,7 @@ pub trait ISpObjectWithToken_Impl: Sized {
     fn SetObjectToken(&self, ptoken: &::core::option::Option<ISpObjectToken>) -> ::windows::core::Result<()>;
     fn GetObjectToken(&self) -> ::windows::core::Result<ISpObjectToken>;
 }
+impl ::windows::core::RuntimeName for ISpObjectWithToken {}
 impl ISpObjectWithToken_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectWithToken_Impl, const OFFSET: isize>() -> ISpObjectWithToken_Vtbl {
         unsafe extern "system" fn SetObjectToken<Identity: ::windows::core::IUnknownImpl, Impl: ISpObjectWithToken_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptoken: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1018,6 +1051,7 @@ pub trait ISpPhoneConverter_Impl: Sized + ISpObjectWithToken_Impl {
     fn PhoneToId(&self, pszphone: &::windows::core::PCWSTR) -> ::windows::core::Result<u16>;
     fn IdToPhone(&self, pid: *const u16, pszphone: ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpPhoneConverter {}
 impl ISpPhoneConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhoneConverter_Impl, const OFFSET: isize>() -> ISpPhoneConverter_Vtbl {
         unsafe extern "system" fn PhoneToId<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhoneConverter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszphone: ::windows::core::PCWSTR, pid: *mut u16) -> ::windows::core::HRESULT {
@@ -1054,6 +1088,8 @@ pub trait ISpPhoneticAlphabetConverter_Impl: Sized {
     fn UPS2SAPI(&self, pszupsid: *const u16, pszsapiid: *mut u16, cmaxlength: u32) -> ::windows::core::Result<()>;
     fn GetMaxConvertLength(&self, csrclength: u32, bsapi2ups: super::super::Foundation::BOOL) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpPhoneticAlphabetConverter {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpPhoneticAlphabetConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhoneticAlphabetConverter_Impl, const OFFSET: isize>() -> ISpPhoneticAlphabetConverter_Vtbl {
@@ -1113,6 +1149,8 @@ pub trait ISpPhoneticAlphabetSelection_Impl: Sized {
     fn SetAlphabetToUPS(&self, fforceups: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpPhoneticAlphabetSelection {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpPhoneticAlphabetSelection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhoneticAlphabetSelection_Impl, const OFFSET: isize>() -> ISpPhoneticAlphabetSelection_Vtbl {
         unsafe extern "system" fn IsAlphabetUPS<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhoneticAlphabetSelection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfisups: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1148,6 +1186,8 @@ pub trait ISpPhrase_Impl: Sized {
     fn GetText(&self, ulstart: u32, ulcount: u32, fusetextreplacements: super::super::Foundation::BOOL, ppszcomemtext: *mut ::windows::core::PWSTR, pbdisplayattributes: *mut u8) -> ::windows::core::Result<()>;
     fn Discard(&self, dwvaluetypes: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpPhrase {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpPhrase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhrase_Impl, const OFFSET: isize>() -> ISpPhrase_Vtbl {
@@ -1202,6 +1242,8 @@ pub trait ISpPhrase2_Impl: Sized + ISpPhrase_Impl {
     fn GetAudio(&self, ulstartelement: u32, celements: u32) -> ::windows::core::Result<ISpStreamFormat>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpPhrase2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpPhrase2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhrase2_Impl, const OFFSET: isize>() -> ISpPhrase2_Vtbl {
         unsafe extern "system" fn GetXMLResult<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhrase2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszcomemxmlresult: *mut ::windows::core::PWSTR, options: SPXMLRESULTOPTIONS) -> ::windows::core::HRESULT {
@@ -1242,6 +1284,8 @@ pub trait ISpPhraseAlt_Impl: Sized + ISpPhrase_Impl {
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpPhraseAlt {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpPhraseAlt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhraseAlt_Impl, const OFFSET: isize>() -> ISpPhraseAlt_Vtbl {
         unsafe extern "system" fn GetAltInfo<Identity: ::windows::core::IUnknownImpl, Impl: ISpPhraseAlt_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppparent: *mut ::windows::core::RawPtr, pulstartelementinparent: *mut u32, pcelementsinparent: *mut u32, pcelementsinalt: *mut u32) -> ::windows::core::HRESULT {
@@ -1270,6 +1314,7 @@ pub trait ISpProperties_Impl: Sized {
     fn SetPropertyString(&self, pname: &::windows::core::PCWSTR, pvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetPropertyString(&self, pname: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISpProperties {}
 impl ISpProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpProperties_Impl, const OFFSET: isize>() -> ISpProperties_Vtbl {
         unsafe extern "system" fn SetPropertyNum<Identity: ::windows::core::IUnknownImpl, Impl: ISpProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pname: ::windows::core::PCWSTR, lvalue: i32) -> ::windows::core::HRESULT {
@@ -1331,6 +1376,8 @@ pub trait ISpRecoContext_Impl: Sized + ISpNotifySource_Impl + ISpEventSource_Imp
     fn SetContextState(&self, econtextstate: SPCONTEXTSTATE) -> ::windows::core::Result<()>;
     fn GetContextState(&self, pecontextstate: *mut SPCONTEXTSTATE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio"))]
+impl ::windows::core::RuntimeName for ISpRecoContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio"))]
 impl ISpRecoContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoContext_Impl, const OFFSET: isize>() -> ISpRecoContext_Vtbl {
@@ -1479,6 +1526,7 @@ pub trait ISpRecoContext2_Impl: Sized {
     fn GetGrammarOptions(&self, pegrammaroptions: *mut u32) -> ::windows::core::Result<()>;
     fn SetAdaptationData2(&self, padaptationdata: &::windows::core::PCWSTR, cch: u32, ptopicname: &::windows::core::PCWSTR, eadaptationsettings: u32, erelevance: SPADAPTATIONRELEVANCE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpRecoContext2 {}
 impl ISpRecoContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoContext2_Impl, const OFFSET: isize>() -> ISpRecoContext2_Vtbl {
         unsafe extern "system" fn SetGrammarOptions<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoContext2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, egrammaroptions: u32) -> ::windows::core::HRESULT {
@@ -1528,6 +1576,8 @@ pub trait ISpRecoGrammar_Impl: Sized + ISpGrammarBuilder_Impl {
     fn SaveCmd(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetGrammarState(&self, pegrammarstate: *mut SPGRAMMARSTATE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpRecoGrammar {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpRecoGrammar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoGrammar_Impl, const OFFSET: isize>() -> ISpRecoGrammar_Vtbl {
@@ -1671,6 +1721,8 @@ pub trait ISpRecoGrammar2_Impl: Sized {
     fn SetSMLSecurityManager(&self, psmlsecuritymanager: &::core::option::Option<super::super::System::Com::Urlmon::IInternetSecurityManager>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com_Urlmon")]
+impl ::windows::core::RuntimeName for ISpRecoGrammar2 {}
+#[cfg(feature = "Win32_System_Com_Urlmon")]
 impl ISpRecoGrammar2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoGrammar2_Impl, const OFFSET: isize>() -> ISpRecoGrammar2_Vtbl {
         unsafe extern "system" fn GetRules<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoGrammar2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppcomemrules: *mut *mut SPRULE, punumrules: *mut u32) -> ::windows::core::HRESULT {
@@ -1739,6 +1791,8 @@ pub trait ISpRecoResult_Impl: Sized + ISpPhrase_Impl {
     fn ScaleAudio(&self, paudioformatid: *const ::windows::core::GUID, pwaveformatex: *const super::Audio::WAVEFORMATEX) -> ::windows::core::Result<()>;
     fn GetRecoContext(&self) -> ::windows::core::Result<ISpRecoContext>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpRecoResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpRecoResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoResult_Impl, const OFFSET: isize>() -> ISpRecoResult_Vtbl {
@@ -1811,6 +1865,8 @@ pub trait ISpRecoResult2_Impl: Sized + ISpPhrase_Impl + ISpRecoResult_Impl {
     fn SetTextFeedback(&self, pszfeedback: &::windows::core::PCWSTR, fsuccessful: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpRecoResult2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpRecoResult2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoResult2_Impl, const OFFSET: isize>() -> ISpRecoResult2_Vtbl {
         unsafe extern "system" fn CommitAlternate<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecoResult2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pphrasealt: ::windows::core::RawPtr, ppnewresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1864,6 +1920,8 @@ pub trait ISpRecognizer_Impl: Sized + ISpProperties_Impl {
     fn DisplayUI(&self, hwndparent: super::super::Foundation::HWND, psztitle: &::windows::core::PCWSTR, psztypeofui: &::windows::core::PCWSTR, pvextradata: *mut ::core::ffi::c_void, cbextradata: u32) -> ::windows::core::Result<()>;
     fn EmulateRecognition(&self, pphrase: &::core::option::Option<ISpPhrase>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISpRecognizer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 impl ISpRecognizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecognizer_Impl, const OFFSET: isize>() -> ISpRecognizer_Vtbl {
@@ -2008,6 +2066,8 @@ pub trait ISpRecognizer2_Impl: Sized {
     fn ResetAcousticModelAdaptation(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISpRecognizer2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISpRecognizer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecognizer2_Impl, const OFFSET: isize>() -> ISpRecognizer2_Vtbl {
         unsafe extern "system" fn EmulateRecognitionEx<Identity: ::windows::core::IUnknownImpl, Impl: ISpRecognizer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pphrase: ::windows::core::RawPtr, dwcompareflags: u32) -> ::windows::core::HRESULT {
@@ -2041,6 +2101,8 @@ pub trait ISpRegDataKey_Impl: Sized + ISpDataKey_Impl {
     fn SetKey(&self, hkey: super::super::System::Registry::HKEY, freadonly: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for ISpRegDataKey {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl ISpRegDataKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpRegDataKey_Impl, const OFFSET: isize>() -> ISpRegDataKey_Vtbl {
         unsafe extern "system" fn SetKey<Identity: ::windows::core::IUnknownImpl, Impl: ISpRegDataKey_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hkey: super::super::System::Registry::HKEY, freadonly: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2059,6 +2121,8 @@ pub trait ISpResourceManager_Impl: Sized + super::super::System::Com::IServicePr
     fn SetObject(&self, guidserviceid: *const ::windows::core::GUID, punkobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetObject(&self, guidserviceid: *const ::windows::core::GUID, objectclsid: *const ::windows::core::GUID, objectiid: *const ::windows::core::GUID, freleasewhenlastexternalrefreleased: super::super::Foundation::BOOL, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISpResourceManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISpResourceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpResourceManager_Impl, const OFFSET: isize>() -> ISpResourceManager_Vtbl {
@@ -2086,6 +2150,7 @@ pub trait ISpSerializeState_Impl: Sized {
     fn GetSerializedState(&self, ppbdata: *mut *mut u8, pulsize: *mut u32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn SetSerializedState(&self, pbdata: *const u8, ulsize: u32, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpSerializeState {}
 impl ISpSerializeState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpSerializeState_Impl, const OFFSET: isize>() -> ISpSerializeState_Vtbl {
         unsafe extern "system" fn GetSerializedState<Identity: ::windows::core::IUnknownImpl, Impl: ISpSerializeState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbdata: *mut *mut u8, pulsize: *mut u32, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -2118,6 +2183,7 @@ pub trait ISpShortcut_Impl: Sized {
     fn GetShortcutsForGeneration(&self, pdwgeneration: *mut u32, pdwcookie: *mut u32, pshortcutpairlist: *mut SPSHORTCUTPAIRLIST) -> ::windows::core::Result<()>;
     fn GetGenerationChange(&self, pdwgeneration: *mut u32, pshortcutpairlist: *mut SPSHORTCUTPAIRLIST) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpShortcut {}
 impl ISpShortcut_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpShortcut_Impl, const OFFSET: isize>() -> ISpShortcut_Vtbl {
         unsafe extern "system" fn AddShortcut<Identity: ::windows::core::IUnknownImpl, Impl: ISpShortcut_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdisplay: ::windows::core::PCWSTR, langid: u16, pszspoken: ::windows::core::PCWSTR, shtype: SPSHORTCUTTYPE) -> ::windows::core::HRESULT {
@@ -2190,6 +2256,8 @@ pub trait ISpStream_Impl: Sized + super::super::System::Com::ISequentialStream_I
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpStream_Impl, const OFFSET: isize>() -> ISpStream_Vtbl {
         unsafe extern "system" fn SetBaseStream<Identity: ::windows::core::IUnknownImpl, Impl: ISpStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstream: ::windows::core::RawPtr, rguidformat: *const ::windows::core::GUID, pwaveformatex: *const super::Audio::WAVEFORMATEX) -> ::windows::core::HRESULT {
@@ -2235,6 +2303,8 @@ pub trait ISpStreamFormat_Impl: Sized + super::super::System::Com::ISequentialSt
     fn GetFormat(&self, pguidformatid: *const ::windows::core::GUID) -> ::windows::core::Result<*mut super::Audio::WAVEFORMATEX>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpStreamFormat {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpStreamFormat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpStreamFormat_Impl, const OFFSET: isize>() -> ISpStreamFormat_Vtbl {
         unsafe extern "system" fn GetFormat<Identity: ::windows::core::IUnknownImpl, Impl: ISpStreamFormat_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidformatid: *const ::windows::core::GUID, ppcomemwaveformatex: *mut *mut super::Audio::WAVEFORMATEX) -> ::windows::core::HRESULT {
@@ -2263,6 +2333,8 @@ pub trait ISpStreamFormatConverter_Impl: Sized + super::super::System::Com::ISeq
     fn ScaleConvertedToBaseOffset(&self, ulloffsetconvertedstream: u64) -> ::windows::core::Result<u64>;
     fn ScaleBaseToConvertedOffset(&self, ulloffsetbasestream: u64) -> ::windows::core::Result<u64>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISpStreamFormatConverter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISpStreamFormatConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpStreamFormatConverter_Impl, const OFFSET: isize>() -> ISpStreamFormatConverter_Vtbl {
@@ -2332,6 +2404,7 @@ pub trait ISpTranscript_Impl: Sized {
     fn GetTranscript(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn AppendTranscript(&self, psztranscript: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpTranscript {}
 impl ISpTranscript_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpTranscript_Impl, const OFFSET: isize>() -> ISpTranscript_Vtbl {
         unsafe extern "system" fn GetTranscript<Identity: ::windows::core::IUnknownImpl, Impl: ISpTranscript_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsztranscript: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2388,6 +2461,8 @@ pub trait ISpVoice_Impl: Sized + ISpNotifySource_Impl + ISpEventSource_Impl {
     fn IsUISupported(&self, psztypeofui: &::windows::core::PCWSTR, pvextradata: *mut ::core::ffi::c_void, cbextradata: u32, pfsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn DisplayUI(&self, hwndparent: super::super::Foundation::HWND, psztitle: &::windows::core::PCWSTR, psztypeofui: &::windows::core::PCWSTR, pvextradata: *mut ::core::ffi::c_void, cbextradata: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISpVoice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISpVoice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpVoice_Impl, const OFFSET: isize>() -> ISpVoice_Vtbl {
@@ -2585,6 +2660,8 @@ pub trait ISpXMLRecoResult_Impl: Sized + ISpPhrase_Impl + ISpRecoResult_Impl {
     fn GetXMLErrorInfo(&self, psemanticerrorinfo: *mut SPSEMANTICERRORINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpXMLRecoResult {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpXMLRecoResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpXMLRecoResult_Impl, const OFFSET: isize>() -> ISpXMLRecoResult_Vtbl {
         unsafe extern "system" fn GetXMLResult<Identity: ::windows::core::IUnknownImpl, Impl: ISpXMLRecoResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszcomemxmlresult: *mut ::windows::core::PWSTR, options: SPXMLRESULTOPTIONS) -> ::windows::core::HRESULT {
@@ -2619,6 +2696,8 @@ pub trait ISpeechAudio_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn EventHandle(&self) -> ::windows::core::Result<i32>;
     fn SetState(&self, state: SpeechAudioState) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechAudio {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechAudio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechAudio_Impl, const OFFSET: isize>() -> ISpeechAudio_Vtbl {
@@ -2730,6 +2809,8 @@ pub trait ISpeechAudioBufferInfo_Impl: Sized + super::super::System::Com::IDispa
     fn SetEventBias(&self, eventbias: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechAudioBufferInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechAudioBufferInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechAudioBufferInfo_Impl, const OFFSET: isize>() -> ISpeechAudioBufferInfo_Vtbl {
         unsafe extern "system" fn MinNotification<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechAudioBufferInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, minnotification: *mut i32) -> ::windows::core::HRESULT {
@@ -2804,6 +2885,8 @@ pub trait ISpeechAudioFormat_Impl: Sized + super::super::System::Com::IDispatch_
     fn SetWaveFormatEx(&self, speechwaveformatex: &::core::option::Option<ISpeechWaveFormatEx>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechAudioFormat {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechAudioFormat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechAudioFormat_Impl, const OFFSET: isize>() -> ISpeechAudioFormat_Vtbl {
         unsafe extern "system" fn Type<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechAudioFormat_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, audioformat: *mut SpeechAudioFormatType) -> ::windows::core::HRESULT {
@@ -2876,6 +2959,8 @@ pub trait ISpeechAudioStatus_Impl: Sized + super::super::System::Com::IDispatch_
     fn CurrentSeekPosition(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn CurrentDevicePosition(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechAudioStatus {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechAudioStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechAudioStatus_Impl, const OFFSET: isize>() -> ISpeechAudioStatus_Vtbl {
@@ -2956,6 +3041,8 @@ pub trait ISpeechBaseStream_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Seek(&self, position: &super::super::System::Com::VARIANT, origin: SpeechStreamSeekPositionType) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechBaseStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechBaseStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechBaseStream_Impl, const OFFSET: isize>() -> ISpeechBaseStream_Vtbl {
         unsafe extern "system" fn Format<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechBaseStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, audioformat: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3020,6 +3107,8 @@ pub trait ISpeechCustomStream_Impl: Sized + super::super::System::Com::IDispatch
     fn putref_BaseStream(&self, punkstream: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechCustomStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechCustomStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechCustomStream_Impl, const OFFSET: isize>() -> ISpeechCustomStream_Vtbl {
         unsafe extern "system" fn BaseStream<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechCustomStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunkstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3063,6 +3152,8 @@ pub trait ISpeechDataKey_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn EnumKeys(&self, index: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn EnumValues(&self, index: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechDataKey {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechDataKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechDataKey_Impl, const OFFSET: isize>() -> ISpeechDataKey_Vtbl {
@@ -3194,6 +3285,8 @@ pub trait ISpeechFileStream_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechFileStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechFileStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechFileStream_Impl, const OFFSET: isize>() -> ISpeechFileStream_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechFileStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, filemode: SpeechStreamFileMode, doevents: i16) -> ::windows::core::HRESULT {
@@ -3222,6 +3315,8 @@ pub trait ISpeechGrammarRule_Impl: Sized + super::super::System::Com::IDispatch_
     fn AddResource(&self, resourcename: &super::super::Foundation::BSTR, resourcevalue: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn AddState(&self) -> ::windows::core::Result<ISpeechGrammarRuleState>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechGrammarRule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechGrammarRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRule_Impl, const OFFSET: isize>() -> ISpeechGrammarRule_Vtbl {
@@ -3314,6 +3409,8 @@ pub trait ISpeechGrammarRuleState_Impl: Sized + super::super::System::Com::IDisp
     fn AddSpecialTransition(&self, destinationstate: &::core::option::Option<ISpeechGrammarRuleState>, r#type: SpeechSpecialTransitionType, propertyname: &super::super::Foundation::BSTR, propertyid: i32, propertyvalue: *const super::super::System::Com::VARIANT, weight: f32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechGrammarRuleState {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechGrammarRuleState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRuleState_Impl, const OFFSET: isize>() -> ISpeechGrammarRuleState_Vtbl {
         unsafe extern "system" fn Rule<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRuleState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rule: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3377,6 +3474,8 @@ pub trait ISpeechGrammarRuleStateTransition_Impl: Sized + super::super::System::
     fn PropertyValue(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn NextState(&self) -> ::windows::core::Result<ISpeechGrammarRuleState>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechGrammarRuleStateTransition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechGrammarRuleStateTransition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRuleStateTransition_Impl, const OFFSET: isize>() -> ISpeechGrammarRuleStateTransition_Vtbl {
@@ -3491,6 +3590,8 @@ pub trait ISpeechGrammarRuleStateTransitions_Impl: Sized + super::super::System:
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechGrammarRuleStateTransitions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechGrammarRuleStateTransitions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRuleStateTransitions_Impl, const OFFSET: isize>() -> ISpeechGrammarRuleStateTransitions_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRuleStateTransitions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -3548,6 +3649,8 @@ pub trait ISpeechGrammarRules_Impl: Sized + super::super::System::Com::IDispatch
     fn Commit(&self) -> ::windows::core::Result<()>;
     fn CommitAndSave(&self, errortext: *mut super::super::Foundation::BSTR, savestream: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechGrammarRules {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechGrammarRules_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechGrammarRules_Impl, const OFFSET: isize>() -> ISpeechGrammarRules_Vtbl {
@@ -3655,6 +3758,8 @@ pub trait ISpeechLexicon_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn GetGenerationChange(&self, generationid: *mut i32, ppwords: *mut ::core::option::Option<ISpeechLexiconWords>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechLexicon {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechLexicon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexicon_Impl, const OFFSET: isize>() -> ISpeechLexicon_Vtbl {
         unsafe extern "system" fn GenerationId<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexicon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, generationid: *mut i32) -> ::windows::core::HRESULT {
@@ -3734,6 +3839,8 @@ pub trait ISpeechLexiconPronunciation_Impl: Sized + super::super::System::Com::I
     fn Symbolic(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechLexiconPronunciation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechLexiconPronunciation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconPronunciation_Impl, const OFFSET: isize>() -> ISpeechLexiconPronunciation_Vtbl {
         unsafe extern "system" fn Type<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconPronunciation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lexicontype: *mut SpeechLexiconType) -> ::windows::core::HRESULT {
@@ -3811,6 +3918,8 @@ pub trait ISpeechLexiconPronunciations_Impl: Sized + super::super::System::Com::
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechLexiconPronunciations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechLexiconPronunciations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconPronunciations_Impl, const OFFSET: isize>() -> ISpeechLexiconPronunciations_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconPronunciations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -3864,6 +3973,8 @@ pub trait ISpeechLexiconWord_Impl: Sized + super::super::System::Com::IDispatch_
     fn Word(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Pronunciations(&self) -> ::windows::core::Result<ISpeechLexiconPronunciations>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechLexiconWord {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechLexiconWord_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconWord_Impl, const OFFSET: isize>() -> ISpeechLexiconWord_Vtbl {
@@ -3930,6 +4041,8 @@ pub trait ISpeechLexiconWords_Impl: Sized + super::super::System::Com::IDispatch
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechLexiconWords {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechLexiconWords_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconWords_Impl, const OFFSET: isize>() -> ISpeechLexiconWords_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechLexiconWords_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -3984,6 +4097,8 @@ pub trait ISpeechMMSysAudio_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetLineId(&self, lineid: i32) -> ::windows::core::Result<()>;
     fn MMHandle(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechMMSysAudio {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechMMSysAudio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechMMSysAudio_Impl, const OFFSET: isize>() -> ISpeechMMSysAudio_Vtbl {
@@ -4049,6 +4164,8 @@ pub trait ISpeechMemoryStream_Impl: Sized + super::super::System::Com::IDispatch
     fn GetData(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechMemoryStream {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechMemoryStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechMemoryStream_Impl, const OFFSET: isize>() -> ISpeechMemoryStream_Vtbl {
         unsafe extern "system" fn SetData<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechMemoryStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, data: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -4093,6 +4210,8 @@ pub trait ISpeechObjectToken_Impl: Sized + super::super::System::Com::IDispatch_
     fn DisplayUI(&self, hwnd: i32, title: &super::super::Foundation::BSTR, typeofui: &super::super::Foundation::BSTR, extradata: *const super::super::System::Com::VARIANT, object: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn MatchesAttributes(&self, attributes: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechObjectToken {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechObjectToken_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechObjectToken_Impl, const OFFSET: isize>() -> ISpeechObjectToken_Vtbl {
@@ -4246,6 +4365,8 @@ pub trait ISpeechObjectTokenCategory_Impl: Sized + super::super::System::Com::ID
     fn EnumerateTokens(&self, requiredattributes: &super::super::Foundation::BSTR, optionalattributes: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISpeechObjectTokens>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechObjectTokenCategory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechObjectTokenCategory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechObjectTokenCategory_Impl, const OFFSET: isize>() -> ISpeechObjectTokenCategory_Vtbl {
         unsafe extern "system" fn Id<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechObjectTokenCategory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4323,6 +4444,8 @@ pub trait ISpeechObjectTokens_Impl: Sized + super::super::System::Com::IDispatch
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechObjectTokens {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechObjectTokens_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechObjectTokens_Impl, const OFFSET: isize>() -> ISpeechObjectTokens_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechObjectTokens_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -4376,6 +4499,8 @@ pub trait ISpeechPhoneConverter_Impl: Sized + super::super::System::Com::IDispat
     fn PhoneToId(&self, phonemes: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn IdToPhone(&self, idarray: &super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhoneConverter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhoneConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhoneConverter_Impl, const OFFSET: isize>() -> ISpeechPhoneConverter_Vtbl {
@@ -4437,6 +4562,8 @@ pub trait ISpeechPhraseAlternate_Impl: Sized + super::super::System::Com::IDispa
     fn PhraseInfo(&self) -> ::windows::core::Result<ISpeechPhraseInfo>;
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseAlternate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseAlternate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseAlternate_Impl, const OFFSET: isize>() -> ISpeechPhraseAlternate_Vtbl {
@@ -4509,6 +4636,8 @@ pub trait ISpeechPhraseAlternates_Impl: Sized + super::super::System::Com::IDisp
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseAlternates {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseAlternates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseAlternates_Impl, const OFFSET: isize>() -> ISpeechPhraseAlternates_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseAlternates_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -4571,6 +4700,8 @@ pub trait ISpeechPhraseElement_Impl: Sized + super::super::System::Com::IDispatc
     fn ActualConfidence(&self) -> ::windows::core::Result<SpeechEngineConfidence>;
     fn EngineConfidence(&self) -> ::windows::core::Result<f32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseElement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseElement_Impl, const OFFSET: isize>() -> ISpeechPhraseElement_Vtbl {
@@ -4745,6 +4876,8 @@ pub trait ISpeechPhraseElements_Impl: Sized + super::super::System::Com::IDispat
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseElements {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseElements_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseElements_Impl, const OFFSET: isize>() -> ISpeechPhraseElements_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseElements_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -4810,6 +4943,8 @@ pub trait ISpeechPhraseInfo_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetText(&self, startelement: i32, elements: i32, usereplacements: i16) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetDisplayAttributes(&self, startelement: i32, elements: i32, usereplacements: i16) -> ::windows::core::Result<SpeechDisplayAttributes>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseInfo_Impl, const OFFSET: isize>() -> ISpeechPhraseInfo_Vtbl {
@@ -5018,6 +5153,8 @@ pub trait ISpeechPhraseInfoBuilder_Impl: Sized + super::super::System::Com::IDis
     fn RestorePhraseFromMemory(&self, phraseinmemory: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<ISpeechPhraseInfo>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseInfoBuilder {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseInfoBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseInfoBuilder_Impl, const OFFSET: isize>() -> ISpeechPhraseInfoBuilder_Vtbl {
         unsafe extern "system" fn RestorePhraseFromMemory<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseInfoBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phraseinmemory: *const super::super::System::Com::VARIANT, phraseinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5046,6 +5183,8 @@ pub trait ISpeechPhraseProperties_Impl: Sized + super::super::System::Com::IDisp
     fn Item(&self, index: i32) -> ::windows::core::Result<ISpeechPhraseProperty>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseProperties_Impl, const OFFSET: isize>() -> ISpeechPhraseProperties_Vtbl {
@@ -5105,6 +5244,8 @@ pub trait ISpeechPhraseProperty_Impl: Sized + super::super::System::Com::IDispat
     fn Parent(&self) -> ::windows::core::Result<ISpeechPhraseProperty>;
     fn Children(&self) -> ::windows::core::Result<ISpeechPhraseProperties>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseProperty_Impl, const OFFSET: isize>() -> ISpeechPhraseProperty_Vtbl {
@@ -5232,6 +5373,8 @@ pub trait ISpeechPhraseReplacement_Impl: Sized + super::super::System::Com::IDis
     fn NumberOfElements(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseReplacement {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseReplacement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseReplacement_Impl, const OFFSET: isize>() -> ISpeechPhraseReplacement_Vtbl {
         unsafe extern "system" fn DisplayAttributes<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseReplacement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, displayattributes: *mut SpeechDisplayAttributes) -> ::windows::core::HRESULT {
@@ -5297,6 +5440,8 @@ pub trait ISpeechPhraseReplacements_Impl: Sized + super::super::System::Com::IDi
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseReplacements {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseReplacements_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseReplacements_Impl, const OFFSET: isize>() -> ISpeechPhraseReplacements_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseReplacements_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -5354,6 +5499,8 @@ pub trait ISpeechPhraseRule_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Confidence(&self) -> ::windows::core::Result<SpeechEngineConfidence>;
     fn EngineConfidence(&self) -> ::windows::core::Result<f32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseRule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseRule_Impl, const OFFSET: isize>() -> ISpeechPhraseRule_Vtbl {
@@ -5468,6 +5615,8 @@ pub trait ISpeechPhraseRules_Impl: Sized + super::super::System::Com::IDispatch_
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechPhraseRules {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechPhraseRules_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseRules_Impl, const OFFSET: isize>() -> ISpeechPhraseRules_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechPhraseRules_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -5542,6 +5691,8 @@ pub trait ISpeechRecoContext_Impl: Sized + super::super::System::Com::IDispatch_
     fn Bookmark(&self, options: SpeechBookmarkOptions, streampos: &super::super::System::Com::VARIANT, bookmarkid: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn SetAdaptationData(&self, adaptationstring: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecoContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecoContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoContext_Impl, const OFFSET: isize>() -> ISpeechRecoContext_Vtbl {
@@ -5804,6 +5955,8 @@ pub trait ISpeechRecoGrammar_Impl: Sized + super::super::System::Com::IDispatch_
     fn IsPronounceable(&self, word: &super::super::Foundation::BSTR) -> ::windows::core::Result<SpeechWordPronounceable>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecoGrammar {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecoGrammar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoGrammar_Impl, const OFFSET: isize>() -> ISpeechRecoGrammar_Vtbl {
         unsafe extern "system" fn Id<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoGrammar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -5972,6 +6125,8 @@ pub trait ISpeechRecoResult_Impl: Sized + super::super::System::Com::IDispatch_I
     fn DiscardResultInfo(&self, valuetypes: SpeechDiscardType) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecoResult {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecoResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResult_Impl, const OFFSET: isize>() -> ISpeechRecoResult_Vtbl {
         unsafe extern "system" fn RecoContext<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, recocontext: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6095,6 +6250,8 @@ pub trait ISpeechRecoResult2_Impl: Sized + super::super::System::Com::IDispatch_
     fn SetTextFeedback(&self, feedback: &super::super::Foundation::BSTR, wassuccessful: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecoResult2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecoResult2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResult2_Impl, const OFFSET: isize>() -> ISpeechRecoResult2_Vtbl {
         unsafe extern "system" fn SetTextFeedback<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResult2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, feedback: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, wassuccessful: i16) -> ::windows::core::HRESULT {
@@ -6124,6 +6281,8 @@ pub trait ISpeechRecoResultDispatch_Impl: Sized + super::super::System::Com::IDi
     fn GetXMLErrorInfo(&self, linenumber: *mut i32, scriptline: *mut super::super::Foundation::BSTR, source: *mut super::super::Foundation::BSTR, description: *mut super::super::Foundation::BSTR, resultcode: *mut ::windows::core::HRESULT, iserror: *mut i16) -> ::windows::core::Result<()>;
     fn SetTextFeedback(&self, feedback: &super::super::Foundation::BSTR, wassuccessful: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecoResultDispatch {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecoResultDispatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResultDispatch_Impl, const OFFSET: isize>() -> ISpeechRecoResultDispatch_Vtbl {
@@ -6275,6 +6434,8 @@ pub trait ISpeechRecoResultTimes_Impl: Sized + super::super::System::Com::IDispa
     fn OffsetFromStart(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecoResultTimes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecoResultTimes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResultTimes_Impl, const OFFSET: isize>() -> ISpeechRecoResultTimes_Vtbl {
         unsafe extern "system" fn StreamTime<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecoResultTimes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, time: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -6362,6 +6523,8 @@ pub trait ISpeechRecognizer_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetAudioInputs(&self, requiredattributes: &super::super::Foundation::BSTR, optionalattributes: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISpeechObjectTokens>;
     fn GetProfiles(&self, requiredattributes: &super::super::Foundation::BSTR, optionalattributes: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISpeechObjectTokens>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecognizer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecognizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecognizer_Impl, const OFFSET: isize>() -> ISpeechRecognizer_Vtbl {
@@ -6635,6 +6798,8 @@ pub trait ISpeechRecognizerStatus_Impl: Sized + super::super::System::Com::IDisp
     fn SupportedLanguages(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechRecognizerStatus {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechRecognizerStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecognizerStatus_Impl, const OFFSET: isize>() -> ISpeechRecognizerStatus_Vtbl {
         unsafe extern "system" fn AudioStatus<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechRecognizerStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, audiostatus: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6724,6 +6889,8 @@ pub trait ISpeechResourceLoader_Impl: Sized + super::super::System::Com::IDispat
     fn ReleaseLocalCopy(&self, pbstrlocalpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechResourceLoader {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechResourceLoader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechResourceLoader_Impl, const OFFSET: isize>() -> ISpeechResourceLoader_Vtbl {
         unsafe extern "system" fn LoadResource<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechResourceLoader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrresourceuri: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, falwaysreload: i16, pstream: *mut *mut ::core::ffi::c_void, pbstrmimetype: *mut super::super::Foundation::BSTR, pfmodified: *mut i16, pbstrredirecturl: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -6763,6 +6930,8 @@ pub trait ISpeechTextSelectionInformation_Impl: Sized + super::super::System::Co
     fn SetSelectionLength(&self, selectionlength: i32) -> ::windows::core::Result<()>;
     fn SelectionLength(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechTextSelectionInformation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechTextSelectionInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechTextSelectionInformation_Impl, const OFFSET: isize>() -> ISpeechTextSelectionInformation_Vtbl {
@@ -6881,6 +7050,8 @@ pub trait ISpeechVoice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsUISupported(&self, typeofui: &super::super::Foundation::BSTR, extradata: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<i16>;
     fn DisplayUI(&self, hwndparent: i32, title: &super::super::Foundation::BSTR, typeofui: &super::super::Foundation::BSTR, extradata: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechVoice {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechVoice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechVoice_Impl, const OFFSET: isize>() -> ISpeechVoice_Vtbl {
@@ -7214,6 +7385,8 @@ pub trait ISpeechVoiceStatus_Impl: Sized + super::super::System::Com::IDispatch_
     fn VisemeId(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechVoiceStatus {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechVoiceStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechVoiceStatus_Impl, const OFFSET: isize>() -> ISpeechVoiceStatus_Vtbl {
         unsafe extern "system" fn CurrentStreamNumber<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechVoiceStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, streamnumber: *mut i32) -> ::windows::core::HRESULT {
@@ -7386,6 +7559,8 @@ pub trait ISpeechWaveFormatEx_Impl: Sized + super::super::System::Com::IDispatch
     fn SetExtraData(&self, extradata: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechWaveFormatEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechWaveFormatEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechWaveFormatEx_Impl, const OFFSET: isize>() -> ISpeechWaveFormatEx_Vtbl {
         unsafe extern "system" fn FormatTag<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechWaveFormatEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, formattag: *mut i16) -> ::windows::core::HRESULT {
@@ -7528,6 +7703,8 @@ pub trait ISpeechXMLRecoResult_Impl: Sized + super::super::System::Com::IDispatc
     fn GetXMLErrorInfo(&self, linenumber: *mut i32, scriptline: *mut super::super::Foundation::BSTR, source: *mut super::super::Foundation::BSTR, description: *mut super::super::Foundation::BSTR, resultcode: *mut i32, iserror: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISpeechXMLRecoResult {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISpeechXMLRecoResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechXMLRecoResult_Impl, const OFFSET: isize>() -> ISpeechXMLRecoResult_Vtbl {
         unsafe extern "system" fn GetXMLResult<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechXMLRecoResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: SPXMLRESULTOPTIONS, presult: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -7559,6 +7736,8 @@ impl ISpeechXMLRecoResult_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ISpeechRecoContextEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ISpeechRecoContextEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ISpeechRecoContextEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ISpeechRecoContextEvents_Impl, const OFFSET: isize>() -> _ISpeechRecoContextEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7569,6 +7748,8 @@ impl _ISpeechRecoContextEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ISpeechVoiceEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ISpeechVoiceEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ISpeechVoiceEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ISpeechVoiceEvents_Impl, const OFFSET: isize>() -> _ISpeechVoiceEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/Streaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Streaming/impl.rs
@@ -22,6 +22,8 @@ pub trait IMFDeviceTransform_Impl: Sized {
     fn FlushOutputStream(&self, dwstreamindex: u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Media_MediaFoundation")]
+impl ::windows::core::RuntimeName for IMFDeviceTransform {}
+#[cfg(feature = "Win32_Media_MediaFoundation")]
 impl IMFDeviceTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDeviceTransform_Impl, const OFFSET: isize>() -> IMFDeviceTransform_Vtbl {
         unsafe extern "system" fn InitializeTransform<Identity: ::windows::core::IUnknownImpl, Impl: IMFDeviceTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pattributes: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -204,6 +206,8 @@ impl IMFDeviceTransform_Vtbl {
 pub trait IMFDeviceTransformCallback_Impl: Sized {
     fn OnBufferSent(&self, pcallbackattributes: &::core::option::Option<super::MediaFoundation::IMFAttributes>, pinid: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Media_MediaFoundation")]
+impl ::windows::core::RuntimeName for IMFDeviceTransformCallback {}
 #[cfg(feature = "Win32_Media_MediaFoundation")]
 impl IMFDeviceTransformCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMFDeviceTransformCallback_Impl, const OFFSET: isize>() -> IMFDeviceTransformCallback_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
@@ -1,6 +1,7 @@
 pub trait IAMWMBufferPass_Impl: Sized {
     fn SetNotify(&self, pcallback: &::core::option::Option<IAMWMBufferPassCallback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAMWMBufferPass {}
 impl IAMWMBufferPass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMWMBufferPass_Impl, const OFFSET: isize>() -> IAMWMBufferPass_Vtbl {
         unsafe extern "system" fn SetNotify<Identity: ::windows::core::IUnknownImpl, Impl: IAMWMBufferPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18,6 +19,8 @@ impl IAMWMBufferPass_Vtbl {
 pub trait IAMWMBufferPassCallback_Impl: Sized {
     fn Notify(&self, pnssbuffer3: &::core::option::Option<INSSBuffer3>, ppin: &::core::option::Option<super::DirectShow::IPin>, prtstart: *const i64, prtend: *const i64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Media_DirectShow")]
+impl ::windows::core::RuntimeName for IAMWMBufferPassCallback {}
 #[cfg(feature = "Win32_Media_DirectShow")]
 impl IAMWMBufferPassCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAMWMBufferPassCallback_Impl, const OFFSET: isize>() -> IAMWMBufferPassCallback_Vtbl {
@@ -43,6 +46,8 @@ pub trait INSNetSourceCreator_Impl: Sized {
     fn GetProtocolName(&self, dwprotocolnum: u32, pwszprotocolname: ::windows::core::PWSTR, pcchprotocolname: *mut u16) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INSNetSourceCreator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INSNetSourceCreator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INSNetSourceCreator_Impl, const OFFSET: isize>() -> INSNetSourceCreator_Vtbl {
@@ -133,6 +138,7 @@ pub trait INSSBuffer_Impl: Sized {
     fn GetBuffer(&self) -> ::windows::core::Result<*mut u8>;
     fn GetBufferAndLength(&self, ppdwbuffer: *mut *mut u8, pdwlength: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INSSBuffer {}
 impl INSSBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer_Impl, const OFFSET: isize>() -> INSSBuffer_Vtbl {
         unsafe extern "system" fn GetLength<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT {
@@ -195,6 +201,7 @@ pub trait INSSBuffer2_Impl: Sized + INSSBuffer_Impl {
     fn GetSampleProperties(&self, cbproperties: u32) -> ::windows::core::Result<u8>;
     fn SetSampleProperties(&self, cbproperties: u32, pbproperties: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INSSBuffer2 {}
 impl INSSBuffer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer2_Impl, const OFFSET: isize>() -> INSSBuffer2_Vtbl {
         unsafe extern "system" fn GetSampleProperties<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbproperties: u32, pbproperties: *mut u8) -> ::windows::core::HRESULT {
@@ -227,6 +234,7 @@ pub trait INSSBuffer3_Impl: Sized + INSSBuffer_Impl + INSSBuffer2_Impl {
     fn SetProperty(&self, guidbufferproperty: &::windows::core::GUID, pvbufferproperty: *const ::core::ffi::c_void, dwbufferpropertysize: u32) -> ::windows::core::Result<()>;
     fn GetProperty(&self, guidbufferproperty: &::windows::core::GUID, pvbufferproperty: *mut ::core::ffi::c_void, pdwbufferpropertysize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INSSBuffer3 {}
 impl INSSBuffer3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer3_Impl, const OFFSET: isize>() -> INSSBuffer3_Vtbl {
         unsafe extern "system" fn SetProperty<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidbufferproperty: ::windows::core::GUID, pvbufferproperty: *const ::core::ffi::c_void, dwbufferpropertysize: u32) -> ::windows::core::HRESULT {
@@ -253,6 +261,7 @@ pub trait INSSBuffer4_Impl: Sized + INSSBuffer_Impl + INSSBuffer2_Impl + INSSBuf
     fn GetPropertyCount(&self) -> ::windows::core::Result<u32>;
     fn GetPropertyByIndex(&self, dwbufferpropertyindex: u32, pguidbufferproperty: *mut ::windows::core::GUID, pvbufferproperty: *mut ::core::ffi::c_void, pdwbufferpropertysize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INSSBuffer4 {}
 impl INSSBuffer4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer4_Impl, const OFFSET: isize>() -> INSSBuffer4_Vtbl {
         unsafe extern "system" fn GetPropertyCount<Identity: ::windows::core::IUnknownImpl, Impl: INSSBuffer4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcbufferproperties: *mut u32) -> ::windows::core::HRESULT {
@@ -287,6 +296,7 @@ pub trait IWMAddressAccess_Impl: Sized {
     fn AddAccessEntry(&self, aetype: WM_AETYPE, paddraccessentry: *const WM_ADDRESS_ACCESSENTRY) -> ::windows::core::Result<()>;
     fn RemoveAccessEntry(&self, aetype: WM_AETYPE, dwentrynum: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMAddressAccess {}
 impl IWMAddressAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMAddressAccess_Impl, const OFFSET: isize>() -> IWMAddressAccess_Vtbl {
         unsafe extern "system" fn GetAccessEntryCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMAddressAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, aetype: WM_AETYPE, pcentries: *mut u32) -> ::windows::core::HRESULT {
@@ -339,6 +349,8 @@ pub trait IWMAddressAccess2_Impl: Sized + IWMAddressAccess_Impl {
     fn AddAccessEntryEx(&self, aetype: WM_AETYPE, bstraddress: &super::super::Foundation::BSTR, bstrmask: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMAddressAccess2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMAddressAccess2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMAddressAccess2_Impl, const OFFSET: isize>() -> IWMAddressAccess2_Vtbl {
         unsafe extern "system" fn GetAccessEntryEx<Identity: ::windows::core::IUnknownImpl, Impl: IWMAddressAccess2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, aetype: WM_AETYPE, dwentrynum: u32, pbstraddress: *mut super::super::Foundation::BSTR, pbstrmask: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -366,6 +378,7 @@ pub trait IWMAuthorizer_Impl: Sized {
     fn GetCert(&self, dwindex: u32) -> ::windows::core::Result<*mut u8>;
     fn GetSharedData(&self, dwcertindex: u32, pbshareddata: *const u8, pbcert: *const u8) -> ::windows::core::Result<*mut u8>;
 }
+impl ::windows::core::RuntimeName for IWMAuthorizer {}
 impl IWMAuthorizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMAuthorizer_Impl, const OFFSET: isize>() -> IWMAuthorizer_Vtbl {
         unsafe extern "system" fn GetCertCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMAuthorizer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pccerts: *mut u32) -> ::windows::core::HRESULT {
@@ -420,6 +433,7 @@ pub trait IWMBackupRestoreProps_Impl: Sized {
     fn RemoveProp(&self, pcwszname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn RemoveAllProps(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMBackupRestoreProps {}
 impl IWMBackupRestoreProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMBackupRestoreProps_Impl, const OFFSET: isize>() -> IWMBackupRestoreProps_Vtbl {
         unsafe extern "system" fn GetPropCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMBackupRestoreProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcprops: *mut u16) -> ::windows::core::HRESULT {
@@ -478,6 +492,7 @@ pub trait IWMBandwidthSharing_Impl: Sized + IWMStreamList_Impl {
     fn GetBandwidth(&self, pdwbitrate: *mut u32, pmsbufferwindow: *mut u32) -> ::windows::core::Result<()>;
     fn SetBandwidth(&self, dwbitrate: u32, msbufferwindow: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMBandwidthSharing {}
 impl IWMBandwidthSharing_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMBandwidthSharing_Impl, const OFFSET: isize>() -> IWMBandwidthSharing_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: IWMBandwidthSharing_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -522,6 +537,7 @@ pub trait IWMClientConnections_Impl: Sized {
     fn GetClientCount(&self) -> ::windows::core::Result<u32>;
     fn GetClientProperties(&self, dwclientnum: u32) -> ::windows::core::Result<WM_CLIENT_PROPERTIES>;
 }
+impl ::windows::core::RuntimeName for IWMClientConnections {}
 impl IWMClientConnections_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMClientConnections_Impl, const OFFSET: isize>() -> IWMClientConnections_Vtbl {
         unsafe extern "system" fn GetClientCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMClientConnections_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcclients: *mut u32) -> ::windows::core::HRESULT {
@@ -559,6 +575,7 @@ impl IWMClientConnections_Vtbl {
 pub trait IWMClientConnections2_Impl: Sized + IWMClientConnections_Impl {
     fn GetClientInfo(&self, dwclientnum: u32, pwsznetworkaddress: ::windows::core::PWSTR, pcchnetworkaddress: *mut u32, pwszport: ::windows::core::PWSTR, pcchport: *mut u32, pwszdnsname: ::windows::core::PWSTR, pcchdnsname: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMClientConnections2 {}
 impl IWMClientConnections2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMClientConnections2_Impl, const OFFSET: isize>() -> IWMClientConnections2_Vtbl {
         unsafe extern "system" fn GetClientInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWMClientConnections2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwclientnum: u32, pwsznetworkaddress: ::windows::core::PWSTR, pcchnetworkaddress: *mut u32, pwszport: ::windows::core::PWSTR, pcchport: *mut u32, pwszdnsname: ::windows::core::PWSTR, pcchdnsname: *mut u32) -> ::windows::core::HRESULT {
@@ -578,6 +595,8 @@ pub trait IWMCodecAMVideoAccelerator_Impl: Sized {
     fn NegotiateConnection(&self, pmediatype: *const super::DirectShow::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
     fn SetPlayerNotify(&self, phook: &::core::option::Option<IWMPlayerTimestampHook>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
+impl ::windows::core::RuntimeName for IWMCodecAMVideoAccelerator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
 impl IWMCodecAMVideoAccelerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecAMVideoAccelerator_Impl, const OFFSET: isize>() -> IWMCodecAMVideoAccelerator_Vtbl {
@@ -612,6 +631,7 @@ pub trait IWMCodecInfo_Impl: Sized {
     fn GetCodecFormatCount(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32) -> ::windows::core::Result<u32>;
     fn GetCodecFormat(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, dwformatindex: u32) -> ::windows::core::Result<IWMStreamConfig>;
 }
+impl ::windows::core::RuntimeName for IWMCodecInfo {}
 impl IWMCodecInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecInfo_Impl, const OFFSET: isize>() -> IWMCodecInfo_Vtbl {
         unsafe extern "system" fn GetCodecInfoCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID, pccodecs: *mut u32) -> ::windows::core::HRESULT {
@@ -662,6 +682,7 @@ pub trait IWMCodecInfo2_Impl: Sized + IWMCodecInfo_Impl {
     fn GetCodecName(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, wszname: ::windows::core::PWSTR, pcchname: *mut u32) -> ::windows::core::Result<()>;
     fn GetCodecFormatDesc(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, dwformatindex: u32, ppistreamconfig: *mut ::core::option::Option<IWMStreamConfig>, wszdesc: ::windows::core::PWSTR, pcchdesc: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMCodecInfo2 {}
 impl IWMCodecInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecInfo2_Impl, const OFFSET: isize>() -> IWMCodecInfo2_Vtbl {
         unsafe extern "system" fn GetCodecName<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, wszname: ::windows::core::PWSTR, pcchname: *mut u32) -> ::windows::core::HRESULT {
@@ -690,6 +711,7 @@ pub trait IWMCodecInfo3_Impl: Sized + IWMCodecInfo_Impl + IWMCodecInfo2_Impl {
     fn SetCodecEnumerationSetting(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, pszname: &::windows::core::PCWSTR, r#type: WMT_ATTR_DATATYPE, pvalue: *const u8, dwsize: u32) -> ::windows::core::Result<()>;
     fn GetCodecEnumerationSetting(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMCodecInfo3 {}
 impl IWMCodecInfo3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecInfo3_Impl, const OFFSET: isize>() -> IWMCodecInfo3_Vtbl {
         unsafe extern "system" fn GetCodecFormatProp<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecInfo3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, dwformatindex: u32, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT {
@@ -730,6 +752,8 @@ pub trait IWMCodecVideoAccelerator_Impl: Sized {
     fn SetPlayerNotify(&self, phook: &::core::option::Option<IWMPlayerTimestampHook>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
+impl ::windows::core::RuntimeName for IWMCodecVideoAccelerator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
 impl IWMCodecVideoAccelerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecVideoAccelerator_Impl, const OFFSET: isize>() -> IWMCodecVideoAccelerator_Vtbl {
         unsafe extern "system" fn NegotiateConnection<Identity: ::windows::core::IUnknownImpl, Impl: IWMCodecVideoAccelerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piamva: ::windows::core::RawPtr, pmediatype: *const super::DirectShow::AM_MEDIA_TYPE) -> ::windows::core::HRESULT {
@@ -755,6 +779,7 @@ impl IWMCodecVideoAccelerator_Vtbl {
 pub trait IWMCredentialCallback_Impl: Sized {
     fn AcquireCredentials(&self, pwszrealm: &::windows::core::PCWSTR, pwszsite: &::windows::core::PCWSTR, pwszuser: ::windows::core::PWSTR, cchuser: u32, pwszpassword: ::windows::core::PWSTR, cchpassword: u32, hrstatus: ::windows::core::HRESULT, pdwflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMCredentialCallback {}
 impl IWMCredentialCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMCredentialCallback_Impl, const OFFSET: isize>() -> IWMCredentialCallback_Vtbl {
         unsafe extern "system" fn AcquireCredentials<Identity: ::windows::core::IUnknownImpl, Impl: IWMCredentialCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszrealm: ::windows::core::PCWSTR, pwszsite: ::windows::core::PCWSTR, pwszuser: ::windows::core::PWSTR, cchuser: u32, pwszpassword: ::windows::core::PWSTR, cchpassword: u32, hrstatus: ::windows::core::HRESULT, pdwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -771,6 +796,7 @@ impl IWMCredentialCallback_Vtbl {
 pub trait IWMDRMEditor_Impl: Sized {
     fn GetDRMProperty(&self, pwstrname: &::windows::core::PCWSTR, pdwtype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDRMEditor {}
 impl IWMDRMEditor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMEditor_Impl, const OFFSET: isize>() -> IWMDRMEditor_Vtbl {
         unsafe extern "system" fn GetDRMProperty<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMEditor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwstrname: ::windows::core::PCWSTR, pdwtype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT {
@@ -789,6 +815,8 @@ pub trait IWMDRMMessageParser_Impl: Sized {
     fn ParseRegistrationReqMsg(&self, pbregistrationreqmsg: *const u8, cbregistrationreqmsg: u32, ppdevicecert: *mut ::core::option::Option<INSSBuffer>, pdeviceserialnumber: *mut DRM_VAL16) -> ::windows::core::Result<()>;
     fn ParseLicenseRequestMsg(&self, pblicenserequestmsg: *const u8, cblicenserequestmsg: u32, ppdevicecert: *mut ::core::option::Option<INSSBuffer>, pdeviceserialnumber: *mut DRM_VAL16, pbstraction: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMMessageParser {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDRMMessageParser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMMessageParser_Impl, const OFFSET: isize>() -> IWMDRMMessageParser_Vtbl {
@@ -822,6 +850,7 @@ pub trait IWMDRMReader_Impl: Sized {
     fn SetDRMProperty(&self, pwstrname: &::windows::core::PCWSTR, dwtype: WMT_ATTR_DATATYPE, pvalue: *const u8, cblength: u16) -> ::windows::core::Result<()>;
     fn GetDRMProperty(&self, pwstrname: &::windows::core::PCWSTR, pdwtype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDRMReader {}
 impl IWMDRMReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMReader_Impl, const OFFSET: isize>() -> IWMDRMReader_Vtbl {
         unsafe extern "system" fn AcquireLicense<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -888,6 +917,8 @@ pub trait IWMDRMReader2_Impl: Sized + IWMDRMReader_Impl {
     fn TryNextLicense(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMReader2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMDRMReader2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMReader2_Impl, const OFFSET: isize>() -> IWMDRMReader2_Vtbl {
         unsafe extern "system" fn SetEvaluateOutputLevelLicenses<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMReader2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fevaluate: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -927,6 +958,8 @@ pub trait IWMDRMReader3_Impl: Sized + IWMDRMReader_Impl + IWMDRMReader2_Impl {
     fn GetInclusionList(&self, ppguids: *mut *mut ::windows::core::GUID, pcguids: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMReader3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMDRMReader3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMReader3_Impl, const OFFSET: isize>() -> IWMDRMReader3_Vtbl {
         unsafe extern "system" fn GetInclusionList<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMReader3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppguids: *mut *mut ::windows::core::GUID, pcguids: *mut u32) -> ::windows::core::HRESULT {
@@ -943,6 +976,7 @@ impl IWMDRMReader3_Vtbl {
 pub trait IWMDRMTranscryptionManager_Impl: Sized {
     fn CreateTranscryptor(&self) -> ::windows::core::Result<IWMDRMTranscryptor>;
 }
+impl ::windows::core::RuntimeName for IWMDRMTranscryptionManager {}
 impl IWMDRMTranscryptionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMTranscryptionManager_Impl, const OFFSET: isize>() -> IWMDRMTranscryptionManager_Vtbl {
         unsafe extern "system" fn CreateTranscryptor<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMTranscryptionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptranscryptor: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -969,6 +1003,8 @@ pub trait IWMDRMTranscryptor_Impl: Sized {
     fn Read(&self, pbdata: *const u8, pcbdata: *const u32) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMTranscryptor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDRMTranscryptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMTranscryptor_Impl, const OFFSET: isize>() -> IWMDRMTranscryptor_Vtbl {
@@ -1011,6 +1047,8 @@ pub trait IWMDRMTranscryptor2_Impl: Sized + IWMDRMTranscryptor_Impl {
     fn GetSeekStartTime(&self) -> ::windows::core::Result<u64>;
     fn GetDuration(&self) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMTranscryptor2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDRMTranscryptor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMTranscryptor2_Impl, const OFFSET: isize>() -> IWMDRMTranscryptor2_Vtbl {
@@ -1064,6 +1102,7 @@ pub trait IWMDRMWriter_Impl: Sized {
     fn GenerateSigningKeyPair(&self, pwszprivkey: ::windows::core::PWSTR, pcwchprivkeylength: *mut u32, pwszpubkey: ::windows::core::PWSTR, pcwchpubkeylength: *mut u32) -> ::windows::core::Result<()>;
     fn SetDRMAttribute(&self, wstreamnum: u16, pszname: &::windows::core::PCWSTR, r#type: WMT_ATTR_DATATYPE, pvalue: *const u8, cblength: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMDRMWriter {}
 impl IWMDRMWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMWriter_Impl, const OFFSET: isize>() -> IWMDRMWriter_Vtbl {
         unsafe extern "system" fn GenerateKeySeed<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszkeyseed: ::windows::core::PWSTR, pcwchlength: *mut u32) -> ::windows::core::HRESULT {
@@ -1103,6 +1142,8 @@ pub trait IWMDRMWriter2_Impl: Sized + IWMDRMWriter_Impl {
     fn SetWMDRMNetEncryption(&self, fsamplesencrypted: super::super::Foundation::BOOL, pbkeyid: *const u8, cbkeyid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMWriter2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMDRMWriter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMWriter2_Impl, const OFFSET: isize>() -> IWMDRMWriter2_Vtbl {
         unsafe extern "system" fn SetWMDRMNetEncryption<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMWriter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fsamplesencrypted: super::super::Foundation::BOOL, pbkeyid: *const u8, cbkeyid: u32) -> ::windows::core::HRESULT {
@@ -1120,6 +1161,8 @@ impl IWMDRMWriter2_Vtbl {
 pub trait IWMDRMWriter3_Impl: Sized + IWMDRMWriter_Impl + IWMDRMWriter2_Impl {
     fn SetProtectStreamSamples(&self, pimportinitstruct: *const WMDRM_IMPORT_INIT_STRUCT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMDRMWriter3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMDRMWriter3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDRMWriter3_Impl, const OFFSET: isize>() -> IWMDRMWriter3_Vtbl {
@@ -1142,6 +1185,7 @@ pub trait IWMDeviceRegistration_Impl: Sized {
     fn GetNextRegisteredDevice(&self) -> ::windows::core::Result<IWMRegisteredDevice>;
     fn GetRegisteredDeviceByID(&self, dwregistertype: u32, pbcertificate: *const u8, cbcertificate: u32, serialnumber: &DRM_VAL16) -> ::windows::core::Result<IWMRegisteredDevice>;
 }
+impl ::windows::core::RuntimeName for IWMDeviceRegistration {}
 impl IWMDeviceRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceRegistration_Impl, const OFFSET: isize>() -> IWMDeviceRegistration_Vtbl {
         unsafe extern "system" fn RegisterDevice<Identity: ::windows::core::IUnknownImpl, Impl: IWMDeviceRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwregistertype: u32, pbcertificate: *const u8, cbcertificate: u32, serialnumber: DRM_VAL16, ppdevice: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1221,6 +1265,7 @@ impl IWMDeviceRegistration_Vtbl {
 pub trait IWMGetSecureChannel_Impl: Sized {
     fn GetPeerSecureChannelInterface(&self) -> ::windows::core::Result<IWMSecureChannel>;
 }
+impl ::windows::core::RuntimeName for IWMGetSecureChannel {}
 impl IWMGetSecureChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMGetSecureChannel_Impl, const OFFSET: isize>() -> IWMGetSecureChannel_Vtbl {
         unsafe extern "system" fn GetPeerSecureChannelInterface<Identity: ::windows::core::IUnknownImpl, Impl: IWMGetSecureChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pppeer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1257,6 +1302,7 @@ pub trait IWMHeaderInfo_Impl: Sized {
     fn AddScript(&self, pwsztype: &::windows::core::PCWSTR, pwszcommand: &::windows::core::PCWSTR, cnsscripttime: u64) -> ::windows::core::Result<()>;
     fn RemoveScript(&self, windex: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMHeaderInfo {}
 impl IWMHeaderInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMHeaderInfo_Impl, const OFFSET: isize>() -> IWMHeaderInfo_Vtbl {
         unsafe extern "system" fn GetAttributeCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMHeaderInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnum: u16, pcattributes: *mut u16) -> ::windows::core::HRESULT {
@@ -1361,6 +1407,7 @@ pub trait IWMHeaderInfo2_Impl: Sized + IWMHeaderInfo_Impl {
     fn GetCodecInfoCount(&self) -> ::windows::core::Result<u32>;
     fn GetCodecInfo(&self, windex: u32, pcchname: *mut u16, pwszname: ::windows::core::PWSTR, pcchdescription: *mut u16, pwszdescription: ::windows::core::PWSTR, pcodectype: *mut WMT_CODEC_INFO_TYPE, pcbcodecinfo: *mut u16, pbcodecinfo: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMHeaderInfo2 {}
 impl IWMHeaderInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMHeaderInfo2_Impl, const OFFSET: isize>() -> IWMHeaderInfo2_Vtbl {
         unsafe extern "system" fn GetCodecInfoCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMHeaderInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pccodecinfos: *mut u32) -> ::windows::core::HRESULT {
@@ -1398,6 +1445,7 @@ pub trait IWMHeaderInfo3_Impl: Sized + IWMHeaderInfo_Impl + IWMHeaderInfo2_Impl 
     fn DeleteAttribute(&self, wstreamnum: u16, windex: u16) -> ::windows::core::Result<()>;
     fn AddCodecInfo(&self, pwszname: &::windows::core::PCWSTR, pwszdescription: &::windows::core::PCWSTR, codectype: WMT_CODEC_INFO_TYPE, cbcodecinfo: u16, pbcodecinfo: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMHeaderInfo3 {}
 impl IWMHeaderInfo3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMHeaderInfo3_Impl, const OFFSET: isize>() -> IWMHeaderInfo3_Vtbl {
         unsafe extern "system" fn GetAttributeCountEx<Identity: ::windows::core::IUnknownImpl, Impl: IWMHeaderInfo3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnum: u16, pcattributes: *mut u16) -> ::windows::core::HRESULT {
@@ -1459,6 +1507,7 @@ impl IWMHeaderInfo3_Vtbl {
 pub trait IWMIStreamProps_Impl: Sized {
     fn GetProperty(&self, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMIStreamProps {}
 impl IWMIStreamProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMIStreamProps_Impl, const OFFSET: isize>() -> IWMIStreamProps_Vtbl {
         unsafe extern "system" fn GetProperty<Identity: ::windows::core::IUnknownImpl, Impl: IWMIStreamProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1476,6 +1525,7 @@ pub trait IWMImageInfo_Impl: Sized {
     fn GetImageCount(&self) -> ::windows::core::Result<u32>;
     fn GetImage(&self, windex: u32, pcchmimetype: *mut u16, pwszmimetype: ::windows::core::PWSTR, pcchdescription: *mut u16, pwszdescription: ::windows::core::PWSTR, pimagetype: *mut u16, pcbimagedata: *mut u32, pbimagedata: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMImageInfo {}
 impl IWMImageInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMImageInfo_Impl, const OFFSET: isize>() -> IWMImageInfo_Vtbl {
         unsafe extern "system" fn GetImageCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMImageInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcimages: *mut u32) -> ::windows::core::HRESULT {
@@ -1508,6 +1558,7 @@ pub trait IWMIndexer_Impl: Sized {
     fn StartIndexing(&self, pwszurl: &::windows::core::PCWSTR, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMIndexer {}
 impl IWMIndexer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMIndexer_Impl, const OFFSET: isize>() -> IWMIndexer_Vtbl {
         unsafe extern "system" fn StartIndexing<Identity: ::windows::core::IUnknownImpl, Impl: IWMIndexer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, pcallback: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1533,6 +1584,7 @@ impl IWMIndexer_Vtbl {
 pub trait IWMIndexer2_Impl: Sized + IWMIndexer_Impl {
     fn Configure(&self, wstreamnum: u16, nindexertype: WMT_INDEXER_TYPE, pvinterval: *const ::core::ffi::c_void, pvindextype: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMIndexer2 {}
 impl IWMIndexer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMIndexer2_Impl, const OFFSET: isize>() -> IWMIndexer2_Vtbl {
         unsafe extern "system" fn Configure<Identity: ::windows::core::IUnknownImpl, Impl: IWMIndexer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnum: u16, nindexertype: WMT_INDEXER_TYPE, pvinterval: *const ::core::ffi::c_void, pvindextype: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1551,6 +1603,8 @@ pub trait IWMInputMediaProps_Impl: Sized + IWMMediaProps_Impl {
     fn GetConnectionName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::Result<()>;
     fn GetGroupName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMInputMediaProps {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMInputMediaProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMInputMediaProps_Impl, const OFFSET: isize>() -> IWMInputMediaProps_Vtbl {
@@ -1579,6 +1633,7 @@ pub trait IWMLanguageList_Impl: Sized {
     fn GetLanguageDetails(&self, windex: u16, pwszlanguagestring: ::windows::core::PWSTR, pcchlanguagestringlength: *mut u16) -> ::windows::core::Result<()>;
     fn AddLanguageByRFC1766String(&self, pwszlanguagestring: &::windows::core::PCWSTR) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IWMLanguageList {}
 impl IWMLanguageList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMLanguageList_Impl, const OFFSET: isize>() -> IWMLanguageList_Vtbl {
         unsafe extern "system" fn GetLanguageCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMLanguageList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwcount: *mut u16) -> ::windows::core::HRESULT {
@@ -1623,6 +1678,7 @@ pub trait IWMLicenseBackup_Impl: Sized {
     fn BackupLicenses(&self, dwflags: u32, pcallback: &::core::option::Option<IWMStatusCallback>) -> ::windows::core::Result<()>;
     fn CancelLicenseBackup(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMLicenseBackup {}
 impl IWMLicenseBackup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMLicenseBackup_Impl, const OFFSET: isize>() -> IWMLicenseBackup_Vtbl {
         unsafe extern "system" fn BackupLicenses<Identity: ::windows::core::IUnknownImpl, Impl: IWMLicenseBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1649,6 +1705,7 @@ pub trait IWMLicenseRestore_Impl: Sized {
     fn RestoreLicenses(&self, dwflags: u32, pcallback: &::core::option::Option<IWMStatusCallback>) -> ::windows::core::Result<()>;
     fn CancelLicenseRestore(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMLicenseRestore {}
 impl IWMLicenseRestore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMLicenseRestore_Impl, const OFFSET: isize>() -> IWMLicenseRestore_Vtbl {
         unsafe extern "system" fn RestoreLicenses<Identity: ::windows::core::IUnknownImpl, Impl: IWMLicenseRestore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1675,6 +1732,7 @@ pub trait IWMLicenseRevocationAgent_Impl: Sized {
     fn GetLRBChallenge(&self, pmachineid: *const u8, dwmachineidlength: u32, pchallenge: *const u8, dwchallengelength: u32, pchallengeoutput: *mut u8, pdwchallengeoutputlength: *mut u32) -> ::windows::core::Result<()>;
     fn ProcessLRB(&self, psignedlrb: *const u8, dwsignedlrblength: u32, psignedack: *mut u8, pdwsignedacklength: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMLicenseRevocationAgent {}
 impl IWMLicenseRevocationAgent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMLicenseRevocationAgent_Impl, const OFFSET: isize>() -> IWMLicenseRevocationAgent_Vtbl {
         unsafe extern "system" fn GetLRBChallenge<Identity: ::windows::core::IUnknownImpl, Impl: IWMLicenseRevocationAgent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmachineid: *const u8, dwmachineidlength: u32, pchallenge: *const u8, dwchallengelength: u32, pchallengeoutput: *mut u8, pdwchallengeoutputlength: *mut u32) -> ::windows::core::HRESULT {
@@ -1703,6 +1761,8 @@ pub trait IWMMediaProps_Impl: Sized {
     fn GetMediaType(&self, ptype: *mut WM_MEDIA_TYPE, pcbtype: *mut u32) -> ::windows::core::Result<()>;
     fn SetMediaType(&self, ptype: *const WM_MEDIA_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMMediaProps {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMMediaProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMMediaProps_Impl, const OFFSET: isize>() -> IWMMediaProps_Vtbl {
@@ -1743,6 +1803,7 @@ pub trait IWMMetadataEditor_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMMetadataEditor {}
 impl IWMMetadataEditor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMMetadataEditor_Impl, const OFFSET: isize>() -> IWMMetadataEditor_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IWMMetadataEditor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1774,6 +1835,7 @@ impl IWMMetadataEditor_Vtbl {
 pub trait IWMMetadataEditor2_Impl: Sized + IWMMetadataEditor_Impl {
     fn OpenEx(&self, pwszfilename: &::windows::core::PCWSTR, dwdesiredaccess: u32, dwsharemode: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMMetadataEditor2 {}
 impl IWMMetadataEditor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMMetadataEditor2_Impl, const OFFSET: isize>() -> IWMMetadataEditor2_Vtbl {
         unsafe extern "system" fn OpenEx<Identity: ::windows::core::IUnknownImpl, Impl: IWMMetadataEditor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR, dwdesiredaccess: u32, dwsharemode: u32) -> ::windows::core::HRESULT {
@@ -1791,6 +1853,7 @@ pub trait IWMMutualExclusion_Impl: Sized + IWMStreamList_Impl {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetType(&self, guidtype: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMMutualExclusion {}
 impl IWMMutualExclusion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMMutualExclusion_Impl, const OFFSET: isize>() -> IWMMutualExclusion_Vtbl {
         unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl, Impl: IWMMutualExclusion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1831,6 +1894,7 @@ pub trait IWMMutualExclusion2_Impl: Sized + IWMStreamList_Impl + IWMMutualExclus
     fn AddStreamForRecord(&self, wrecordnumber: u16, wstreamnumber: u16) -> ::windows::core::Result<()>;
     fn RemoveStreamForRecord(&self, wrecordnumber: u16, wstreamnumber: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMMutualExclusion2 {}
 impl IWMMutualExclusion2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMMutualExclusion2_Impl, const OFFSET: isize>() -> IWMMutualExclusion2_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IWMMutualExclusion2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::HRESULT {
@@ -1913,6 +1977,8 @@ pub trait IWMOutputMediaProps_Impl: Sized + IWMMediaProps_Impl {
     fn GetConnectionName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMOutputMediaProps {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMOutputMediaProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMOutputMediaProps_Impl, const OFFSET: isize>() -> IWMOutputMediaProps_Vtbl {
         unsafe extern "system" fn GetStreamGroupName<Identity: ::windows::core::IUnknownImpl, Impl: IWMOutputMediaProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::HRESULT {
@@ -1939,6 +2005,7 @@ pub trait IWMPacketSize_Impl: Sized {
     fn GetMaxPacketSize(&self) -> ::windows::core::Result<u32>;
     fn SetMaxPacketSize(&self, dwmaxpacketsize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPacketSize {}
 impl IWMPacketSize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPacketSize_Impl, const OFFSET: isize>() -> IWMPacketSize_Vtbl {
         unsafe extern "system" fn GetMaxPacketSize<Identity: ::windows::core::IUnknownImpl, Impl: IWMPacketSize_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwmaxpacketsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1971,6 +2038,7 @@ pub trait IWMPacketSize2_Impl: Sized + IWMPacketSize_Impl {
     fn GetMinPacketSize(&self) -> ::windows::core::Result<u32>;
     fn SetMinPacketSize(&self, dwminpacketsize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPacketSize2 {}
 impl IWMPacketSize2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPacketSize2_Impl, const OFFSET: isize>() -> IWMPacketSize2_Vtbl {
         unsafe extern "system" fn GetMinPacketSize<Identity: ::windows::core::IUnknownImpl, Impl: IWMPacketSize2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwminpacketsize: *mut u32) -> ::windows::core::HRESULT {
@@ -2002,6 +2070,7 @@ impl IWMPacketSize2_Vtbl {
 pub trait IWMPlayerHook_Impl: Sized {
     fn PreDecode(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPlayerHook {}
 impl IWMPlayerHook_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPlayerHook_Impl, const OFFSET: isize>() -> IWMPlayerHook_Vtbl {
         unsafe extern "system" fn PreDecode<Identity: ::windows::core::IUnknownImpl, Impl: IWMPlayerHook_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2018,6 +2087,7 @@ impl IWMPlayerHook_Vtbl {
 pub trait IWMPlayerTimestampHook_Impl: Sized {
     fn MapTimestamp(&self, rtin: i64) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IWMPlayerTimestampHook {}
 impl IWMPlayerTimestampHook_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPlayerTimestampHook_Impl, const OFFSET: isize>() -> IWMPlayerTimestampHook_Vtbl {
         unsafe extern "system" fn MapTimestamp<Identity: ::windows::core::IUnknownImpl, Impl: IWMPlayerTimestampHook_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rtin: i64, prtout: *mut i64) -> ::windows::core::HRESULT {
@@ -2057,6 +2127,7 @@ pub trait IWMProfile_Impl: Sized {
     fn AddMutualExclusion(&self, pme: &::core::option::Option<IWMMutualExclusion>) -> ::windows::core::Result<()>;
     fn CreateNewMutualExclusion(&self) -> ::windows::core::Result<IWMMutualExclusion>;
 }
+impl ::windows::core::RuntimeName for IWMProfile {}
 impl IWMProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfile_Impl, const OFFSET: isize>() -> IWMProfile_Vtbl {
         unsafe extern "system" fn GetVersion<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwversion: *mut WMT_VERSION) -> ::windows::core::HRESULT {
@@ -2226,6 +2297,7 @@ impl IWMProfile_Vtbl {
 pub trait IWMProfile2_Impl: Sized + IWMProfile_Impl {
     fn GetProfileID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IWMProfile2 {}
 impl IWMProfile2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfile2_Impl, const OFFSET: isize>() -> IWMProfile2_Vtbl {
         unsafe extern "system" fn GetProfileID<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfile2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2259,6 +2331,7 @@ pub trait IWMProfile3_Impl: Sized + IWMProfile_Impl + IWMProfile2_Impl {
     fn CreateNewStreamPrioritization(&self) -> ::windows::core::Result<IWMStreamPrioritization>;
     fn GetExpectedPacketCount(&self, msduration: u64) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IWMProfile3 {}
 impl IWMProfile3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfile3_Impl, const OFFSET: isize>() -> IWMProfile3_Vtbl {
         unsafe extern "system" fn GetStorageFormat<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfile3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnstorageformat: *mut WMT_STORAGE_FORMAT) -> ::windows::core::HRESULT {
@@ -2391,6 +2464,7 @@ pub trait IWMProfileManager_Impl: Sized {
     fn GetSystemProfileCount(&self) -> ::windows::core::Result<u32>;
     fn LoadSystemProfile(&self, dwprofileindex: u32) -> ::windows::core::Result<IWMProfile>;
 }
+impl ::windows::core::RuntimeName for IWMProfileManager {}
 impl IWMProfileManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfileManager_Impl, const OFFSET: isize>() -> IWMProfileManager_Vtbl {
         unsafe extern "system" fn CreateEmptyProfile<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfileManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwversion: WMT_VERSION, ppprofile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2471,6 +2545,7 @@ pub trait IWMProfileManager2_Impl: Sized + IWMProfileManager_Impl {
     fn GetSystemProfileVersion(&self, pdwversion: *mut WMT_VERSION) -> ::windows::core::Result<()>;
     fn SetSystemProfileVersion(&self, dwversion: WMT_VERSION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMProfileManager2 {}
 impl IWMProfileManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfileManager2_Impl, const OFFSET: isize>() -> IWMProfileManager2_Vtbl {
         unsafe extern "system" fn GetSystemProfileVersion<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfileManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwversion: *mut WMT_VERSION) -> ::windows::core::HRESULT {
@@ -2497,6 +2572,7 @@ pub trait IWMProfileManagerLanguage_Impl: Sized {
     fn GetUserLanguageID(&self, wlangid: *mut u16) -> ::windows::core::Result<()>;
     fn SetUserLanguageID(&self, wlangid: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMProfileManagerLanguage {}
 impl IWMProfileManagerLanguage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfileManagerLanguage_Impl, const OFFSET: isize>() -> IWMProfileManagerLanguage_Vtbl {
         unsafe extern "system" fn GetUserLanguageID<Identity: ::windows::core::IUnknownImpl, Impl: IWMProfileManagerLanguage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wlangid: *mut u16) -> ::windows::core::HRESULT {
@@ -2527,6 +2603,7 @@ pub trait IWMPropertyVault_Impl: Sized {
     fn CopyPropertiesFrom(&self, piwmpropertyvault: &::core::option::Option<IWMPropertyVault>) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMPropertyVault {}
 impl IWMPropertyVault_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMPropertyVault_Impl, const OFFSET: isize>() -> IWMPropertyVault_Vtbl {
         unsafe extern "system" fn GetPropertyCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMPropertyVault_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *const u32) -> ::windows::core::HRESULT {
@@ -2576,6 +2653,7 @@ impl IWMPropertyVault_Vtbl {
 pub trait IWMProximityDetection_Impl: Sized {
     fn StartDetection(&self, pbregistrationmsg: *const u8, cbregistrationmsg: u32, pblocaladdress: *const u8, cblocaladdress: u32, dwextraportsallowed: u32, ppregistrationresponsemsg: *mut ::core::option::Option<INSSBuffer>, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMProximityDetection {}
 impl IWMProximityDetection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMProximityDetection_Impl, const OFFSET: isize>() -> IWMProximityDetection_Vtbl {
         unsafe extern "system" fn StartDetection<Identity: ::windows::core::IUnknownImpl, Impl: IWMProximityDetection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbregistrationmsg: *const u8, cbregistrationmsg: u32, pblocaladdress: *const u8, cblocaladdress: u32, dwextraportsallowed: u32, ppregistrationresponsemsg: *mut ::windows::core::RawPtr, pcallback: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2602,6 +2680,7 @@ pub trait IWMReader_Impl: Sized {
     fn Pause(&self) -> ::windows::core::Result<()>;
     fn Resume(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReader {}
 impl IWMReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReader_Impl, const OFFSET: isize>() -> IWMReader_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IWMReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, pcallback: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2708,6 +2787,8 @@ pub trait IWMReaderAccelerator_Impl: Sized {
     fn Notify(&self, dwoutputnum: u32, psubtype: *const WM_MEDIA_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMReaderAccelerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMReaderAccelerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAccelerator_Impl, const OFFSET: isize>() -> IWMReaderAccelerator_Vtbl {
         unsafe extern "system" fn GetCodecInterface<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAccelerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoutputnum: u32, riid: *const ::windows::core::GUID, ppvcodecinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2753,6 +2834,8 @@ pub trait IWMReaderAdvanced_Impl: Sized {
     fn GetMaxStreamSampleSize(&self, wstream: u16) -> ::windows::core::Result<u32>;
     fn NotifyLateDelivery(&self, cnslateness: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMReaderAdvanced {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMReaderAdvanced_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced_Impl, const OFFSET: isize>() -> IWMReaderAdvanced_Vtbl {
@@ -2957,6 +3040,8 @@ pub trait IWMReaderAdvanced2_Impl: Sized + IWMReaderAdvanced_Impl {
     fn OpenStream(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>, pcallback: &::core::option::Option<IWMReaderCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMReaderAdvanced2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMReaderAdvanced2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced2_Impl, const OFFSET: isize>() -> IWMReaderAdvanced2_Vtbl {
         unsafe extern "system" fn SetPlayMode<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mode: WMT_PLAY_MODE) -> ::windows::core::HRESULT {
@@ -3081,6 +3166,8 @@ pub trait IWMReaderAdvanced3_Impl: Sized + IWMReaderAdvanced_Impl + IWMReaderAdv
     fn StartAtPosition(&self, wstreamnum: u16, pvoffsetstart: *const ::core::ffi::c_void, pvduration: *const ::core::ffi::c_void, dwoffsetformat: WMT_OFFSET_FORMAT, frate: f32, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMReaderAdvanced3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMReaderAdvanced3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced3_Impl, const OFFSET: isize>() -> IWMReaderAdvanced3_Vtbl {
         unsafe extern "system" fn StopNetStreaming<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3115,6 +3202,8 @@ pub trait IWMReaderAdvanced4_Impl: Sized + IWMReaderAdvanced_Impl + IWMReaderAdv
     fn CancelSaveFileAs(&self) -> ::windows::core::Result<()>;
     fn GetURL(&self, pwszurl: ::windows::core::PWSTR, pcchurl: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMReaderAdvanced4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMReaderAdvanced4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced4_Impl, const OFFSET: isize>() -> IWMReaderAdvanced4_Vtbl {
@@ -3209,6 +3298,8 @@ pub trait IWMReaderAdvanced5_Impl: Sized + IWMReaderAdvanced_Impl + IWMReaderAdv
     fn SetPlayerHook(&self, dwoutputnum: u32, phook: &::core::option::Option<IWMPlayerHook>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMReaderAdvanced5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMReaderAdvanced5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced5_Impl, const OFFSET: isize>() -> IWMReaderAdvanced5_Vtbl {
         unsafe extern "system" fn SetPlayerHook<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoutputnum: u32, phook: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3227,6 +3318,8 @@ pub trait IWMReaderAdvanced6_Impl: Sized + IWMReaderAdvanced_Impl + IWMReaderAdv
     fn SetProtectStreamSamples(&self, pbcertificate: *const u8, cbcertificate: u32, dwcertificatetype: u32, dwflags: u32, pbinitializationvector: *mut u8, pcbinitializationvector: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMReaderAdvanced6 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMReaderAdvanced6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced6_Impl, const OFFSET: isize>() -> IWMReaderAdvanced6_Vtbl {
         unsafe extern "system" fn SetProtectStreamSamples<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAdvanced6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbcertificate: *const u8, cbcertificate: u32, dwcertificatetype: u32, dwflags: u32, pbinitializationvector: *mut u8, pcbinitializationvector: *mut u32) -> ::windows::core::HRESULT {
@@ -3244,6 +3337,7 @@ pub trait IWMReaderAllocatorEx_Impl: Sized {
     fn AllocateForStreamEx(&self, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn AllocateForOutputEx(&self, dwoutputnum: u32, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReaderAllocatorEx {}
 impl IWMReaderAllocatorEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAllocatorEx_Impl, const OFFSET: isize>() -> IWMReaderAllocatorEx_Vtbl {
         unsafe extern "system" fn AllocateForStreamEx<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderAllocatorEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut ::windows::core::RawPtr, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3269,6 +3363,7 @@ impl IWMReaderAllocatorEx_Vtbl {
 pub trait IWMReaderCallback_Impl: Sized + IWMStatusCallback_Impl {
     fn OnSample(&self, dwoutputnum: u32, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReaderCallback {}
 impl IWMReaderCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderCallback_Impl, const OFFSET: isize>() -> IWMReaderCallback_Vtbl {
         unsafe extern "system" fn OnSample<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoutputnum: u32, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3291,6 +3386,8 @@ pub trait IWMReaderCallbackAdvanced_Impl: Sized {
     fn AllocateForStream(&self, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn AllocateForOutput(&self, dwoutputnum: u32, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMReaderCallbackAdvanced {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMReaderCallbackAdvanced_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderCallbackAdvanced_Impl, const OFFSET: isize>() -> IWMReaderCallbackAdvanced_Vtbl {
@@ -3374,6 +3471,8 @@ pub trait IWMReaderNetworkConfig_Impl: Sized {
     fn GetLoggingUrlCount(&self) -> ::windows::core::Result<u32>;
     fn ResetLoggingUrlList(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMReaderNetworkConfig {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMReaderNetworkConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderNetworkConfig_Impl, const OFFSET: isize>() -> IWMReaderNetworkConfig_Vtbl {
@@ -3672,6 +3771,8 @@ pub trait IWMReaderNetworkConfig2_Impl: Sized + IWMReaderNetworkConfig_Impl {
     fn GetMaxNetPacketSize(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMReaderNetworkConfig2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMReaderNetworkConfig2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderNetworkConfig2_Impl, const OFFSET: isize>() -> IWMReaderNetworkConfig2_Vtbl {
         unsafe extern "system" fn GetEnableContentCaching<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderNetworkConfig2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfenablecontentcaching: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3808,6 +3909,7 @@ pub trait IWMReaderPlaylistBurn_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn EndPlaylistBurn(&self, hrburnresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReaderPlaylistBurn {}
 impl IWMReaderPlaylistBurn_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderPlaylistBurn_Impl, const OFFSET: isize>() -> IWMReaderPlaylistBurn_Vtbl {
         unsafe extern "system" fn InitPlaylistBurn<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderPlaylistBurn_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cfiles: u32, ppwszfilenames: *const ::windows::core::PWSTR, pcallback: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3853,6 +3955,7 @@ pub trait IWMReaderStreamClock_Impl: Sized {
     fn SetTimer(&self, cnswhen: u64, pvparam: *const ::core::ffi::c_void) -> ::windows::core::Result<u32>;
     fn KillTimer(&self, dwtimerid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReaderStreamClock {}
 impl IWMReaderStreamClock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderStreamClock_Impl, const OFFSET: isize>() -> IWMReaderStreamClock_Vtbl {
         unsafe extern "system" fn GetTime<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderStreamClock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcnsnow: *const u64) -> ::windows::core::HRESULT {
@@ -3891,6 +3994,7 @@ pub trait IWMReaderTimecode_Impl: Sized {
     fn GetTimecodeRangeCount(&self, wstreamnum: u16) -> ::windows::core::Result<u16>;
     fn GetTimecodeRangeBounds(&self, wstreamnum: u16, wrangenum: u16, pstarttimecode: *mut u32, pendtimecode: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReaderTimecode {}
 impl IWMReaderTimecode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderTimecode_Impl, const OFFSET: isize>() -> IWMReaderTimecode_Vtbl {
         unsafe extern "system" fn GetTimecodeRangeCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderTimecode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnum: u16, pwrangecount: *mut u16) -> ::windows::core::HRESULT {
@@ -3922,6 +4026,7 @@ impl IWMReaderTimecode_Vtbl {
 pub trait IWMReaderTypeNegotiation_Impl: Sized {
     fn TryOutputProps(&self, dwoutputnum: u32, poutput: &::core::option::Option<IWMOutputMediaProps>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMReaderTypeNegotiation {}
 impl IWMReaderTypeNegotiation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderTypeNegotiation_Impl, const OFFSET: isize>() -> IWMReaderTypeNegotiation_Vtbl {
         unsafe extern "system" fn TryOutputProps<Identity: ::windows::core::IUnknownImpl, Impl: IWMReaderTypeNegotiation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoutputnum: u32, poutput: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3939,6 +4044,7 @@ pub trait IWMRegisterCallback_Impl: Sized {
     fn Advise(&self, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Unadvise(&self, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMRegisterCallback {}
 impl IWMRegisterCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMRegisterCallback_Impl, const OFFSET: isize>() -> IWMRegisterCallback_Vtbl {
         unsafe extern "system" fn Advise<Identity: ::windows::core::IUnknownImpl, Impl: IWMRegisterCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3978,6 +4084,8 @@ pub trait IWMRegisteredDevice_Impl: Sized {
     fn Open(&self) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMRegisteredDevice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMRegisteredDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMRegisteredDevice_Impl, const OFFSET: isize>() -> IWMRegisteredDevice_Vtbl {
@@ -4131,6 +4239,7 @@ pub trait IWMSBufferAllocator_Impl: Sized {
     fn AllocateBuffer(&self, dwmaxbuffersize: u32) -> ::windows::core::Result<INSSBuffer>;
     fn AllocatePageSizeBuffer(&self, dwmaxbuffersize: u32) -> ::windows::core::Result<INSSBuffer>;
 }
+impl ::windows::core::RuntimeName for IWMSBufferAllocator {}
 impl IWMSBufferAllocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSBufferAllocator_Impl, const OFFSET: isize>() -> IWMSBufferAllocator_Vtbl {
         unsafe extern "system" fn AllocateBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IWMSBufferAllocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmaxbuffersize: u32, ppbuffer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4179,6 +4288,8 @@ pub trait IWMSInternalAdminNetSource_Impl: Sized {
     fn ShutdownProxyContext(&self, dwproxycontext: u32) -> ::windows::core::Result<()>;
     fn IsUsingIE(&self, dwproxycontext: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMSInternalAdminNetSource {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMSInternalAdminNetSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSInternalAdminNetSource_Impl, const OFFSET: isize>() -> IWMSInternalAdminNetSource_Vtbl {
@@ -4282,6 +4393,8 @@ pub trait IWMSInternalAdminNetSource2_Impl: Sized {
     fn FindProxyForURLEx(&self, bstrprotocol: &super::super::Foundation::BSTR, bstrhost: &super::super::Foundation::BSTR, bstrurl: &super::super::Foundation::BSTR, pfproxyenabled: *mut super::super::Foundation::BOOL, pbstrproxyserver: *mut super::super::Foundation::BSTR, pdwproxyport: *mut u32, pdwproxycontext: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMSInternalAdminNetSource2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMSInternalAdminNetSource2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSInternalAdminNetSource2_Impl, const OFFSET: isize>() -> IWMSInternalAdminNetSource2_Vtbl {
         unsafe extern "system" fn SetCredentialsEx<Identity: ::windows::core::IUnknownImpl, Impl: IWMSInternalAdminNetSource2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrrealm: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrurl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, fproxy: super::super::Foundation::BOOL, bstrname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, fpersist: super::super::Foundation::BOOL, fconfirmedgood: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -4326,6 +4439,8 @@ pub trait IWMSInternalAdminNetSource3_Impl: Sized + IWMSInternalAdminNetSource2_
     fn SetCredentialsEx2(&self, bstrrealm: &super::super::Foundation::BSTR, bstrurl: &super::super::Foundation::BSTR, fproxy: super::super::Foundation::BOOL, bstrname: &super::super::Foundation::BSTR, bstrpassword: &super::super::Foundation::BSTR, fpersist: super::super::Foundation::BOOL, fconfirmedgood: super::super::Foundation::BOOL, fcleartextauthentication: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetCredentialsEx2(&self, bstrrealm: &super::super::Foundation::BSTR, bstrurl: &super::super::Foundation::BSTR, fproxy: super::super::Foundation::BOOL, fcleartextauthentication: super::super::Foundation::BOOL, pdwurlpolicy: *mut NETSOURCE_URLCREDPOLICY_SETTINGS, pbstrname: *mut super::super::Foundation::BSTR, pbstrpassword: *mut super::super::Foundation::BSTR, pfconfirmedgood: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMSInternalAdminNetSource3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMSInternalAdminNetSource3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSInternalAdminNetSource3_Impl, const OFFSET: isize>() -> IWMSInternalAdminNetSource3_Vtbl {
@@ -4405,6 +4520,8 @@ pub trait IWMSecureChannel_Impl: Sized + IWMAuthorizer_Impl {
     fn WMSC_Unlock(&self) -> ::windows::core::Result<()>;
     fn WMSC_SetSharedData(&self, dwcertindex: u32, pbshareddata: *const u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMSecureChannel {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMSecureChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSecureChannel_Impl, const OFFSET: isize>() -> IWMSecureChannel_Vtbl {
@@ -4491,6 +4608,7 @@ impl IWMSecureChannel_Vtbl {
 pub trait IWMStatusCallback_Impl: Sized {
     fn OnStatus(&self, status: WMT_STATUS, hr: ::windows::core::HRESULT, dwtype: WMT_ATTR_DATATYPE, pvalue: *const u8, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMStatusCallback {}
 impl IWMStatusCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMStatusCallback_Impl, const OFFSET: isize>() -> IWMStatusCallback_Vtbl {
         unsafe extern "system" fn OnStatus<Identity: ::windows::core::IUnknownImpl, Impl: IWMStatusCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, status: WMT_STATUS, hr: ::windows::core::HRESULT, dwtype: WMT_ATTR_DATATYPE, pvalue: *const u8, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4517,6 +4635,7 @@ pub trait IWMStreamConfig_Impl: Sized {
     fn GetBufferWindow(&self) -> ::windows::core::Result<u32>;
     fn SetBufferWindow(&self, msbufferwindow: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMStreamConfig {}
 impl IWMStreamConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamConfig_Impl, const OFFSET: isize>() -> IWMStreamConfig_Vtbl {
         unsafe extern "system" fn GetStreamType<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidstreamtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -4625,6 +4744,7 @@ pub trait IWMStreamConfig2_Impl: Sized + IWMStreamConfig_Impl {
     fn GetDataUnitExtension(&self, wdataunitextensionnumber: u16, pguidextensionsystemid: *mut ::windows::core::GUID, pcbextensiondatasize: *mut u16, pbextensionsysteminfo: *mut u8, pcbextensionsysteminfo: *mut u32) -> ::windows::core::Result<()>;
     fn RemoveAllDataUnitExtensions(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMStreamConfig2 {}
 impl IWMStreamConfig2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamConfig2_Impl, const OFFSET: isize>() -> IWMStreamConfig2_Vtbl {
         unsafe extern "system" fn GetTransportType<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamConfig2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pntransporttype: *mut WMT_TRANSPORT_TYPE) -> ::windows::core::HRESULT {
@@ -4687,6 +4807,7 @@ pub trait IWMStreamConfig3_Impl: Sized + IWMStreamConfig_Impl + IWMStreamConfig2
     fn GetLanguage(&self, pwszlanguagestring: ::windows::core::PWSTR, pcchlanguagestringlength: *mut u16) -> ::windows::core::Result<()>;
     fn SetLanguage(&self, pwszlanguagestring: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMStreamConfig3 {}
 impl IWMStreamConfig3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamConfig3_Impl, const OFFSET: isize>() -> IWMStreamConfig3_Vtbl {
         unsafe extern "system" fn GetLanguage<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamConfig3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszlanguagestring: ::windows::core::PWSTR, pcchlanguagestringlength: *mut u16) -> ::windows::core::HRESULT {
@@ -4714,6 +4835,7 @@ pub trait IWMStreamList_Impl: Sized {
     fn AddStream(&self, wstreamnum: u16) -> ::windows::core::Result<()>;
     fn RemoveStream(&self, wstreamnum: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMStreamList {}
 impl IWMStreamList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamList_Impl, const OFFSET: isize>() -> IWMStreamList_Vtbl {
         unsafe extern "system" fn GetStreams<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwstreamnumarray: *mut u16, pcstreams: *mut u16) -> ::windows::core::HRESULT {
@@ -4747,6 +4869,8 @@ pub trait IWMStreamPrioritization_Impl: Sized {
     fn GetPriorityRecords(&self, precordarray: *mut WM_STREAM_PRIORITY_RECORD, pcrecords: *mut u16) -> ::windows::core::Result<()>;
     fn SetPriorityRecords(&self, precordarray: *const WM_STREAM_PRIORITY_RECORD, crecords: u16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMStreamPrioritization {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMStreamPrioritization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMStreamPrioritization_Impl, const OFFSET: isize>() -> IWMStreamPrioritization_Vtbl {
@@ -4794,6 +4918,8 @@ pub trait IWMSyncReader_Impl: Sized {
     fn GetMaxStreamSampleSize(&self, wstream: u16) -> ::windows::core::Result<u32>;
     fn OpenStream(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMSyncReader {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMSyncReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSyncReader_Impl, const OFFSET: isize>() -> IWMSyncReader_Vtbl {
@@ -5001,6 +5127,8 @@ pub trait IWMSyncReader2_Impl: Sized + IWMSyncReader_Impl {
     fn GetAllocateForStream(&self, dwsreamnum: u16) -> ::windows::core::Result<IWMReaderAllocatorEx>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWMSyncReader2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWMSyncReader2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMSyncReader2_Impl, const OFFSET: isize>() -> IWMSyncReader2_Vtbl {
         unsafe extern "system" fn SetRangeByTimecode<Identity: ::windows::core::IUnknownImpl, Impl: IWMSyncReader2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnum: u16, pstart: *const WMT_TIMECODE_EXTENSION_DATA, pend: *const WMT_TIMECODE_EXTENSION_DATA) -> ::windows::core::HRESULT {
@@ -5073,6 +5201,8 @@ pub trait IWMVideoMediaProps_Impl: Sized + IWMMediaProps_Impl {
     fn SetQuality(&self, dwquality: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMVideoMediaProps {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMVideoMediaProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoMediaProps_Impl, const OFFSET: isize>() -> IWMVideoMediaProps_Vtbl {
         unsafe extern "system" fn GetMaxKeyFrameSpacing<Identity: ::windows::core::IUnknownImpl, Impl: IWMVideoMediaProps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plltime: *mut i64) -> ::windows::core::HRESULT {
@@ -5123,6 +5253,7 @@ pub trait IWMWatermarkInfo_Impl: Sized {
     fn GetWatermarkEntryCount(&self, wmettype: WMT_WATERMARK_ENTRY_TYPE) -> ::windows::core::Result<u32>;
     fn GetWatermarkEntry(&self, wmettype: WMT_WATERMARK_ENTRY_TYPE, dwentrynum: u32) -> ::windows::core::Result<WMT_WATERMARK_ENTRY>;
 }
+impl ::windows::core::RuntimeName for IWMWatermarkInfo {}
 impl IWMWatermarkInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWatermarkInfo_Impl, const OFFSET: isize>() -> IWMWatermarkInfo_Vtbl {
         unsafe extern "system" fn GetWatermarkEntryCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMWatermarkInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wmettype: WMT_WATERMARK_ENTRY_TYPE, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -5172,6 +5303,7 @@ pub trait IWMWriter_Impl: Sized {
     fn WriteSample(&self, dwinputnum: u32, cnssampletime: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMWriter {}
 impl IWMWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriter_Impl, const OFFSET: isize>() -> IWMWriter_Vtbl {
         unsafe extern "system" fn SetProfileByID<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidprofile: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -5305,6 +5437,8 @@ pub trait IWMWriterAdvanced_Impl: Sized {
     fn GetSyncTolerance(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterAdvanced {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMWriterAdvanced_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterAdvanced_Impl, const OFFSET: isize>() -> IWMWriterAdvanced_Vtbl {
         unsafe extern "system" fn GetSinkCount<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterAdvanced_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcsinks: *mut u32) -> ::windows::core::HRESULT {
@@ -5423,6 +5557,8 @@ pub trait IWMWriterAdvanced2_Impl: Sized + IWMWriterAdvanced_Impl {
     fn SetInputSetting(&self, dwinputnum: u32, pszname: &::windows::core::PCWSTR, r#type: WMT_ATTR_DATATYPE, pvalue: *const u8, cblength: u16) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterAdvanced2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMWriterAdvanced2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterAdvanced2_Impl, const OFFSET: isize>() -> IWMWriterAdvanced2_Vtbl {
         unsafe extern "system" fn GetInputSetting<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterAdvanced2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwinputnum: u32, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT {
@@ -5450,6 +5586,8 @@ pub trait IWMWriterAdvanced3_Impl: Sized + IWMWriterAdvanced_Impl + IWMWriterAdv
     fn GetStatisticsEx(&self, wstreamnum: u16) -> ::windows::core::Result<WM_WRITER_STATISTICS_EX>;
     fn SetNonBlocking(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterAdvanced3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMWriterAdvanced3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterAdvanced3_Impl, const OFFSET: isize>() -> IWMWriterAdvanced3_Vtbl {
@@ -5484,6 +5622,8 @@ pub trait IWMWriterFileSink_Impl: Sized + IWMWriterSink_Impl {
     fn Open(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterFileSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMWriterFileSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterFileSink_Impl, const OFFSET: isize>() -> IWMWriterFileSink_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterFileSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -5507,6 +5647,8 @@ pub trait IWMWriterFileSink2_Impl: Sized + IWMWriterSink_Impl + IWMWriterFileSin
     fn Close(&self) -> ::windows::core::Result<()>;
     fn IsClosed(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterFileSink2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMWriterFileSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterFileSink2_Impl, const OFFSET: isize>() -> IWMWriterFileSink2_Vtbl {
@@ -5596,6 +5738,8 @@ pub trait IWMWriterFileSink3_Impl: Sized + IWMWriterSink_Impl + IWMWriterFileSin
     fn CompleteOperations(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterFileSink3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMWriterFileSink3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterFileSink3_Impl, const OFFSET: isize>() -> IWMWriterFileSink3_Vtbl {
         unsafe extern "system" fn SetAutoIndexing<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterFileSink3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fdoautoindexing: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5684,6 +5828,8 @@ pub trait IWMWriterNetworkSink_Impl: Sized + IWMWriterSink_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterNetworkSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMWriterNetworkSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterNetworkSink_Impl, const OFFSET: isize>() -> IWMWriterNetworkSink_Vtbl {
         unsafe extern "system" fn SetMaximumClients<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterNetworkSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmaxclients: u32) -> ::windows::core::HRESULT {
@@ -5766,6 +5912,8 @@ pub trait IWMWriterPostView_Impl: Sized {
     fn SetAllocateForPostView(&self, wstreamnumber: u16, fallocate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetAllocateForPostView(&self, wstreamnumber: u16) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterPostView {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMWriterPostView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPostView_Impl, const OFFSET: isize>() -> IWMWriterPostView_Vtbl {
@@ -5865,6 +6013,7 @@ pub trait IWMWriterPostViewCallback_Impl: Sized + IWMStatusCallback_Impl {
     fn OnPostViewSample(&self, wstreamnumber: u16, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn AllocateForPostView(&self, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMWriterPostViewCallback {}
 impl IWMWriterPostViewCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPostViewCallback_Impl, const OFFSET: isize>() -> IWMWriterPostViewCallback_Vtbl {
         unsafe extern "system" fn OnPostViewSample<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPostViewCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wstreamnumber: u16, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: ::windows::core::RawPtr, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5894,6 +6043,7 @@ pub trait IWMWriterPreprocess_Impl: Sized {
     fn PreprocessSample(&self, dwinputnum: u32, cnssampletime: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>) -> ::windows::core::Result<()>;
     fn EndPreprocessingPass(&self, dwinputnum: u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWMWriterPreprocess {}
 impl IWMWriterPreprocess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPreprocess_Impl, const OFFSET: isize>() -> IWMWriterPreprocess_Vtbl {
         unsafe extern "system" fn GetMaxPreprocessingPasses<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPreprocess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwinputnum: u32, dwflags: u32, pdwmaxnumpasses: *mut u32) -> ::windows::core::HRESULT {
@@ -5947,6 +6097,8 @@ pub trait IWMWriterPushSink_Impl: Sized + IWMWriterSink_Impl {
     fn EndSession(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterPushSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWMWriterPushSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPushSink_Impl, const OFFSET: isize>() -> IWMWriterPushSink_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterPushSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, pwsztemplateurl: ::windows::core::PCWSTR, fautodestroy: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5983,6 +6135,8 @@ pub trait IWMWriterSink_Impl: Sized {
     fn OnDataUnit(&self, pdataunit: &::core::option::Option<INSSBuffer>) -> ::windows::core::Result<()>;
     fn OnEndWriting(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWMWriterSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWMWriterSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMWriterSink_Impl, const OFFSET: isize>() -> IWMWriterSink_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/impl.rs
@@ -6,6 +6,8 @@ pub trait IReferenceClock_Impl: Sized {
     fn Unadvise(&self, dwadvisecookie: usize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IReferenceClock {}
+#[cfg(feature = "Win32_Foundation")]
 impl IReferenceClock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceClock_Impl, const OFFSET: isize>() -> IReferenceClock_Vtbl {
         unsafe extern "system" fn GetTime<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceClock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptime: *mut i64) -> ::windows::core::HRESULT {
@@ -61,6 +63,8 @@ impl IReferenceClock_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IReferenceClock2_Impl: Sized + IReferenceClock_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IReferenceClock2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IReferenceClock2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceClock2_Impl, const OFFSET: isize>() -> IReferenceClock2_Vtbl {
         Self { base__: IReferenceClock_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -73,6 +77,7 @@ pub trait IReferenceClockTimerControl_Impl: Sized {
     fn SetDefaultTimerResolution(&self, timerresolution: i64) -> ::windows::core::Result<()>;
     fn GetDefaultTimerResolution(&self) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IReferenceClockTimerControl {}
 impl IReferenceClockTimerControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceClockTimerControl_Impl, const OFFSET: isize>() -> IReferenceClockTimerControl_Vtbl {
         unsafe extern "system" fn SetDefaultTimerResolution<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceClockTimerControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timerresolution: i64) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
@@ -1,6 +1,8 @@
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDummyMBNUCMExt_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDummyMBNUCMExt {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDummyMBNUCMExt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDummyMBNUCMExt_Impl, const OFFSET: isize>() -> IDummyMBNUCMExt_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -19,6 +21,8 @@ pub trait IMbnConnection_Impl: Sized {
     fn GetVoiceCallState(&self) -> ::windows::core::Result<MBN_VOICE_CALL_STATE>;
     fn GetActivationNetworkError(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMbnConnection {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMbnConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnection_Impl, const OFFSET: isize>() -> IMbnConnection_Vtbl {
@@ -114,6 +118,8 @@ pub trait IMbnConnectionContext_Impl: Sized {
     fn SetProvisionedContext(&self, provisionedcontexts: &MBN_CONTEXT, providerid: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnConnectionContext {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnConnectionContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionContext_Impl, const OFFSET: isize>() -> IMbnConnectionContext_Vtbl {
         unsafe extern "system" fn GetProvisionedContexts<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, provisionedcontexts: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -152,6 +158,7 @@ pub trait IMbnConnectionContextEvents_Impl: Sized {
     fn OnProvisionedContextListChange(&self, newinterface: &::core::option::Option<IMbnConnectionContext>) -> ::windows::core::Result<()>;
     fn OnSetProvisionedContextComplete(&self, newinterface: &::core::option::Option<IMbnConnectionContext>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnConnectionContextEvents {}
 impl IMbnConnectionContextEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionContextEvents_Impl, const OFFSET: isize>() -> IMbnConnectionContextEvents_Vtbl {
         unsafe extern "system" fn OnProvisionedContextListChange<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionContextEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newinterface: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -180,6 +187,7 @@ pub trait IMbnConnectionEvents_Impl: Sized {
     fn OnConnectStateChange(&self, newconnection: &::core::option::Option<IMbnConnection>) -> ::windows::core::Result<()>;
     fn OnVoiceCallStateChange(&self, newconnection: &::core::option::Option<IMbnConnection>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnConnectionEvents {}
 impl IMbnConnectionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionEvents_Impl, const OFFSET: isize>() -> IMbnConnectionEvents_Vtbl {
         unsafe extern "system" fn OnConnectComplete<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newconnection: ::windows::core::RawPtr, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -220,6 +228,8 @@ pub trait IMbnConnectionManager_Impl: Sized {
     fn GetConnections(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnConnectionManager {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMbnConnectionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionManager_Impl, const OFFSET: isize>() -> IMbnConnectionManager_Vtbl {
         unsafe extern "system" fn GetConnection<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::PCWSTR, mbnconnection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -258,6 +268,7 @@ pub trait IMbnConnectionManagerEvents_Impl: Sized {
     fn OnConnectionArrival(&self, newconnection: &::core::option::Option<IMbnConnection>) -> ::windows::core::Result<()>;
     fn OnConnectionRemoval(&self, oldconnection: &::core::option::Option<IMbnConnection>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnConnectionManagerEvents {}
 impl IMbnConnectionManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionManagerEvents_Impl, const OFFSET: isize>() -> IMbnConnectionManagerEvents_Vtbl {
         unsafe extern "system" fn OnConnectionArrival<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newconnection: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -286,6 +297,8 @@ pub trait IMbnConnectionProfile_Impl: Sized {
     fn UpdateProfile(&self, strprofile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMbnConnectionProfile {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMbnConnectionProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionProfile_Impl, const OFFSET: isize>() -> IMbnConnectionProfile_Vtbl {
@@ -324,6 +337,7 @@ impl IMbnConnectionProfile_Vtbl {
 pub trait IMbnConnectionProfileEvents_Impl: Sized {
     fn OnProfileUpdate(&self, newprofile: &::core::option::Option<IMbnConnectionProfile>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnConnectionProfileEvents {}
 impl IMbnConnectionProfileEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionProfileEvents_Impl, const OFFSET: isize>() -> IMbnConnectionProfileEvents_Vtbl {
         unsafe extern "system" fn OnProfileUpdate<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionProfileEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newprofile: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -343,6 +357,8 @@ pub trait IMbnConnectionProfileManager_Impl: Sized {
     fn GetConnectionProfile(&self, mbninterface: &::core::option::Option<IMbnInterface>, profilename: &::windows::core::PCWSTR) -> ::windows::core::Result<IMbnConnectionProfile>;
     fn CreateConnectionProfile(&self, xmlprofile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnConnectionProfileManager {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMbnConnectionProfileManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionProfileManager_Impl, const OFFSET: isize>() -> IMbnConnectionProfileManager_Vtbl {
@@ -388,6 +404,7 @@ pub trait IMbnConnectionProfileManagerEvents_Impl: Sized {
     fn OnConnectionProfileArrival(&self, newconnectionprofile: &::core::option::Option<IMbnConnectionProfile>) -> ::windows::core::Result<()>;
     fn OnConnectionProfileRemoval(&self, oldconnectionprofile: &::core::option::Option<IMbnConnectionProfile>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnConnectionProfileManagerEvents {}
 impl IMbnConnectionProfileManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionProfileManagerEvents_Impl, const OFFSET: isize>() -> IMbnConnectionProfileManagerEvents_Vtbl {
         unsafe extern "system" fn OnConnectionProfileArrival<Identity: ::windows::core::IUnknownImpl, Impl: IMbnConnectionProfileManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newconnectionprofile: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -425,6 +442,8 @@ pub trait IMbnDeviceService_Impl: Sized {
     fn IsCommandSessionOpen(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn IsDataSessionOpen(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnDeviceService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnDeviceService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceService_Impl, const OFFSET: isize>() -> IMbnDeviceService_Vtbl {
@@ -585,6 +604,8 @@ pub trait IMbnDeviceServiceStateEvents_Impl: Sized {
     fn OnSessionsStateChange(&self, interfaceid: &super::super::Foundation::BSTR, statechange: MBN_DEVICE_SERVICE_SESSIONS_STATE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMbnDeviceServiceStateEvents {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMbnDeviceServiceStateEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceServiceStateEvents_Impl, const OFFSET: isize>() -> IMbnDeviceServiceStateEvents_Vtbl {
         unsafe extern "system" fn OnSessionsStateChange<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceServiceStateEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interfaceid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, statechange: MBN_DEVICE_SERVICE_SESSIONS_STATE) -> ::windows::core::HRESULT {
@@ -605,6 +626,8 @@ pub trait IMbnDeviceServicesContext_Impl: Sized {
     fn MaxCommandSize(&self) -> ::windows::core::Result<u32>;
     fn MaxDataSize(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnDeviceServicesContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnDeviceServicesContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceServicesContext_Impl, const OFFSET: isize>() -> IMbnDeviceServicesContext_Vtbl {
@@ -678,6 +701,8 @@ pub trait IMbnDeviceServicesEvents_Impl: Sized {
     fn OnReadData(&self, deviceservice: &::core::option::Option<IMbnDeviceService>, deviceservicedata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn OnInterfaceStateChange(&self, interfaceid: &super::super::Foundation::BSTR, statechange: MBN_DEVICE_SERVICES_INTERFACE_STATE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnDeviceServicesEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnDeviceServicesEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceServicesEvents_Impl, const OFFSET: isize>() -> IMbnDeviceServicesEvents_Vtbl {
@@ -760,6 +785,8 @@ pub trait IMbnDeviceServicesManager_Impl: Sized {
     fn GetDeviceServicesContext(&self, networkinterfaceid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IMbnDeviceServicesContext>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMbnDeviceServicesManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMbnDeviceServicesManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceServicesManager_Impl, const OFFSET: isize>() -> IMbnDeviceServicesManager_Vtbl {
         unsafe extern "system" fn GetDeviceServicesContext<Identity: ::windows::core::IUnknownImpl, Impl: IMbnDeviceServicesManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, networkinterfaceid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, mbndevicescontext: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -793,6 +820,8 @@ pub trait IMbnInterface_Impl: Sized {
     fn ScanNetwork(&self) -> ::windows::core::Result<u32>;
     fn GetConnection(&self) -> ::windows::core::Result<IMbnConnection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnInterface {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterface_Impl, const OFFSET: isize>() -> IMbnInterface_Vtbl {
@@ -940,6 +969,7 @@ pub trait IMbnInterfaceEvents_Impl: Sized {
     fn OnSetPreferredProvidersComplete(&self, newinterface: &::core::option::Option<IMbnInterface>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnScanNetworkComplete(&self, newinterface: &::core::option::Option<IMbnInterface>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnInterfaceEvents {}
 impl IMbnInterfaceEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterfaceEvents_Impl, const OFFSET: isize>() -> IMbnInterfaceEvents_Vtbl {
         unsafe extern "system" fn OnInterfaceCapabilityAvailable<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterfaceEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newinterface: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1004,6 +1034,8 @@ pub trait IMbnInterfaceManager_Impl: Sized {
     fn GetInterfaces(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnInterfaceManager {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMbnInterfaceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterfaceManager_Impl, const OFFSET: isize>() -> IMbnInterfaceManager_Vtbl {
         unsafe extern "system" fn GetInterface<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterfaceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interfaceid: ::windows::core::PCWSTR, mbninterface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1042,6 +1074,7 @@ pub trait IMbnInterfaceManagerEvents_Impl: Sized {
     fn OnInterfaceArrival(&self, newinterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<()>;
     fn OnInterfaceRemoval(&self, oldinterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnInterfaceManagerEvents {}
 impl IMbnInterfaceManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterfaceManagerEvents_Impl, const OFFSET: isize>() -> IMbnInterfaceManagerEvents_Vtbl {
         unsafe extern "system" fn OnInterfaceArrival<Identity: ::windows::core::IUnknownImpl, Impl: IMbnInterfaceManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newinterface: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1073,6 +1106,8 @@ pub trait IMbnMultiCarrier_Impl: Sized {
     fn GetCurrentCellularClass(&self) -> ::windows::core::Result<MBN_CELLULAR_CLASS>;
     fn ScanNetwork(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnMultiCarrier {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnMultiCarrier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnMultiCarrier_Impl, const OFFSET: isize>() -> IMbnMultiCarrier_Vtbl {
@@ -1157,6 +1192,7 @@ pub trait IMbnMultiCarrierEvents_Impl: Sized {
     fn OnScanNetworkComplete(&self, mbninterface: &::core::option::Option<IMbnMultiCarrier>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnInterfaceCapabilityChange(&self, mbninterface: &::core::option::Option<IMbnMultiCarrier>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnMultiCarrierEvents {}
 impl IMbnMultiCarrierEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnMultiCarrierEvents_Impl, const OFFSET: isize>() -> IMbnMultiCarrierEvents_Vtbl {
         unsafe extern "system" fn OnSetHomeProviderComplete<Identity: ::windows::core::IUnknownImpl, Impl: IMbnMultiCarrierEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mbninterface: ::windows::core::RawPtr, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1210,6 +1246,7 @@ pub trait IMbnPin_Impl: Sized {
     fn Unblock(&self, puk: &::windows::core::PCWSTR, newpin: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
     fn GetPinManager(&self) -> ::windows::core::Result<IMbnPinManager>;
 }
+impl ::windows::core::RuntimeName for IMbnPin {}
 impl IMbnPin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPin_Impl, const OFFSET: isize>() -> IMbnPin_Vtbl {
         unsafe extern "system" fn PinType<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pintype: *mut MBN_PIN_TYPE) -> ::windows::core::HRESULT {
@@ -1359,6 +1396,7 @@ pub trait IMbnPinEvents_Impl: Sized {
     fn OnChangeComplete(&self, pin: &::core::option::Option<IMbnPin>, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnUnblockComplete(&self, pin: &::core::option::Option<IMbnPin>, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnPinEvents {}
 impl IMbnPinEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPinEvents_Impl, const OFFSET: isize>() -> IMbnPinEvents_Vtbl {
         unsafe extern "system" fn OnEnableComplete<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPinEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pin: ::windows::core::RawPtr, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1405,6 +1443,8 @@ pub trait IMbnPinManager_Impl: Sized {
     fn GetPin(&self, pintype: MBN_PIN_TYPE) -> ::windows::core::Result<IMbnPin>;
     fn GetPinState(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnPinManager {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMbnPinManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPinManager_Impl, const OFFSET: isize>() -> IMbnPinManager_Vtbl {
@@ -1456,6 +1496,7 @@ pub trait IMbnPinManagerEvents_Impl: Sized {
     fn OnPinListAvailable(&self, pinmanager: &::core::option::Option<IMbnPinManager>) -> ::windows::core::Result<()>;
     fn OnGetPinStateComplete(&self, pinmanager: &::core::option::Option<IMbnPinManager>, pininfo: &MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnPinManagerEvents {}
 impl IMbnPinManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPinManagerEvents_Impl, const OFFSET: isize>() -> IMbnPinManagerEvents_Vtbl {
         unsafe extern "system" fn OnPinListAvailable<Identity: ::windows::core::IUnknownImpl, Impl: IMbnPinManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinmanager: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1483,6 +1524,7 @@ pub trait IMbnRadio_Impl: Sized {
     fn HardwareRadioState(&self) -> ::windows::core::Result<MBN_RADIO>;
     fn SetSoftwareRadioState(&self, radiostate: MBN_RADIO) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMbnRadio {}
 impl IMbnRadio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRadio_Impl, const OFFSET: isize>() -> IMbnRadio_Vtbl {
         unsafe extern "system" fn SoftwareRadioState<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRadio_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, softwareradiostate: *mut MBN_RADIO) -> ::windows::core::HRESULT {
@@ -1533,6 +1575,7 @@ pub trait IMbnRadioEvents_Impl: Sized {
     fn OnRadioStateChange(&self, newinterface: &::core::option::Option<IMbnRadio>) -> ::windows::core::Result<()>;
     fn OnSetSoftwareRadioStateComplete(&self, newinterface: &::core::option::Option<IMbnRadio>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnRadioEvents {}
 impl IMbnRadioEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRadioEvents_Impl, const OFFSET: isize>() -> IMbnRadioEvents_Vtbl {
         unsafe extern "system" fn OnRadioStateChange<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRadioEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newinterface: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1568,6 +1611,8 @@ pub trait IMbnRegistration_Impl: Sized {
     fn GetPacketAttachNetworkError(&self) -> ::windows::core::Result<u32>;
     fn SetRegisterMode(&self, registermode: MBN_REGISTER_MODE, providerid: &::windows::core::PCWSTR, dataclass: u32) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMbnRegistration {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMbnRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRegistration_Impl, const OFFSET: isize>() -> IMbnRegistration_Vtbl {
@@ -1705,6 +1750,7 @@ pub trait IMbnRegistrationEvents_Impl: Sized {
     fn OnPacketServiceStateChange(&self, newinterface: &::core::option::Option<IMbnRegistration>) -> ::windows::core::Result<()>;
     fn OnSetRegisterModeComplete(&self, newinterface: &::core::option::Option<IMbnRegistration>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnRegistrationEvents {}
 impl IMbnRegistrationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRegistrationEvents_Impl, const OFFSET: isize>() -> IMbnRegistrationEvents_Vtbl {
         unsafe extern "system" fn OnRegisterModeAvailable<Identity: ::windows::core::IUnknownImpl, Impl: IMbnRegistrationEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newinterface: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1744,6 +1790,8 @@ pub trait IMbnServiceActivation_Impl: Sized {
     fn Activate(&self, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnServiceActivation {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMbnServiceActivation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnServiceActivation_Impl, const OFFSET: isize>() -> IMbnServiceActivation_Vtbl {
         unsafe extern "system" fn Activate<Identity: ::windows::core::IUnknownImpl, Impl: IMbnServiceActivation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: *mut u32) -> ::windows::core::HRESULT {
@@ -1768,6 +1816,8 @@ pub trait IMbnServiceActivationEvents_Impl: Sized {
     fn OnActivationComplete(&self, serviceactivation: &::core::option::Option<IMbnServiceActivation>, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: u32, status: ::windows::core::HRESULT, networkerror: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnServiceActivationEvents {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMbnServiceActivationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnServiceActivationEvents_Impl, const OFFSET: isize>() -> IMbnServiceActivationEvents_Vtbl {
         unsafe extern "system" fn OnActivationComplete<Identity: ::windows::core::IUnknownImpl, Impl: IMbnServiceActivationEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, serviceactivation: ::windows::core::RawPtr, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: u32, status: ::windows::core::HRESULT, networkerror: u32) -> ::windows::core::HRESULT {
@@ -1785,6 +1835,7 @@ pub trait IMbnSignal_Impl: Sized {
     fn GetSignalStrength(&self) -> ::windows::core::Result<u32>;
     fn GetSignalError(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMbnSignal {}
 impl IMbnSignal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSignal_Impl, const OFFSET: isize>() -> IMbnSignal_Vtbl {
         unsafe extern "system" fn GetSignalStrength<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSignal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, signalstrength: *mut u32) -> ::windows::core::HRESULT {
@@ -1822,6 +1873,7 @@ impl IMbnSignal_Vtbl {
 pub trait IMbnSignalEvents_Impl: Sized {
     fn OnSignalStateChange(&self, newinterface: &::core::option::Option<IMbnSignal>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMbnSignalEvents {}
 impl IMbnSignalEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSignalEvents_Impl, const OFFSET: isize>() -> IMbnSignalEvents_Vtbl {
         unsafe extern "system" fn OnSignalStateChange<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSignalEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newinterface: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1846,6 +1898,8 @@ pub trait IMbnSms_Impl: Sized {
     fn SmsDelete(&self, smsfilter: *const MBN_SMS_FILTER) -> ::windows::core::Result<u32>;
     fn GetSmsStatus(&self) -> ::windows::core::Result<MBN_SMS_STATUS_INFO>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnSms {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMbnSms_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSms_Impl, const OFFSET: isize>() -> IMbnSms_Vtbl {
@@ -1963,6 +2017,8 @@ pub trait IMbnSmsConfiguration_Impl: Sized {
     fn SetSmsFormat(&self, smsformat: MBN_SMS_FORMAT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMbnSmsConfiguration {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMbnSmsConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSmsConfiguration_Impl, const OFFSET: isize>() -> IMbnSmsConfiguration_Vtbl {
         unsafe extern "system" fn ServiceCenterAddress<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSmsConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scaddress: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2044,6 +2100,8 @@ pub trait IMbnSmsEvents_Impl: Sized {
     fn OnSmsStatusChange(&self, sms: &::core::option::Option<IMbnSms>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnSmsEvents {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMbnSmsEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSmsEvents_Impl, const OFFSET: isize>() -> IMbnSmsEvents_Vtbl {
         unsafe extern "system" fn OnSmsConfigurationChange<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSmsEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sms: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2103,6 +2161,8 @@ pub trait IMbnSmsReadMsgPdu_Impl: Sized {
     fn PduData(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Message(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnSmsReadMsgPdu {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnSmsReadMsgPdu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSmsReadMsgPdu_Impl, const OFFSET: isize>() -> IMbnSmsReadMsgPdu_Vtbl {
@@ -2173,6 +2233,8 @@ pub trait IMbnSmsReadMsgTextCdma_Impl: Sized {
     fn SizeInCharacters(&self) -> ::windows::core::Result<u32>;
     fn Message(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnSmsReadMsgTextCdma {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnSmsReadMsgTextCdma_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSmsReadMsgTextCdma_Impl, const OFFSET: isize>() -> IMbnSmsReadMsgTextCdma_Vtbl {
@@ -2287,6 +2349,8 @@ pub trait IMbnSubscriberInformation_Impl: Sized {
     fn TelephoneNumbers(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMbnSubscriberInformation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMbnSubscriberInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSubscriberInformation_Impl, const OFFSET: isize>() -> IMbnSubscriberInformation_Vtbl {
         unsafe extern "system" fn SubscriberID<Identity: ::windows::core::IUnknownImpl, Impl: IMbnSubscriberInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, subscriberid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2339,6 +2403,8 @@ pub trait IMbnVendorSpecificEvents_Impl: Sized {
     fn OnSetVendorSpecificComplete(&self, vendoroperation: &::core::option::Option<IMbnVendorSpecificOperation>, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnVendorSpecificEvents {}
+#[cfg(feature = "Win32_System_Com")]
 impl IMbnVendorSpecificEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnVendorSpecificEvents_Impl, const OFFSET: isize>() -> IMbnVendorSpecificEvents_Vtbl {
         unsafe extern "system" fn OnEventNotification<Identity: ::windows::core::IUnknownImpl, Impl: IMbnVendorSpecificEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, vendoroperation: ::windows::core::RawPtr, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -2365,6 +2431,8 @@ impl IMbnVendorSpecificEvents_Vtbl {
 pub trait IMbnVendorSpecificOperation_Impl: Sized {
     fn SetVendorSpecific(&self, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IMbnVendorSpecificOperation {}
 #[cfg(feature = "Win32_System_Com")]
 impl IMbnVendorSpecificOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMbnVendorSpecificOperation_Impl, const OFFSET: isize>() -> IMbnVendorSpecificOperation_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
@@ -4,6 +4,7 @@ pub trait IEnumNetCfgBindingInterface_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetCfgBindingInterface>;
 }
+impl ::windows::core::RuntimeName for IEnumNetCfgBindingInterface {}
 impl IEnumNetCfgBindingInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetCfgBindingInterface_Impl, const OFFSET: isize>() -> IEnumNetCfgBindingInterface_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetCfgBindingInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -50,6 +51,7 @@ pub trait IEnumNetCfgBindingPath_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetCfgBindingPath>;
 }
+impl ::windows::core::RuntimeName for IEnumNetCfgBindingPath {}
 impl IEnumNetCfgBindingPath_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetCfgBindingPath_Impl, const OFFSET: isize>() -> IEnumNetCfgBindingPath_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetCfgBindingPath_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -96,6 +98,7 @@ pub trait IEnumNetCfgComponent_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetCfgComponent>;
 }
+impl ::windows::core::RuntimeName for IEnumNetCfgComponent {}
 impl IEnumNetCfgComponent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetCfgComponent_Impl, const OFFSET: isize>() -> IEnumNetCfgComponent_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetCfgComponent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -145,6 +148,7 @@ pub trait INetCfg_Impl: Sized {
     fn FindComponent(&self, pszwinfid: &::windows::core::PCWSTR) -> ::windows::core::Result<INetCfgComponent>;
     fn QueryNetCfgClass(&self, pguidclass: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfg {}
 impl INetCfg_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfg_Impl, const OFFSET: isize>() -> INetCfg_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: INetCfg_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -214,6 +218,7 @@ pub trait INetCfgBindingInterface_Impl: Sized {
     fn GetUpperComponent(&self) -> ::windows::core::Result<INetCfgComponent>;
     fn GetLowerComponent(&self) -> ::windows::core::Result<INetCfgComponent>;
 }
+impl ::windows::core::RuntimeName for INetCfgBindingInterface {}
 impl INetCfgBindingInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgBindingInterface_Impl, const OFFSET: isize>() -> INetCfgBindingInterface_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgBindingInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszwinterfacename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -271,6 +276,8 @@ pub trait INetCfgBindingPath_Impl: Sized {
     fn GetDepth(&self) -> ::windows::core::Result<u32>;
     fn EnumBindingInterfaces(&self) -> ::windows::core::Result<IEnumNetCfgBindingInterface>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetCfgBindingPath {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetCfgBindingPath_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgBindingPath_Impl, const OFFSET: isize>() -> INetCfgBindingPath_Vtbl {
@@ -358,6 +365,7 @@ pub trait INetCfgClass_Impl: Sized {
     fn FindComponent(&self, pszwinfid: &::windows::core::PCWSTR) -> ::windows::core::Result<INetCfgComponent>;
     fn EnumComponents(&self) -> ::windows::core::Result<IEnumNetCfgComponent>;
 }
+impl ::windows::core::RuntimeName for INetCfgClass {}
 impl INetCfgClass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgClass_Impl, const OFFSET: isize>() -> INetCfgClass_Vtbl {
         unsafe extern "system" fn FindComponent<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszwinfid: ::windows::core::PCWSTR, ppnccitem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -398,6 +406,8 @@ pub trait INetCfgClassSetup_Impl: Sized {
     fn Install(&self, pszwinfid: &::windows::core::PCWSTR, pobotoken: *const OBO_TOKEN, dwsetupflags: u32, dwupgradefrombuildno: u32, pszwanswerfile: &::windows::core::PCWSTR, pszwanswersections: &::windows::core::PCWSTR) -> ::windows::core::Result<INetCfgComponent>;
     fn DeInstall(&self, pcomponent: &::core::option::Option<INetCfgComponent>, pobotoken: *const OBO_TOKEN, pmszwrefs: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetCfgClassSetup {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetCfgClassSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgClassSetup_Impl, const OFFSET: isize>() -> INetCfgClassSetup_Vtbl {
@@ -444,6 +454,8 @@ pub trait INetCfgClassSetup2_Impl: Sized + INetCfgClassSetup_Impl {
     fn UpdateNonEnumeratedComponent(&self, picomp: &::core::option::Option<INetCfgComponent>, dwsetupflags: u32, dwupgradefrombuildno: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetCfgClassSetup2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl INetCfgClassSetup2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgClassSetup2_Impl, const OFFSET: isize>() -> INetCfgClassSetup2_Vtbl {
         unsafe extern "system" fn UpdateNonEnumeratedComponent<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgClassSetup2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, picomp: ::windows::core::RawPtr, dwsetupflags: u32, dwupgradefrombuildno: u32) -> ::windows::core::HRESULT {
@@ -475,6 +487,8 @@ pub trait INetCfgComponent_Impl: Sized {
     fn OpenParamKey(&self) -> ::windows::core::Result<super::super::System::Registry::HKEY>;
     fn RaisePropertyUi(&self, hwndparent: super::super::Foundation::HWND, dwflags: u32, punkcontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for INetCfgComponent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl INetCfgComponent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponent_Impl, const OFFSET: isize>() -> INetCfgComponent_Vtbl {
@@ -628,6 +642,7 @@ pub trait INetCfgComponentBindings_Impl: Sized {
     fn MoveBefore(&self, pncbitemsrc: &::core::option::Option<INetCfgBindingPath>, pncbitemdest: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
     fn MoveAfter(&self, pncbitemsrc: &::core::option::Option<INetCfgBindingPath>, pncbitemdest: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfgComponentBindings {}
 impl INetCfgComponentBindings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentBindings_Impl, const OFFSET: isize>() -> INetCfgComponentBindings_Vtbl {
         unsafe extern "system" fn BindTo<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentBindings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnccitem: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -700,6 +715,8 @@ pub trait INetCfgComponentControl_Impl: Sized {
     fn CancelChanges(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetCfgComponentControl {}
+#[cfg(feature = "Win32_Foundation")]
 impl INetCfgComponentControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentControl_Impl, const OFFSET: isize>() -> INetCfgComponentControl_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, picomp: ::windows::core::RawPtr, pinetcfg: ::windows::core::RawPtr, finstalling: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -738,6 +755,7 @@ pub trait INetCfgComponentNotifyBinding_Impl: Sized {
     fn QueryBindingPath(&self, dwchangeflag: u32, pipath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
     fn NotifyBindingPath(&self, dwchangeflag: u32, pipath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfgComponentNotifyBinding {}
 impl INetCfgComponentNotifyBinding_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentNotifyBinding_Impl, const OFFSET: isize>() -> INetCfgComponentNotifyBinding_Vtbl {
         unsafe extern "system" fn QueryBindingPath<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentNotifyBinding_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwchangeflag: u32, pipath: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -766,6 +784,7 @@ pub trait INetCfgComponentNotifyGlobal_Impl: Sized {
     fn SysNotifyBindingPath(&self, dwchangeflag: u32, pipath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
     fn SysNotifyComponent(&self, dwchangeflag: u32, picomp: &::core::option::Option<INetCfgComponent>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfgComponentNotifyGlobal {}
 impl INetCfgComponentNotifyGlobal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentNotifyGlobal_Impl, const OFFSET: isize>() -> INetCfgComponentNotifyGlobal_Vtbl {
         unsafe extern "system" fn GetSupportedNotifications<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentNotifyGlobal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwnotifications: *mut u32) -> ::windows::core::HRESULT {
@@ -815,6 +834,8 @@ pub trait INetCfgComponentPropertyUi_Impl: Sized {
     fn ApplyProperties(&self) -> ::windows::core::Result<()>;
     fn CancelProperties(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetCfgComponentPropertyUi {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetCfgComponentPropertyUi_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentPropertyUi_Impl, const OFFSET: isize>() -> INetCfgComponentPropertyUi_Vtbl {
@@ -868,6 +889,7 @@ pub trait INetCfgComponentSetup_Impl: Sized {
     fn ReadAnswerFile(&self, pszwanswerfile: &::windows::core::PCWSTR, pszwanswersections: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Removing(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfgComponentSetup {}
 impl INetCfgComponentSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentSetup_Impl, const OFFSET: isize>() -> INetCfgComponentSetup_Vtbl {
         unsafe extern "system" fn Install<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentSetup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsetupflags: u32) -> ::windows::core::HRESULT {
@@ -906,6 +928,7 @@ pub trait INetCfgComponentSysPrep_Impl: Sized {
     fn SaveAdapterParameters(&self, pncsp: &::core::option::Option<INetCfgSysPrep>, pszwanswersections: &::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn RestoreAdapterParameters(&self, pszwanswerfile: &::windows::core::PCWSTR, pszwanswersection: &::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfgComponentSysPrep {}
 impl INetCfgComponentSysPrep_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentSysPrep_Impl, const OFFSET: isize>() -> INetCfgComponentSysPrep_Vtbl {
         unsafe extern "system" fn SaveAdapterParameters<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgComponentSysPrep_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pncsp: ::windows::core::RawPtr, pszwanswersections: ::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -933,6 +956,7 @@ pub trait INetCfgLock_Impl: Sized {
     fn ReleaseWriteLock(&self) -> ::windows::core::Result<()>;
     fn IsWriteLocked(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for INetCfgLock {}
 impl INetCfgLock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgLock_Impl, const OFFSET: isize>() -> INetCfgLock_Vtbl {
         unsafe extern "system" fn AcquireWriteLock<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgLock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cmstimeout: u32, pszwclientdescription: ::windows::core::PCWSTR, ppszwclientdescription: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -976,6 +1000,7 @@ impl INetCfgLock_Vtbl {
 pub trait INetCfgPnpReconfigCallback_Impl: Sized {
     fn SendPnpReconfig(&self, layer: NCPNP_RECONFIG_LAYER, pszwupper: &::windows::core::PCWSTR, pszwlower: &::windows::core::PCWSTR, pvdata: *const ::core::ffi::c_void, dwsizeofdata: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetCfgPnpReconfigCallback {}
 impl INetCfgPnpReconfigCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgPnpReconfigCallback_Impl, const OFFSET: isize>() -> INetCfgPnpReconfigCallback_Vtbl {
         unsafe extern "system" fn SendPnpReconfig<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgPnpReconfigCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, layer: NCPNP_RECONFIG_LAYER, pszwupper: ::windows::core::PCWSTR, pszwlower: ::windows::core::PCWSTR, pvdata: *const ::core::ffi::c_void, dwsizeofdata: u32) -> ::windows::core::HRESULT {
@@ -996,6 +1021,8 @@ pub trait INetCfgSysPrep_Impl: Sized {
     fn HrSetupSetFirstStringAsBool(&self, pwszsection: &::windows::core::PCWSTR, pwszkey: &::windows::core::PCWSTR, fvalue: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn HrSetupSetFirstMultiSzField(&self, pwszsection: &::windows::core::PCWSTR, pwszkey: &::windows::core::PCWSTR, pmszvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetCfgSysPrep {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetCfgSysPrep_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetCfgSysPrep_Impl, const OFFSET: isize>() -> INetCfgSysPrep_Vtbl {
@@ -1034,6 +1061,7 @@ impl INetCfgSysPrep_Vtbl {
 pub trait INetLanConnectionUiInfo_Impl: Sized {
     fn GetDeviceGuid(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for INetLanConnectionUiInfo {}
 impl INetLanConnectionUiInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetLanConnectionUiInfo_Impl, const OFFSET: isize>() -> INetLanConnectionUiInfo_Vtbl {
         unsafe extern "system" fn GetDeviceGuid<Identity: ::windows::core::IUnknownImpl, Impl: INetLanConnectionUiInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1057,6 +1085,8 @@ impl INetLanConnectionUiInfo_Vtbl {
 pub trait INetRasConnectionIpUiInfo_Impl: Sized {
     fn GetUiInfo(&self) -> ::windows::core::Result<RASCON_IPUI>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetRasConnectionIpUiInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetRasConnectionIpUiInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetRasConnectionIpUiInfo_Impl, const OFFSET: isize>() -> INetRasConnectionIpUiInfo_Vtbl {
@@ -1082,6 +1112,8 @@ pub trait IProvisioningDomain_Impl: Sized {
     fn Add(&self, pszwpathtofolder: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Query(&self, pszwdomain: &::windows::core::PCWSTR, pszwlanguage: &::windows::core::PCWSTR, pszwxpathquery: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMNodeList>;
 }
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IProvisioningDomain {}
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
 impl IProvisioningDomain_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvisioningDomain_Impl, const OFFSET: isize>() -> IProvisioningDomain_Vtbl {
@@ -1111,6 +1143,8 @@ impl IProvisioningDomain_Vtbl {
 pub trait IProvisioningProfileWireless_Impl: Sized {
     fn CreateProfile(&self, bstrxmlwirelessconfigprofile: &super::super::Foundation::BSTR, bstrxmlconnectionconfigprofile: &super::super::Foundation::BSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IProvisioningProfileWireless {}
 #[cfg(feature = "Win32_Foundation")]
 impl IProvisioningProfileWireless_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvisioningProfileWireless_Impl, const OFFSET: isize>() -> IProvisioningProfileWireless_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
@@ -3,6 +3,8 @@ pub trait INetDiagExtensibleHelper_Impl: Sized {
     fn ResolveAttributes(&self, celt: u32, rgkeyattributes: *const HELPER_ATTRIBUTE, pcelt: *mut u32, prgmatchvalues: *mut *mut HELPER_ATTRIBUTE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetDiagExtensibleHelper {}
+#[cfg(feature = "Win32_Foundation")]
 impl INetDiagExtensibleHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagExtensibleHelper_Impl, const OFFSET: isize>() -> INetDiagExtensibleHelper_Vtbl {
         unsafe extern "system" fn ResolveAttributes<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagExtensibleHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgkeyattributes: *const HELPER_ATTRIBUTE, pcelt: *mut u32, prgmatchvalues: *mut *mut HELPER_ATTRIBUTE) -> ::windows::core::HRESULT {
@@ -37,6 +39,8 @@ pub trait INetDiagHelper_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn Cleanup(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetDiagHelper {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetDiagHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelper_Impl, const OFFSET: isize>() -> INetDiagHelper_Vtbl {
@@ -181,6 +185,8 @@ pub trait INetDiagHelperEx_Impl: Sized {
     fn ReproduceFailure(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetDiagHelperEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl INetDiagHelperEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelperEx_Impl, const OFFSET: isize>() -> INetDiagHelperEx_Vtbl {
         unsafe extern "system" fn ReconfirmLowHealth<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelperEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, presults: *const HypothesisResult, ppwszupdateddescription: *mut ::windows::core::PWSTR, pupdatedstatus: *mut DIAGNOSIS_STATUS) -> ::windows::core::HRESULT {
@@ -212,6 +218,7 @@ impl INetDiagHelperEx_Vtbl {
 pub trait INetDiagHelperInfo_Impl: Sized {
     fn GetAttributeInfo(&self, pcelt: *mut u32, pprgattributeinfos: *mut *mut HelperAttributeInfo) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetDiagHelperInfo {}
 impl INetDiagHelperInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelperInfo_Impl, const OFFSET: isize>() -> INetDiagHelperInfo_Vtbl {
         unsafe extern "system" fn GetAttributeInfo<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelperInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcelt: *mut u32, pprgattributeinfos: *mut *mut HelperAttributeInfo) -> ::windows::core::HRESULT {
@@ -228,6 +235,7 @@ impl INetDiagHelperInfo_Vtbl {
 pub trait INetDiagHelperUtilFactory_Impl: Sized {
     fn CreateUtilityInstance(&self, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetDiagHelperUtilFactory {}
 impl INetDiagHelperUtilFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelperUtilFactory_Impl, const OFFSET: isize>() -> INetDiagHelperUtilFactory_Vtbl {
         unsafe extern "system" fn CreateUtilityInstance<Identity: ::windows::core::IUnknownImpl, Impl: INetDiagHelperUtilFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
@@ -9,6 +9,8 @@ pub trait ISdo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISdo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISdo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISdo_Impl, const OFFSET: isize>() -> ISdo_Vtbl {
         unsafe extern "system" fn GetPropertyInfo<Identity: ::windows::core::IUnknownImpl, Impl: ISdo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: i32, pppropertyinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -90,6 +92,8 @@ pub trait ISdoCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Item(&self, name: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISdoCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISdoCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISdoCollection_Impl, const OFFSET: isize>() -> ISdoCollection_Vtbl {
@@ -182,6 +186,8 @@ pub trait ISdoDictionaryOld_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetAttributeID(&self, bstrattributename: &super::super::Foundation::BSTR) -> ::windows::core::Result<ATTRIBUTEID>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISdoDictionaryOld {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISdoDictionaryOld_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISdoDictionaryOld_Impl, const OFFSET: isize>() -> ISdoDictionaryOld_Vtbl {
         unsafe extern "system" fn EnumAttributes<Identity: ::windows::core::IUnknownImpl, Impl: ISdoDictionaryOld_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut super::super::System::Com::VARIANT, pvalues: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -252,6 +258,8 @@ pub trait ISdoMachine_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetAttachedComputer(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetSDOSchema(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISdoMachine {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISdoMachine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISdoMachine_Impl, const OFFSET: isize>() -> ISdoMachine_Vtbl {
@@ -374,6 +382,8 @@ pub trait ISdoMachine2_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn Reload(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISdoMachine2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISdoMachine2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISdoMachine2_Impl, const OFFSET: isize>() -> ISdoMachine2_Vtbl {
         unsafe extern "system" fn GetTemplatesSDO<Identity: ::windows::core::IUnknownImpl, Impl: ISdoMachine2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrservicename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pptemplatessdo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -428,6 +438,8 @@ pub trait ISdoServiceControl_Impl: Sized + super::super::System::Com::IDispatch_
     fn ResetService(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISdoServiceControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISdoServiceControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISdoServiceControl_Impl, const OFFSET: isize>() -> ISdoServiceControl_Vtbl {
         unsafe extern "system" fn StartService<Identity: ::windows::core::IUnknownImpl, Impl: ISdoServiceControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -474,6 +486,8 @@ pub trait ITemplateSdo_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn AddToSdo(&self, bstrname: &super::super::Foundation::BSTR, psdotarget: &::core::option::Option<super::super::System::Com::IDispatch>, ppitem: *mut ::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
     fn AddToSdoAsProperty(&self, psdotarget: &::core::option::Option<super::super::System::Com::IDispatch>, id: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITemplateSdo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITemplateSdo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITemplateSdo_Impl, const OFFSET: isize>() -> ITemplateSdo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
@@ -9,6 +9,7 @@ pub trait IDot11AdHocInterface_Impl: Sized {
     fn GetIEnumDot11AdHocNetworks(&self, pfilterguid: *const ::windows::core::GUID) -> ::windows::core::Result<IEnumDot11AdHocNetworks>;
     fn GetStatus(&self, pstate: *mut DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDot11AdHocInterface {}
 impl IDot11AdHocInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocInterface_Impl, const OFFSET: isize>() -> IDot11AdHocInterface_Vtbl {
         unsafe extern "system" fn GetDeviceSignature<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psignature: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -100,6 +101,7 @@ impl IDot11AdHocInterface_Vtbl {
 pub trait IDot11AdHocInterfaceNotificationSink_Impl: Sized {
     fn OnConnectionStatusChange(&self, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDot11AdHocInterfaceNotificationSink {}
 impl IDot11AdHocInterfaceNotificationSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocInterfaceNotificationSink_Impl, const OFFSET: isize>() -> IDot11AdHocInterfaceNotificationSink_Vtbl {
         unsafe extern "system" fn OnConnectionStatusChange<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocInterfaceNotificationSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::HRESULT {
@@ -121,6 +123,8 @@ pub trait IDot11AdHocManager_Impl: Sized {
     fn GetIEnumDot11AdHocInterfaces(&self) -> ::windows::core::Result<IEnumDot11AdHocInterfaces>;
     fn GetNetwork(&self, networksignature: *const ::windows::core::GUID) -> ::windows::core::Result<IDot11AdHocNetwork>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDot11AdHocManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDot11AdHocManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocManager_Impl, const OFFSET: isize>() -> IDot11AdHocManager_Vtbl {
@@ -192,6 +196,7 @@ pub trait IDot11AdHocManagerNotificationSink_Impl: Sized {
     fn OnInterfaceAdd(&self, piadhocinterface: &::core::option::Option<IDot11AdHocInterface>) -> ::windows::core::Result<()>;
     fn OnInterfaceRemove(&self, signature: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDot11AdHocManagerNotificationSink {}
 impl IDot11AdHocManagerNotificationSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocManagerNotificationSink_Impl, const OFFSET: isize>() -> IDot11AdHocManagerNotificationSink_Vtbl {
         unsafe extern "system" fn OnNetworkAdd<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocManagerNotificationSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piadhocnetwork: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -241,6 +246,8 @@ pub trait IDot11AdHocNetwork_Impl: Sized {
     fn Connect(&self, passphrase: &::windows::core::PCWSTR, geographicalid: i32, fsaveprofile: super::super::Foundation::BOOLEAN, fmakesavedprofileuserspecific: super::super::Foundation::BOOLEAN) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDot11AdHocNetwork {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDot11AdHocNetwork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocNetwork_Impl, const OFFSET: isize>() -> IDot11AdHocNetwork_Vtbl {
@@ -352,6 +359,7 @@ pub trait IDot11AdHocNetworkNotificationSink_Impl: Sized {
     fn OnStatusChange(&self, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::Result<()>;
     fn OnConnectFail(&self, efailreason: DOT11_ADHOC_CONNECT_FAIL_REASON) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDot11AdHocNetworkNotificationSink {}
 impl IDot11AdHocNetworkNotificationSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocNetworkNotificationSink_Impl, const OFFSET: isize>() -> IDot11AdHocNetworkNotificationSink_Vtbl {
         unsafe extern "system" fn OnStatusChange<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocNetworkNotificationSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::HRESULT {
@@ -378,6 +386,7 @@ pub trait IDot11AdHocSecuritySettings_Impl: Sized {
     fn GetDot11AuthAlgorithm(&self, pauth: *mut DOT11_ADHOC_AUTH_ALGORITHM) -> ::windows::core::Result<()>;
     fn GetDot11CipherAlgorithm(&self, pcipher: *mut DOT11_ADHOC_CIPHER_ALGORITHM) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDot11AdHocSecuritySettings {}
 impl IDot11AdHocSecuritySettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocSecuritySettings_Impl, const OFFSET: isize>() -> IDot11AdHocSecuritySettings_Vtbl {
         unsafe extern "system" fn GetDot11AuthAlgorithm<Identity: ::windows::core::IUnknownImpl, Impl: IDot11AdHocSecuritySettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pauth: *mut DOT11_ADHOC_AUTH_ALGORITHM) -> ::windows::core::HRESULT {
@@ -406,6 +415,7 @@ pub trait IEnumDot11AdHocInterfaces_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDot11AdHocInterfaces>;
 }
+impl ::windows::core::RuntimeName for IEnumDot11AdHocInterfaces {}
 impl IEnumDot11AdHocInterfaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDot11AdHocInterfaces_Impl, const OFFSET: isize>() -> IEnumDot11AdHocInterfaces_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDot11AdHocInterfaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -452,6 +462,7 @@ pub trait IEnumDot11AdHocNetworks_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDot11AdHocNetworks>;
 }
+impl ::windows::core::RuntimeName for IEnumDot11AdHocNetworks {}
 impl IEnumDot11AdHocNetworks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDot11AdHocNetworks_Impl, const OFFSET: isize>() -> IEnumDot11AdHocNetworks_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDot11AdHocNetworks_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -498,6 +509,7 @@ pub trait IEnumDot11AdHocSecuritySettings_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDot11AdHocSecuritySettings>;
 }
+impl ::windows::core::RuntimeName for IEnumDot11AdHocSecuritySettings {}
 impl IEnumDot11AdHocSecuritySettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDot11AdHocSecuritySettings_Impl, const OFFSET: isize>() -> IEnumDot11AdHocSecuritySettings_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDot11AdHocSecuritySettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
@@ -2,6 +2,7 @@ pub trait IWCNConnectNotify_Impl: Sized {
     fn ConnectSucceeded(&self) -> ::windows::core::Result<()>;
     fn ConnectFailed(&self, hrfailure: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWCNConnectNotify {}
 impl IWCNConnectNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWCNConnectNotify_Impl, const OFFSET: isize>() -> IWCNConnectNotify_Vtbl {
         unsafe extern "system" fn ConnectSucceeded<Identity: ::windows::core::IUnknownImpl, Impl: IWCNConnectNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -37,6 +38,7 @@ pub trait IWCNDevice_Impl: Sized {
     fn Unadvise(&self) -> ::windows::core::Result<()>;
     fn SetNFCPasswordParams(&self, r#type: WCN_PASSWORD_TYPE, dwoobpasswordid: u32, dwpasswordlength: u32, pbpassword: *const u8, dwremotepublickeyhashlength: u32, pbremotepublickeyhash: *const u8, dwdhkeybloblength: u32, pbdhkeyblob: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWCNDevice {}
 impl IWCNDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWCNDevice_Impl, const OFFSET: isize>() -> IWCNDevice_Vtbl {
         unsafe extern "system" fn SetPassword<Identity: ::windows::core::IUnknownImpl, Impl: IWCNDevice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: WCN_PASSWORD_TYPE, dwpasswordlength: u32, pbpassword: *const u8) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
@@ -16,6 +16,8 @@ pub trait IDynamicPortMapping_Impl: Sized + super::super::System::Com::IDispatch
     fn EditInternalPort(&self, linternalport: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDynamicPortMapping {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDynamicPortMapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicPortMapping_Impl, const OFFSET: isize>() -> IDynamicPortMapping_Vtbl {
         unsafe extern "system" fn ExternalIPAddress<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicPortMapping_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -179,6 +181,8 @@ pub trait IDynamicPortMappingCollection_Impl: Sized + super::super::System::Com:
     fn Add(&self, bstrremotehost: &super::super::Foundation::BSTR, lexternalport: i32, bstrprotocol: &super::super::Foundation::BSTR, linternalport: i32, bstrinternalclient: &super::super::Foundation::BSTR, benabled: i16, bstrdescription: &super::super::Foundation::BSTR, lleaseduration: i32) -> ::windows::core::Result<IDynamicPortMapping>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDynamicPortMappingCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDynamicPortMappingCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicPortMappingCollection_Impl, const OFFSET: isize>() -> IDynamicPortMappingCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicPortMappingCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -249,6 +253,7 @@ pub trait IEnumNetConnection_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetConnection>;
 }
+impl ::windows::core::RuntimeName for IEnumNetConnection {}
 impl IEnumNetConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetConnection_Impl, const OFFSET: isize>() -> IEnumNetConnection_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -296,6 +301,8 @@ pub trait IEnumNetSharingEveryConnection_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetSharingEveryConnection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumNetSharingEveryConnection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumNetSharingEveryConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetSharingEveryConnection_Impl, const OFFSET: isize>() -> IEnumNetSharingEveryConnection_Vtbl {
@@ -345,6 +352,8 @@ pub trait IEnumNetSharingPortMapping_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumNetSharingPortMapping>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumNetSharingPortMapping {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumNetSharingPortMapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetSharingPortMapping_Impl, const OFFSET: isize>() -> IEnumNetSharingPortMapping_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetSharingPortMapping_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -392,6 +401,8 @@ pub trait IEnumNetSharingPrivateConnection_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetSharingPrivateConnection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumNetSharingPrivateConnection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumNetSharingPrivateConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetSharingPrivateConnection_Impl, const OFFSET: isize>() -> IEnumNetSharingPrivateConnection_Vtbl {
@@ -441,6 +452,8 @@ pub trait IEnumNetSharingPublicConnection_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumNetSharingPublicConnection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumNetSharingPublicConnection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumNetSharingPublicConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetSharingPublicConnection_Impl, const OFFSET: isize>() -> IEnumNetSharingPublicConnection_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetSharingPublicConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -487,6 +500,8 @@ pub trait INATEventManager_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn SetNumberOfEntriesCallback(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INATEventManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INATEventManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INATEventManager_Impl, const OFFSET: isize>() -> INATEventManager_Vtbl {
         unsafe extern "system" fn SetExternalIPAddressCallback<Identity: ::windows::core::IUnknownImpl, Impl: INATEventManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -514,6 +529,8 @@ pub trait INATExternalIPAddressCallback_Impl: Sized {
     fn NewExternalIPAddress(&self, bstrnewexternalipaddress: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INATExternalIPAddressCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl INATExternalIPAddressCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INATExternalIPAddressCallback_Impl, const OFFSET: isize>() -> INATExternalIPAddressCallback_Vtbl {
         unsafe extern "system" fn NewExternalIPAddress<Identity: ::windows::core::IUnknownImpl, Impl: INATExternalIPAddressCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrnewexternalipaddress: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -530,6 +547,7 @@ impl INATExternalIPAddressCallback_Vtbl {
 pub trait INATNumberOfEntriesCallback_Impl: Sized {
     fn NewNumberOfEntries(&self, lnewnumberofentries: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INATNumberOfEntriesCallback {}
 impl INATNumberOfEntriesCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INATNumberOfEntriesCallback_Impl, const OFFSET: isize>() -> INATNumberOfEntriesCallback_Vtbl {
         unsafe extern "system" fn NewNumberOfEntries<Identity: ::windows::core::IUnknownImpl, Impl: INATNumberOfEntriesCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnewnumberofentries: i32) -> ::windows::core::HRESULT {
@@ -552,6 +570,7 @@ pub trait INetConnection_Impl: Sized {
     fn GetUiObjectClassId(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn Rename(&self, pszwnewname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetConnection {}
 impl INetConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetConnection_Impl, const OFFSET: isize>() -> INetConnection_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: INetConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -629,6 +648,8 @@ pub trait INetConnectionConnectUi_Impl: Sized {
     fn Disconnect(&self, hwndparent: super::super::Foundation::HWND, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetConnectionConnectUi {}
+#[cfg(feature = "Win32_Foundation")]
 impl INetConnectionConnectUi_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetConnectionConnectUi_Impl, const OFFSET: isize>() -> INetConnectionConnectUi_Vtbl {
         unsafe extern "system" fn SetConnection<Identity: ::windows::core::IUnknownImpl, Impl: INetConnectionConnectUi_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcon: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -660,6 +681,7 @@ impl INetConnectionConnectUi_Vtbl {
 pub trait INetConnectionManager_Impl: Sized {
     fn EnumConnections(&self, flags: NETCONMGR_ENUM_FLAGS) -> ::windows::core::Result<IEnumNetConnection>;
 }
+impl ::windows::core::RuntimeName for INetConnectionManager {}
 impl INetConnectionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetConnectionManager_Impl, const OFFSET: isize>() -> INetConnectionManager_Vtbl {
         unsafe extern "system" fn EnumConnections<Identity: ::windows::core::IUnknownImpl, Impl: INetConnectionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: NETCONMGR_ENUM_FLAGS, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -688,6 +710,8 @@ pub trait INetConnectionProps_Impl: Sized + super::super::System::Com::IDispatch
     fn MediaType(&self) -> ::windows::core::Result<NETCON_MEDIATYPE>;
     fn Characteristics(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetConnectionProps {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetConnectionProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetConnectionProps_Impl, const OFFSET: isize>() -> INetConnectionProps_Vtbl {
@@ -786,6 +810,8 @@ pub trait INetFwAuthorizedApplication_Impl: Sized + super::super::System::Com::I
     fn Enabled(&self) -> ::windows::core::Result<i16>;
     fn SetEnabled(&self, enabled: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwAuthorizedApplication {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwAuthorizedApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwAuthorizedApplication_Impl, const OFFSET: isize>() -> INetFwAuthorizedApplication_Vtbl {
@@ -914,6 +940,8 @@ pub trait INetFwAuthorizedApplications_Impl: Sized + super::super::System::Com::
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwAuthorizedApplications {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwAuthorizedApplications_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwAuthorizedApplications_Impl, const OFFSET: isize>() -> INetFwAuthorizedApplications_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: INetFwAuthorizedApplications_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -995,6 +1023,8 @@ pub trait INetFwIcmpSettings_Impl: Sized + super::super::System::Com::IDispatch_
     fn AllowOutboundPacketTooBig(&self) -> ::windows::core::Result<i16>;
     fn SetAllowOutboundPacketTooBig(&self, allow: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwIcmpSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwIcmpSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwIcmpSettings_Impl, const OFFSET: isize>() -> INetFwIcmpSettings_Vtbl {
@@ -1195,6 +1225,8 @@ pub trait INetFwMgr_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsIcmpTypeAllowed(&self, ipversion: NET_FW_IP_VERSION, localaddress: &super::super::Foundation::BSTR, r#type: u8, allowed: *mut super::super::System::Com::VARIANT, restricted: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwMgr {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwMgr_Impl, const OFFSET: isize>() -> INetFwMgr_Vtbl {
         unsafe extern "system" fn LocalPolicy<Identity: ::windows::core::IUnknownImpl, Impl: INetFwMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, localpolicy: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1265,6 +1297,8 @@ pub trait INetFwOpenPort_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SetEnabled(&self, enabled: i16) -> ::windows::core::Result<()>;
     fn BuiltIn(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwOpenPort {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwOpenPort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwOpenPort_Impl, const OFFSET: isize>() -> INetFwOpenPort_Vtbl {
@@ -1423,6 +1457,8 @@ pub trait INetFwOpenPorts_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwOpenPorts {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwOpenPorts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwOpenPorts_Impl, const OFFSET: isize>() -> INetFwOpenPorts_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: INetFwOpenPorts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -1487,6 +1523,8 @@ pub trait INetFwPolicy_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetProfileByType(&self, profiletype: NET_FW_PROFILE_TYPE) -> ::windows::core::Result<INetFwProfile>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwPolicy {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwPolicy_Impl, const OFFSET: isize>() -> INetFwPolicy_Vtbl {
         unsafe extern "system" fn CurrentProfile<Identity: ::windows::core::IUnknownImpl, Impl: INetFwPolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, profile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1546,6 +1584,8 @@ pub trait INetFwPolicy2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn get_IsRuleGroupCurrentlyEnabled(&self, group: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
     fn LocalPolicyModifyState(&self) -> ::windows::core::Result<NET_FW_MODIFY_STATE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwPolicy2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwPolicy2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwPolicy2_Impl, const OFFSET: isize>() -> INetFwPolicy2_Vtbl {
@@ -1776,6 +1816,8 @@ pub trait INetFwProduct_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn PathToSignedProductExe(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwProduct {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwProduct_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwProduct_Impl, const OFFSET: isize>() -> INetFwProduct_Vtbl {
         unsafe extern "system" fn RuleCategories<Identity: ::windows::core::IUnknownImpl, Impl: INetFwProduct_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rulecategories: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1841,6 +1883,8 @@ pub trait INetFwProducts_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Item(&self, index: i32) -> ::windows::core::Result<INetFwProduct>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwProducts {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwProducts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwProducts_Impl, const OFFSET: isize>() -> INetFwProducts_Vtbl {
@@ -1917,6 +1961,8 @@ pub trait INetFwProfile_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Services(&self) -> ::windows::core::Result<INetFwServices>;
     fn AuthorizedApplications(&self) -> ::windows::core::Result<INetFwAuthorizedApplications>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwProfile {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwProfile_Impl, const OFFSET: isize>() -> INetFwProfile_Vtbl {
@@ -2084,6 +2130,8 @@ pub trait INetFwRemoteAdminSettings_Impl: Sized + super::super::System::Com::IDi
     fn SetEnabled(&self, enabled: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwRemoteAdminSettings {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwRemoteAdminSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRemoteAdminSettings_Impl, const OFFSET: isize>() -> INetFwRemoteAdminSettings_Vtbl {
         unsafe extern "system" fn IpVersion<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRemoteAdminSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ipversion: *mut NET_FW_IP_VERSION) -> ::windows::core::HRESULT {
@@ -2205,6 +2253,8 @@ pub trait INetFwRule_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Action(&self) -> ::windows::core::Result<NET_FW_ACTION>;
     fn SetAction(&self, action: NET_FW_ACTION) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwRule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRule_Impl, const OFFSET: isize>() -> INetFwRule_Vtbl {
@@ -2546,6 +2596,8 @@ pub trait INetFwRule2_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn SetEdgeTraversalOptions(&self, loptions: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwRule2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwRule2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRule2_Impl, const OFFSET: isize>() -> INetFwRule2_Vtbl {
         unsafe extern "system" fn EdgeTraversalOptions<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRule2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, loptions: *mut i32) -> ::windows::core::HRESULT {
@@ -2589,6 +2641,8 @@ pub trait INetFwRule3_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn SecureFlags(&self) -> ::windows::core::Result<i32>;
     fn SetSecureFlags(&self, loptions: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwRule3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwRule3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRule3_Impl, const OFFSET: isize>() -> INetFwRule3_Vtbl {
@@ -2717,6 +2771,8 @@ pub trait INetFwRules_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwRules {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwRules_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRules_Impl, const OFFSET: isize>() -> INetFwRules_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: INetFwRules_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -2790,6 +2846,8 @@ pub trait INetFwService_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetEnabled(&self, enabled: i16) -> ::windows::core::Result<()>;
     fn GloballyOpenPorts(&self) -> ::windows::core::Result<INetFwOpenPorts>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwService_Impl, const OFFSET: isize>() -> INetFwService_Vtbl {
@@ -2928,6 +2986,8 @@ pub trait INetFwServiceRestriction_Impl: Sized + super::super::System::Com::IDis
     fn Rules(&self) -> ::windows::core::Result<INetFwRules>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwServiceRestriction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwServiceRestriction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwServiceRestriction_Impl, const OFFSET: isize>() -> INetFwServiceRestriction_Vtbl {
         unsafe extern "system" fn RestrictService<Identity: ::windows::core::IUnknownImpl, Impl: INetFwServiceRestriction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, servicename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, appname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, restrictservice: i16, servicesidrestricted: i16) -> ::windows::core::HRESULT {
@@ -2974,6 +3034,8 @@ pub trait INetFwServices_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Item(&self, svctype: NET_FW_SERVICE_TYPE) -> ::windows::core::Result<INetFwService>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetFwServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetFwServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetFwServices_Impl, const OFFSET: isize>() -> INetFwServices_Vtbl {
@@ -3034,6 +3096,8 @@ pub trait INetSharingConfiguration_Impl: Sized + super::super::System::Com::IDis
     fn AddPortMapping(&self, bstrname: &super::super::Foundation::BSTR, ucipprotocol: u8, usexternalport: u16, usinternalport: u16, dwoptions: u32, bstrtargetnameoripaddress: &super::super::Foundation::BSTR, etargettype: ICS_TARGETTYPE) -> ::windows::core::Result<INetSharingPortMapping>;
     fn RemovePortMapping(&self, pmapping: &::core::option::Option<INetSharingPortMapping>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingConfiguration {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingConfiguration_Impl, const OFFSET: isize>() -> INetSharingConfiguration_Vtbl {
@@ -3141,6 +3205,8 @@ pub trait INetSharingEveryConnectionCollection_Impl: Sized + super::super::Syste
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingEveryConnectionCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingEveryConnectionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingEveryConnectionCollection_Impl, const OFFSET: isize>() -> INetSharingEveryConnectionCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingEveryConnectionCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3184,6 +3250,8 @@ pub trait INetSharingManager_Impl: Sized + super::super::System::Com::IDispatch_
     fn EnumEveryConnection(&self) -> ::windows::core::Result<INetSharingEveryConnectionCollection>;
     fn get_NetConnectionProps(&self, pnetconnection: &::core::option::Option<INetConnection>) -> ::windows::core::Result<INetConnectionProps>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingManager_Impl, const OFFSET: isize>() -> INetSharingManager_Vtbl {
@@ -3275,6 +3343,8 @@ pub trait INetSharingPortMapping_Impl: Sized + super::super::System::Com::IDispa
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingPortMapping {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingPortMapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPortMapping_Impl, const OFFSET: isize>() -> INetSharingPortMapping_Vtbl {
         unsafe extern "system" fn Disable<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPortMapping_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3321,6 +3391,8 @@ pub trait INetSharingPortMappingCollection_Impl: Sized + super::super::System::C
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingPortMappingCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingPortMappingCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPortMappingCollection_Impl, const OFFSET: isize>() -> INetSharingPortMappingCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPortMappingCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3366,6 +3438,8 @@ pub trait INetSharingPortMappingProps_Impl: Sized + super::super::System::Com::I
     fn TargetIPAddress(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Enabled(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingPortMappingProps {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingPortMappingProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPortMappingProps_Impl, const OFFSET: isize>() -> INetSharingPortMappingProps_Vtbl {
@@ -3479,6 +3553,8 @@ pub trait INetSharingPrivateConnectionCollection_Impl: Sized + super::super::Sys
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingPrivateConnectionCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingPrivateConnectionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPrivateConnectionCollection_Impl, const OFFSET: isize>() -> INetSharingPrivateConnectionCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPrivateConnectionCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3518,6 +3594,8 @@ pub trait INetSharingPublicConnectionCollection_Impl: Sized + super::super::Syst
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetSharingPublicConnectionCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetSharingPublicConnectionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetSharingPublicConnectionCollection_Impl, const OFFSET: isize>() -> INetSharingPublicConnectionCollection_Vtbl {
@@ -3567,6 +3645,8 @@ pub trait IStaticPortMapping_Impl: Sized + super::super::System::Com::IDispatch_
     fn EditDescription(&self, bstrdescription: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn EditInternalPort(&self, linternalport: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IStaticPortMapping {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IStaticPortMapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStaticPortMapping_Impl, const OFFSET: isize>() -> IStaticPortMapping_Vtbl {
@@ -3695,6 +3775,8 @@ pub trait IStaticPortMappingCollection_Impl: Sized + super::super::System::Com::
     fn Add(&self, lexternalport: i32, bstrprotocol: &super::super::Foundation::BSTR, linternalport: i32, bstrinternalclient: &super::super::Foundation::BSTR, benabled: i16, bstrdescription: &super::super::Foundation::BSTR) -> ::windows::core::Result<IStaticPortMapping>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IStaticPortMappingCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IStaticPortMappingCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStaticPortMappingCollection_Impl, const OFFSET: isize>() -> IStaticPortMappingCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IStaticPortMappingCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3765,6 +3847,8 @@ pub trait IUPnPNAT_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DynamicPortMappingCollection(&self) -> ::windows::core::Result<IDynamicPortMappingCollection>;
     fn NATEventManager(&self) -> ::windows::core::Result<INATEventManager>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUPnPNAT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUPnPNAT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUPnPNAT_Impl, const OFFSET: isize>() -> IUPnPNAT_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
@@ -15,6 +15,8 @@ pub trait IADs_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetInfoEx(&self, vproperties: &super::super::System::Com::VARIANT, lnreserved: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADs_Impl, const OFFSET: isize>() -> IADs_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IADs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -167,6 +169,8 @@ pub trait IADsADSystemInfo_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn RefreshSchemaCache(&self) -> ::windows::core::Result<()>;
     fn GetTrees(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsADSystemInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsADSystemInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsADSystemInfo_Impl, const OFFSET: isize>() -> IADsADSystemInfo_Vtbl {
@@ -346,6 +350,8 @@ pub trait IADsAccessControlEntry_Impl: Sized + super::super::System::Com::IDispa
     fn SetTrustee(&self, bstrtrustee: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsAccessControlEntry {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsAccessControlEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsAccessControlEntry_Impl, const OFFSET: isize>() -> IADsAccessControlEntry_Vtbl {
         unsafe extern "system" fn AccessMask<Identity: ::windows::core::IUnknownImpl, Impl: IADsAccessControlEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -494,6 +500,8 @@ pub trait IADsAccessControlList_Impl: Sized + super::super::System::Com::IDispat
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsAccessControlList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsAccessControlList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsAccessControlList_Impl, const OFFSET: isize>() -> IADsAccessControlList_Vtbl {
         unsafe extern "system" fn AclRevision<Identity: ::windows::core::IUnknownImpl, Impl: IADsAccessControlList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -587,6 +595,8 @@ pub trait IADsAcl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CopyAcl(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsAcl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsAcl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsAcl_Impl, const OFFSET: isize>() -> IADsAcl_Vtbl {
         unsafe extern "system" fn ProtectedAttrName<Identity: ::windows::core::IUnknownImpl, Impl: IADsAcl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -669,6 +679,7 @@ pub trait IADsAggregatee_Impl: Sized {
     fn RelinquishInterface(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn RestoreInterface(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IADsAggregatee {}
 impl IADsAggregatee_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsAggregatee_Impl, const OFFSET: isize>() -> IADsAggregatee_Vtbl {
         unsafe extern "system" fn ConnectAsAggregatee<Identity: ::windows::core::IUnknownImpl, Impl: IADsAggregatee_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pouterunknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -707,6 +718,7 @@ pub trait IADsAggregator_Impl: Sized {
     fn ConnectAsAggregator(&self, paggregatee: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn DisconnectAsAggregator(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IADsAggregator {}
 impl IADsAggregator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsAggregator_Impl, const OFFSET: isize>() -> IADsAggregator_Vtbl {
         unsafe extern "system" fn ConnectAsAggregator<Identity: ::windows::core::IUnknownImpl, Impl: IADsAggregator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, paggregatee: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -736,6 +748,8 @@ pub trait IADsBackLink_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ObjectName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetObjectName(&self, bstrobjectname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsBackLink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsBackLink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsBackLink_Impl, const OFFSET: isize>() -> IADsBackLink_Vtbl {
@@ -788,6 +802,8 @@ pub trait IADsCaseIgnoreList_Impl: Sized + super::super::System::Com::IDispatch_
     fn CaseIgnoreList(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetCaseIgnoreList(&self, vcaseignorelist: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsCaseIgnoreList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsCaseIgnoreList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsCaseIgnoreList_Impl, const OFFSET: isize>() -> IADsCaseIgnoreList_Vtbl {
@@ -850,6 +866,8 @@ pub trait IADsClass_Impl: Sized + super::super::System::Com::IDispatch_Impl + IA
     fn SetHelpFileContext(&self, lnhelpfilecontext: i32) -> ::windows::core::Result<()>;
     fn Qualifiers(&self) -> ::windows::core::Result<IADsCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsClass {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsClass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsClass_Impl, const OFFSET: isize>() -> IADsClass_Vtbl {
@@ -1145,6 +1163,8 @@ pub trait IADsCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn GetObject(&self, bstrname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsCollection_Impl, const OFFSET: isize>() -> IADsCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IADsCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1226,6 +1246,8 @@ pub trait IADsComputer_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn NetAddresses(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetNetAddresses(&self, vnetaddresses: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsComputer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsComputer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsComputer_Impl, const OFFSET: isize>() -> IADsComputer_Vtbl {
@@ -1537,6 +1559,8 @@ pub trait IADsComputerOperations_Impl: Sized + super::super::System::Com::IDispa
     fn Shutdown(&self, breboot: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsComputerOperations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsComputerOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsComputerOperations_Impl, const OFFSET: isize>() -> IADsComputerOperations_Vtbl {
         unsafe extern "system" fn Status<Identity: ::windows::core::IUnknownImpl, Impl: IADsComputerOperations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1575,6 +1599,8 @@ pub trait IADsContainer_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn CopyHere(&self, sourcename: &super::super::Foundation::BSTR, newname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn MoveHere(&self, sourcename: &super::super::Foundation::BSTR, newname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsContainer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsContainer_Impl, const OFFSET: isize>() -> IADsContainer_Vtbl {
@@ -1708,6 +1734,8 @@ pub trait IADsDNWithBinary_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn SetDNString(&self, bstrdnstring: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsDNWithBinary {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsDNWithBinary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsDNWithBinary_Impl, const OFFSET: isize>() -> IADsDNWithBinary_Vtbl {
         unsafe extern "system" fn BinaryValue<Identity: ::windows::core::IUnknownImpl, Impl: IADsDNWithBinary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1762,6 +1790,8 @@ pub trait IADsDNWithString_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn SetDNString(&self, bstrdnstring: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsDNWithString {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsDNWithString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsDNWithString_Impl, const OFFSET: isize>() -> IADsDNWithString_Vtbl {
         unsafe extern "system" fn StringValue<Identity: ::windows::core::IUnknownImpl, Impl: IADsDNWithString_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1813,6 +1843,8 @@ pub trait IADsDeleteOps_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn DeleteObject(&self, lnflags: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsDeleteOps {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsDeleteOps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsDeleteOps_Impl, const OFFSET: isize>() -> IADsDeleteOps_Vtbl {
         unsafe extern "system" fn DeleteObject<Identity: ::windows::core::IUnknownImpl, Impl: IADsDeleteOps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnflags: i32) -> ::windows::core::HRESULT {
@@ -1846,6 +1878,8 @@ pub trait IADsDomain_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn LockoutObservationInterval(&self) -> ::windows::core::Result<i32>;
     fn SetLockoutObservationInterval(&self, lnlockoutobservationinterval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsDomain {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsDomain_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsDomain_Impl, const OFFSET: isize>() -> IADsDomain_Vtbl {
@@ -2021,6 +2055,8 @@ pub trait IADsEmail_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetAddress(&self, bstraddress: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsEmail {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsEmail_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsEmail_Impl, const OFFSET: isize>() -> IADsEmail_Vtbl {
         unsafe extern "system" fn Type<Identity: ::windows::core::IUnknownImpl, Impl: IADsEmail_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -2074,6 +2110,8 @@ pub trait IADsExtension_Impl: Sized {
     fn PrivateInvoke(&self, dispidmember: i32, riid: *const ::windows::core::GUID, lcid: u32, wflags: u16, pdispparams: *const super::super::System::Com::DISPPARAMS, pvarresult: *mut super::super::System::Com::VARIANT, pexcepinfo: *mut super::super::System::Com::EXCEPINFO, puargerr: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsExtension {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsExtension_Impl, const OFFSET: isize>() -> IADsExtension_Vtbl {
         unsafe extern "system" fn Operate<Identity: ::windows::core::IUnknownImpl, Impl: IADsExtension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcode: u32, vardata1: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, vardata2: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, vardata3: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -2115,6 +2153,8 @@ pub trait IADsFaxNumber_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Parameters(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetParameters(&self, vparameters: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsFaxNumber {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsFaxNumber_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsFaxNumber_Impl, const OFFSET: isize>() -> IADsFaxNumber_Vtbl {
@@ -2170,6 +2210,8 @@ pub trait IADsFileService_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn SetMaxUserCount(&self, lnmaxusercount: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsFileService {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsFileService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsFileService_Impl, const OFFSET: isize>() -> IADsFileService_Vtbl {
         unsafe extern "system" fn Description<Identity: ::windows::core::IUnknownImpl, Impl: IADsFileService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2222,6 +2264,8 @@ pub trait IADsFileServiceOperations_Impl: Sized + super::super::System::Com::IDi
     fn Resources(&self) -> ::windows::core::Result<IADsCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsFileServiceOperations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsFileServiceOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsFileServiceOperations_Impl, const OFFSET: isize>() -> IADsFileServiceOperations_Vtbl {
         unsafe extern "system" fn Sessions<Identity: ::windows::core::IUnknownImpl, Impl: IADsFileServiceOperations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsessions: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2268,6 +2312,8 @@ pub trait IADsFileShare_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn MaxUserCount(&self) -> ::windows::core::Result<i32>;
     fn SetMaxUserCount(&self, lnmaxusercount: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsFileShare {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsFileShare_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsFileShare_Impl, const OFFSET: isize>() -> IADsFileShare_Vtbl {
@@ -2373,6 +2419,8 @@ pub trait IADsGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl + IA
     fn Remove(&self, bstritemtoberemoved: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsGroup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsGroup_Impl, const OFFSET: isize>() -> IADsGroup_Vtbl {
         unsafe extern "system" fn Description<Identity: ::windows::core::IUnknownImpl, Impl: IADsGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2445,6 +2493,8 @@ pub trait IADsHold_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetAmount(&self, lnamount: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsHold {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsHold_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsHold_Impl, const OFFSET: isize>() -> IADsHold_Vtbl {
         unsafe extern "system" fn ObjectName<Identity: ::windows::core::IUnknownImpl, Impl: IADsHold_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2498,6 +2548,8 @@ pub trait IADsLargeInteger_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn LowPart(&self) -> ::windows::core::Result<i32>;
     fn SetLowPart(&self, lnlowpart: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsLargeInteger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsLargeInteger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsLargeInteger_Impl, const OFFSET: isize>() -> IADsLargeInteger_Vtbl {
@@ -2556,6 +2608,8 @@ pub trait IADsLocality_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn SeeAlso(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetSeeAlso(&self, vseealso: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsLocality {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsLocality_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsLocality_Impl, const OFFSET: isize>() -> IADsLocality_Vtbl {
@@ -2647,6 +2701,8 @@ pub trait IADsMembers_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetFilter(&self, pvfilter: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsMembers {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsMembers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsMembers_Impl, const OFFSET: isize>() -> IADsMembers_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IADsMembers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2709,6 +2765,8 @@ pub trait IADsNameTranslate_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetEx(&self, lnformattype: i32, pvar: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn GetEx(&self, lnformattype: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsNameTranslate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsNameTranslate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsNameTranslate_Impl, const OFFSET: isize>() -> IADsNameTranslate_Vtbl {
@@ -2780,6 +2838,8 @@ pub trait IADsNamespaces_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SetDefaultContainer(&self, bstrdefaultcontainer: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsNamespaces {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsNamespaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsNamespaces_Impl, const OFFSET: isize>() -> IADsNamespaces_Vtbl {
         unsafe extern "system" fn DefaultContainer<Identity: ::windows::core::IUnknownImpl, Impl: IADsNamespaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2815,6 +2875,8 @@ pub trait IADsNetAddress_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Address(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetAddress(&self, vaddress: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsNetAddress {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsNetAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsNetAddress_Impl, const OFFSET: isize>() -> IADsNetAddress_Vtbl {
@@ -2877,6 +2939,8 @@ pub trait IADsO_Impl: Sized + super::super::System::Com::IDispatch_Impl + IADs_I
     fn SeeAlso(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetSeeAlso(&self, vseealso: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsO_Impl, const OFFSET: isize>() -> IADsO_Vtbl {
@@ -3013,6 +3077,8 @@ pub trait IADsOU_Impl: Sized + super::super::System::Com::IDispatch_Impl + IADs_
     fn BusinessCategory(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetBusinessCategory(&self, bstrbusinesscategory: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsOU {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsOU_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsOU_Impl, const OFFSET: isize>() -> IADsOU_Vtbl {
@@ -3156,6 +3222,8 @@ pub trait IADsObjectOptions_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetOption(&self, lnoption: i32, vvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsObjectOptions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsObjectOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsObjectOptions_Impl, const OFFSET: isize>() -> IADsObjectOptions_Vtbl {
         unsafe extern "system" fn GetOption<Identity: ::windows::core::IUnknownImpl, Impl: IADsObjectOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnoption: i32, pvvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3190,6 +3258,8 @@ pub trait IADsOctetList_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetOctetList(&self, voctetlist: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsOctetList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsOctetList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsOctetList_Impl, const OFFSET: isize>() -> IADsOctetList_Vtbl {
         unsafe extern "system" fn OctetList<Identity: ::windows::core::IUnknownImpl, Impl: IADsOctetList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3223,6 +3293,8 @@ pub trait IADsOpenDSObject_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn OpenDSObject(&self, lpszdnname: &super::super::Foundation::BSTR, lpszusername: &super::super::Foundation::BSTR, lpszpassword: &super::super::Foundation::BSTR, lnreserved: i32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsOpenDSObject {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsOpenDSObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsOpenDSObject_Impl, const OFFSET: isize>() -> IADsOpenDSObject_Vtbl {
         unsafe extern "system" fn OpenDSObject<Identity: ::windows::core::IUnknownImpl, Impl: IADsOpenDSObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpszdnname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lpszusername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lpszpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lnreserved: i32, ppoledsobj: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3251,6 +3323,8 @@ pub trait IADsPath_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Path(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetPath(&self, bstrpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPath {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPath_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPath_Impl, const OFFSET: isize>() -> IADsPath_Vtbl {
@@ -3330,6 +3404,8 @@ pub trait IADsPathname_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EscapedMode(&self) -> ::windows::core::Result<i32>;
     fn SetEscapedMode(&self, lnescapedmode: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPathname {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPathname_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPathname_Impl, const OFFSET: isize>() -> IADsPathname_Vtbl {
@@ -3449,6 +3525,8 @@ pub trait IADsPostalAddress_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetPostalAddress(&self, vpostaladdress: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPostalAddress {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPostalAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPostalAddress_Impl, const OFFSET: isize>() -> IADsPostalAddress_Vtbl {
         unsafe extern "system" fn PostalAddress<Identity: ::windows::core::IUnknownImpl, Impl: IADsPostalAddress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3498,6 +3576,8 @@ pub trait IADsPrintJob_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn NotifyPath(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetNotifyPath(&self, bstrnotifypath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPrintJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPrintJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPrintJob_Impl, const OFFSET: isize>() -> IADsPrintJob_Vtbl {
@@ -3700,6 +3780,8 @@ pub trait IADsPrintJobOperations_Impl: Sized + super::super::System::Com::IDispa
     fn Resume(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPrintJobOperations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPrintJobOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPrintJobOperations_Impl, const OFFSET: isize>() -> IADsPrintJobOperations_Vtbl {
         unsafe extern "system" fn Status<Identity: ::windows::core::IUnknownImpl, Impl: IADsPrintJobOperations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -3805,6 +3887,8 @@ pub trait IADsPrintQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn NetAddresses(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetNetAddresses(&self, vnetaddresses: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPrintQueue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPrintQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPrintQueue_Impl, const OFFSET: isize>() -> IADsPrintQueue_Vtbl {
@@ -4059,6 +4143,8 @@ pub trait IADsPrintQueueOperations_Impl: Sized + super::super::System::Com::IDis
     fn Purge(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPrintQueueOperations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPrintQueueOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPrintQueueOperations_Impl, const OFFSET: isize>() -> IADsPrintQueueOperations_Vtbl {
         unsafe extern "system" fn Status<Identity: ::windows::core::IUnknownImpl, Impl: IADsPrintQueueOperations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -4125,6 +4211,8 @@ pub trait IADsProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn SetMultiValued(&self, fmultivalued: i16) -> ::windows::core::Result<()>;
     fn Qualifiers(&self) -> ::windows::core::Result<IADsCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsProperty_Impl, const OFFSET: isize>() -> IADsProperty_Vtbl {
@@ -4251,6 +4339,8 @@ pub trait IADsPropertyEntry_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetValues(&self, vvalues: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPropertyEntry {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPropertyEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPropertyEntry_Impl, const OFFSET: isize>() -> IADsPropertyEntry_Vtbl {
         unsafe extern "system" fn Clear<Identity: ::windows::core::IUnknownImpl, Impl: IADsPropertyEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4351,6 +4441,8 @@ pub trait IADsPropertyList_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn ResetPropertyItem(&self, varentry: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn PurgePropertyList(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPropertyList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPropertyList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPropertyList_Impl, const OFFSET: isize>() -> IADsPropertyList_Vtbl {
@@ -4462,6 +4554,8 @@ pub trait IADsPropertyValue_Impl: Sized + super::super::System::Com::IDispatch_I
     fn UTCTime(&self) -> ::windows::core::Result<f64>;
     fn SetUTCTime(&self, dautctime: f64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPropertyValue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPropertyValue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPropertyValue_Impl, const OFFSET: isize>() -> IADsPropertyValue_Vtbl {
@@ -4701,6 +4795,8 @@ pub trait IADsPropertyValue2_Impl: Sized + super::super::System::Com::IDispatch_
     fn PutObjectProperty(&self, lnadstype: i32, vprop: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsPropertyValue2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsPropertyValue2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsPropertyValue2_Impl, const OFFSET: isize>() -> IADsPropertyValue2_Vtbl {
         unsafe extern "system" fn GetObjectProperty<Identity: ::windows::core::IUnknownImpl, Impl: IADsPropertyValue2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnadstype: *mut i32, pvprop: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4736,6 +4832,8 @@ pub trait IADsReplicaPointer_Impl: Sized + super::super::System::Com::IDispatch_
     fn ReplicaAddressHints(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetReplicaAddressHints(&self, vreplicaaddresshints: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsReplicaPointer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsReplicaPointer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsReplicaPointer_Impl, const OFFSET: isize>() -> IADsReplicaPointer_Vtbl {
@@ -4845,6 +4943,8 @@ pub trait IADsResource_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn LockCount(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsResource {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsResource_Impl, const OFFSET: isize>() -> IADsResource_Vtbl {
         unsafe extern "system" fn User<Identity: ::windows::core::IUnknownImpl, Impl: IADsResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4927,6 +5027,8 @@ pub trait IADsSecurityDescriptor_Impl: Sized + super::super::System::Com::IDispa
     fn SetSaclDefaulted(&self, fsacldefaulted: i16) -> ::windows::core::Result<()>;
     fn CopySecurityDescriptor(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsSecurityDescriptor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsSecurityDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsSecurityDescriptor_Impl, const OFFSET: isize>() -> IADsSecurityDescriptor_Vtbl {
@@ -5139,6 +5241,8 @@ pub trait IADsSecurityUtility_Impl: Sized + super::super::System::Com::IDispatch
     fn SetSecurityMask(&self, lnsecuritymask: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsSecurityUtility {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsSecurityUtility_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsSecurityUtility_Impl, const OFFSET: isize>() -> IADsSecurityUtility_Vtbl {
         unsafe extern "system" fn GetSecurityDescriptor<Identity: ::windows::core::IUnknownImpl, Impl: IADsSecurityUtility_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, varpath: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, lpathformat: i32, lformat: i32, pvariant: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -5224,6 +5328,8 @@ pub trait IADsService_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn Dependencies(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetDependencies(&self, vdependencies: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsService_Impl, const OFFSET: isize>() -> IADsService_Vtbl {
@@ -5461,6 +5567,8 @@ pub trait IADsServiceOperations_Impl: Sized + super::super::System::Com::IDispat
     fn SetPassword(&self, bstrnewpassword: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsServiceOperations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsServiceOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsServiceOperations_Impl, const OFFSET: isize>() -> IADsServiceOperations_Vtbl {
         unsafe extern "system" fn Status<Identity: ::windows::core::IUnknownImpl, Impl: IADsServiceOperations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -5522,6 +5630,8 @@ pub trait IADsSession_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn ConnectTime(&self) -> ::windows::core::Result<i32>;
     fn IdleTime(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsSession_Impl, const OFFSET: isize>() -> IADsSession_Vtbl {
@@ -5611,6 +5721,8 @@ pub trait IADsSyntax_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn SetOleAutoDataType(&self, lnoleautodatatype: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsSyntax {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsSyntax_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsSyntax_Impl, const OFFSET: isize>() -> IADsSyntax_Vtbl {
         unsafe extern "system" fn OleAutoDataType<Identity: ::windows::core::IUnknownImpl, Impl: IADsSyntax_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -5646,6 +5758,8 @@ pub trait IADsTimestamp_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn EventID(&self) -> ::windows::core::Result<i32>;
     fn SetEventID(&self, lneventid: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsTimestamp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsTimestamp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsTimestamp_Impl, const OFFSET: isize>() -> IADsTimestamp_Vtbl {
@@ -5702,6 +5816,8 @@ pub trait IADsTypedName_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Interval(&self) -> ::windows::core::Result<i32>;
     fn SetInterval(&self, lninterval: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsTypedName {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsTypedName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsTypedName_Impl, const OFFSET: isize>() -> IADsTypedName_Vtbl {
@@ -5861,6 +5977,8 @@ pub trait IADsUser_Impl: Sized + super::super::System::Com::IDispatch_Impl + IAD
     fn SetPassword(&self, newpassword: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn ChangePassword(&self, bstroldpassword: &super::super::Foundation::BSTR, bstrnewpassword: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsUser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsUser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsUser_Impl, const OFFSET: isize>() -> IADsUser_Vtbl {
@@ -6714,6 +6832,8 @@ pub trait IADsWinNTSystemInfo_Impl: Sized + super::super::System::Com::IDispatch
     fn PDC(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsWinNTSystemInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsWinNTSystemInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsWinNTSystemInfo_Impl, const OFFSET: isize>() -> IADsWinNTSystemInfo_Vtbl {
         unsafe extern "system" fn UserName<Identity: ::windows::core::IUnknownImpl, Impl: IADsWinNTSystemInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -6777,6 +6897,8 @@ pub trait ICommonQuery_Impl: Sized {
     fn OpenQueryWindow(&self, hwndparent: super::super::Foundation::HWND, pquerywnd: *mut OPENQUERYWINDOW, ppdataobject: *mut ::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ICommonQuery {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ICommonQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommonQuery_Impl, const OFFSET: isize>() -> ICommonQuery_Vtbl {
         unsafe extern "system" fn OpenQueryWindow<Identity: ::windows::core::IUnknownImpl, Impl: ICommonQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, pquerywnd: *mut OPENQUERYWINDOW, ppdataobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6798,6 +6920,8 @@ pub trait IDirectoryObject_Impl: Sized {
     fn CreateDSObject(&self, pszrdnname: &::windows::core::PCWSTR, pattributeentries: *const ADS_ATTR_INFO, dwnumattributes: u32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn DeleteDSObject(&self, pszrdnname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDirectoryObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDirectoryObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectoryObject_Impl, const OFFSET: isize>() -> IDirectoryObject_Vtbl {
@@ -6868,6 +6992,8 @@ pub trait IDirectorySchemaMgmt_Impl: Sized {
     fn CreateClassDefinition(&self, pszclassname: &::windows::core::PCWSTR, pclassdefinition: *const ADS_CLASS_DEF) -> ::windows::core::Result<()>;
     fn DeleteClassDefinition(&self, pszclassname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectorySchemaMgmt {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectorySchemaMgmt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectorySchemaMgmt_Impl, const OFFSET: isize>() -> IDirectorySchemaMgmt_Vtbl {
@@ -6940,6 +7066,8 @@ pub trait IDirectorySearch_Impl: Sized {
     fn FreeColumn(&self, psearchcolumn: *const ads_search_column) -> ::windows::core::Result<()>;
     fn CloseSearchHandle(&self, hsearchresult: isize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDirectorySearch {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDirectorySearch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectorySearch_Impl, const OFFSET: isize>() -> IDirectorySearch_Vtbl {
@@ -7029,6 +7157,8 @@ pub trait IDsAdminCreateObj_Impl: Sized {
     fn CreateModal(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<IADs>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDsAdminCreateObj {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDsAdminCreateObj_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminCreateObj_Impl, const OFFSET: isize>() -> IDsAdminCreateObj_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminCreateObj_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, padscontainerobj: ::windows::core::RawPtr, padscopysource: ::windows::core::RawPtr, lpszclassname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -7063,6 +7193,8 @@ pub trait IDsAdminNewObj_Impl: Sized {
     fn GetPageCounts(&self, pntotal: *mut i32, pnstartindex: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDsAdminNewObj {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDsAdminNewObj_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminNewObj_Impl, const OFFSET: isize>() -> IDsAdminNewObj_Vtbl {
         unsafe extern "system" fn SetButtons<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminNewObj_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ncurrindex: u32, bvalid: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -7094,6 +7226,8 @@ pub trait IDsAdminNewObjExt_Impl: Sized {
     fn OnError(&self, hwnd: super::super::Foundation::HWND, hr: ::windows::core::HRESULT, ucontext: u32) -> ::windows::core::Result<()>;
     fn GetSummaryInfo(&self, pbstrtext: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDsAdminNewObjExt {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDsAdminNewObjExt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminNewObjExt_Impl, const OFFSET: isize>() -> IDsAdminNewObjExt_Vtbl {
@@ -7145,6 +7279,7 @@ pub trait IDsAdminNewObjPrimarySite_Impl: Sized {
     fn CreateNew(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDsAdminNewObjPrimarySite {}
 impl IDsAdminNewObjPrimarySite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminNewObjPrimarySite_Impl, const OFFSET: isize>() -> IDsAdminNewObjPrimarySite_Vtbl {
         unsafe extern "system" fn CreateNew<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminNewObjPrimarySite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -7174,6 +7309,8 @@ pub trait IDsAdminNotifyHandler_Impl: Sized {
     fn Notify(&self, nitem: u32, uflags: u32) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDsAdminNotifyHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDsAdminNotifyHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsAdminNotifyHandler_Impl, const OFFSET: isize>() -> IDsAdminNotifyHandler_Vtbl {
@@ -7217,6 +7354,8 @@ pub trait IDsBrowseDomainTree_Impl: Sized {
     fn FlushCachedDomains(&self) -> ::windows::core::Result<()>;
     fn SetComputer(&self, pszcomputername: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDsBrowseDomainTree {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDsBrowseDomainTree_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsBrowseDomainTree_Impl, const OFFSET: isize>() -> IDsBrowseDomainTree_Vtbl {
@@ -7272,6 +7411,8 @@ pub trait IDsDisplaySpecifier_Impl: Sized {
     fn EnumClassAttributes(&self, pszobjectclass: &::windows::core::PCWSTR, pcbenum: &LPDSENUMATTRIBUTES, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
     fn GetAttributeADsType(&self, pszattributename: &::windows::core::PCWSTR) -> ADSTYPEENUM;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDsDisplaySpecifier {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDsDisplaySpecifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsDisplaySpecifier_Impl, const OFFSET: isize>() -> IDsDisplaySpecifier_Vtbl {
@@ -7355,6 +7496,8 @@ pub trait IDsObjectPicker_Impl: Sized {
     fn InvokeDialog(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<super::super::System::Com::IDataObject>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDsObjectPicker {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDsObjectPicker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsObjectPicker_Impl, const OFFSET: isize>() -> IDsObjectPicker_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDsObjectPicker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinitinfo: *mut DSOP_INIT_INFO) -> ::windows::core::HRESULT {
@@ -7388,6 +7531,8 @@ pub trait IDsObjectPickerCredentials_Impl: Sized + IDsObjectPicker_Impl {
     fn SetCredentials(&self, szusername: &::windows::core::PCWSTR, szpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDsObjectPickerCredentials {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDsObjectPickerCredentials_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDsObjectPickerCredentials_Impl, const OFFSET: isize>() -> IDsObjectPickerCredentials_Vtbl {
         unsafe extern "system" fn SetCredentials<Identity: ::windows::core::IUnknownImpl, Impl: IDsObjectPickerCredentials_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szusername: ::windows::core::PCWSTR, szpassword: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -7411,6 +7556,8 @@ pub trait IPersistQuery_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn ReadStruct(&self, psection: &::windows::core::PCWSTR, pvaluename: &::windows::core::PCWSTR, pstruct: *mut ::core::ffi::c_void, cbstruct: u32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IPersistQuery {}
 #[cfg(feature = "Win32_System_Com")]
 impl IPersistQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistQuery_Impl, const OFFSET: isize>() -> IPersistQuery_Vtbl {
@@ -7472,6 +7619,8 @@ pub trait IPrivateDispatch_Impl: Sized {
     fn ADSIGetIDsOfNames(&self, riid: *const ::windows::core::GUID, rgsznames: *const *const u16, cnames: u32, lcid: u32) -> ::windows::core::Result<i32>;
     fn ADSIInvoke(&self, dispidmember: i32, riid: *const ::windows::core::GUID, lcid: u32, wflags: u16, pdispparams: *const super::super::System::Com::DISPPARAMS, pvarresult: *mut super::super::System::Com::VARIANT, pexcepinfo: *mut super::super::System::Com::EXCEPINFO, puargerr: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrivateDispatch {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrivateDispatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrivateDispatch_Impl, const OFFSET: isize>() -> IPrivateDispatch_Vtbl {
@@ -7537,6 +7686,8 @@ pub trait IPrivateUnknown_Impl: Sized {
     fn ADSIReleaseObject(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrivateUnknown {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPrivateUnknown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrivateUnknown_Impl, const OFFSET: isize>() -> IPrivateUnknown_Vtbl {
         unsafe extern "system" fn ADSIInitializeObject<Identity: ::windows::core::IUnknownImpl, Impl: IPrivateUnknown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpszusername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lpszpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lnreserved: i32) -> ::windows::core::HRESULT {
@@ -7565,6 +7716,8 @@ pub trait IQueryForm_Impl: Sized {
     fn AddForms(&self, paddformsproc: &LPCQADDFORMSPROC, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
     fn AddPages(&self, paddpagesproc: &LPCQADDPAGESPROC, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IQueryForm {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IQueryForm_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryForm_Impl, const OFFSET: isize>() -> IQueryForm_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
@@ -6,6 +6,7 @@ pub trait AsyncIBackgroundCopyCallback_Impl: Sized {
     fn Begin_JobModification(&self, pjob: &::core::option::Option<IBackgroundCopyJob>, dwreserved: u32) -> ::windows::core::Result<()>;
     fn Finish_JobModification(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIBackgroundCopyCallback {}
 impl AsyncIBackgroundCopyCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIBackgroundCopyCallback_Impl, const OFFSET: isize>() -> AsyncIBackgroundCopyCallback_Vtbl {
         unsafe extern "system" fn Begin_JobTransferred<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIBackgroundCopyCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pjob: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -60,6 +61,8 @@ pub trait IBITSExtensionSetup_Impl: Sized + super::super::System::Com::IDispatch
     fn GetCleanupTask(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBITSExtensionSetup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBITSExtensionSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBITSExtensionSetup_Impl, const OFFSET: isize>() -> IBITSExtensionSetup_Vtbl {
         unsafe extern "system" fn EnableBITSUploads<Identity: ::windows::core::IUnknownImpl, Impl: IBITSExtensionSetup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -111,6 +114,8 @@ pub trait IBITSExtensionSetupFactory_Impl: Sized + super::super::System::Com::ID
     fn GetObject(&self, path: &super::super::Foundation::BSTR) -> ::windows::core::Result<IBITSExtensionSetup>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBITSExtensionSetupFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBITSExtensionSetupFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBITSExtensionSetupFactory_Impl, const OFFSET: isize>() -> IBITSExtensionSetupFactory_Vtbl {
         unsafe extern "system" fn GetObject<Identity: ::windows::core::IUnknownImpl, Impl: IBITSExtensionSetupFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, path: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppextensionsetup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -135,6 +140,7 @@ pub trait IBackgroundCopyCallback_Impl: Sized {
     fn JobError(&self, pjob: &::core::option::Option<IBackgroundCopyJob>, perror: &::core::option::Option<IBackgroundCopyError>) -> ::windows::core::Result<()>;
     fn JobModification(&self, pjob: &::core::option::Option<IBackgroundCopyJob>, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyCallback {}
 impl IBackgroundCopyCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback_Impl, const OFFSET: isize>() -> IBackgroundCopyCallback_Vtbl {
         unsafe extern "system" fn JobTransferred<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pjob: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -168,6 +174,7 @@ pub trait IBackgroundCopyCallback1_Impl: Sized {
     fn OnProgress(&self, progresstype: u32, pgroup: &::core::option::Option<IBackgroundCopyGroup>, pjob: &::core::option::Option<IBackgroundCopyJob1>, dwfileindex: u32, dwprogressvalue: u32) -> ::windows::core::Result<()>;
     fn OnProgressEx(&self, progresstype: u32, pgroup: &::core::option::Option<IBackgroundCopyGroup>, pjob: &::core::option::Option<IBackgroundCopyJob1>, dwfileindex: u32, dwprogressvalue: u32, dwbytearraysize: u32, pbyte: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyCallback1 {}
 impl IBackgroundCopyCallback1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback1_Impl, const OFFSET: isize>() -> IBackgroundCopyCallback1_Vtbl {
         unsafe extern "system" fn OnStatus<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pgroup: ::windows::core::RawPtr, pjob: ::windows::core::RawPtr, dwfileindex: u32, dwstatus: u32, dwnumofretries: u32, dwwin32result: u32, dwtransportresult: u32) -> ::windows::core::HRESULT {
@@ -199,6 +206,7 @@ impl IBackgroundCopyCallback1_Vtbl {
 pub trait IBackgroundCopyCallback2_Impl: Sized + IBackgroundCopyCallback_Impl {
     fn FileTransferred(&self, pjob: &::core::option::Option<IBackgroundCopyJob>, pfile: &::core::option::Option<IBackgroundCopyFile>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyCallback2 {}
 impl IBackgroundCopyCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback2_Impl, const OFFSET: isize>() -> IBackgroundCopyCallback2_Vtbl {
         unsafe extern "system" fn FileTransferred<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pjob: ::windows::core::RawPtr, pfile: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -215,6 +223,7 @@ impl IBackgroundCopyCallback2_Vtbl {
 pub trait IBackgroundCopyCallback3_Impl: Sized + IBackgroundCopyCallback_Impl + IBackgroundCopyCallback2_Impl {
     fn FileRangesTransferred(&self, job: &::core::option::Option<IBackgroundCopyJob>, file: &::core::option::Option<IBackgroundCopyFile>, rangecount: u32, ranges: *const BG_FILE_RANGE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyCallback3 {}
 impl IBackgroundCopyCallback3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback3_Impl, const OFFSET: isize>() -> IBackgroundCopyCallback3_Vtbl {
         unsafe extern "system" fn FileRangesTransferred<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyCallback3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, job: ::windows::core::RawPtr, file: ::windows::core::RawPtr, rangecount: u32, ranges: *const BG_FILE_RANGE) -> ::windows::core::HRESULT {
@@ -235,6 +244,7 @@ pub trait IBackgroundCopyError_Impl: Sized {
     fn GetErrorContextDescription(&self, languageid: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetProtocol(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyError {}
 impl IBackgroundCopyError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyError_Impl, const OFFSET: isize>() -> IBackgroundCopyError_Vtbl {
         unsafe extern "system" fn GetError<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontext: *mut BG_ERROR_CONTEXT, pcode: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -306,6 +316,8 @@ pub trait IBackgroundCopyFile_Impl: Sized {
     fn GetProgress(&self) -> ::windows::core::Result<BG_FILE_PROGRESS>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyFile {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile_Impl, const OFFSET: isize>() -> IBackgroundCopyFile_Vtbl {
         unsafe extern "system" fn GetRemoteName<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -358,6 +370,8 @@ pub trait IBackgroundCopyFile2_Impl: Sized + IBackgroundCopyFile_Impl {
     fn SetRemoteName(&self, val: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyFile2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyFile2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile2_Impl, const OFFSET: isize>() -> IBackgroundCopyFile2_Vtbl {
         unsafe extern "system" fn GetFileRanges<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rangecount: *mut u32, ranges: *mut *mut BG_FILE_RANGE) -> ::windows::core::HRESULT {
@@ -387,6 +401,8 @@ pub trait IBackgroundCopyFile3_Impl: Sized + IBackgroundCopyFile_Impl + IBackgro
     fn GetValidationState(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn IsDownloadedFromPeer(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyFile3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyFile3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile3_Impl, const OFFSET: isize>() -> IBackgroundCopyFile3_Vtbl {
@@ -445,6 +461,8 @@ pub trait IBackgroundCopyFile4_Impl: Sized + IBackgroundCopyFile_Impl + IBackgro
     fn GetPeerDownloadStats(&self, pfromorigin: *mut u64, pfrompeers: *mut u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyFile4 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyFile4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile4_Impl, const OFFSET: isize>() -> IBackgroundCopyFile4_Vtbl {
         unsafe extern "system" fn GetPeerDownloadStats<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfromorigin: *mut u64, pfrompeers: *mut u64) -> ::windows::core::HRESULT {
@@ -463,6 +481,8 @@ pub trait IBackgroundCopyFile5_Impl: Sized + IBackgroundCopyFile_Impl + IBackgro
     fn SetProperty(&self, propertyid: BITS_FILE_PROPERTY_ID, propertyvalue: &BITS_FILE_PROPERTY_VALUE) -> ::windows::core::Result<()>;
     fn GetProperty(&self, propertyid: BITS_FILE_PROPERTY_ID) -> ::windows::core::Result<BITS_FILE_PROPERTY_VALUE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyFile5 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyFile5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile5_Impl, const OFFSET: isize>() -> IBackgroundCopyFile5_Vtbl {
@@ -498,6 +518,8 @@ pub trait IBackgroundCopyFile6_Impl: Sized + IBackgroundCopyFile_Impl + IBackgro
     fn RequestFileRanges(&self, rangecount: u32, ranges: *const BG_FILE_RANGE) -> ::windows::core::Result<()>;
     fn GetFilledFileRanges(&self, rangecount: *mut u32, ranges: *mut *mut BG_FILE_RANGE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyFile6 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyFile6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyFile6_Impl, const OFFSET: isize>() -> IBackgroundCopyFile6_Vtbl {
@@ -545,6 +567,8 @@ pub trait IBackgroundCopyGroup_Impl: Sized {
     fn QueryNewJobInterface(&self, iid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetNotificationPointer(&self, iid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBackgroundCopyGroup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBackgroundCopyGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyGroup_Impl, const OFFSET: isize>() -> IBackgroundCopyGroup_Vtbl {
@@ -729,6 +753,8 @@ pub trait IBackgroundCopyJob_Impl: Sized {
     fn GetProxySettings(&self, pproxyusage: *mut BG_JOB_PROXY_USAGE, pproxylist: *mut ::windows::core::PWSTR, pproxybypasslist: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn TakeOwnership(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyJob {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob_Impl, const OFFSET: isize>() -> IBackgroundCopyJob_Vtbl {
@@ -1040,6 +1066,8 @@ pub trait IBackgroundCopyJob1_Impl: Sized {
     fn JobID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyJob1 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyJob1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob1_Impl, const OFFSET: isize>() -> IBackgroundCopyJob1_Vtbl {
         unsafe extern "system" fn CancelJob<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1134,6 +1162,8 @@ pub trait IBackgroundCopyJob2_Impl: Sized + IBackgroundCopyJob_Impl {
     fn RemoveCredentials(&self, target: BG_AUTH_TARGET, scheme: BG_AUTH_SCHEME) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyJob2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyJob2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob2_Impl, const OFFSET: isize>() -> IBackgroundCopyJob2_Vtbl {
         unsafe extern "system" fn SetNotifyCmdLine<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, program: ::windows::core::PCWSTR, parameters: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1206,6 +1236,8 @@ pub trait IBackgroundCopyJob3_Impl: Sized + IBackgroundCopyJob_Impl + IBackgroun
     fn GetFileACLFlags(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyJob3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyJob3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob3_Impl, const OFFSET: isize>() -> IBackgroundCopyJob3_Vtbl {
         unsafe extern "system" fn ReplaceRemotePrefix<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, oldprefix: ::windows::core::PCWSTR, newprefix: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1255,6 +1287,8 @@ pub trait IBackgroundCopyJob4_Impl: Sized + IBackgroundCopyJob_Impl + IBackgroun
     fn SetMaximumDownloadTime(&self, timeout: u32) -> ::windows::core::Result<()>;
     fn GetMaximumDownloadTime(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyJob4 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyJob4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob4_Impl, const OFFSET: isize>() -> IBackgroundCopyJob4_Vtbl {
@@ -1332,6 +1366,8 @@ pub trait IBackgroundCopyJob5_Impl: Sized + IBackgroundCopyJob_Impl + IBackgroun
     fn GetProperty(&self, propertyid: BITS_JOB_PROPERTY_ID) -> ::windows::core::Result<BITS_JOB_PROPERTY_VALUE>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBackgroundCopyJob5 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBackgroundCopyJob5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob5_Impl, const OFFSET: isize>() -> IBackgroundCopyJob5_Vtbl {
         unsafe extern "system" fn SetProperty<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJob5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertyid: BITS_JOB_PROPERTY_ID, propertyvalue: BITS_JOB_PROPERTY_VALUE) -> ::windows::core::HRESULT {
@@ -1370,6 +1406,7 @@ pub trait IBackgroundCopyJobHttpOptions_Impl: Sized {
     fn SetSecurityFlags(&self, flags: u32) -> ::windows::core::Result<()>;
     fn GetSecurityFlags(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyJobHttpOptions {}
 impl IBackgroundCopyJobHttpOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJobHttpOptions_Impl, const OFFSET: isize>() -> IBackgroundCopyJobHttpOptions_Vtbl {
         unsafe extern "system" fn SetClientCertificateByID<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJobHttpOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storelocation: BG_CERT_STORE_LOCATION, storename: ::windows::core::PCWSTR, pcerthashblob: *const u8) -> ::windows::core::HRESULT {
@@ -1444,6 +1481,7 @@ pub trait IBackgroundCopyJobHttpOptions2_Impl: Sized + IBackgroundCopyJobHttpOpt
     fn SetHttpMethod(&self, method: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetHttpMethod(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyJobHttpOptions2 {}
 impl IBackgroundCopyJobHttpOptions2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJobHttpOptions2_Impl, const OFFSET: isize>() -> IBackgroundCopyJobHttpOptions2_Vtbl {
         unsafe extern "system" fn SetHttpMethod<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJobHttpOptions2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, method: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1476,6 +1514,7 @@ pub trait IBackgroundCopyJobHttpOptions3_Impl: Sized + IBackgroundCopyJobHttpOpt
     fn SetServerCertificateValidationInterface(&self, certvalidationcallback: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn MakeCustomHeadersWriteOnly(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyJobHttpOptions3 {}
 impl IBackgroundCopyJobHttpOptions3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJobHttpOptions3_Impl, const OFFSET: isize>() -> IBackgroundCopyJobHttpOptions3_Vtbl {
         unsafe extern "system" fn SetServerCertificateValidationInterface<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyJobHttpOptions3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, certvalidationcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1504,6 +1543,7 @@ pub trait IBackgroundCopyManager_Impl: Sized {
     fn EnumJobs(&self, dwflags: u32) -> ::windows::core::Result<IEnumBackgroundCopyJobs>;
     fn GetErrorDescription(&self, hresult: ::windows::core::HRESULT, languageid: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyManager {}
 impl IBackgroundCopyManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyManager_Impl, const OFFSET: isize>() -> IBackgroundCopyManager_Vtbl {
         unsafe extern "system" fn CreateJob<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, displayname: ::windows::core::PCWSTR, r#type: BG_JOB_TYPE, pjobid: *mut ::windows::core::GUID, ppjob: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1561,6 +1601,7 @@ pub trait IBackgroundCopyQMgr_Impl: Sized {
     fn GetGroup(&self, groupid: &::windows::core::GUID) -> ::windows::core::Result<IBackgroundCopyGroup>;
     fn EnumGroups(&self, dwflags: u32) -> ::windows::core::Result<IEnumBackgroundCopyGroups>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyQMgr {}
 impl IBackgroundCopyQMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyQMgr_Impl, const OFFSET: isize>() -> IBackgroundCopyQMgr_Vtbl {
         unsafe extern "system" fn CreateGroup<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyQMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidgroupid: ::windows::core::GUID, ppgroup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1610,6 +1651,7 @@ impl IBackgroundCopyQMgr_Vtbl {
 pub trait IBackgroundCopyServerCertificateValidationCallback_Impl: Sized {
     fn ValidateServerCertificate(&self, job: &::core::option::Option<IBackgroundCopyJob>, file: &::core::option::Option<IBackgroundCopyFile>, certlength: u32, certdata: *const u8, certencodingtype: u32, certstorelength: u32, certstoredata: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBackgroundCopyServerCertificateValidationCallback {}
 impl IBackgroundCopyServerCertificateValidationCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyServerCertificateValidationCallback_Impl, const OFFSET: isize>() -> IBackgroundCopyServerCertificateValidationCallback_Vtbl {
         unsafe extern "system" fn ValidateServerCertificate<Identity: ::windows::core::IUnknownImpl, Impl: IBackgroundCopyServerCertificateValidationCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, job: ::windows::core::RawPtr, file: ::windows::core::RawPtr, certlength: u32, certdata: *const u8, certencodingtype: u32, certstorelength: u32, certstoredata: *const u8) -> ::windows::core::HRESULT {
@@ -1629,6 +1671,8 @@ pub trait IBitsPeer_Impl: Sized {
     fn IsAuthenticated(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn IsAvailable(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBitsPeer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBitsPeer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBitsPeer_Impl, const OFFSET: isize>() -> IBitsPeer_Vtbl {
@@ -1692,6 +1736,7 @@ pub trait IBitsPeerCacheAdministration_Impl: Sized {
     fn ClearPeers(&self) -> ::windows::core::Result<()>;
     fn DiscoverPeers(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBitsPeerCacheAdministration {}
 impl IBitsPeerCacheAdministration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBitsPeerCacheAdministration_Impl, const OFFSET: isize>() -> IBitsPeerCacheAdministration_Vtbl {
         unsafe extern "system" fn GetMaximumCacheSize<Identity: ::windows::core::IUnknownImpl, Impl: IBitsPeerCacheAdministration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::HRESULT {
@@ -1833,6 +1878,8 @@ pub trait IBitsPeerCacheRecord_Impl: Sized {
     fn GetFileRanges(&self, prangecount: *mut u32, ppranges: *mut *mut BG_FILE_RANGE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBitsPeerCacheRecord {}
+#[cfg(feature = "Win32_Foundation")]
 impl IBitsPeerCacheRecord_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBitsPeerCacheRecord_Impl, const OFFSET: isize>() -> IBitsPeerCacheRecord_Vtbl {
         unsafe extern "system" fn GetId<Identity: ::windows::core::IUnknownImpl, Impl: IBitsPeerCacheRecord_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1922,6 +1969,7 @@ pub trait IBitsTokenOptions_Impl: Sized {
     fn ClearHelperToken(&self) -> ::windows::core::Result<()>;
     fn GetHelperTokenSid(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IBitsTokenOptions {}
 impl IBitsTokenOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBitsTokenOptions_Impl, const OFFSET: isize>() -> IBitsTokenOptions_Vtbl {
         unsafe extern "system" fn SetHelperTokenFlags<Identity: ::windows::core::IUnknownImpl, Impl: IBitsTokenOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, usageflags: BG_TOKEN) -> ::windows::core::HRESULT {
@@ -1981,6 +2029,7 @@ pub trait IEnumBackgroundCopyFiles_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumBackgroundCopyFiles>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumBackgroundCopyFiles {}
 impl IEnumBackgroundCopyFiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyFiles_Impl, const OFFSET: isize>() -> IEnumBackgroundCopyFiles_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyFiles_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2040,6 +2089,7 @@ pub trait IEnumBackgroundCopyGroups_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumBackgroundCopyGroups>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumBackgroundCopyGroups {}
 impl IEnumBackgroundCopyGroups_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyGroups_Impl, const OFFSET: isize>() -> IEnumBackgroundCopyGroups_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyGroups_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2099,6 +2149,7 @@ pub trait IEnumBackgroundCopyJobs_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumBackgroundCopyJobs>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumBackgroundCopyJobs {}
 impl IEnumBackgroundCopyJobs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyJobs_Impl, const OFFSET: isize>() -> IEnumBackgroundCopyJobs_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyJobs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2158,6 +2209,7 @@ pub trait IEnumBackgroundCopyJobs1_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumBackgroundCopyJobs1>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumBackgroundCopyJobs1 {}
 impl IEnumBackgroundCopyJobs1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyJobs1_Impl, const OFFSET: isize>() -> IEnumBackgroundCopyJobs1_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBackgroundCopyJobs1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2217,6 +2269,7 @@ pub trait IEnumBitsPeerCacheRecords_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumBitsPeerCacheRecords>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumBitsPeerCacheRecords {}
 impl IEnumBitsPeerCacheRecords_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBitsPeerCacheRecords_Impl, const OFFSET: isize>() -> IEnumBitsPeerCacheRecords_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBitsPeerCacheRecords_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2276,6 +2329,7 @@ pub trait IEnumBitsPeers_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumBitsPeers>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumBitsPeers {}
 impl IEnumBitsPeers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBitsPeers_Impl, const OFFSET: isize>() -> IEnumBitsPeers_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumBitsPeers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
@@ -5,6 +5,8 @@ pub trait IGetClusterDataInfo_Impl: Sized {
     fn GetObjectCount(&self) -> i32;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGetClusterDataInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IGetClusterDataInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterDataInfo_Impl, const OFFSET: isize>() -> IGetClusterDataInfo_Vtbl {
         unsafe extern "system" fn GetClusterName<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterDataInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpszname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pcchname: *mut i32) -> ::windows::core::HRESULT {
@@ -36,6 +38,7 @@ impl IGetClusterDataInfo_Vtbl {
 pub trait IGetClusterGroupInfo_Impl: Sized {
     fn GetGroupHandle(&self, lobjindex: i32) -> *mut _HGROUP;
 }
+impl ::windows::core::RuntimeName for IGetClusterGroupInfo {}
 impl IGetClusterGroupInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterGroupInfo_Impl, const OFFSET: isize>() -> IGetClusterGroupInfo_Vtbl {
         unsafe extern "system" fn GetGroupHandle<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterGroupInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HGROUP {
@@ -52,6 +55,7 @@ impl IGetClusterGroupInfo_Vtbl {
 pub trait IGetClusterNetInterfaceInfo_Impl: Sized {
     fn GetNetInterfaceHandle(&self, lobjindex: i32) -> *mut _HNETINTERFACE;
 }
+impl ::windows::core::RuntimeName for IGetClusterNetInterfaceInfo {}
 impl IGetClusterNetInterfaceInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterNetInterfaceInfo_Impl, const OFFSET: isize>() -> IGetClusterNetInterfaceInfo_Vtbl {
         unsafe extern "system" fn GetNetInterfaceHandle<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterNetInterfaceInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HNETINTERFACE {
@@ -68,6 +72,7 @@ impl IGetClusterNetInterfaceInfo_Vtbl {
 pub trait IGetClusterNetworkInfo_Impl: Sized {
     fn GetNetworkHandle(&self, lobjindex: i32) -> *mut _HNETWORK;
 }
+impl ::windows::core::RuntimeName for IGetClusterNetworkInfo {}
 impl IGetClusterNetworkInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterNetworkInfo_Impl, const OFFSET: isize>() -> IGetClusterNetworkInfo_Vtbl {
         unsafe extern "system" fn GetNetworkHandle<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterNetworkInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HNETWORK {
@@ -84,6 +89,7 @@ impl IGetClusterNetworkInfo_Vtbl {
 pub trait IGetClusterNodeInfo_Impl: Sized {
     fn GetNodeHandle(&self, lobjindex: i32) -> *mut _HNODE;
 }
+impl ::windows::core::RuntimeName for IGetClusterNodeInfo {}
 impl IGetClusterNodeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterNodeInfo_Impl, const OFFSET: isize>() -> IGetClusterNodeInfo_Vtbl {
         unsafe extern "system" fn GetNodeHandle<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterNodeInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HNODE {
@@ -102,6 +108,8 @@ pub trait IGetClusterObjectInfo_Impl: Sized {
     fn GetObjectName(&self, lobjindex: i32, lpszname: super::super::Foundation::BSTR, pcchname: *mut i32) -> ::windows::core::Result<()>;
     fn GetObjectType(&self, lobjindex: i32) -> CLUADMEX_OBJECT_TYPE;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGetClusterObjectInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGetClusterObjectInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterObjectInfo_Impl, const OFFSET: isize>() -> IGetClusterObjectInfo_Vtbl {
@@ -131,6 +139,8 @@ pub trait IGetClusterResourceInfo_Impl: Sized {
     fn GetResourceTypeName(&self, lobjindex: i32, lpszrestypename: super::super::Foundation::BSTR, pcchrestypename: *mut i32) -> ::windows::core::Result<()>;
     fn GetResourceNetworkName(&self, lobjindex: i32, lpsznetname: super::super::Foundation::BSTR, pcchnetname: *mut u32) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGetClusterResourceInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGetClusterResourceInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterResourceInfo_Impl, const OFFSET: isize>() -> IGetClusterResourceInfo_Vtbl {
@@ -167,6 +177,8 @@ pub trait IGetClusterUIInfo_Impl: Sized {
     fn GetFont(&self) -> super::super::Graphics::Gdi::HFONT;
     fn GetIcon(&self) -> super::super::UI::WindowsAndMessaging::HICON;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IGetClusterUIInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IGetClusterUIInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetClusterUIInfo_Impl, const OFFSET: isize>() -> IGetClusterUIInfo_Vtbl {
@@ -208,6 +220,8 @@ pub trait ISClusApplication_Impl: Sized + super::super::System::Com::IDispatch_I
     fn get_ClusterNames(&self, bstrdomainname: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISClusterNames>;
     fn OpenCluster(&self, bstrclustername: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISCluster>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusApplication {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusApplication_Impl, const OFFSET: isize>() -> ISClusApplication_Vtbl {
@@ -264,6 +278,8 @@ pub trait ISClusCryptoKeys_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn AddItem(&self, bstrcryptokey: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusCryptoKeys {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusCryptoKeys_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusCryptoKeys_Impl, const OFFSET: isize>() -> ISClusCryptoKeys_Vtbl {
@@ -337,6 +353,8 @@ pub trait ISClusDisk_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Partitions(&self) -> ::windows::core::Result<ISClusPartitions>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusDisk {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusDisk_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusDisk_Impl, const OFFSET: isize>() -> ISClusDisk_Vtbl {
         unsafe extern "system" fn Signature<Identity: ::windows::core::IUnknownImpl, Impl: ISClusDisk_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plsignature: *mut i32) -> ::windows::core::HRESULT {
@@ -402,6 +420,8 @@ pub trait ISClusDisks_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusDisk>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusDisks {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusDisks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusDisks_Impl, const OFFSET: isize>() -> ISClusDisks_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusDisks_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -459,6 +479,8 @@ pub trait ISClusNetInterface_Impl: Sized + super::super::System::Com::IDispatch_
     fn State(&self) -> ::windows::core::Result<CLUSTER_NETINTERFACE_STATE>;
     fn Cluster(&self) -> ::windows::core::Result<ISCluster>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNetInterface {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNetInterface_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetInterface_Impl, const OFFSET: isize>() -> ISClusNetInterface_Vtbl {
@@ -574,6 +596,8 @@ pub trait ISClusNetInterfaces_Impl: Sized + super::super::System::Com::IDispatch
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusNetInterface>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNetInterfaces {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNetInterfaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetInterfaces_Impl, const OFFSET: isize>() -> ISClusNetInterfaces_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetInterfaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -640,6 +664,8 @@ pub trait ISClusNetwork_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn NetInterfaces(&self) -> ::windows::core::Result<ISClusNetworkNetInterfaces>;
     fn Cluster(&self) -> ::windows::core::Result<ISCluster>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNetwork {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNetwork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetwork_Impl, const OFFSET: isize>() -> ISClusNetwork_Vtbl {
@@ -785,6 +811,8 @@ pub trait ISClusNetworkNetInterfaces_Impl: Sized + super::super::System::Com::ID
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusNetInterface>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNetworkNetInterfaces {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNetworkNetInterfaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetworkNetInterfaces_Impl, const OFFSET: isize>() -> ISClusNetworkNetInterfaces_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetworkNetInterfaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -844,6 +872,8 @@ pub trait ISClusNetworks_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusNetwork>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNetworks {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNetworks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNetworks_Impl, const OFFSET: isize>() -> ISClusNetworks_Vtbl {
@@ -914,6 +944,8 @@ pub trait ISClusNode_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Cluster(&self) -> ::windows::core::Result<ISCluster>;
     fn NetInterfaces(&self) -> ::windows::core::Result<ISClusNodeNetInterfaces>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNode {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNode_Impl, const OFFSET: isize>() -> ISClusNode_Vtbl {
@@ -1083,6 +1115,8 @@ pub trait ISClusNodeNetInterfaces_Impl: Sized + super::super::System::Com::IDisp
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusNetInterface>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNodeNetInterfaces {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNodeNetInterfaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNodeNetInterfaces_Impl, const OFFSET: isize>() -> ISClusNodeNetInterfaces_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNodeNetInterfaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1142,6 +1176,8 @@ pub trait ISClusNodes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusNode>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusNodes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusNodes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusNodes_Impl, const OFFSET: isize>() -> ISClusNodes_Vtbl {
@@ -1205,6 +1241,8 @@ pub trait ISClusPartition_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn FileSystemFlags(&self) -> ::windows::core::Result<i32>;
     fn FileSystem(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusPartition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusPartition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPartition_Impl, const OFFSET: isize>() -> ISClusPartition_Vtbl {
@@ -1309,6 +1347,8 @@ pub trait ISClusPartitionEx_Impl: Sized + super::super::System::Com::IDispatch_I
     fn VolumeGuid(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusPartitionEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusPartitionEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPartitionEx_Impl, const OFFSET: isize>() -> ISClusPartitionEx_Vtbl {
         unsafe extern "system" fn TotalSize<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPartitionEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pltotalsize: *mut i32) -> ::windows::core::HRESULT {
@@ -1386,6 +1426,8 @@ pub trait ISClusPartitions_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusPartition>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusPartitions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusPartitions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPartitions_Impl, const OFFSET: isize>() -> ISClusPartitions_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPartitions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1446,6 +1488,8 @@ pub trait ISClusProperties_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn Common(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn Modified(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusProperties_Impl, const OFFSET: isize>() -> ISClusProperties_Vtbl {
@@ -1595,6 +1639,8 @@ pub trait ISClusProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Modified(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn UseDefaultValue(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusProperty_Impl, const OFFSET: isize>() -> ISClusProperty_Vtbl {
@@ -1775,6 +1821,8 @@ pub trait ISClusPropertyValue_Impl: Sized + super::super::System::Com::IDispatch
     fn Data(&self) -> ::windows::core::Result<ISClusPropertyValueData>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusPropertyValue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusPropertyValue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPropertyValue_Impl, const OFFSET: isize>() -> ISClusPropertyValue_Vtbl {
         unsafe extern "system" fn Value<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPropertyValue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvarvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1884,6 +1932,8 @@ pub trait ISClusPropertyValueData_Impl: Sized + super::super::System::Com::IDisp
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusPropertyValueData {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusPropertyValueData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPropertyValueData_Impl, const OFFSET: isize>() -> ISClusPropertyValueData_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPropertyValueData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1957,6 +2007,8 @@ pub trait ISClusPropertyValues_Impl: Sized + super::super::System::Com::IDispatc
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusPropertyValues {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusPropertyValues_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPropertyValues_Impl, const OFFSET: isize>() -> ISClusPropertyValues_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusPropertyValues_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2026,6 +2078,8 @@ pub trait ISClusRefObject_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Handle(&self) -> ::windows::core::Result<usize>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusRefObject {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusRefObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusRefObject_Impl, const OFFSET: isize>() -> ISClusRefObject_Vtbl {
         unsafe extern "system" fn Handle<Identity: ::windows::core::IUnknownImpl, Impl: ISClusRefObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phandle: *mut usize) -> ::windows::core::HRESULT {
@@ -2054,6 +2108,8 @@ pub trait ISClusRegistryKeys_Impl: Sized + super::super::System::Com::IDispatch_
     fn AddItem(&self, bstrregistrykey: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusRegistryKeys {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusRegistryKeys_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusRegistryKeys_Impl, const OFFSET: isize>() -> ISClusRegistryKeys_Vtbl {
@@ -2130,6 +2186,8 @@ pub trait ISClusResDependencies_Impl: Sized + super::super::System::Com::IDispat
     fn AddItem(&self, presource: &::core::option::Option<ISClusResource>) -> ::windows::core::Result<()>;
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResDependencies {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResDependencies_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResDependencies_Impl, const OFFSET: isize>() -> ISClusResDependencies_Vtbl {
@@ -2224,6 +2282,8 @@ pub trait ISClusResDependents_Impl: Sized + super::super::System::Com::IDispatch
     fn AddItem(&self, presource: &::core::option::Option<ISClusResource>) -> ::windows::core::Result<()>;
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResDependents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResDependents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResDependents_Impl, const OFFSET: isize>() -> ISClusResDependents_Vtbl {
@@ -2326,6 +2386,8 @@ pub trait ISClusResGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Offline(&self, vartimeout: &super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn Cluster(&self) -> ::windows::core::Result<ISCluster>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResGroup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResGroup_Impl, const OFFSET: isize>() -> ISClusResGroup_Vtbl {
@@ -2530,6 +2592,8 @@ pub trait ISClusResGroupPreferredOwnerNodes_Impl: Sized + super::super::System::
     fn AddItem(&self, pnode: &::core::option::Option<ISClusNode>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResGroupPreferredOwnerNodes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResGroupPreferredOwnerNodes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResGroupPreferredOwnerNodes_Impl, const OFFSET: isize>() -> ISClusResGroupPreferredOwnerNodes_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResGroupPreferredOwnerNodes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2628,6 +2692,8 @@ pub trait ISClusResGroupResources_Impl: Sized + super::super::System::Com::IDisp
     fn DeleteItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResGroupResources {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResGroupResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResGroupResources_Impl, const OFFSET: isize>() -> ISClusResGroupResources_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResGroupResources_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2707,6 +2773,8 @@ pub trait ISClusResGroups_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn CreateItem(&self, bstrresourcegroupname: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISClusResGroup>;
     fn DeleteItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResGroups {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResGroups_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResGroups_Impl, const OFFSET: isize>() -> ISClusResGroups_Vtbl {
@@ -2788,6 +2856,8 @@ pub trait ISClusResPossibleOwnerNodes_Impl: Sized + super::super::System::Com::I
     fn RemoveItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Modified(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResPossibleOwnerNodes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResPossibleOwnerNodes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResPossibleOwnerNodes_Impl, const OFFSET: isize>() -> ISClusResPossibleOwnerNodes_Vtbl {
@@ -2878,6 +2948,8 @@ pub trait ISClusResType_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn PossibleOwnerNodes(&self) -> ::windows::core::Result<ISClusResTypePossibleOwnerNodes>;
     fn AvailableDisks(&self) -> ::windows::core::Result<ISClusDisks>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResType_Impl, const OFFSET: isize>() -> ISClusResType_Vtbl {
@@ -3011,6 +3083,8 @@ pub trait ISClusResTypePossibleOwnerNodes_Impl: Sized + super::super::System::Co
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<ISClusNode>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResTypePossibleOwnerNodes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResTypePossibleOwnerNodes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResTypePossibleOwnerNodes_Impl, const OFFSET: isize>() -> ISClusResTypePossibleOwnerNodes_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResTypePossibleOwnerNodes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -3072,6 +3146,8 @@ pub trait ISClusResTypeResources_Impl: Sized + super::super::System::Com::IDispa
     fn CreateItem(&self, bstrresourcename: &super::super::Foundation::BSTR, bstrgroupname: &super::super::Foundation::BSTR, dwflags: CLUSTER_RESOURCE_CREATE_FLAGS) -> ::windows::core::Result<ISClusResource>;
     fn DeleteItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResTypeResources {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResTypeResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResTypeResources_Impl, const OFFSET: isize>() -> ISClusResTypeResources_Vtbl {
@@ -3152,6 +3228,8 @@ pub trait ISClusResTypes_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn CreateItem(&self, bstrresourcetypename: &super::super::Foundation::BSTR, bstrdisplayname: &super::super::Foundation::BSTR, bstrresourcetypedll: &super::super::Foundation::BSTR, dwlooksalivepollinterval: i32, dwisalivepollinterval: i32) -> ::windows::core::Result<ISClusResType>;
     fn DeleteItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResTypes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResTypes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResTypes_Impl, const OFFSET: isize>() -> ISClusResTypes_Vtbl {
@@ -3258,6 +3336,8 @@ pub trait ISClusResource_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn MaintenanceMode(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn SetMaintenanceMode(&self, bmaintenancemode: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResource {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResource_Impl, const OFFSET: isize>() -> ISClusResource_Vtbl {
@@ -3615,6 +3695,8 @@ pub trait ISClusResources_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn DeleteItem(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusResources {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResources_Impl, const OFFSET: isize>() -> ISClusResources_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusResources_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -3693,6 +3775,8 @@ pub trait ISClusScsiAddress_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Lun(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusScsiAddress {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusScsiAddress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusScsiAddress_Impl, const OFFSET: isize>() -> ISClusScsiAddress_Vtbl {
         unsafe extern "system" fn PortNumber<Identity: ::windows::core::IUnknownImpl, Impl: ISClusScsiAddress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvarportnumber: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3764,6 +3848,8 @@ pub trait ISClusVersion_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Flags(&self) -> ::windows::core::Result<i32>;
     fn MixedVersion(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusVersion {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusVersion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusVersion_Impl, const OFFSET: isize>() -> ISClusVersion_Vtbl {
@@ -3919,6 +4005,8 @@ pub trait ISCluster_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Networks(&self) -> ::windows::core::Result<ISClusNetworks>;
     fn NetInterfaces(&self) -> ::windows::core::Result<ISClusNetInterfaces>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISCluster {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISCluster_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISCluster_Impl, const OFFSET: isize>() -> ISCluster_Vtbl {
@@ -4161,6 +4249,8 @@ pub trait ISClusterNames_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn DomainName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISClusterNames {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISClusterNames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISClusterNames_Impl, const OFFSET: isize>() -> ISClusterNames_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISClusterNames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -4233,6 +4323,8 @@ pub trait ISDomainNames_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn get_Item(&self, varindex: &super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISDomainNames {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISDomainNames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISDomainNames_Impl, const OFFSET: isize>() -> ISDomainNames_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISDomainNames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -4290,6 +4382,8 @@ pub trait IWCContextMenuCallback_Impl: Sized {
     fn AddExtensionMenuItem(&self, lpszname: &super::super::Foundation::BSTR, lpszstatusbartext: &super::super::Foundation::BSTR, ncommandid: u32, nsubmenucommandid: u32, uflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWCContextMenuCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWCContextMenuCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWCContextMenuCallback_Impl, const OFFSET: isize>() -> IWCContextMenuCallback_Vtbl {
         unsafe extern "system" fn AddExtensionMenuItem<Identity: ::windows::core::IUnknownImpl, Impl: IWCContextMenuCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpszname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lpszstatusbartext: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ncommandid: u32, nsubmenucommandid: u32, uflags: u32) -> ::windows::core::HRESULT {
@@ -4306,6 +4400,7 @@ impl IWCContextMenuCallback_Vtbl {
 pub trait IWCPropertySheetCallback_Impl: Sized {
     fn AddPropertySheetPage(&self, hpage: *const i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWCPropertySheetCallback {}
 impl IWCPropertySheetCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWCPropertySheetCallback_Impl, const OFFSET: isize>() -> IWCPropertySheetCallback_Vtbl {
         unsafe extern "system" fn AddPropertySheetPage<Identity: ::windows::core::IUnknownImpl, Impl: IWCPropertySheetCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hpage: *const i32) -> ::windows::core::HRESULT {
@@ -4324,6 +4419,8 @@ pub trait IWCWizard97Callback_Impl: Sized {
     fn AddWizard97Page(&self, hpage: *const i32) -> ::windows::core::Result<()>;
     fn EnableNext(&self, hpage: *const i32, benable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWCWizard97Callback {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWCWizard97Callback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWCWizard97Callback_Impl, const OFFSET: isize>() -> IWCWizard97Callback_Vtbl {
@@ -4353,6 +4450,8 @@ pub trait IWCWizardCallback_Impl: Sized {
     fn EnableNext(&self, hpage: *const i32, benable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWCWizardCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWCWizardCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWCWizardCallback_Impl, const OFFSET: isize>() -> IWCWizardCallback_Vtbl {
         unsafe extern "system" fn AddWizardPage<Identity: ::windows::core::IUnknownImpl, Impl: IWCWizardCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hpage: *const i32) -> ::windows::core::HRESULT {
@@ -4378,6 +4477,7 @@ impl IWCWizardCallback_Vtbl {
 pub trait IWEExtendContextMenu_Impl: Sized {
     fn AddContextMenuItems(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCContextMenuCallback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWEExtendContextMenu {}
 impl IWEExtendContextMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendContextMenu_Impl, const OFFSET: isize>() -> IWEExtendContextMenu_Vtbl {
         unsafe extern "system" fn AddContextMenuItems<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendContextMenu_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4394,6 +4494,7 @@ impl IWEExtendContextMenu_Vtbl {
 pub trait IWEExtendPropertySheet_Impl: Sized {
     fn CreatePropertySheetPages(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCPropertySheetCallback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWEExtendPropertySheet {}
 impl IWEExtendPropertySheet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendPropertySheet_Impl, const OFFSET: isize>() -> IWEExtendPropertySheet_Vtbl {
         unsafe extern "system" fn CreatePropertySheetPages<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendPropertySheet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4410,6 +4511,7 @@ impl IWEExtendPropertySheet_Vtbl {
 pub trait IWEExtendWizard_Impl: Sized {
     fn CreateWizardPages(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCWizardCallback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWEExtendWizard {}
 impl IWEExtendWizard_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendWizard_Impl, const OFFSET: isize>() -> IWEExtendWizard_Vtbl {
         unsafe extern "system" fn CreateWizardPages<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendWizard_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4426,6 +4528,7 @@ impl IWEExtendWizard_Vtbl {
 pub trait IWEExtendWizard97_Impl: Sized {
     fn CreateWizard97Pages(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCWizard97Callback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWEExtendWizard97 {}
 impl IWEExtendWizard97_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendWizard97_Impl, const OFFSET: isize>() -> IWEExtendWizard97_Vtbl {
         unsafe extern "system" fn CreateWizard97Pages<Identity: ::windows::core::IUnknownImpl, Impl: IWEExtendWizard97_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4442,6 +4545,7 @@ impl IWEExtendWizard97_Vtbl {
 pub trait IWEInvokeCommand_Impl: Sized {
     fn InvokeCommand(&self, ncommandid: u32, pidata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWEInvokeCommand {}
 impl IWEInvokeCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWEInvokeCommand_Impl, const OFFSET: isize>() -> IWEInvokeCommand_Vtbl {
         unsafe extern "system" fn InvokeCommand<Identity: ::windows::core::IUnknownImpl, Impl: IWEInvokeCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ncommandid: u32, pidata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
@@ -7,6 +7,8 @@ pub trait IEnumNetworkConnections_Impl: Sized + super::super::System::Com::IDisp
     fn Clone(&self) -> ::windows::core::Result<IEnumNetworkConnections>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumNetworkConnections {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumNetworkConnections_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetworkConnections_Impl, const OFFSET: isize>() -> IEnumNetworkConnections_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetworkConnections_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenumvar: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -67,6 +69,8 @@ pub trait IEnumNetworks_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNetworks>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumNetworks {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumNetworks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNetworks_Impl, const OFFSET: isize>() -> IEnumNetworks_Vtbl {
@@ -136,6 +140,8 @@ pub trait INetwork_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetCategory(&self) -> ::windows::core::Result<NLM_NETWORK_CATEGORY>;
     fn SetCategory(&self, newcategory: NLM_NETWORK_CATEGORY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetwork {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetwork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetwork_Impl, const OFFSET: isize>() -> INetwork_Vtbl {
@@ -290,6 +296,8 @@ pub trait INetworkConnection_Impl: Sized + super::super::System::Com::IDispatch_
     fn GetDomainType(&self) -> ::windows::core::Result<NLM_DOMAIN_TYPE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetworkConnection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetworkConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnection_Impl, const OFFSET: isize>() -> INetworkConnection_Vtbl {
         unsafe extern "system" fn GetNetwork<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppnetwork: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -390,6 +398,8 @@ pub trait INetworkConnectionCost_Impl: Sized {
     fn GetDataPlanStatus(&self) -> ::windows::core::Result<NLM_DATAPLAN_STATUS>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetworkConnectionCost {}
+#[cfg(feature = "Win32_Foundation")]
 impl INetworkConnectionCost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnectionCost_Impl, const OFFSET: isize>() -> INetworkConnectionCost_Vtbl {
         unsafe extern "system" fn GetCost<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnectionCost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcost: *mut u32) -> ::windows::core::HRESULT {
@@ -428,6 +438,7 @@ pub trait INetworkConnectionCostEvents_Impl: Sized {
     fn ConnectionCostChanged(&self, connectionid: &::windows::core::GUID, newcost: u32) -> ::windows::core::Result<()>;
     fn ConnectionDataPlanStatusChanged(&self, connectionid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetworkConnectionCostEvents {}
 impl INetworkConnectionCostEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnectionCostEvents_Impl, const OFFSET: isize>() -> INetworkConnectionCostEvents_Vtbl {
         unsafe extern "system" fn ConnectionCostChanged<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnectionCostEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::GUID, newcost: u32) -> ::windows::core::HRESULT {
@@ -454,6 +465,7 @@ pub trait INetworkConnectionEvents_Impl: Sized {
     fn NetworkConnectionConnectivityChanged(&self, connectionid: &::windows::core::GUID, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::Result<()>;
     fn NetworkConnectionPropertyChanged(&self, connectionid: &::windows::core::GUID, flags: NLM_CONNECTION_PROPERTY_CHANGE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetworkConnectionEvents {}
 impl INetworkConnectionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnectionEvents_Impl, const OFFSET: isize>() -> INetworkConnectionEvents_Vtbl {
         unsafe extern "system" fn NetworkConnectionConnectivityChanged<Identity: ::windows::core::IUnknownImpl, Impl: INetworkConnectionEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::GUID, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::HRESULT {
@@ -482,6 +494,8 @@ pub trait INetworkCostManager_Impl: Sized {
     fn GetDataPlanStatus(&self, pdataplanstatus: *mut NLM_DATAPLAN_STATUS, pdestipaddr: *const NLM_SOCKADDR) -> ::windows::core::Result<()>;
     fn SetDestinationAddresses(&self, length: u32, pdestipaddrlist: *const NLM_SOCKADDR, bappend: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INetworkCostManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl INetworkCostManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkCostManager_Impl, const OFFSET: isize>() -> INetworkCostManager_Vtbl {
@@ -515,6 +529,7 @@ pub trait INetworkCostManagerEvents_Impl: Sized {
     fn CostChanged(&self, newcost: u32, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::Result<()>;
     fn DataPlanStatusChanged(&self, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetworkCostManagerEvents {}
 impl INetworkCostManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkCostManagerEvents_Impl, const OFFSET: isize>() -> INetworkCostManagerEvents_Vtbl {
         unsafe extern "system" fn CostChanged<Identity: ::windows::core::IUnknownImpl, Impl: INetworkCostManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newcost: u32, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::HRESULT {
@@ -543,6 +558,7 @@ pub trait INetworkEvents_Impl: Sized {
     fn NetworkConnectivityChanged(&self, networkid: &::windows::core::GUID, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::Result<()>;
     fn NetworkPropertyChanged(&self, networkid: &::windows::core::GUID, flags: NLM_NETWORK_PROPERTY_CHANGE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetworkEvents {}
 impl INetworkEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkEvents_Impl, const OFFSET: isize>() -> INetworkEvents_Vtbl {
         unsafe extern "system" fn NetworkAdded<Identity: ::windows::core::IUnknownImpl, Impl: INetworkEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, networkid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -589,6 +605,8 @@ pub trait INetworkListManager_Impl: Sized + super::super::System::Com::IDispatch
     fn SetSimulatedProfileInfo(&self, psimulatedinfo: *const NLM_SIMULATED_PROFILE_INFO) -> ::windows::core::Result<()>;
     fn ClearSimulatedProfileInfo(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetworkListManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetworkListManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkListManager_Impl, const OFFSET: isize>() -> INetworkListManager_Vtbl {
@@ -699,6 +717,7 @@ impl INetworkListManager_Vtbl {
 pub trait INetworkListManagerEvents_Impl: Sized {
     fn ConnectivityChanged(&self, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INetworkListManagerEvents {}
 impl INetworkListManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkListManagerEvents_Impl, const OFFSET: isize>() -> INetworkListManagerEvents_Vtbl {
         unsafe extern "system" fn ConnectivityChanged<Identity: ::windows::core::IUnknownImpl, Impl: INetworkListManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
@@ -2,6 +2,7 @@ pub trait IFindSimilarResults_Impl: Sized {
     fn GetSize(&self) -> ::windows::core::Result<u32>;
     fn GetNextFileId(&self, numtraitsmatched: *mut u32, similarityfileid: *mut SimilarityFileId) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFindSimilarResults {}
 impl IFindSimilarResults_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFindSimilarResults_Impl, const OFFSET: isize>() -> IFindSimilarResults_Vtbl {
         unsafe extern "system" fn GetSize<Identity: ::windows::core::IUnknownImpl, Impl: IFindSimilarResults_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, size: *mut u32) -> ::windows::core::HRESULT {
@@ -35,6 +36,8 @@ pub trait IRdcComparator_Impl: Sized {
     fn Process(&self, endofinput: super::super::Foundation::BOOL, endofoutput: *mut super::super::Foundation::BOOL, inputbuffer: *mut RdcBufferPointer, outputbuffer: *mut RdcNeedPointer, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRdcComparator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRdcComparator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcComparator_Impl, const OFFSET: isize>() -> IRdcComparator_Vtbl {
         unsafe extern "system" fn Process<Identity: ::windows::core::IUnknownImpl, Impl: IRdcComparator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, endofinput: super::super::Foundation::BOOL, endofoutput: *mut super::super::Foundation::BOOL, inputbuffer: *mut RdcBufferPointer, outputbuffer: *mut RdcNeedPointer, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::HRESULT {
@@ -54,6 +57,8 @@ pub trait IRdcFileReader_Impl: Sized {
     fn Read(&self, offsetfilestart: u64, bytestoread: u32, bytesactuallyread: *mut u32, buffer: *mut u8, eof: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetFilePosition(&self) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRdcFileReader {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRdcFileReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcFileReader_Impl, const OFFSET: isize>() -> IRdcFileReader_Vtbl {
@@ -102,6 +107,8 @@ pub trait IRdcFileWriter_Impl: Sized + IRdcFileReader_Impl {
     fn DeleteOnClose(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRdcFileWriter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRdcFileWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcFileWriter_Impl, const OFFSET: isize>() -> IRdcFileWriter_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows::core::IUnknownImpl, Impl: IRdcFileWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offsetfilestart: u64, bytestowrite: u32, buffer: *mut u8) -> ::windows::core::HRESULT {
@@ -142,6 +149,8 @@ pub trait IRdcGenerator_Impl: Sized {
     fn Process(&self, endofinput: super::super::Foundation::BOOL, endofoutput: *mut super::super::Foundation::BOOL, inputbuffer: *mut RdcBufferPointer, depth: u32, outputbuffers: *mut *mut RdcBufferPointer, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRdcGenerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRdcGenerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcGenerator_Impl, const OFFSET: isize>() -> IRdcGenerator_Vtbl {
         unsafe extern "system" fn GetGeneratorParameters<Identity: ::windows::core::IUnknownImpl, Impl: IRdcGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, level: u32, igeneratorparameters: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -176,6 +185,7 @@ pub trait IRdcGeneratorFilterMaxParameters_Impl: Sized {
     fn GetHashWindowSize(&self) -> ::windows::core::Result<u32>;
     fn SetHashWindowSize(&self, hashwindowsize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRdcGeneratorFilterMaxParameters {}
 impl IRdcGeneratorFilterMaxParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcGeneratorFilterMaxParameters_Impl, const OFFSET: isize>() -> IRdcGeneratorFilterMaxParameters_Vtbl {
         unsafe extern "system" fn GetHorizonSize<Identity: ::windows::core::IUnknownImpl, Impl: IRdcGeneratorFilterMaxParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, horizonsize: *mut u32) -> ::windows::core::HRESULT {
@@ -228,6 +238,7 @@ pub trait IRdcGeneratorParameters_Impl: Sized {
     fn GetSerializeSize(&self) -> ::windows::core::Result<u32>;
     fn Serialize(&self, size: u32, parametersblob: *mut u8, byteswritten: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRdcGeneratorParameters {}
 impl IRdcGeneratorParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcGeneratorParameters_Impl, const OFFSET: isize>() -> IRdcGeneratorParameters_Vtbl {
         unsafe extern "system" fn GetGeneratorParametersType<Identity: ::windows::core::IUnknownImpl, Impl: IRdcGeneratorParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parameterstype: *mut GeneratorParametersType) -> ::windows::core::HRESULT {
@@ -283,6 +294,7 @@ pub trait IRdcLibrary_Impl: Sized {
     fn CreateSignatureReader(&self, ifilereader: &::core::option::Option<IRdcFileReader>) -> ::windows::core::Result<IRdcSignatureReader>;
     fn GetRDCVersion(&self, currentversion: *mut u32, minimumcompatibleappversion: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRdcLibrary {}
 impl IRdcLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcLibrary_Impl, const OFFSET: isize>() -> IRdcLibrary_Vtbl {
         unsafe extern "system" fn ComputeDefaultRecursionDepth<Identity: ::windows::core::IUnknownImpl, Impl: IRdcLibrary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filesize: u64, depth: *mut u32) -> ::windows::core::HRESULT {
@@ -377,6 +389,8 @@ pub trait IRdcSignatureReader_Impl: Sized {
     fn ReadSignatures(&self, rdcsignaturepointer: *mut RdcSignaturePointer, endofoutput: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRdcSignatureReader {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRdcSignatureReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcSignatureReader_Impl, const OFFSET: isize>() -> IRdcSignatureReader_Vtbl {
         unsafe extern "system" fn ReadHeader<Identity: ::windows::core::IUnknownImpl, Impl: IRdcSignatureReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::HRESULT {
@@ -409,6 +423,7 @@ pub trait IRdcSimilarityGenerator_Impl: Sized {
     fn EnableSimilarity(&self) -> ::windows::core::Result<()>;
     fn Results(&self) -> ::windows::core::Result<SimilarityData>;
 }
+impl ::windows::core::RuntimeName for IRdcSimilarityGenerator {}
 impl IRdcSimilarityGenerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRdcSimilarityGenerator_Impl, const OFFSET: isize>() -> IRdcSimilarityGenerator_Vtbl {
         unsafe extern "system" fn EnableSimilarity<Identity: ::windows::core::IUnknownImpl, Impl: IRdcSimilarityGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -447,6 +462,8 @@ pub trait ISimilarity_Impl: Sized {
     fn CopyAndSwap(&self, newsimilaritytables: &::core::option::Option<ISimilarity>, reportprogress: &::core::option::Option<ISimilarityReportProgress>) -> ::windows::core::Result<()>;
     fn GetRecordCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimilarity {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISimilarity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarity_Impl, const OFFSET: isize>() -> ISimilarity_Vtbl {
@@ -535,6 +552,8 @@ pub trait ISimilarityFileIdTable_Impl: Sized {
     fn GetRecordCount(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimilarityFileIdTable {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISimilarityFileIdTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityFileIdTable_Impl, const OFFSET: isize>() -> ISimilarityFileIdTable_Vtbl {
         unsafe extern "system" fn CreateTable<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityFileIdTable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8, recordsize: u32, isnew: *mut RdcCreatedTables) -> ::windows::core::HRESULT {
@@ -620,6 +639,7 @@ impl ISimilarityFileIdTable_Vtbl {
 pub trait ISimilarityReportProgress_Impl: Sized {
     fn ReportProgress(&self, percentcompleted: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISimilarityReportProgress {}
 impl ISimilarityReportProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityReportProgress_Impl, const OFFSET: isize>() -> ISimilarityReportProgress_Vtbl {
         unsafe extern "system" fn ReportProgress<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityReportProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, percentcompleted: u32) -> ::windows::core::HRESULT {
@@ -637,6 +657,8 @@ impl ISimilarityReportProgress_Vtbl {
 pub trait ISimilarityTableDumpState_Impl: Sized {
     fn GetNextData(&self, resultssize: u32, resultsused: *mut u32, eof: *mut super::super::Foundation::BOOL, results: *mut SimilarityDumpData) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimilarityTableDumpState {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISimilarityTableDumpState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityTableDumpState_Impl, const OFFSET: isize>() -> ISimilarityTableDumpState_Vtbl {
@@ -658,6 +680,8 @@ pub trait ISimilarityTraitsMappedView_Impl: Sized {
     fn Get(&self, index: u64, dirty: super::super::Foundation::BOOL, numelements: u32) -> ::windows::core::Result<SimilarityMappedViewInfo>;
     fn GetView(&self, mappedpagebegin: *mut *mut u8, mappedpageend: *mut *mut u8);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimilarityTraitsMappedView {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISimilarityTraitsMappedView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityTraitsMappedView_Impl, const OFFSET: isize>() -> ISimilarityTraitsMappedView_Vtbl {
@@ -708,6 +732,7 @@ pub trait ISimilarityTraitsMapping_Impl: Sized {
     fn GetPageSize(&self, pagesize: *mut u32);
     fn CreateView(&self, minimummappedpages: u32, accessmode: RdcMappingAccessMode) -> ::windows::core::Result<ISimilarityTraitsMappedView>;
 }
+impl ::windows::core::RuntimeName for ISimilarityTraitsMapping {}
 impl ISimilarityTraitsMapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityTraitsMapping_Impl, const OFFSET: isize>() -> ISimilarityTraitsMapping_Vtbl {
         unsafe extern "system" fn CloseMapping<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityTraitsMapping_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -794,6 +819,8 @@ pub trait ISimilarityTraitsTable_Impl: Sized {
     fn BeginDump(&self) -> ::windows::core::Result<ISimilarityTableDumpState>;
     fn GetLastIndex(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimilarityTraitsTable {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISimilarityTraitsTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimilarityTraitsTable_Impl, const OFFSET: isize>() -> ISimilarityTraitsTable_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
@@ -4,6 +4,8 @@ pub trait IDialBranding_Impl: Sized {
     fn GetBitmap(&self, dwindex: u32) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IDialBranding {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IDialBranding_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDialBranding_Impl, const OFFSET: isize>() -> IDialBranding_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDialBranding_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzconnectoid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -41,6 +43,7 @@ pub trait IDialEngine_Impl: Sized {
     fn GetConnectedState(&self) -> ::windows::core::Result<u32>;
     fn GetConnectHandle(&self) -> ::windows::core::Result<usize>;
 }
+impl ::windows::core::RuntimeName for IDialEngine {}
 impl IDialEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDialEngine_Impl, const OFFSET: isize>() -> IDialEngine_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDialEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzconnectoid: ::windows::core::PCWSTR, pides: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -108,6 +111,7 @@ impl IDialEngine_Vtbl {
 pub trait IDialEventSink_Impl: Sized {
     fn OnEvent(&self, dwevent: u32, dwstatus: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDialEventSink {}
 impl IDialEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDialEventSink_Impl, const OFFSET: isize>() -> IDialEventSink_Vtbl {
         unsafe extern "system" fn OnEvent<Identity: ::windows::core::IUnknownImpl, Impl: IDialEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwevent: u32, dwstatus: u32) -> ::windows::core::HRESULT {
@@ -124,6 +128,7 @@ impl IDialEventSink_Vtbl {
 pub trait IProofOfPossessionCookieInfoManager_Impl: Sized {
     fn GetCookieInfoForUri(&self, uri: &::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProofOfPossessionCookieInfoManager {}
 impl IProofOfPossessionCookieInfoManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProofOfPossessionCookieInfoManager_Impl, const OFFSET: isize>() -> IProofOfPossessionCookieInfoManager_Vtbl {
         unsafe extern "system" fn GetCookieInfoForUri<Identity: ::windows::core::IUnknownImpl, Impl: IProofOfPossessionCookieInfoManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uri: ::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::HRESULT {
@@ -140,6 +145,7 @@ impl IProofOfPossessionCookieInfoManager_Vtbl {
 pub trait IProofOfPossessionCookieInfoManager2_Impl: Sized {
     fn GetCookieInfoWithUriForAccount(&self, webaccount: &::core::option::Option<::windows::core::IInspectable>, uri: &::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProofOfPossessionCookieInfoManager2 {}
 impl IProofOfPossessionCookieInfoManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProofOfPossessionCookieInfoManager2_Impl, const OFFSET: isize>() -> IProofOfPossessionCookieInfoManager2_Vtbl {
         unsafe extern "system" fn GetCookieInfoWithUriForAccount<Identity: ::windows::core::IUnknownImpl, Impl: IProofOfPossessionCookieInfoManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, webaccount: *mut ::core::ffi::c_void, uri: ::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/impl.rs
@@ -2,9 +2,7 @@ pub trait IContentPrefetcherTaskTrigger_Impl: Sized {
     fn TriggerContentPrefetcherTask(&self, packagefullname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn IsRegisteredForContentPrefetch(&self, packagefullname: &::windows::core::PCWSTR) -> ::windows::core::Result<u8>;
 }
-impl ::windows::core::RuntimeName for IContentPrefetcherTaskTrigger {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IContentPrefetcherTaskTrigger {}
 impl IContentPrefetcherTaskTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContentPrefetcherTaskTrigger_Impl, const OFFSET: isize>() -> IContentPrefetcherTaskTrigger_Vtbl {
         unsafe extern "system" fn TriggerContentPrefetcherTask<Identity: ::windows::core::IUnknownImpl, Impl: IContentPrefetcherTaskTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagefullname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
@@ -8,6 +8,8 @@ pub trait AsyncIAssociatedIdentityProvider_Impl: Sized {
     fn Finish_ChangeCredential(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for AsyncIAssociatedIdentityProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl AsyncIAssociatedIdentityProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIAssociatedIdentityProvider_Impl, const OFFSET: isize>() -> AsyncIAssociatedIdentityProvider_Vtbl {
         unsafe extern "system" fn Begin_AssociateIdentity<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIAssociatedIdentityProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: super::super::super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -73,6 +75,8 @@ pub trait AsyncIConnectedIdentityProvider_Impl: Sized {
     fn Begin_GetAccountState(&self) -> ::windows::core::Result<()>;
     fn Finish_GetAccountState(&self) -> ::windows::core::Result<ACCOUNT_STATE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for AsyncIConnectedIdentityProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl AsyncIConnectedIdentityProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIConnectedIdentityProvider_Impl, const OFFSET: isize>() -> AsyncIConnectedIdentityProvider_Vtbl {
@@ -160,6 +164,7 @@ pub trait AsyncIIdentityAdvise_Impl: Sized {
     fn Begin_IdentityUpdated(&self, dwidentityupdateevents: u32, lpszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_IdentityUpdated(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIIdentityAdvise {}
 impl AsyncIIdentityAdvise_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityAdvise_Impl, const OFFSET: isize>() -> AsyncIIdentityAdvise_Vtbl {
         unsafe extern "system" fn Begin_IdentityUpdated<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityAdvise_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwidentityupdateevents: u32, lpszuniqueid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -189,6 +194,8 @@ pub trait AsyncIIdentityAuthentication_Impl: Sized {
     fn Begin_ValidateIdentityCredential(&self, credbuffer: *const u8, credbufferlength: u32, ppidentityproperties: *mut ::core::option::Option<super::super::super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
     fn Finish_ValidateIdentityCredential(&self, ppidentityproperties: *mut ::core::option::Option<super::super::super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for AsyncIIdentityAuthentication {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl AsyncIIdentityAuthentication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityAuthentication_Impl, const OFFSET: isize>() -> AsyncIIdentityAuthentication_Vtbl {
@@ -243,6 +250,8 @@ pub trait AsyncIIdentityProvider_Impl: Sized {
     fn Begin_UnAdvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
     fn Finish_UnAdvise(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for AsyncIIdentityProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl AsyncIIdentityProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityProvider_Impl, const OFFSET: isize>() -> AsyncIIdentityProvider_Vtbl {
@@ -396,6 +405,8 @@ pub trait AsyncIIdentityStore_Impl: Sized {
     fn Finish_Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for AsyncIIdentityStore {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl AsyncIIdentityStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityStore_Impl, const OFFSET: isize>() -> AsyncIIdentityStore_Vtbl {
         unsafe extern "system" fn Begin_GetCount<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -496,6 +507,7 @@ pub trait AsyncIIdentityStoreEx_Impl: Sized {
     fn Begin_DeleteConnectedIdentity(&self, connectedname: &::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Finish_DeleteConnectedIdentity(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIIdentityStoreEx {}
 impl AsyncIIdentityStoreEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityStoreEx_Impl, const OFFSET: isize>() -> AsyncIIdentityStoreEx_Vtbl {
         unsafe extern "system" fn Begin_CreateConnectedIdentity<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIIdentityStoreEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, localname: ::windows::core::PCWSTR, connectedname: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -536,6 +548,8 @@ pub trait IAssociatedIdentityProvider_Impl: Sized {
     fn DisassociateIdentity(&self, hwndparent: super::super::super::super::Foundation::HWND, lpszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ChangeCredential(&self, hwndparent: super::super::super::super::Foundation::HWND, lpszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IAssociatedIdentityProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IAssociatedIdentityProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssociatedIdentityProvider_Impl, const OFFSET: isize>() -> IAssociatedIdentityProvider_Vtbl {
@@ -579,6 +593,8 @@ pub trait IConnectedIdentityProvider_Impl: Sized {
     fn GetUrl(&self, identifier: IDENTITY_URL, context: &::core::option::Option<super::super::super::super::System::Com::IBindCtx>, postdata: *mut super::super::super::super::System::Com::VARIANT, url: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn GetAccountState(&self) -> ::windows::core::Result<ACCOUNT_STATE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IConnectedIdentityProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IConnectedIdentityProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConnectedIdentityProvider_Impl, const OFFSET: isize>() -> IConnectedIdentityProvider_Vtbl {
@@ -635,6 +651,7 @@ impl IConnectedIdentityProvider_Vtbl {
 pub trait IIdentityAdvise_Impl: Sized {
     fn IdentityUpdated(&self, dwidentityupdateevents: IdentityUpdateEvent, lpszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIdentityAdvise {}
 impl IIdentityAdvise_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityAdvise_Impl, const OFFSET: isize>() -> IIdentityAdvise_Vtbl {
         unsafe extern "system" fn IdentityUpdated<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityAdvise_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwidentityupdateevents: IdentityUpdateEvent, lpszuniqueid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -653,6 +670,8 @@ pub trait IIdentityAuthentication_Impl: Sized {
     fn SetIdentityCredential(&self, credbuffer: *const u8, credbufferlength: u32) -> ::windows::core::Result<()>;
     fn ValidateIdentityCredential(&self, credbuffer: *const u8, credbufferlength: u32, ppidentityproperties: *mut ::core::option::Option<super::super::super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IIdentityAuthentication {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IIdentityAuthentication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityAuthentication_Impl, const OFFSET: isize>() -> IIdentityAuthentication_Vtbl {
@@ -687,6 +706,8 @@ pub trait IIdentityProvider_Impl: Sized {
     fn Advise(&self, pidentityadvise: &::core::option::Option<IIdentityAdvise>, dwidentityupdateevents: IdentityUpdateEvent) -> ::windows::core::Result<u32>;
     fn UnAdvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IIdentityProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IIdentityProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityProvider_Impl, const OFFSET: isize>() -> IIdentityProvider_Vtbl {
@@ -780,6 +801,8 @@ pub trait IIdentityStore_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IIdentityStore {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IIdentityStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityStore_Impl, const OFFSET: isize>() -> IIdentityStore_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwproviders: *mut u32) -> ::windows::core::HRESULT {
@@ -842,6 +865,7 @@ pub trait IIdentityStoreEx_Impl: Sized {
     fn CreateConnectedIdentity(&self, localname: &::windows::core::PCWSTR, connectedname: &::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn DeleteConnectedIdentity(&self, connectedname: &::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIdentityStoreEx {}
 impl IIdentityStoreEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityStoreEx_Impl, const OFFSET: isize>() -> IIdentityStoreEx_Vtbl {
         unsafe extern "system" fn CreateConnectedIdentity<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityStoreEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, localname: ::windows::core::PCWSTR, connectedname: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/impl.rs
@@ -1,6 +1,7 @@
 pub trait ICcgDomainAuthCredentials_Impl: Sized {
     fn GetPasswordCredentials(&self, plugininput: &::windows::core::PCWSTR, domainname: *mut ::windows::core::PWSTR, username: *mut ::windows::core::PWSTR, password: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICcgDomainAuthCredentials {}
 impl ICcgDomainAuthCredentials_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICcgDomainAuthCredentials_Impl, const OFFSET: isize>() -> ICcgDomainAuthCredentials_Vtbl {
         unsafe extern "system" fn GetPasswordCredentials<Identity: ::windows::core::IUnknownImpl, Impl: ICcgDomainAuthCredentials_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plugininput: ::windows::core::PCWSTR, domainname: *mut ::windows::core::PWSTR, username: *mut ::windows::core::PWSTR, password: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
@@ -3,6 +3,8 @@ pub trait IEffectivePermission_Impl: Sized {
     fn GetEffectivePermission(&self, pguidobjecttype: *const ::windows::core::GUID, pusersid: super::super::super::Foundation::PSID, pszservername: &::windows::core::PCWSTR, psd: super::super::PSECURITY_DESCRIPTOR, ppobjecttypelist: *mut *mut super::super::OBJECT_TYPE_LIST, pcobjecttypelistlength: *mut u32, ppgrantedaccesslist: *mut *mut u32, pcgrantedaccesslistlength: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEffectivePermission {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEffectivePermission_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEffectivePermission_Impl, const OFFSET: isize>() -> IEffectivePermission_Vtbl {
         unsafe extern "system" fn GetEffectivePermission<Identity: ::windows::core::IUnknownImpl, Impl: IEffectivePermission_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidobjecttype: *const ::windows::core::GUID, pusersid: super::super::super::Foundation::PSID, pszservername: ::windows::core::PCWSTR, psd: super::super::PSECURITY_DESCRIPTOR, ppobjecttypelist: *mut *mut super::super::OBJECT_TYPE_LIST, pcobjecttypelistlength: *mut u32, ppgrantedaccesslist: *mut *mut u32, pcgrantedaccesslistlength: *mut u32) -> ::windows::core::HRESULT {
@@ -36,6 +38,8 @@ pub trait IEffectivePermission2_Impl: Sized {
         peffpermresultlists: *mut EFFPERM_RESULT_LIST,
     ) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEffectivePermission2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEffectivePermission2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEffectivePermission2_Impl, const OFFSET: isize>() -> IEffectivePermission2_Vtbl {
@@ -97,6 +101,8 @@ pub trait ISecurityInformation_Impl: Sized {
     fn PropertySheetPageCallback(&self, hwnd: super::super::super::Foundation::HWND, umsg: super::super::super::UI::Controls::PSPCB_MESSAGE, upage: SI_PAGE_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
+impl ::windows::core::RuntimeName for ISecurityInformation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl ISecurityInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation_Impl, const OFFSET: isize>() -> ISecurityInformation_Vtbl {
         unsafe extern "system" fn GetObjectInformation<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobjectinfo: *mut SI_OBJECT_INFO) -> ::windows::core::HRESULT {
@@ -155,6 +161,8 @@ pub trait ISecurityInformation2_Impl: Sized {
     fn LookupSids(&self, csids: u32, rgpsids: *mut super::super::super::Foundation::PSID, ppdo: *mut ::core::option::Option<super::super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISecurityInformation2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISecurityInformation2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation2_Impl, const OFFSET: isize>() -> ISecurityInformation2_Vtbl {
         unsafe extern "system" fn IsDaclCanonical<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdacl: *mut super::super::ACL) -> super::super::super::Foundation::BOOL {
@@ -182,6 +190,8 @@ pub trait ISecurityInformation3_Impl: Sized {
     fn GetFullResourceName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn OpenElevatedEditor(&self, hwnd: super::super::super::Foundation::HWND, upage: SI_PAGE_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISecurityInformation3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISecurityInformation3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation3_Impl, const OFFSET: isize>() -> ISecurityInformation3_Vtbl {
@@ -216,6 +226,8 @@ pub trait ISecurityInformation4_Impl: Sized {
     fn GetSecondarySecurity(&self, psecurityobjects: *mut *mut SECURITY_OBJECT, psecurityobjectcount: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISecurityInformation4 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISecurityInformation4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation4_Impl, const OFFSET: isize>() -> ISecurityInformation4_Vtbl {
         unsafe extern "system" fn GetSecondarySecurity<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInformation4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psecurityobjects: *mut *mut SECURITY_OBJECT, psecurityobjectcount: *mut u32) -> ::windows::core::HRESULT {
@@ -232,6 +244,7 @@ impl ISecurityInformation4_Vtbl {
 pub trait ISecurityObjectTypeInfo_Impl: Sized {
     fn GetInheritSource(&self, si: u32, pacl: *mut super::super::ACL, ppinheritarray: *mut *mut super::INHERITED_FROMA) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISecurityObjectTypeInfo {}
 impl ISecurityObjectTypeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityObjectTypeInfo_Impl, const OFFSET: isize>() -> ISecurityObjectTypeInfo_Vtbl {
         unsafe extern "system" fn GetInheritSource<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityObjectTypeInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, si: u32, pacl: *mut super::super::ACL, ppinheritarray: *mut *mut super::INHERITED_FROMA) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/impl.rs
@@ -63,6 +63,8 @@ pub trait IAzApplication_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn DeleteDelegatedPolicyUserName(&self, bstrdelegatedpolicyuser: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplication {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplication_Impl, const OFFSET: isize>() -> IAzApplication_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -643,6 +645,8 @@ pub trait IAzApplication2_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn InitializeClientContext2(&self, identifyingstring: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IAzClientContext2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplication2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplication2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplication2_Impl, const OFFSET: isize>() -> IAzApplication2_Vtbl {
         unsafe extern "system" fn InitializeClientContextFromToken2<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplication2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ultokenhandlelowpart: u32, ultokenhandlehighpart: u32, varreserved: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, ppclientcontext: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -694,6 +698,8 @@ pub trait IAzApplication3_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn BizRulesEnabled(&self) -> ::windows::core::Result<i16>;
     fn SetBizRulesEnabled(&self, benabled: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplication3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplication3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplication3_Impl, const OFFSET: isize>() -> IAzApplication3_Vtbl {
@@ -884,6 +890,8 @@ pub trait IAzApplicationGroup_Impl: Sized + super::super::System::Com::IDispatch
     fn MembersName(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn NonMembersName(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplicationGroup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplicationGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplicationGroup_Impl, const OFFSET: isize>() -> IAzApplicationGroup_Vtbl {
@@ -1170,6 +1178,8 @@ pub trait IAzApplicationGroup2_Impl: Sized + super::super::System::Com::IDispatc
     fn RoleAssignments(&self, bstrscopename: &super::super::Foundation::BSTR, brecursive: i16) -> ::windows::core::Result<IAzRoleAssignments>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplicationGroup2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplicationGroup2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplicationGroup2_Impl, const OFFSET: isize>() -> IAzApplicationGroup2_Vtbl {
         unsafe extern "system" fn BizRule<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplicationGroup2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrprop: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1253,6 +1263,8 @@ pub trait IAzApplicationGroups_Impl: Sized + super::super::System::Com::IDispatc
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplicationGroups {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplicationGroups_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplicationGroups_Impl, const OFFSET: isize>() -> IAzApplicationGroups_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplicationGroups_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pvarobtptr: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1305,6 +1317,8 @@ pub trait IAzApplications_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzApplications {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzApplications_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzApplications_Impl, const OFFSET: isize>() -> IAzApplications_Vtbl {
@@ -1406,6 +1420,8 @@ pub trait IAzAuthorizationStore_Impl: Sized + super::super::System::Com::IDispat
     fn DeleteDelegatedPolicyUserName(&self, bstrdelegatedpolicyuser: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn CloseApplication(&self, bstrapplicationname: &super::super::Foundation::BSTR, lflag: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzAuthorizationStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzAuthorizationStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzAuthorizationStore_Impl, const OFFSET: isize>() -> IAzAuthorizationStore_Vtbl {
@@ -1861,6 +1877,8 @@ pub trait IAzAuthorizationStore2_Impl: Sized + super::super::System::Com::IDispa
     fn CreateApplication2(&self, bstrapplicationname: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IAzApplication2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzAuthorizationStore2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzAuthorizationStore2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzAuthorizationStore2_Impl, const OFFSET: isize>() -> IAzAuthorizationStore2_Vtbl {
         unsafe extern "system" fn OpenApplication2<Identity: ::windows::core::IUnknownImpl, Impl: IAzAuthorizationStore2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrapplicationname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, varreserved: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, ppapplication: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1903,6 +1921,8 @@ pub trait IAzAuthorizationStore3_Impl: Sized + super::super::System::Com::IDispa
     fn IsFunctionalLevelUpgradeSupported(&self, lfunctionallevel: i32) -> ::windows::core::Result<i16>;
     fn GetSchemaVersion(&self, plmajorversion: *mut i32, plminorversion: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzAuthorizationStore3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzAuthorizationStore3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzAuthorizationStore3_Impl, const OFFSET: isize>() -> IAzAuthorizationStore3_Vtbl {
@@ -1970,6 +1990,8 @@ pub trait IAzBizRuleContext_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetParameter(&self, bstrparametername: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzBizRuleContext {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzBizRuleContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzBizRuleContext_Impl, const OFFSET: isize>() -> IAzBizRuleContext_Vtbl {
         unsafe extern "system" fn SetBusinessRuleResult<Identity: ::windows::core::IUnknownImpl, Impl: IAzBizRuleContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bresult: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2025,6 +2047,8 @@ pub trait IAzBizRuleInterfaces_Impl: Sized + super::super::System::Com::IDispatc
     fn RemoveAll(&self) -> ::windows::core::Result<()>;
     fn Count(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzBizRuleInterfaces {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzBizRuleInterfaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzBizRuleInterfaces_Impl, const OFFSET: isize>() -> IAzBizRuleInterfaces_Vtbl {
@@ -2087,6 +2111,8 @@ pub trait IAzBizRuleParameters_Impl: Sized + super::super::System::Com::IDispatc
     fn RemoveAll(&self) -> ::windows::core::Result<()>;
     fn Count(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzBizRuleParameters {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzBizRuleParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzBizRuleParameters_Impl, const OFFSET: isize>() -> IAzBizRuleParameters_Vtbl {
@@ -2162,6 +2188,8 @@ pub trait IAzClientContext_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn RoleForAccessCheck(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetRoleForAccessCheck(&self, bstrprop: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzClientContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzClientContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzClientContext_Impl, const OFFSET: isize>() -> IAzClientContext_Vtbl {
@@ -2344,6 +2372,8 @@ pub trait IAzClientContext2_Impl: Sized + super::super::System::Com::IDispatch_I
     fn LDAPQueryDN(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzClientContext2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzClientContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzClientContext2_Impl, const OFFSET: isize>() -> IAzClientContext2_Vtbl {
         unsafe extern "system" fn GetAssignedScopesPage<Identity: ::windows::core::IUnknownImpl, Impl: IAzClientContext2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, loptions: i32, pagesize: i32, pvarcursor: *mut super::super::System::Com::VARIANT, pvarscopenames: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2407,6 +2437,8 @@ pub trait IAzClientContext3_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetGroups(&self, bstrscopename: &super::super::Foundation::BSTR, uloptions: AZ_PROP_CONSTANTS) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn Sids(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzClientContext3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzClientContext3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzClientContext3_Impl, const OFFSET: isize>() -> IAzClientContext3_Vtbl {
@@ -2520,6 +2552,8 @@ pub trait IAzNameResolver_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn NamesFromSids(&self, vsids: &super::super::System::Com::VARIANT, pvsidtypes: *mut super::super::System::Com::VARIANT, pvnames: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzNameResolver {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzNameResolver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzNameResolver_Impl, const OFFSET: isize>() -> IAzNameResolver_Vtbl {
         unsafe extern "system" fn NameFromSid<Identity: ::windows::core::IUnknownImpl, Impl: IAzNameResolver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrsid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, psidtype: *mut i32, pbstrname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2547,6 +2581,8 @@ pub trait IAzObjectPicker_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn GetPrincipals(&self, hparentwnd: super::super::Foundation::HWND, bstrtitle: &super::super::Foundation::BSTR, pvsidtypes: *mut super::super::System::Com::VARIANT, pvnames: *mut super::super::System::Com::VARIANT, pvsids: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzObjectPicker {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzObjectPicker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzObjectPicker_Impl, const OFFSET: isize>() -> IAzObjectPicker_Vtbl {
@@ -2591,6 +2627,8 @@ pub trait IAzOperation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetProperty(&self, lpropid: i32, varprop: &super::super::System::Com::VARIANT, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Submit(&self, lflags: i32, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzOperation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzOperation_Impl, const OFFSET: isize>() -> IAzOperation_Vtbl {
@@ -2715,6 +2753,8 @@ pub trait IAzOperation2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn RoleAssignments(&self, bstrscopename: &super::super::Foundation::BSTR, brecursive: i16) -> ::windows::core::Result<IAzRoleAssignments>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzOperation2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzOperation2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzOperation2_Impl, const OFFSET: isize>() -> IAzOperation2_Vtbl {
         unsafe extern "system" fn RoleAssignments<Identity: ::windows::core::IUnknownImpl, Impl: IAzOperation2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrscopename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, brecursive: i16, pproleassignments: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2740,6 +2780,8 @@ pub trait IAzOperations_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzOperations {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzOperations_Impl, const OFFSET: isize>() -> IAzOperations_Vtbl {
@@ -2792,6 +2834,8 @@ pub trait IAzPrincipalLocator_Impl: Sized + super::super::System::Com::IDispatch
     fn NameResolver(&self) -> ::windows::core::Result<IAzNameResolver>;
     fn ObjectPicker(&self) -> ::windows::core::Result<IAzObjectPicker>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzPrincipalLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzPrincipalLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzPrincipalLocator_Impl, const OFFSET: isize>() -> IAzPrincipalLocator_Vtbl {
@@ -2857,6 +2901,8 @@ pub trait IAzRole_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeleteMemberName(&self, bstrprop: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn MembersName(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzRole {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzRole_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzRole_Impl, const OFFSET: isize>() -> IAzRole_Vtbl {
@@ -3098,6 +3144,8 @@ pub trait IAzRoleAssignment_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Scope(&self) -> ::windows::core::Result<IAzScope>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzRoleAssignment {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzRoleAssignment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleAssignment_Impl, const OFFSET: isize>() -> IAzRoleAssignment_Vtbl {
         unsafe extern "system" fn AddRoleDefinition<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleAssignment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrroledefinition: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3150,6 +3198,8 @@ pub trait IAzRoleAssignments_Impl: Sized + super::super::System::Com::IDispatch_
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzRoleAssignments {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzRoleAssignments_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleAssignments_Impl, const OFFSET: isize>() -> IAzRoleAssignments_Vtbl {
@@ -3205,6 +3255,8 @@ pub trait IAzRoleDefinition_Impl: Sized + super::super::System::Com::IDispatch_I
     fn RoleDefinitions(&self) -> ::windows::core::Result<IAzRoleDefinitions>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzRoleDefinition {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzRoleDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleDefinition_Impl, const OFFSET: isize>() -> IAzRoleDefinition_Vtbl {
         unsafe extern "system" fn RoleAssignments<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleDefinition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrscopename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, brecursive: i16, pproleassignments: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3258,6 +3310,8 @@ pub trait IAzRoleDefinitions_Impl: Sized + super::super::System::Com::IDispatch_
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzRoleDefinitions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzRoleDefinitions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleDefinitions_Impl, const OFFSET: isize>() -> IAzRoleDefinitions_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoleDefinitions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pvarobtptr: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3310,6 +3364,8 @@ pub trait IAzRoles_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzRoles {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzRoles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzRoles_Impl, const OFFSET: isize>() -> IAzRoles_Vtbl {
@@ -3398,6 +3454,8 @@ pub trait IAzScope_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddPolicyReaderName(&self, bstrreader: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn DeletePolicyReaderName(&self, bstrreader: &super::super::Foundation::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzScope {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzScope_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzScope_Impl, const OFFSET: isize>() -> IAzScope_Vtbl {
@@ -3769,6 +3827,8 @@ pub trait IAzScope2_Impl: Sized + super::super::System::Com::IDispatch_Impl + IA
     fn DeleteRoleAssignment(&self, bstrroleassignmentname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzScope2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzScope2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzScope2_Impl, const OFFSET: isize>() -> IAzScope2_Vtbl {
         unsafe extern "system" fn RoleDefinitions<Identity: ::windows::core::IUnknownImpl, Impl: IAzScope2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pproledefinitions: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3870,6 +3930,8 @@ pub trait IAzScopes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzScopes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzScopes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzScopes_Impl, const OFFSET: isize>() -> IAzScopes_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IAzScopes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pvarobtptr: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3945,6 +4007,8 @@ pub trait IAzTask_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeletePropertyItem(&self, lpropid: i32, varprop: &super::super::System::Com::VARIANT, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Submit(&self, lflags: i32, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzTask {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzTask_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzTask_Impl, const OFFSET: isize>() -> IAzTask_Vtbl {
@@ -4183,6 +4247,8 @@ pub trait IAzTask2_Impl: Sized + super::super::System::Com::IDispatch_Impl + IAz
     fn RoleAssignments(&self, bstrscopename: &super::super::Foundation::BSTR, brecursive: i16) -> ::windows::core::Result<IAzRoleAssignments>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzTask2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzTask2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzTask2_Impl, const OFFSET: isize>() -> IAzTask2_Vtbl {
         unsafe extern "system" fn RoleAssignments<Identity: ::windows::core::IUnknownImpl, Impl: IAzTask2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrscopename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, brecursive: i16, pproleassignments: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4208,6 +4274,8 @@ pub trait IAzTasks_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAzTasks {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAzTasks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAzTasks_Impl, const OFFSET: isize>() -> IAzTasks_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/impl.rs
@@ -4,6 +4,7 @@ pub trait ISceSvcAttachmentData_Impl: Sized {
     fn FreeBuffer(&self, pvdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CloseHandle(&self, scesvchandle: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISceSvcAttachmentData {}
 impl ISceSvcAttachmentData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISceSvcAttachmentData_Impl, const OFFSET: isize>() -> ISceSvcAttachmentData_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: ISceSvcAttachmentData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scesvchandle: *mut ::core::ffi::c_void, scetype: SCESVC_INFO_TYPE, ppvdata: *mut *mut ::core::ffi::c_void, psceenumhandle: *mut u32) -> ::windows::core::HRESULT {
@@ -44,6 +45,8 @@ pub trait ISceSvcAttachmentPersistInfo_Impl: Sized {
     fn IsDirty(&self, lptemplatename: *mut i8) -> ::windows::core::HRESULT;
     fn FreeBuffer(&self, pvdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISceSvcAttachmentPersistInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISceSvcAttachmentPersistInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISceSvcAttachmentPersistInfo_Impl, const OFFSET: isize>() -> ISceSvcAttachmentPersistInfo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
@@ -9,6 +9,8 @@ pub trait IAlternativeName_Impl: Sized + super::super::super::System::Com::IDisp
     fn get_RawData(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAlternativeName {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAlternativeName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAlternativeName_Impl, const OFFSET: isize>() -> IAlternativeName_Vtbl {
         unsafe extern "system" fn InitializeFromString<Identity: ::windows::core::IUnknownImpl, Impl: IAlternativeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, r#type: AlternativeNameType, strvalue: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -95,6 +97,8 @@ pub trait IAlternativeNames_Impl: Sized + super::super::super::System::Com::IDis
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAlternativeNames {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAlternativeNames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAlternativeNames_Impl, const OFFSET: isize>() -> IAlternativeNames_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: IAlternativeNames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -166,6 +170,8 @@ pub trait IBinaryConverter_Impl: Sized + super::super::super::System::Com::IDisp
     fn StringToVariantByteArray(&self, strencoded: &super::super::super::Foundation::BSTR, encoding: EncodingType) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBinaryConverter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBinaryConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBinaryConverter_Impl, const OFFSET: isize>() -> IBinaryConverter_Vtbl {
         unsafe extern "system" fn StringToString<Identity: ::windows::core::IUnknownImpl, Impl: IBinaryConverter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodedin: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encodingin: EncodingType, encoding: EncodingType, pstrencoded: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -217,6 +223,8 @@ pub trait IBinaryConverter2_Impl: Sized + super::super::super::System::Com::IDis
     fn StringArrayToVariantArray(&self, pvarstringarray: *const super::super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
     fn VariantArrayToStringArray(&self, pvarvariantarray: *const super::super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBinaryConverter2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBinaryConverter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBinaryConverter2_Impl, const OFFSET: isize>() -> IBinaryConverter2_Vtbl {
@@ -311,6 +319,8 @@ pub trait ICEnroll_Impl: Sized + super::super::super::System::Com::IDispatch_Imp
     fn HashAlgorithm(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn SetHashAlgorithm(&self, bstr: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICEnroll {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICEnroll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICEnroll_Impl, const OFFSET: isize>() -> ICEnroll_Vtbl {
@@ -836,6 +846,8 @@ pub trait ICEnroll2_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn SetEnableT61DNEncoding(&self, fbool: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICEnroll2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICEnroll2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICEnroll2_Impl, const OFFSET: isize>() -> ICEnroll2_Vtbl {
         unsafe extern "system" fn addCertTypeToRequest<Identity: ::windows::core::IUnknownImpl, Impl: ICEnroll2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, certtype: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -911,6 +923,8 @@ pub trait ICEnroll3_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn SetEnableSMIMECapabilities(&self, fenablesmimecapabilities: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn EnableSMIMECapabilities(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICEnroll3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICEnroll3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICEnroll3_Impl, const OFFSET: isize>() -> ICEnroll3_Vtbl {
@@ -1090,6 +1104,8 @@ pub trait ICEnroll4_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn SetIncludeSubjectKeyID(&self, finclude: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn IncludeSubjectKeyID(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICEnroll4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICEnroll4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICEnroll4_Impl, const OFFSET: isize>() -> ICEnroll4_Vtbl {
@@ -1397,6 +1413,8 @@ pub trait ICertAdmin_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn ImportCertificate(&self, strconfig: &super::super::super::Foundation::BSTR, strcertificate: &super::super::super::Foundation::BSTR, flags: CERT_IMPORT_FLAGS) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertAdmin {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertAdmin_Impl, const OFFSET: isize>() -> ICertAdmin_Vtbl {
         unsafe extern "system" fn IsValidCertificate<Identity: ::windows::core::IUnknownImpl, Impl: ICertAdmin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strconfig: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strserialnumber: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, pdisposition: *mut i32) -> ::windows::core::HRESULT {
@@ -1511,6 +1529,8 @@ pub trait ICertAdmin2_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn GetMyRoles(&self, strconfig: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<CERTADMIN_GET_ROLES_FLAGS>;
     fn DeleteRow(&self, strconfig: &super::super::super::Foundation::BSTR, flags: CERT_DELETE_ROW_FLAGS, date: f64, table: CVRC_TABLE, rowid: i32) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertAdmin2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertAdmin2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertAdmin2_Impl, const OFFSET: isize>() -> ICertAdmin2_Vtbl {
@@ -1638,6 +1658,8 @@ pub trait ICertConfig_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn GetConfig(&self, flags: i32) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertConfig {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertConfig_Impl, const OFFSET: isize>() -> ICertConfig_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: ICertConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1701,6 +1723,8 @@ pub trait ICertConfig2_Impl: Sized + super::super::super::System::Com::IDispatch
     fn SetSharedFolder(&self, strsharedfolder: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertConfig2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertConfig2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertConfig2_Impl, const OFFSET: isize>() -> ICertConfig2_Vtbl {
         unsafe extern "system" fn SetSharedFolder<Identity: ::windows::core::IUnknownImpl, Impl: ICertConfig2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strsharedfolder: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -1724,6 +1748,8 @@ pub trait ICertEncodeAltName_Impl: Sized + super::super::super::System::Com::IDi
     fn SetNameEntry(&self, nameindex: i32, namechoice: CERT_ALT_NAME, strname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Encode(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeAltName {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeAltName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeAltName_Impl, const OFFSET: isize>() -> ICertEncodeAltName_Vtbl {
@@ -1809,6 +1835,8 @@ pub trait ICertEncodeAltName2_Impl: Sized + super::super::super::System::Com::ID
     fn SetNameEntryBlob(&self, nameindex: i32, namechoice: i32, strname: &super::super::super::Foundation::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeAltName2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeAltName2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeAltName2_Impl, const OFFSET: isize>() -> ICertEncodeAltName2_Vtbl {
         unsafe extern "system" fn DecodeBlob<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeAltName2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -1862,6 +1890,8 @@ pub trait ICertEncodeBitString_Impl: Sized + super::super::super::System::Com::I
     fn GetBitString(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn Encode(&self, bitcount: i32, strbitstring: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeBitString {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeBitString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeBitString_Impl, const OFFSET: isize>() -> ICertEncodeBitString_Vtbl {
@@ -1922,6 +1952,8 @@ pub trait ICertEncodeBitString2_Impl: Sized + super::super::super::System::Com::
     fn GetBitStringBlob(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeBitString2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeBitString2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeBitString2_Impl, const OFFSET: isize>() -> ICertEncodeBitString2_Vtbl {
         unsafe extern "system" fn DecodeBlob<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeBitString2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -1974,6 +2006,8 @@ pub trait ICertEncodeCRLDistInfo_Impl: Sized + super::super::super::System::Com:
     fn SetNameEntry(&self, distpointindex: i32, nameindex: i32, namechoice: CERT_ALT_NAME, strname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Encode(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeCRLDistInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeCRLDistInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeCRLDistInfo_Impl, const OFFSET: isize>() -> ICertEncodeCRLDistInfo_Vtbl {
@@ -2075,6 +2109,8 @@ pub trait ICertEncodeCRLDistInfo2_Impl: Sized + super::super::super::System::Com
     fn EncodeBlob(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeCRLDistInfo2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeCRLDistInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeCRLDistInfo2_Impl, const OFFSET: isize>() -> ICertEncodeCRLDistInfo2_Vtbl {
         unsafe extern "system" fn DecodeBlob<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeCRLDistInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -2112,6 +2148,8 @@ pub trait ICertEncodeDateArray_Impl: Sized + super::super::super::System::Com::I
     fn SetValue(&self, index: i32, value: f64) -> ::windows::core::Result<()>;
     fn Encode(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeDateArray {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeDateArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeDateArray_Impl, const OFFSET: isize>() -> ICertEncodeDateArray_Vtbl {
@@ -2183,6 +2221,8 @@ pub trait ICertEncodeDateArray2_Impl: Sized + super::super::super::System::Com::
     fn EncodeBlob(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeDateArray2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeDateArray2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeDateArray2_Impl, const OFFSET: isize>() -> ICertEncodeDateArray2_Vtbl {
         unsafe extern "system" fn DecodeBlob<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeDateArray2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -2220,6 +2260,8 @@ pub trait ICertEncodeLongArray_Impl: Sized + super::super::super::System::Com::I
     fn SetValue(&self, index: i32, value: i32) -> ::windows::core::Result<()>;
     fn Encode(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeLongArray {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeLongArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeLongArray_Impl, const OFFSET: isize>() -> ICertEncodeLongArray_Vtbl {
@@ -2291,6 +2333,8 @@ pub trait ICertEncodeLongArray2_Impl: Sized + super::super::super::System::Com::
     fn EncodeBlob(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeLongArray2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeLongArray2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeLongArray2_Impl, const OFFSET: isize>() -> ICertEncodeLongArray2_Vtbl {
         unsafe extern "system" fn DecodeBlob<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeLongArray2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -2329,6 +2373,8 @@ pub trait ICertEncodeStringArray_Impl: Sized + super::super::super::System::Com:
     fn SetValue(&self, index: i32, str: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Encode(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeStringArray {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeStringArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeStringArray_Impl, const OFFSET: isize>() -> ICertEncodeStringArray_Vtbl {
@@ -2412,6 +2458,8 @@ pub trait ICertEncodeStringArray2_Impl: Sized + super::super::super::System::Com
     fn EncodeBlob(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertEncodeStringArray2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertEncodeStringArray2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeStringArray2_Impl, const OFFSET: isize>() -> ICertEncodeStringArray2_Vtbl {
         unsafe extern "system" fn DecodeBlob<Identity: ::windows::core::IUnknownImpl, Impl: ICertEncodeStringArray2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -2446,6 +2494,8 @@ pub trait ICertExit_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn Notify(&self, exitevent: i32, context: i32) -> ::windows::core::Result<()>;
     fn GetDescription(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertExit {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertExit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertExit_Impl, const OFFSET: isize>() -> ICertExit_Vtbl {
@@ -2492,6 +2542,8 @@ pub trait ICertExit2_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn GetManageModule(&self) -> ::windows::core::Result<ICertManageModule>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertExit2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertExit2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertExit2_Impl, const OFFSET: isize>() -> ICertExit2_Vtbl {
         unsafe extern "system" fn GetManageModule<Identity: ::windows::core::IUnknownImpl, Impl: ICertExit2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmanagemodule: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2515,6 +2567,8 @@ impl ICertExit2_Vtbl {
 pub trait ICertGetConfig_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetConfig(&self, flags: CERT_GET_CONFIG_FLAGS) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertGetConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertGetConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertGetConfig_Impl, const OFFSET: isize>() -> ICertGetConfig_Vtbl {
@@ -2541,6 +2595,8 @@ pub trait ICertManageModule_Impl: Sized + super::super::super::System::Com::IDis
     fn SetProperty(&self, strconfig: &super::super::super::Foundation::BSTR, strstoragelocation: &super::super::super::Foundation::BSTR, strpropertyname: &super::super::super::Foundation::BSTR, flags: i32, pvarproperty: *const super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Configure(&self, strconfig: &super::super::super::Foundation::BSTR, strstoragelocation: &super::super::super::Foundation::BSTR, flags: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertManageModule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertManageModule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertManageModule_Impl, const OFFSET: isize>() -> ICertManageModule_Vtbl {
@@ -2583,6 +2639,8 @@ pub trait ICertPolicy_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn GetDescription(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn ShutDown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPolicy {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPolicy_Impl, const OFFSET: isize>() -> ICertPolicy_Vtbl {
@@ -2635,6 +2693,8 @@ pub trait ICertPolicy2_Impl: Sized + super::super::super::System::Com::IDispatch
     fn GetManageModule(&self) -> ::windows::core::Result<ICertManageModule>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPolicy2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPolicy2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPolicy2_Impl, const OFFSET: isize>() -> ICertPolicy2_Vtbl {
         unsafe extern "system" fn GetManageModule<Identity: ::windows::core::IUnknownImpl, Impl: ICertPolicy2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppmanagemodule: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2664,6 +2724,8 @@ pub trait ICertProperties_Impl: Sized + super::super::super::System::Com::IDispa
     fn Clear(&self) -> ::windows::core::Result<()>;
     fn InitializeFromCertificate(&self, machinecontext: i16, encoding: EncodingType, strcertificate: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertProperties_Impl, const OFFSET: isize>() -> ICertProperties_Vtbl {
@@ -2746,6 +2808,8 @@ pub trait ICertProperty_Impl: Sized + super::super::super::System::Com::IDispatc
     fn SetValueOnCertificate(&self, machinecontext: i16, encoding: EncodingType, strcertificate: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertProperty_Impl, const OFFSET: isize>() -> ICertProperty_Vtbl {
         unsafe extern "system" fn InitializeFromCertificate<Identity: ::windows::core::IUnknownImpl, Impl: ICertProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, machinecontext: i16, encoding: EncodingType, strcertificate: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -2816,6 +2880,8 @@ pub trait ICertPropertyArchived_Impl: Sized + super::super::super::System::Com::
     fn Archived(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyArchived {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyArchived_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyArchived_Impl, const OFFSET: isize>() -> ICertPropertyArchived_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyArchived_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, archivedvalue: i16) -> ::windows::core::HRESULT {
@@ -2850,6 +2916,8 @@ pub trait ICertPropertyArchivedKeyHash_Impl: Sized + super::super::super::System
     fn get_ArchivedKeyHash(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyArchivedKeyHash {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyArchivedKeyHash_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyArchivedKeyHash_Impl, const OFFSET: isize>() -> ICertPropertyArchivedKeyHash_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyArchivedKeyHash_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, encoding: EncodingType, strarchivedkeyhashvalue: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -2883,6 +2951,8 @@ pub trait ICertPropertyAutoEnroll_Impl: Sized + super::super::super::System::Com
     fn Initialize(&self, strtemplatename: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn TemplateName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyAutoEnroll {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyAutoEnroll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyAutoEnroll_Impl, const OFFSET: isize>() -> ICertPropertyAutoEnroll_Vtbl {
@@ -2919,6 +2989,8 @@ pub trait ICertPropertyBackedUp_Impl: Sized + super::super::super::System::Com::
     fn BackedUpValue(&self) -> ::windows::core::Result<i16>;
     fn BackedUpTime(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyBackedUp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyBackedUp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyBackedUp_Impl, const OFFSET: isize>() -> ICertPropertyBackedUp_Vtbl {
@@ -2972,6 +3044,8 @@ pub trait ICertPropertyDescription_Impl: Sized + super::super::super::System::Co
     fn Description(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyDescription {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyDescription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyDescription_Impl, const OFFSET: isize>() -> ICertPropertyDescription_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyDescription_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strdescription: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3008,6 +3082,8 @@ pub trait ICertPropertyEnrollment_Impl: Sized + super::super::super::System::Com
     fn CAName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn FriendlyName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyEnrollment {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyEnrollment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyEnrollment_Impl, const OFFSET: isize>() -> ICertPropertyEnrollment_Vtbl {
@@ -3085,6 +3161,8 @@ pub trait ICertPropertyEnrollmentPolicyServer_Impl: Sized + super::super::super:
     fn GetAuthentication(&self) -> ::windows::core::Result<X509EnrollmentAuthFlags>;
     fn GetEnrollmentServerAuthentication(&self) -> ::windows::core::Result<X509EnrollmentAuthFlags>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyEnrollmentPolicyServer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyEnrollmentPolicyServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyEnrollmentPolicyServer_Impl, const OFFSET: isize>() -> ICertPropertyEnrollmentPolicyServer_Vtbl {
@@ -3204,6 +3282,8 @@ pub trait ICertPropertyFriendlyName_Impl: Sized + super::super::super::System::C
     fn FriendlyName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyFriendlyName {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyFriendlyName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyFriendlyName_Impl, const OFFSET: isize>() -> ICertPropertyFriendlyName_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyFriendlyName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strfriendlyname: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3237,6 +3317,8 @@ pub trait ICertPropertyKeyProvInfo_Impl: Sized + super::super::super::System::Co
     fn Initialize(&self, pvalue: &::core::option::Option<IX509PrivateKey>) -> ::windows::core::Result<()>;
     fn PrivateKey(&self) -> ::windows::core::Result<IX509PrivateKey>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyKeyProvInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyKeyProvInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyKeyProvInfo_Impl, const OFFSET: isize>() -> ICertPropertyKeyProvInfo_Vtbl {
@@ -3272,6 +3354,8 @@ pub trait ICertPropertyRenewal_Impl: Sized + super::super::super::System::Com::I
     fn InitializeFromCertificateHash(&self, machinecontext: i16, encoding: EncodingType, strcertificate: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_Renewal(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyRenewal {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyRenewal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyRenewal_Impl, const OFFSET: isize>() -> ICertPropertyRenewal_Vtbl {
@@ -3314,6 +3398,8 @@ pub trait ICertPropertyRequestOriginator_Impl: Sized + super::super::super::Syst
     fn RequestOriginator(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertyRequestOriginator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertyRequestOriginator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyRequestOriginator_Impl, const OFFSET: isize>() -> ICertPropertyRequestOriginator_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertyRequestOriginator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strrequestoriginator: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3354,6 +3440,8 @@ pub trait ICertPropertySHA1Hash_Impl: Sized + super::super::super::System::Com::
     fn get_SHA1Hash(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertPropertySHA1Hash {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertPropertySHA1Hash_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertySHA1Hash_Impl, const OFFSET: isize>() -> ICertPropertySHA1Hash_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertPropertySHA1Hash_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, encoding: EncodingType, strrenewalvalue: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3392,6 +3480,8 @@ pub trait ICertRequest_Impl: Sized + super::super::super::System::Com::IDispatch
     fn GetCACertificate(&self, fexchangecertificate: i32, strconfig: &super::super::super::Foundation::BSTR, flags: i32) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn GetCertificate(&self, flags: i32) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequest_Impl, const OFFSET: isize>() -> ICertRequest_Vtbl {
@@ -3497,6 +3587,8 @@ pub trait ICertRequest2_Impl: Sized + super::super::super::System::Com::IDispatc
     fn GetFullResponseProperty(&self, propid: FULL_RESPONSE_PROPERTY_ID, propindex: i32, proptype: CERT_PROPERTY_TYPE, flags: CERT_REQUEST_OUT_TYPE) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertRequest2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertRequest2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequest2_Impl, const OFFSET: isize>() -> ICertRequest2_Vtbl {
         unsafe extern "system" fn GetIssuedCertificate<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequest2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strconfig: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, requestid: i32, strserialnumber: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, pdisposition: *mut CR_DISP) -> ::windows::core::HRESULT {
@@ -3587,6 +3679,8 @@ pub trait ICertRequest3_Impl: Sized + super::super::super::System::Com::IDispatc
     fn GetRefreshPolicy(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertRequest3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertRequest3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequest3_Impl, const OFFSET: isize>() -> ICertRequest3_Vtbl {
         unsafe extern "system" fn SetCredential<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequest3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: i32, authtype: X509EnrollmentAuthFlags, strcredential: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strpassword: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3644,6 +3738,7 @@ pub trait ICertRequestD_Impl: Sized {
     fn GetCACert(&self, fchain: u32, pwszauthority: &::windows::core::PCWSTR) -> ::windows::core::Result<CERTTRANSBLOB>;
     fn Ping(&self, pwszauthority: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICertRequestD {}
 impl ICertRequestD_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequestD_Impl, const OFFSET: isize>() -> ICertRequestD_Vtbl {
         unsafe extern "system" fn Request<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequestD_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pwszauthority: ::windows::core::PCWSTR, pdwrequestid: *mut u32, pdwdisposition: *mut u32, pwszattributes: ::windows::core::PCWSTR, pctbrequest: *const CERTTRANSBLOB, pctbcertchain: *mut CERTTRANSBLOB, pctbencodedcert: *mut CERTTRANSBLOB, pctbdispositionmessage: *mut CERTTRANSBLOB) -> ::windows::core::HRESULT {
@@ -3684,6 +3779,7 @@ pub trait ICertRequestD2_Impl: Sized + ICertRequestD_Impl {
     fn GetCAPropertyInfo(&self, pwszauthority: &::windows::core::PCWSTR, pcproperty: *mut i32, pctbpropinfo: *mut CERTTRANSBLOB) -> ::windows::core::Result<()>;
     fn Ping2(&self, pwszauthority: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICertRequestD2 {}
 impl ICertRequestD2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequestD2_Impl, const OFFSET: isize>() -> ICertRequestD2_Vtbl {
         unsafe extern "system" fn Request2<Identity: ::windows::core::IUnknownImpl, Impl: ICertRequestD2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszauthority: ::windows::core::PCWSTR, dwflags: u32, pwszserialnumber: ::windows::core::PCWSTR, pdwrequestid: *mut u32, pdwdisposition: *mut u32, pwszattributes: ::windows::core::PCWSTR, pctbrequest: *const CERTTRANSBLOB, pctbfullresponse: *mut CERTTRANSBLOB, pctbencodedcert: *mut CERTTRANSBLOB, pctbdispositionmessage: *mut CERTTRANSBLOB) -> ::windows::core::HRESULT {
@@ -3739,6 +3835,8 @@ pub trait ICertServerExit_Impl: Sized + super::super::super::System::Com::IDispa
     fn EnumerateAttributes(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn EnumerateAttributesClose(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertServerExit {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertServerExit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertServerExit_Impl, const OFFSET: isize>() -> ICertServerExit_Vtbl {
@@ -3881,6 +3979,8 @@ pub trait ICertServerPolicy_Impl: Sized + super::super::super::System::Com::IDis
     fn EnumerateAttributes(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn EnumerateAttributesClose(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertServerPolicy {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertServerPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertServerPolicy_Impl, const OFFSET: isize>() -> ICertServerPolicy_Vtbl {
@@ -4030,6 +4130,8 @@ pub trait ICertView_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn OpenView(&self) -> ::windows::core::Result<IEnumCERTVIEWROW>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertView {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertView_Impl, const OFFSET: isize>() -> ICertView_Vtbl {
         unsafe extern "system" fn OpenConnection<Identity: ::windows::core::IUnknownImpl, Impl: ICertView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strconfig: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -4105,6 +4207,8 @@ pub trait ICertView2_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn SetTable(&self, table: CVRC_TABLE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertView2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertView2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertView2_Impl, const OFFSET: isize>() -> ICertView2_Vtbl {
         unsafe extern "system" fn SetTable<Identity: ::windows::core::IUnknownImpl, Impl: ICertView2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, table: CVRC_TABLE) -> ::windows::core::HRESULT {
@@ -4124,6 +4228,8 @@ pub trait ICertificateAttestationChallenge_Impl: Sized + super::super::super::Sy
     fn DecryptChallenge(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn RequestID(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificateAttestationChallenge {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificateAttestationChallenge_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificateAttestationChallenge_Impl, const OFFSET: isize>() -> ICertificateAttestationChallenge_Vtbl {
@@ -4171,6 +4277,8 @@ pub trait ICertificateAttestationChallenge2_Impl: Sized + super::super::super::S
     fn put_KeyBlob(&self, encoding: EncodingType, value: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificateAttestationChallenge2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificateAttestationChallenge2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificateAttestationChallenge2_Impl, const OFFSET: isize>() -> ICertificateAttestationChallenge2_Vtbl {
         unsafe extern "system" fn SetKeyContainerName<Identity: ::windows::core::IUnknownImpl, Impl: ICertificateAttestationChallenge2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -4202,6 +4310,8 @@ pub trait ICertificatePolicies_Impl: Sized + super::super::super::System::Com::I
     fn Remove(&self, index: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificatePolicies {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificatePolicies_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificatePolicies_Impl, const OFFSET: isize>() -> ICertificatePolicies_Vtbl {
@@ -4274,6 +4384,8 @@ pub trait ICertificatePolicy_Impl: Sized + super::super::super::System::Com::IDi
     fn PolicyQualifiers(&self) -> ::windows::core::Result<IPolicyQualifiers>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificatePolicy {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificatePolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificatePolicy_Impl, const OFFSET: isize>() -> ICertificatePolicy_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICertificatePolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4325,6 +4437,8 @@ pub trait ICertificationAuthorities_Impl: Sized + super::super::super::System::C
     fn ComputeSiteCosts(&self) -> ::windows::core::Result<()>;
     fn get_ItemByName(&self, strname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<ICertificationAuthority>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificationAuthorities {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificationAuthorities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificationAuthorities_Impl, const OFFSET: isize>() -> ICertificationAuthorities_Vtbl {
@@ -4413,6 +4527,8 @@ pub trait ICertificationAuthority_Impl: Sized + super::super::super::System::Com
     fn get_Property(&self, property: EnrollmentCAProperty) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificationAuthority {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificationAuthority_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificationAuthority_Impl, const OFFSET: isize>() -> ICertificationAuthority_Vtbl {
         unsafe extern "system" fn get_Property<Identity: ::windows::core::IUnknownImpl, Impl: ICertificationAuthority_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, property: EnrollmentCAProperty, pvalue: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4439,6 +4555,8 @@ pub trait ICryptAttribute_Impl: Sized + super::super::super::System::Com::IDispa
     fn ObjectId(&self) -> ::windows::core::Result<IObjectId>;
     fn Values(&self) -> ::windows::core::Result<IX509Attributes>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICryptAttribute {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICryptAttribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICryptAttribute_Impl, const OFFSET: isize>() -> ICryptAttribute_Vtbl {
@@ -4497,6 +4615,8 @@ pub trait ICryptAttributes_Impl: Sized + super::super::super::System::Com::IDisp
     fn get_IndexByObjectId(&self, pobjectid: &::core::option::Option<IObjectId>) -> ::windows::core::Result<i32>;
     fn AddRange(&self, pvalue: &::core::option::Option<ICryptAttributes>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICryptAttributes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICryptAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICryptAttributes_Impl, const OFFSET: isize>() -> ICryptAttributes_Vtbl {
@@ -4593,6 +4713,8 @@ pub trait ICspAlgorithm_Impl: Sized + super::super::super::System::Com::IDispatc
     fn Type(&self) -> ::windows::core::Result<AlgorithmType>;
     fn Operations(&self) -> ::windows::core::Result<AlgorithmOperationFlags>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICspAlgorithm {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICspAlgorithm_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICspAlgorithm_Impl, const OFFSET: isize>() -> ICspAlgorithm_Vtbl {
@@ -4736,6 +4858,8 @@ pub trait ICspAlgorithms_Impl: Sized + super::super::super::System::Com::IDispat
     fn get_IndexByObjectId(&self, pobjectid: &::core::option::Option<IObjectId>) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICspAlgorithms {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICspAlgorithms_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICspAlgorithms_Impl, const OFFSET: isize>() -> ICspAlgorithms_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: ICspAlgorithms_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4844,6 +4968,8 @@ pub trait ICspInformation_Impl: Sized + super::super::super::System::Com::IDispa
     fn LegacyCsp(&self) -> ::windows::core::Result<i16>;
     fn GetCspStatusFromOperations(&self, palgorithm: &::core::option::Option<IObjectId>, operations: AlgorithmOperationFlags) -> ::windows::core::Result<ICspStatus>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICspInformation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICspInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICspInformation_Impl, const OFFSET: isize>() -> ICspInformation_Vtbl {
@@ -5063,6 +5189,8 @@ pub trait ICspInformations_Impl: Sized + super::super::super::System::Com::IDisp
     fn GetHashAlgorithms(&self, pcspinformation: &::core::option::Option<ICspInformation>) -> ::windows::core::Result<IObjectIds>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICspInformations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICspInformations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICspInformations_Impl, const OFFSET: isize>() -> ICspInformations_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: ICspInformations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5204,6 +5332,8 @@ pub trait ICspStatus_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn DisplayName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICspStatus {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICspStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICspStatus_Impl, const OFFSET: isize>() -> ICspStatus_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICspStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcsp: ::windows::core::RawPtr, palgorithm: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5299,6 +5429,8 @@ pub trait ICspStatuses_Impl: Sized + super::super::super::System::Com::IDispatch
     fn get_ItemByOperations(&self, strcspname: &super::super::super::Foundation::BSTR, stralgorithmname: &super::super::super::Foundation::BSTR, operations: AlgorithmOperationFlags) -> ::windows::core::Result<ICspStatus>;
     fn get_ItemByProvider(&self, pcspstatus: &::core::option::Option<ICspStatus>) -> ::windows::core::Result<ICspStatus>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICspStatuses {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICspStatuses_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICspStatuses_Impl, const OFFSET: isize>() -> ICspStatuses_Vtbl {
@@ -5485,6 +5617,8 @@ pub trait IEnroll_Impl: Sized {
     fn AddAuthenticatedAttributesToPKCS7Request(&self, pattributes: *mut super::CRYPT_ATTRIBUTES) -> ::windows::core::Result<()>;
     fn CreatePKCS7RequestFromRequest(&self, prequest: *mut super::CRYPTOAPI_BLOB, psigningcertcontext: *const super::CERT_CONTEXT, ppkcs7blob: *mut super::CRYPTOAPI_BLOB) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnroll {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnroll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnroll_Impl, const OFFSET: isize>() -> IEnroll_Vtbl {
@@ -5938,6 +6072,8 @@ pub trait IEnroll2_Impl: Sized + IEnroll_Impl {
     fn EnableSMIMECapabilities(&self, fenablesmimecapabilities: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnroll2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnroll2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnroll2_Impl, const OFFSET: isize>() -> IEnroll2_Vtbl {
         unsafe extern "system" fn InstallPKCS7Blob<Identity: ::windows::core::IUnknownImpl, Impl: IEnroll2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pblobpkcs7: *mut super::CRYPTOAPI_BLOB) -> ::windows::core::HRESULT {
@@ -6091,6 +6227,8 @@ pub trait IEnroll4_Impl: Sized + IEnroll_Impl + IEnroll2_Impl {
     fn SetIncludeSubjectKeyID(&self, finclude: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn IncludeSubjectKeyID(&self, pfinclude: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnroll4 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnroll4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnroll4_Impl, const OFFSET: isize>() -> IEnroll4_Vtbl {
@@ -6304,6 +6442,8 @@ pub trait IEnumCERTVIEWATTRIBUTE_Impl: Sized + super::super::super::System::Com:
     fn Clone(&self) -> ::windows::core::Result<IEnumCERTVIEWATTRIBUTE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumCERTVIEWATTRIBUTE {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumCERTVIEWATTRIBUTE_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCERTVIEWATTRIBUTE_Impl, const OFFSET: isize>() -> IEnumCERTVIEWATTRIBUTE_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCERTVIEWATTRIBUTE_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pindex: *mut i32) -> ::windows::core::HRESULT {
@@ -6369,6 +6509,8 @@ pub trait IEnumCERTVIEWCOLUMN_Impl: Sized + super::super::super::System::Com::ID
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumCERTVIEWCOLUMN>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumCERTVIEWCOLUMN {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumCERTVIEWCOLUMN_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCERTVIEWCOLUMN_Impl, const OFFSET: isize>() -> IEnumCERTVIEWCOLUMN_Vtbl {
@@ -6457,6 +6599,8 @@ pub trait IEnumCERTVIEWEXTENSION_Impl: Sized + super::super::super::System::Com:
     fn Clone(&self) -> ::windows::core::Result<IEnumCERTVIEWEXTENSION>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumCERTVIEWEXTENSION {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumCERTVIEWEXTENSION_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCERTVIEWEXTENSION_Impl, const OFFSET: isize>() -> IEnumCERTVIEWEXTENSION_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCERTVIEWEXTENSION_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pindex: *mut i32) -> ::windows::core::HRESULT {
@@ -6526,6 +6670,8 @@ pub trait IEnumCERTVIEWROW_Impl: Sized + super::super::super::System::Com::IDisp
     fn Clone(&self) -> ::windows::core::Result<IEnumCERTVIEWROW>;
     fn GetMaxIndex(&self, pindex: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumCERTVIEWROW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumCERTVIEWROW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCERTVIEWROW_Impl, const OFFSET: isize>() -> IEnumCERTVIEWROW_Vtbl {
@@ -6618,6 +6764,8 @@ pub trait INDESPolicy_Impl: Sized {
     fn Notify(&self, pwszchallenge: &::windows::core::PCWSTR, pwsztransactionid: &::windows::core::PCWSTR, disposition: X509SCEPDisposition, lasthresult: i32, pctbissuedcertencoded: *mut CERTTRANSBLOB) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INDESPolicy {}
+#[cfg(feature = "Win32_Foundation")]
 impl INDESPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INDESPolicy_Impl, const OFFSET: isize>() -> INDESPolicy_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: INDESPolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6677,6 +6825,8 @@ pub trait IOCSPAdmin_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn GetSigningCertificates(&self, bstrservername: &super::super::super::Foundation::BSTR, pcacertvar: *const super::super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
     fn GetHashAlgorithms(&self, bstrservername: &super::super::super::Foundation::BSTR, bstrcaid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOCSPAdmin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOCSPAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPAdmin_Impl, const OFFSET: isize>() -> IOCSPAdmin_Vtbl {
@@ -6811,6 +6961,8 @@ pub trait IOCSPCAConfiguration_Impl: Sized + super::super::super::System::Com::I
     fn CAConfig(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn SetCAConfig(&self, newval: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOCSPCAConfiguration {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOCSPCAConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPCAConfiguration_Impl, const OFFSET: isize>() -> IOCSPCAConfiguration_Vtbl {
@@ -7066,6 +7218,8 @@ pub trait IOCSPCAConfigurationCollection_Impl: Sized + super::super::super::Syst
     fn DeleteCAConfiguration(&self, bstridentifier: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOCSPCAConfigurationCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOCSPCAConfigurationCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPCAConfigurationCollection_Impl, const OFFSET: isize>() -> IOCSPCAConfigurationCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPCAConfigurationCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7150,6 +7304,8 @@ pub trait IOCSPProperty_Impl: Sized + super::super::super::System::Com::IDispatc
     fn Modified(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOCSPProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOCSPProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPProperty_Impl, const OFFSET: isize>() -> IOCSPProperty_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -7213,6 +7369,8 @@ pub trait IOCSPPropertyCollection_Impl: Sized + super::super::super::System::Com
     fn InitializeFromProperties(&self, pvarproperties: *const super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn GetAllProperties(&self) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOCSPPropertyCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOCSPPropertyCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOCSPPropertyCollection_Impl, const OFFSET: isize>() -> IOCSPPropertyCollection_Vtbl {
@@ -7320,6 +7478,8 @@ pub trait IObjectId_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn GetAlgorithmName(&self, groupid: ObjectIdGroupId, keyflags: ObjectIdPublicKeyFlags) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IObjectId {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IObjectId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectId_Impl, const OFFSET: isize>() -> IObjectId_Vtbl {
         unsafe extern "system" fn InitializeFromName<Identity: ::windows::core::IUnknownImpl, Impl: IObjectId_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: CERTENROLL_OBJECTID) -> ::windows::core::HRESULT {
@@ -7413,6 +7573,8 @@ pub trait IObjectIds_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn AddRange(&self, pvalue: &::core::option::Option<IObjectIds>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IObjectIds {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IObjectIds_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectIds_Impl, const OFFSET: isize>() -> IObjectIds_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: IObjectIds_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7492,6 +7654,8 @@ pub trait IPolicyQualifier_Impl: Sized + super::super::super::System::Com::IDisp
     fn get_RawData(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPolicyQualifier {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPolicyQualifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPolicyQualifier_Impl, const OFFSET: isize>() -> IPolicyQualifier_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IPolicyQualifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strqualifier: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, r#type: PolicyQualifierType) -> ::windows::core::HRESULT {
@@ -7565,6 +7729,8 @@ pub trait IPolicyQualifiers_Impl: Sized + super::super::super::System::Com::IDis
     fn Remove(&self, index: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPolicyQualifiers {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPolicyQualifiers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPolicyQualifiers_Impl, const OFFSET: isize>() -> IPolicyQualifiers_Vtbl {
@@ -7644,6 +7810,8 @@ pub trait ISignerCertificate_Impl: Sized + super::super::super::System::Com::IDi
     fn SetPin(&self, value: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SignatureInformation(&self) -> ::windows::core::Result<IX509SignatureInformation>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISignerCertificate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISignerCertificate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISignerCertificate_Impl, const OFFSET: isize>() -> ISignerCertificate_Vtbl {
@@ -7768,6 +7936,8 @@ pub trait ISignerCertificates_Impl: Sized + super::super::super::System::Com::ID
     fn Find(&self, psignercert: &::core::option::Option<ISignerCertificate>) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISignerCertificates {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISignerCertificates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISignerCertificates_Impl, const OFFSET: isize>() -> ISignerCertificates_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: ISignerCertificates_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7856,6 +8026,8 @@ pub trait ISmimeCapabilities_Impl: Sized + super::super::super::System::Com::IDi
     fn AddAvailableSmimeCapabilities(&self, machinecontext: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISmimeCapabilities {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISmimeCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISmimeCapabilities_Impl, const OFFSET: isize>() -> ISmimeCapabilities_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: ISmimeCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7939,6 +8111,8 @@ pub trait ISmimeCapability_Impl: Sized + super::super::super::System::Com::IDisp
     fn BitCount(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISmimeCapability {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISmimeCapability_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISmimeCapability_Impl, const OFFSET: isize>() -> ISmimeCapability_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ISmimeCapability_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobjectid: ::windows::core::RawPtr, bitcount: i32) -> ::windows::core::HRESULT {
@@ -7986,6 +8160,8 @@ pub trait IX500DistinguishedName_Impl: Sized + super::super::super::System::Com:
     fn Name(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn get_EncodedName(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX500DistinguishedName {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX500DistinguishedName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX500DistinguishedName_Impl, const OFFSET: isize>() -> IX500DistinguishedName_Vtbl {
@@ -8040,6 +8216,8 @@ pub trait IX509Attribute_Impl: Sized + super::super::super::System::Com::IDispat
     fn get_RawData(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509Attribute {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509Attribute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509Attribute_Impl, const OFFSET: isize>() -> IX509Attribute_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IX509Attribute_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobjectid: ::windows::core::RawPtr, encoding: EncodingType, strencodeddata: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -8088,6 +8266,8 @@ pub trait IX509AttributeArchiveKey_Impl: Sized + super::super::super::System::Co
     fn EncryptionAlgorithm(&self) -> ::windows::core::Result<IObjectId>;
     fn EncryptionStrength(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeArchiveKey {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeArchiveKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeArchiveKey_Impl, const OFFSET: isize>() -> IX509AttributeArchiveKey_Vtbl {
@@ -8154,6 +8334,8 @@ pub trait IX509AttributeArchiveKeyHash_Impl: Sized + super::super::super::System
     fn get_EncryptedKeyHashBlob(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeArchiveKeyHash {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeArchiveKeyHash_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeArchiveKeyHash_Impl, const OFFSET: isize>() -> IX509AttributeArchiveKeyHash_Vtbl {
         unsafe extern "system" fn InitializeEncodeFromEncryptedKeyBlob<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeArchiveKeyHash_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, encoding: EncodingType, strencryptedkeyblob: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -8197,6 +8379,8 @@ pub trait IX509AttributeClientId_Impl: Sized + super::super::super::System::Com:
     fn UserSamName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn ProcessName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeClientId {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeClientId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeClientId_Impl, const OFFSET: isize>() -> IX509AttributeClientId_Vtbl {
@@ -8277,6 +8461,8 @@ pub trait IX509AttributeCspProvider_Impl: Sized + super::super::super::System::C
     fn get_Signature(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeCspProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeCspProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeCspProvider_Impl, const OFFSET: isize>() -> IX509AttributeCspProvider_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeCspProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keyspec: X509KeySpec, strprovidername: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType, strsignature: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -8342,6 +8528,8 @@ pub trait IX509AttributeExtensions_Impl: Sized + super::super::super::System::Co
     fn X509Extensions(&self) -> ::windows::core::Result<IX509Extensions>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeExtensions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeExtensions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeExtensions_Impl, const OFFSET: isize>() -> IX509AttributeExtensions_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeExtensions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pextensions: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8383,6 +8571,8 @@ pub trait IX509AttributeOSVersion_Impl: Sized + super::super::super::System::Com
     fn OSVersion(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeOSVersion {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeOSVersion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeOSVersion_Impl, const OFFSET: isize>() -> IX509AttributeOSVersion_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeOSVersion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strosversion: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -8423,6 +8613,8 @@ pub trait IX509AttributeRenewalCertificate_Impl: Sized + super::super::super::Sy
     fn InitializeDecode(&self, encoding: EncodingType, strencodeddata: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_RenewalCertificate(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509AttributeRenewalCertificate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509AttributeRenewalCertificate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509AttributeRenewalCertificate_Impl, const OFFSET: isize>() -> IX509AttributeRenewalCertificate_Vtbl {
@@ -8467,6 +8659,8 @@ pub trait IX509Attributes_Impl: Sized + super::super::super::System::Com::IDispa
     fn Remove(&self, index: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509Attributes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509Attributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509Attributes_Impl, const OFFSET: isize>() -> IX509Attributes_Vtbl {
@@ -8560,6 +8754,8 @@ pub trait IX509CertificateRequest_Impl: Sized + super::super::super::System::Com
     fn SetAlternateSignatureAlgorithm(&self, value: i16) -> ::windows::core::Result<()>;
     fn get_RawData(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequest {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequest_Impl, const OFFSET: isize>() -> IX509CertificateRequest_Vtbl {
@@ -8814,6 +9010,8 @@ pub trait IX509CertificateRequestCertificate_Impl: Sized + super::super::super::
     fn SetSignerCertificate(&self, pvalue: &::core::option::Option<ISignerCertificate>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestCertificate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestCertificate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCertificate_Impl, const OFFSET: isize>() -> IX509CertificateRequestCertificate_Vtbl {
         unsafe extern "system" fn CheckPublicKeySignature<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCertificate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppublickey: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8928,6 +9126,8 @@ pub trait IX509CertificateRequestCertificate2_Impl: Sized + super::super::super:
     fn Template(&self) -> ::windows::core::Result<IX509CertificateTemplate>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestCertificate2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestCertificate2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCertificate2_Impl, const OFFSET: isize>() -> IX509CertificateRequestCertificate2_Vtbl {
         unsafe extern "system" fn InitializeFromTemplate<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCertificate2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: X509CertificateEnrollmentContext, ppolicyserver: ::windows::core::RawPtr, ptemplate: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9000,6 +9200,8 @@ pub trait IX509CertificateRequestCmc_Impl: Sized + super::super::super::System::
     fn get_EncryptedKeyHash(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn SignerCertificates(&self) -> ::windows::core::Result<ISignerCertificates>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestCmc {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestCmc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCmc_Impl, const OFFSET: isize>() -> IX509CertificateRequestCmc_Vtbl {
@@ -9255,6 +9457,8 @@ pub trait IX509CertificateRequestCmc2_Impl: Sized + super::super::super::System:
     fn CheckCertificateSignature(&self, psignercertificate: &::core::option::Option<ISignerCertificate>, validatecertificatechain: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestCmc2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestCmc2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCmc2_Impl, const OFFSET: isize>() -> IX509CertificateRequestCmc2_Vtbl {
         unsafe extern "system" fn InitializeFromTemplate<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestCmc2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: X509CertificateEnrollmentContext, ppolicyserver: ::windows::core::RawPtr, ptemplate: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9344,6 +9548,8 @@ pub trait IX509CertificateRequestPkcs10_Impl: Sized + super::super::super::Syste
     fn get_Signature(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn GetCspStatuses(&self, keyspec: X509KeySpec) -> ::windows::core::Result<ICspStatuses>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestPkcs10 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestPkcs10_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs10_Impl, const OFFSET: isize>() -> IX509CertificateRequestPkcs10_Vtbl {
@@ -9646,6 +9852,8 @@ pub trait IX509CertificateRequestPkcs10V2_Impl: Sized + super::super::super::Sys
     fn Template(&self) -> ::windows::core::Result<IX509CertificateTemplate>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestPkcs10V2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestPkcs10V2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs10V2_Impl, const OFFSET: isize>() -> IX509CertificateRequestPkcs10V2_Vtbl {
         unsafe extern "system" fn InitializeFromTemplate<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs10V2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: X509CertificateEnrollmentContext, ppolicyserver: ::windows::core::RawPtr, ptemplate: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9712,6 +9920,8 @@ pub trait IX509CertificateRequestPkcs10V3_Impl: Sized + super::super::super::Sys
     fn SetChallengePassword(&self, value: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn NameValuePairs(&self) -> ::windows::core::Result<IX509NameValuePairs>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestPkcs10V3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestPkcs10V3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs10V3_Impl, const OFFSET: isize>() -> IX509CertificateRequestPkcs10V3_Vtbl {
@@ -9833,6 +10043,8 @@ pub trait IX509CertificateRequestPkcs10V4_Impl: Sized + super::super::super::Sys
     fn SetAttestPrivateKeyPreferred(&self, value: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestPkcs10V4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestPkcs10V4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs10V4_Impl, const OFFSET: isize>() -> IX509CertificateRequestPkcs10V4_Vtbl {
         unsafe extern "system" fn ClaimType<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs10V4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut KeyAttestationClaimType) -> ::windows::core::HRESULT {
@@ -9890,6 +10102,8 @@ pub trait IX509CertificateRequestPkcs7_Impl: Sized + super::super::super::System
     fn SignerCertificate(&self) -> ::windows::core::Result<ISignerCertificate>;
     fn SetSignerCertificate(&self, pvalue: &::core::option::Option<ISignerCertificate>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestPkcs7 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestPkcs7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs7_Impl, const OFFSET: isize>() -> IX509CertificateRequestPkcs7_Vtbl {
@@ -9968,6 +10182,8 @@ pub trait IX509CertificateRequestPkcs7V2_Impl: Sized + super::super::super::Syst
     fn Template(&self) -> ::windows::core::Result<IX509CertificateTemplate>;
     fn CheckCertificateSignature(&self, validatecertificatechain: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRequestPkcs7V2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRequestPkcs7V2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRequestPkcs7V2_Impl, const OFFSET: isize>() -> IX509CertificateRequestPkcs7V2_Vtbl {
@@ -10049,6 +10265,8 @@ pub trait IX509CertificateRevocationList_Impl: Sized + super::super::super::Syst
     fn get_RawDataToBeSigned(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn get_Signature(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRevocationList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRevocationList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRevocationList_Impl, const OFFSET: isize>() -> IX509CertificateRevocationList_Vtbl {
@@ -10360,6 +10578,8 @@ pub trait IX509CertificateRevocationListEntries_Impl: Sized + super::super::supe
     fn AddRange(&self, pvalue: &::core::option::Option<IX509CertificateRevocationListEntries>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRevocationListEntries {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRevocationListEntries_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRevocationListEntries_Impl, const OFFSET: isize>() -> IX509CertificateRevocationListEntries_Vtbl {
         unsafe extern "system" fn get_ItemByIndex<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRevocationListEntries_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -10453,6 +10673,8 @@ pub trait IX509CertificateRevocationListEntry_Impl: Sized + super::super::super:
     fn CriticalExtensions(&self) -> ::windows::core::Result<IObjectIds>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateRevocationListEntry {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateRevocationListEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRevocationListEntry_Impl, const OFFSET: isize>() -> IX509CertificateRevocationListEntry_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateRevocationListEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, encoding: EncodingType, serialnumber: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, revocationdate: f64) -> ::windows::core::HRESULT {
@@ -10540,6 +10762,8 @@ pub trait IX509CertificateTemplate_Impl: Sized + super::super::super::System::Co
     fn get_Property(&self, property: EnrollmentTemplateProperty) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateTemplate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateTemplate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateTemplate_Impl, const OFFSET: isize>() -> IX509CertificateTemplate_Vtbl {
         unsafe extern "system" fn get_Property<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateTemplate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, property: EnrollmentTemplateProperty, pvalue: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -10567,6 +10791,8 @@ pub trait IX509CertificateTemplateWritable_Impl: Sized + super::super::super::Sy
     fn put_Property(&self, property: EnrollmentTemplateProperty, value: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Template(&self) -> ::windows::core::Result<IX509CertificateTemplate>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateTemplateWritable {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateTemplateWritable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateTemplateWritable_Impl, const OFFSET: isize>() -> IX509CertificateTemplateWritable_Vtbl {
@@ -10631,6 +10857,8 @@ pub trait IX509CertificateTemplates_Impl: Sized + super::super::super::System::C
     fn get_ItemByName(&self, bstrname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IX509CertificateTemplate>;
     fn get_ItemByOid(&self, poid: &::core::option::Option<IObjectId>) -> ::windows::core::Result<IX509CertificateTemplate>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509CertificateTemplates {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509CertificateTemplates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509CertificateTemplates_Impl, const OFFSET: isize>() -> IX509CertificateTemplates_Vtbl {
@@ -10734,6 +10962,8 @@ pub trait IX509EndorsementKey_Impl: Sized + super::super::super::System::Com::ID
     fn Open(&self) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509EndorsementKey {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509EndorsementKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509EndorsementKey_Impl, const OFFSET: isize>() -> IX509EndorsementKey_Vtbl {
@@ -10873,6 +11103,8 @@ pub trait IX509Enrollment_Impl: Sized + super::super::super::System::Com::IDispa
     fn RequestId(&self) -> ::windows::core::Result<i32>;
     fn CAConfigString(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509Enrollment {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509Enrollment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509Enrollment_Impl, const OFFSET: isize>() -> IX509Enrollment_Vtbl {
@@ -11115,6 +11347,8 @@ pub trait IX509Enrollment2_Impl: Sized + super::super::super::System::Com::IDisp
     fn RequestIdString(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509Enrollment2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509Enrollment2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509Enrollment2_Impl, const OFFSET: isize>() -> IX509Enrollment2_Vtbl {
         unsafe extern "system" fn InitializeFromTemplate<Identity: ::windows::core::IUnknownImpl, Impl: IX509Enrollment2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: X509CertificateEnrollmentContext, ppolicyserver: ::windows::core::RawPtr, ptemplate: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11180,6 +11414,8 @@ pub trait IX509EnrollmentHelper_Impl: Sized + super::super::super::System::Com::
     fn Enroll(&self, strenrollmentpolicyserveruri: &super::super::super::Foundation::BSTR, strtemplatename: &super::super::super::Foundation::BSTR, encoding: EncodingType, enrollflags: WebEnrollmentFlags) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn Initialize(&self, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509EnrollmentHelper {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509EnrollmentHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509EnrollmentHelper_Impl, const OFFSET: isize>() -> IX509EnrollmentHelper_Vtbl {
@@ -11248,6 +11484,8 @@ pub trait IX509EnrollmentPolicyServer_Impl: Sized + super::super::super::System:
     fn Cost(&self) -> ::windows::core::Result<u32>;
     fn SetCost(&self, value: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509EnrollmentPolicyServer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509EnrollmentPolicyServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509EnrollmentPolicyServer_Impl, const OFFSET: isize>() -> IX509EnrollmentPolicyServer_Vtbl {
@@ -11527,6 +11765,8 @@ pub trait IX509EnrollmentStatus_Impl: Sized + super::super::super::System::Com::
     fn ErrorText(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509EnrollmentStatus {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509EnrollmentStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509EnrollmentStatus_Impl, const OFFSET: isize>() -> IX509EnrollmentStatus_Vtbl {
         unsafe extern "system" fn AppendText<Identity: ::windows::core::IUnknownImpl, Impl: IX509EnrollmentStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strtext: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -11650,6 +11890,8 @@ pub trait IX509EnrollmentWebClassFactory_Impl: Sized + super::super::super::Syst
     fn CreateObject(&self, strprogid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509EnrollmentWebClassFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509EnrollmentWebClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509EnrollmentWebClassFactory_Impl, const OFFSET: isize>() -> IX509EnrollmentWebClassFactory_Vtbl {
         unsafe extern "system" fn CreateObject<Identity: ::windows::core::IUnknownImpl, Impl: IX509EnrollmentWebClassFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strprogid: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, ppiunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11677,6 +11919,8 @@ pub trait IX509Extension_Impl: Sized + super::super::super::System::Com::IDispat
     fn Critical(&self) -> ::windows::core::Result<i16>;
     fn SetCritical(&self, value: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509Extension {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509Extension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509Extension_Impl, const OFFSET: isize>() -> IX509Extension_Vtbl {
@@ -11743,6 +11987,8 @@ pub trait IX509ExtensionAlternativeNames_Impl: Sized + super::super::super::Syst
     fn AlternativeNames(&self) -> ::windows::core::Result<IAlternativeNames>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionAlternativeNames {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionAlternativeNames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionAlternativeNames_Impl, const OFFSET: isize>() -> IX509ExtensionAlternativeNames_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionAlternativeNames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11783,6 +12029,8 @@ pub trait IX509ExtensionAuthorityKeyIdentifier_Impl: Sized + super::super::super
     fn InitializeDecode(&self, encoding: EncodingType, strencodeddata: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_AuthorityKeyIdentifier(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionAuthorityKeyIdentifier {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionAuthorityKeyIdentifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionAuthorityKeyIdentifier_Impl, const OFFSET: isize>() -> IX509ExtensionAuthorityKeyIdentifier_Vtbl {
@@ -11825,6 +12073,8 @@ pub trait IX509ExtensionBasicConstraints_Impl: Sized + super::super::super::Syst
     fn IsCA(&self) -> ::windows::core::Result<i16>;
     fn PathLenConstraint(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionBasicConstraints {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionBasicConstraints_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionBasicConstraints_Impl, const OFFSET: isize>() -> IX509ExtensionBasicConstraints_Vtbl {
@@ -11879,6 +12129,8 @@ pub trait IX509ExtensionCertificatePolicies_Impl: Sized + super::super::super::S
     fn Policies(&self) -> ::windows::core::Result<ICertificatePolicies>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionCertificatePolicies {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionCertificatePolicies_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionCertificatePolicies_Impl, const OFFSET: isize>() -> IX509ExtensionCertificatePolicies_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionCertificatePolicies_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11919,6 +12171,8 @@ pub trait IX509ExtensionEnhancedKeyUsage_Impl: Sized + super::super::super::Syst
     fn InitializeDecode(&self, encoding: EncodingType, strencodeddata: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn EnhancedKeyUsage(&self) -> ::windows::core::Result<IObjectIds>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionEnhancedKeyUsage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionEnhancedKeyUsage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionEnhancedKeyUsage_Impl, const OFFSET: isize>() -> IX509ExtensionEnhancedKeyUsage_Vtbl {
@@ -11961,6 +12215,8 @@ pub trait IX509ExtensionKeyUsage_Impl: Sized + super::super::super::System::Com:
     fn KeyUsage(&self) -> ::windows::core::Result<X509KeyUsageFlags>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionKeyUsage {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionKeyUsage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionKeyUsage_Impl, const OFFSET: isize>() -> IX509ExtensionKeyUsage_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionKeyUsage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, usageflags: X509KeyUsageFlags) -> ::windows::core::HRESULT {
@@ -12001,6 +12257,8 @@ pub trait IX509ExtensionMSApplicationPolicies_Impl: Sized + super::super::super:
     fn InitializeDecode(&self, encoding: EncodingType, strencodeddata: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Policies(&self) -> ::windows::core::Result<ICertificatePolicies>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionMSApplicationPolicies {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionMSApplicationPolicies_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionMSApplicationPolicies_Impl, const OFFSET: isize>() -> IX509ExtensionMSApplicationPolicies_Vtbl {
@@ -12043,6 +12301,8 @@ pub trait IX509ExtensionSmimeCapabilities_Impl: Sized + super::super::super::Sys
     fn SmimeCapabilities(&self) -> ::windows::core::Result<ISmimeCapabilities>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionSmimeCapabilities {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionSmimeCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionSmimeCapabilities_Impl, const OFFSET: isize>() -> IX509ExtensionSmimeCapabilities_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionSmimeCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12083,6 +12343,8 @@ pub trait IX509ExtensionSubjectKeyIdentifier_Impl: Sized + super::super::super::
     fn InitializeDecode(&self, encoding: EncodingType, strencodeddata: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_SubjectKeyIdentifier(&self, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionSubjectKeyIdentifier {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionSubjectKeyIdentifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionSubjectKeyIdentifier_Impl, const OFFSET: isize>() -> IX509ExtensionSubjectKeyIdentifier_Vtbl {
@@ -12126,6 +12388,8 @@ pub trait IX509ExtensionTemplate_Impl: Sized + super::super::super::System::Com:
     fn MajorVersion(&self) -> ::windows::core::Result<i32>;
     fn MinorVersion(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionTemplate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionTemplate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionTemplate_Impl, const OFFSET: isize>() -> IX509ExtensionTemplate_Vtbl {
@@ -12192,6 +12456,8 @@ pub trait IX509ExtensionTemplateName_Impl: Sized + super::super::super::System::
     fn TemplateName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509ExtensionTemplateName {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509ExtensionTemplateName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionTemplateName_Impl, const OFFSET: isize>() -> IX509ExtensionTemplateName_Vtbl {
         unsafe extern "system" fn InitializeEncode<Identity: ::windows::core::IUnknownImpl, Impl: IX509ExtensionTemplateName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strtemplatename: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -12237,6 +12503,8 @@ pub trait IX509Extensions_Impl: Sized + super::super::super::System::Com::IDispa
     fn get_IndexByObjectId(&self, pobjectid: &::core::option::Option<IObjectId>) -> ::windows::core::Result<i32>;
     fn AddRange(&self, pvalue: &::core::option::Option<IX509Extensions>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509Extensions {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509Extensions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509Extensions_Impl, const OFFSET: isize>() -> IX509Extensions_Vtbl {
@@ -12325,6 +12593,8 @@ pub trait IX509MachineEnrollmentFactory_Impl: Sized + super::super::super::Syste
     fn CreateObject(&self, strprogid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<IX509EnrollmentHelper>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509MachineEnrollmentFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509MachineEnrollmentFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509MachineEnrollmentFactory_Impl, const OFFSET: isize>() -> IX509MachineEnrollmentFactory_Vtbl {
         unsafe extern "system" fn CreateObject<Identity: ::windows::core::IUnknownImpl, Impl: IX509MachineEnrollmentFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strprogid: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, ppihelper: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -12350,6 +12620,8 @@ pub trait IX509NameValuePair_Impl: Sized + super::super::super::System::Com::IDi
     fn Value(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn Name(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509NameValuePair {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509NameValuePair_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509NameValuePair_Impl, const OFFSET: isize>() -> IX509NameValuePair_Vtbl {
@@ -12400,6 +12672,8 @@ pub trait IX509NameValuePairs_Impl: Sized + super::super::super::System::Com::ID
     fn Remove(&self, index: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509NameValuePairs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509NameValuePairs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509NameValuePairs_Impl, const OFFSET: isize>() -> IX509NameValuePairs_Vtbl {
@@ -12475,6 +12749,8 @@ pub trait IX509PolicyServerListManager_Impl: Sized + super::super::super::System
     fn Clear(&self) -> ::windows::core::Result<()>;
     fn Initialize(&self, context: X509CertificateEnrollmentContext, flags: PolicyServerUrlFlags) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509PolicyServerListManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509PolicyServerListManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509PolicyServerListManager_Impl, const OFFSET: isize>() -> IX509PolicyServerListManager_Vtbl {
@@ -12564,6 +12840,8 @@ pub trait IX509PolicyServerUrl_Impl: Sized + super::super::super::System::Com::I
     fn UpdateRegistry(&self, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
     fn RemoveFromRegistry(&self, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509PolicyServerUrl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509PolicyServerUrl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509PolicyServerUrl_Impl, const OFFSET: isize>() -> IX509PolicyServerUrl_Vtbl {
@@ -12762,6 +13040,8 @@ pub trait IX509PrivateKey_Impl: Sized + super::super::super::System::Com::IDispa
     fn Description(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn SetDescription(&self, value: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509PrivateKey {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509PrivateKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509PrivateKey_Impl, const OFFSET: isize>() -> IX509PrivateKey_Vtbl {
@@ -13303,6 +13583,8 @@ pub trait IX509PrivateKey2_Impl: Sized + super::super::super::System::Com::IDisp
     fn SetParametersExportType(&self, value: X509KeyParametersExportType) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509PrivateKey2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509PrivateKey2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509PrivateKey2_Impl, const OFFSET: isize>() -> IX509PrivateKey2_Vtbl {
         unsafe extern "system" fn HardwareKeyUsage<Identity: ::windows::core::IUnknownImpl, Impl: IX509PrivateKey2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut X509HardwareKeyUsageFlags) -> ::windows::core::HRESULT {
@@ -13414,6 +13696,8 @@ pub trait IX509PublicKey_Impl: Sized + super::super::super::System::Com::IDispat
     fn ComputeKeyIdentifier(&self, algorithm: KeyIdentifierHashAlgorithm, encoding: EncodingType) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509PublicKey {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509PublicKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509PublicKey_Impl, const OFFSET: isize>() -> IX509PublicKey_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IX509PublicKey_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobjectid: ::windows::core::RawPtr, strencodedkey: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, strencodedparameters: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, encoding: EncodingType) -> ::windows::core::HRESULT {
@@ -13521,6 +13805,8 @@ pub trait IX509SCEPEnrollment_Impl: Sized + super::super::super::System::Com::ID
     fn SetSilent(&self, value: i16) -> ::windows::core::Result<()>;
     fn DeleteRequest(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509SCEPEnrollment {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509SCEPEnrollment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509SCEPEnrollment_Impl, const OFFSET: isize>() -> IX509SCEPEnrollment_Vtbl {
@@ -13752,6 +14038,8 @@ pub trait IX509SCEPEnrollment2_Impl: Sized + super::super::super::System::Com::I
     fn SetActivityId(&self, value: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509SCEPEnrollment2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509SCEPEnrollment2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509SCEPEnrollment2_Impl, const OFFSET: isize>() -> IX509SCEPEnrollment2_Vtbl {
         unsafe extern "system" fn CreateChallengeAnswerMessage<Identity: ::windows::core::IUnknownImpl, Impl: IX509SCEPEnrollment2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, encoding: EncodingType, pvalue: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -13837,6 +14125,8 @@ pub trait IX509SCEPEnrollmentHelper_Impl: Sized + super::super::super::System::C
     fn X509SCEPEnrollment(&self) -> ::windows::core::Result<IX509SCEPEnrollment>;
     fn ResultMessageText(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509SCEPEnrollmentHelper {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509SCEPEnrollmentHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509SCEPEnrollmentHelper_Impl, const OFFSET: isize>() -> IX509SCEPEnrollmentHelper_Vtbl {
@@ -13924,6 +14214,8 @@ pub trait IX509SignatureInformation_Impl: Sized + super::super::super::System::C
     fn GetSignatureAlgorithm(&self, pkcs7signature: i16, signaturekey: i16) -> ::windows::core::Result<IObjectId>;
     fn SetDefaultValues(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IX509SignatureInformation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IX509SignatureInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IX509SignatureInformation_Impl, const OFFSET: isize>() -> IX509SignatureInformation_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/impl.rs
@@ -22,6 +22,8 @@ pub trait ICertSrvSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn PostUnInstall(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertSrvSetup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertSrvSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertSrvSetup_Impl, const OFFSET: isize>() -> ICertSrvSetup_Vtbl {
         unsafe extern "system" fn CAErrorId<Identity: ::windows::core::IUnknownImpl, Impl: ICertSrvSetup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -234,6 +236,8 @@ pub trait ICertSrvSetupKeyInformation_Impl: Sized + super::super::System::Com::I
     fn SetExistingCACertificate(&self, varval: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertSrvSetupKeyInformation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertSrvSetupKeyInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertSrvSetupKeyInformation_Impl, const OFFSET: isize>() -> ICertSrvSetupKeyInformation_Vtbl {
         unsafe extern "system" fn ProviderName<Identity: ::windows::core::IUnknownImpl, Impl: ICertSrvSetupKeyInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -360,6 +364,8 @@ pub trait ICertSrvSetupKeyInformationCollection_Impl: Sized + super::super::Syst
     fn Add(&self, pikeyinformation: &::core::option::Option<ICertSrvSetupKeyInformation>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertSrvSetupKeyInformationCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertSrvSetupKeyInformationCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertSrvSetupKeyInformationCollection_Impl, const OFFSET: isize>() -> ICertSrvSetupKeyInformationCollection_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: ICertSrvSetupKeyInformationCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -421,6 +427,8 @@ pub trait ICertificateEnrollmentPolicyServerSetup_Impl: Sized + super::super::Sy
     fn Install(&self) -> ::windows::core::Result<()>;
     fn UnInstall(&self, pauthkeybasedrenewal: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificateEnrollmentPolicyServerSetup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificateEnrollmentPolicyServerSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificateEnrollmentPolicyServerSetup_Impl, const OFFSET: isize>() -> ICertificateEnrollmentPolicyServerSetup_Vtbl {
@@ -490,6 +498,8 @@ pub trait ICertificateEnrollmentServerSetup_Impl: Sized + super::super::System::
     fn Install(&self) -> ::windows::core::Result<()>;
     fn UnInstall(&self, pcaconfig: *const super::super::System::Com::VARIANT, pauthentication: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICertificateEnrollmentServerSetup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICertificateEnrollmentServerSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICertificateEnrollmentServerSetup_Impl, const OFFSET: isize>() -> ICertificateEnrollmentServerSetup_Vtbl {
@@ -570,6 +580,8 @@ pub trait IMSCEPSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PreUnInstall(&self) -> ::windows::core::Result<()>;
     fn PostUnInstall(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSCEPSetup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSCEPSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSCEPSetup_Impl, const OFFSET: isize>() -> IMSCEPSetup_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/impl.rs
@@ -4,9 +4,7 @@ pub trait IProtectionPolicyManagerInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IProtectionPolicyManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IProtectionPolicyManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IProtectionPolicyManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProtectionPolicyManagerInterop_Impl, const OFFSET: isize>() -> IProtectionPolicyManagerInterop_Vtbl {
@@ -39,9 +37,7 @@ pub trait IProtectionPolicyManagerInterop2_Impl: Sized {
     fn RequestAccessForAppWithMessageForWindowAsync(&self, appwindow: super::super::Foundation::HWND, sourceidentity: &::windows::core::HSTRING, apppackagefamilyname: &::windows::core::HSTRING, auditinfounk: &::core::option::Option<::windows::core::IUnknown>, messagefromapp: &::windows::core::HSTRING, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IProtectionPolicyManagerInterop2 {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IProtectionPolicyManagerInterop2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IProtectionPolicyManagerInterop2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProtectionPolicyManagerInterop2_Impl, const OFFSET: isize>() -> IProtectionPolicyManagerInterop2_Vtbl {
@@ -93,9 +89,7 @@ pub trait IProtectionPolicyManagerInterop3_Impl: Sized {
     fn RequestAccessToFilesForProcessWithMessageAndBehaviorForWindowAsync(&self, appwindow: super::super::Foundation::HWND, sourceitemlistunk: &::core::option::Option<::windows::core::IUnknown>, processid: u32, auditinfounk: &::core::option::Option<::windows::core::IUnknown>, messagefromapp: &::windows::core::HSTRING, behavior: u32, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IProtectionPolicyManagerInterop3 {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IProtectionPolicyManagerInterop3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IProtectionPolicyManagerInterop3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProtectionPolicyManagerInterop3_Impl, const OFFSET: isize>() -> IProtectionPolicyManagerInterop3_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
@@ -7,6 +7,8 @@ pub trait IAccountingProviderConfig_Impl: Sized {
     fn Deactivate(&self, uconnectionparam: usize, ureserved1: usize, ureserved2: usize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAccountingProviderConfig {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAccountingProviderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccountingProviderConfig_Impl, const OFFSET: isize>() -> IAccountingProviderConfig_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IAccountingProviderConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszmachinename: ::windows::core::PCWSTR, puconnectionparam: *mut usize) -> ::windows::core::HRESULT {
@@ -61,6 +63,8 @@ pub trait IAuthenticationProviderConfig_Impl: Sized {
     fn Activate(&self, uconnectionparam: usize, ureserved1: usize, ureserved2: usize) -> ::windows::core::Result<()>;
     fn Deactivate(&self, uconnectionparam: usize, ureserved1: usize, ureserved2: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAuthenticationProviderConfig {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAuthenticationProviderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAuthenticationProviderConfig_Impl, const OFFSET: isize>() -> IAuthenticationProviderConfig_Vtbl {
@@ -117,6 +121,8 @@ pub trait IEAPProviderConfig_Impl: Sized {
     fn RouterInvokeCredentialsUI(&self, dweaptypeid: u32, uconnectionparam: usize, hwndparent: super::super::Foundation::HWND, dwflags: u32, pconnectiondatain: *const u8, dwsizeofconnectiondatain: u32, puserdatain: *const u8, dwsizeofuserdatain: u32, ppuserdataout: *mut *mut u8, pdwsizeofuserdataout: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEAPProviderConfig {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEAPProviderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEAPProviderConfig_Impl, const OFFSET: isize>() -> IEAPProviderConfig_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IEAPProviderConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszmachinename: ::windows::core::PCWSTR, dweaptypeid: u32, puconnectionparam: *mut usize) -> ::windows::core::HRESULT {
@@ -171,6 +177,8 @@ pub trait IEAPProviderConfig2_Impl: Sized + IEAPProviderConfig_Impl {
     fn GetGlobalConfig(&self, dweaptypeid: u32, ppconfigdataout: *mut *mut u8, pdwsizeofconfigdataout: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEAPProviderConfig2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEAPProviderConfig2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEAPProviderConfig2_Impl, const OFFSET: isize>() -> IEAPProviderConfig2_Vtbl {
         unsafe extern "system" fn ServerInvokeConfigUI2<Identity: ::windows::core::IUnknownImpl, Impl: IEAPProviderConfig2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dweaptypeid: u32, uconnectionparam: usize, hwnd: super::super::Foundation::HWND, pconfigdatain: *const u8, dwsizeofconfigdatain: u32, ppconfigdataout: *mut *mut u8, pdwsizeofconfigdataout: *mut u32) -> ::windows::core::HRESULT {
@@ -198,6 +206,8 @@ pub trait IEAPProviderConfig3_Impl: Sized + IEAPProviderConfig_Impl + IEAPProvid
     fn ServerInvokeCertificateConfigUI(&self, dweaptypeid: u32, uconnectionparam: usize, hwnd: super::super::Foundation::HWND, pconfigdatain: *const u8, dwsizeofconfigdatain: u32, ppconfigdataout: *mut *mut u8, pdwsizeofconfigdataout: *mut u32, ureserved: usize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEAPProviderConfig3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEAPProviderConfig3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEAPProviderConfig3_Impl, const OFFSET: isize>() -> IEAPProviderConfig3_Vtbl {
         unsafe extern "system" fn ServerInvokeCertificateConfigUI<Identity: ::windows::core::IUnknownImpl, Impl: IEAPProviderConfig3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dweaptypeid: u32, uconnectionparam: usize, hwnd: super::super::Foundation::HWND, pconfigdatain: *const u8, dwsizeofconfigdatain: u32, ppconfigdataout: *mut *mut u8, pdwsizeofconfigdataout: *mut u32, ureserved: usize) -> ::windows::core::HRESULT {
@@ -219,6 +229,8 @@ pub trait IRouterProtocolConfig_Impl: Sized {
     fn AddProtocol(&self, pszmachinename: &::windows::core::PCWSTR, dwtransportid: u32, dwprotocolid: u32, hwnd: super::super::Foundation::HWND, dwflags: u32, prouter: &::core::option::Option<::windows::core::IUnknown>, ureserved1: usize) -> ::windows::core::Result<()>;
     fn RemoveProtocol(&self, pszmachinename: &::windows::core::PCWSTR, dwtransportid: u32, dwprotocolid: u32, hwnd: super::super::Foundation::HWND, dwflags: u32, prouter: &::core::option::Option<::windows::core::IUnknown>, ureserved1: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRouterProtocolConfig {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRouterProtocolConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRouterProtocolConfig_Impl, const OFFSET: isize>() -> IRouterProtocolConfig_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/impl.rs
@@ -3,6 +3,8 @@ pub trait IIsolatedAppLauncher_Impl: Sized {
     fn Launch(&self, appusermodelid: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, telemetryparameters: *const IsolatedAppLauncherTelemetryParameters) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsolatedAppLauncher {}
+#[cfg(feature = "Win32_Foundation")]
 impl IIsolatedAppLauncher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsolatedAppLauncher_Impl, const OFFSET: isize>() -> IIsolatedAppLauncher_Vtbl {
         unsafe extern "system" fn Launch<Identity: ::windows::core::IUnknownImpl, Impl: IIsolatedAppLauncher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, telemetryparameters: *const IsolatedAppLauncherTelemetryParameters) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
@@ -4,6 +4,8 @@ pub trait ITpmVirtualSmartCardManager_Impl: Sized {
     fn DestroyVirtualSmartCard(&self, pszinstanceid: &::windows::core::PCWSTR, pstatuscallback: &::core::option::Option<ITpmVirtualSmartCardManagerStatusCallback>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITpmVirtualSmartCardManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITpmVirtualSmartCardManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManager_Impl, const OFFSET: isize>() -> ITpmVirtualSmartCardManager_Vtbl {
         unsafe extern "system" fn CreateVirtualSmartCard<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfriendlyname: ::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, fgenerate: super::super::Foundation::BOOL, pstatuscallback: ::windows::core::RawPtr, ppszinstanceid: *mut ::windows::core::PWSTR, pfneedreboot: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -54,6 +56,8 @@ pub trait ITpmVirtualSmartCardManager2_Impl: Sized + ITpmVirtualSmartCardManager
     fn CreateVirtualSmartCardWithPinPolicy(&self, pszfriendlyname: &::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, pbpinpolicy: *const u8, cbpinpolicy: u32, fgenerate: super::super::Foundation::BOOL, pstatuscallback: &::core::option::Option<ITpmVirtualSmartCardManagerStatusCallback>, ppszinstanceid: *mut ::windows::core::PWSTR, pfneedreboot: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITpmVirtualSmartCardManager2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITpmVirtualSmartCardManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManager2_Impl, const OFFSET: isize>() -> ITpmVirtualSmartCardManager2_Vtbl {
         unsafe extern "system" fn CreateVirtualSmartCardWithPinPolicy<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfriendlyname: ::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, pbpinpolicy: *const u8, cbpinpolicy: u32, fgenerate: super::super::Foundation::BOOL, pstatuscallback: ::windows::core::RawPtr, ppszinstanceid: *mut ::windows::core::PWSTR, pfneedreboot: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -93,6 +97,8 @@ impl ITpmVirtualSmartCardManager2_Vtbl {
 pub trait ITpmVirtualSmartCardManager3_Impl: Sized + ITpmVirtualSmartCardManager_Impl + ITpmVirtualSmartCardManager2_Impl {
     fn CreateVirtualSmartCardWithAttestation(&self, pszfriendlyname: &::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, pbpinpolicy: *const u8, cbpinpolicy: u32, attestationtype: TPMVSC_ATTESTATION_TYPE, fgenerate: super::super::Foundation::BOOL, pstatuscallback: &::core::option::Option<ITpmVirtualSmartCardManagerStatusCallback>) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITpmVirtualSmartCardManager3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITpmVirtualSmartCardManager3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManager3_Impl, const OFFSET: isize>() -> ITpmVirtualSmartCardManager3_Vtbl {
@@ -136,6 +142,7 @@ pub trait ITpmVirtualSmartCardManagerStatusCallback_Impl: Sized {
     fn ReportProgress(&self, status: TPMVSCMGR_STATUS) -> ::windows::core::Result<()>;
     fn ReportError(&self, error: TPMVSCMGR_ERROR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITpmVirtualSmartCardManagerStatusCallback {}
 impl ITpmVirtualSmartCardManagerStatusCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManagerStatusCallback_Impl, const OFFSET: isize>() -> ITpmVirtualSmartCardManagerStatusCallback_Vtbl {
         unsafe extern "system" fn ReportProgress<Identity: ::windows::core::IUnknownImpl, Impl: ITpmVirtualSmartCardManagerStatusCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, status: TPMVSCMGR_STATUS) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
@@ -3,6 +3,8 @@ pub trait IDedupBackupSupport_Impl: Sized {
     fn RestoreFiles(&self, numberoffiles: u32, filefullpaths: *const super::super::Foundation::BSTR, store: &::core::option::Option<IDedupReadFileCallback>, flags: u32, fileresults: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDedupBackupSupport {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDedupBackupSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDedupBackupSupport_Impl, const OFFSET: isize>() -> IDedupBackupSupport_Vtbl {
         unsafe extern "system" fn RestoreFiles<Identity: ::windows::core::IUnknownImpl, Impl: IDedupBackupSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, numberoffiles: u32, filefullpaths: *const super::super::Foundation::BSTR, store: ::windows::core::RawPtr, flags: u32, fileresults: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -23,6 +25,8 @@ pub trait IDedupChunkLibrary_Impl: Sized {
     fn SetParameter(&self, dwparamtype: u32, vparamvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn StartChunking(&self, iiditeratorinterfaceid: &::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDedupChunkLibrary {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDedupChunkLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDedupChunkLibrary_Impl, const OFFSET: isize>() -> IDedupChunkLibrary_Vtbl {
@@ -79,6 +83,8 @@ pub trait IDedupDataPort_Impl: Sized {
     fn GetRequestStatus(&self, requestid: &::windows::core::GUID) -> ::windows::core::Result<DedupDataPortRequestStatus>;
     fn GetRequestResults(&self, requestid: &::windows::core::GUID, maxwaitms: u32, pbatchresult: *mut ::windows::core::HRESULT, pbatchcount: *mut u32, pstatus: *mut DedupDataPortRequestStatus, ppitemresults: *mut *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDedupDataPort {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDedupDataPort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDedupDataPort_Impl, const OFFSET: isize>() -> IDedupDataPort_Vtbl {
@@ -217,6 +223,8 @@ pub trait IDedupDataPortManager_Impl: Sized {
     fn GetVolumeDataPort(&self, options: u32, path: &super::super::Foundation::BSTR) -> ::windows::core::Result<IDedupDataPort>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDedupDataPortManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDedupDataPortManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDedupDataPortManager_Impl, const OFFSET: isize>() -> IDedupDataPortManager_Vtbl {
         unsafe extern "system" fn GetConfiguration<Identity: ::windows::core::IUnknownImpl, Impl: IDedupDataPortManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pminchunksize: *mut u32, pmaxchunksize: *mut u32, pchunkingalgorithm: *mut DedupChunkingAlgorithm, phashingalgorithm: *mut DedupHashingAlgorithm, pcompressionalgorithm: *mut DedupCompressionAlgorithm) -> ::windows::core::HRESULT {
@@ -263,6 +271,7 @@ pub trait IDedupIterateChunksHash32_Impl: Sized {
     fn Drain(&self) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDedupIterateChunksHash32 {}
 impl IDedupIterateChunksHash32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDedupIterateChunksHash32_Impl, const OFFSET: isize>() -> IDedupIterateChunksHash32_Vtbl {
         unsafe extern "system" fn PushBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IDedupIterateChunksHash32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffer: *const u8, ulbufferlength: u32) -> ::windows::core::HRESULT {
@@ -303,6 +312,8 @@ pub trait IDedupReadFileCallback_Impl: Sized {
     fn OrderContainersRestore(&self, numberofcontainers: u32, containerpaths: *const super::super::Foundation::BSTR, readplanentries: *mut u32, readplan: *mut *mut DEDUP_CONTAINER_EXTENT) -> ::windows::core::Result<()>;
     fn PreviewContainerRead(&self, filefullpath: &super::super::Foundation::BSTR, numberofreads: u32, readoffsets: *const DDP_FILE_EXTENT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDedupReadFileCallback {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDedupReadFileCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDedupReadFileCallback_Impl, const OFFSET: isize>() -> IDedupReadFileCallback_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
@@ -6,6 +6,7 @@ pub trait IEnhancedStorageACT_Impl: Sized {
     fn GetUniqueIdentity(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetSilos(&self, pppienhancedstoragesilos: *mut *mut ::core::option::Option<IEnhancedStorageSilo>, pcenhancedstoragesilos: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnhancedStorageACT {}
 impl IEnhancedStorageACT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageACT_Impl, const OFFSET: isize>() -> IEnhancedStorageACT_Vtbl {
         unsafe extern "system" fn Authorize<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageACT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: u32, dwflags: u32) -> ::windows::core::HRESULT {
@@ -76,6 +77,8 @@ pub trait IEnhancedStorageACT2_Impl: Sized + IEnhancedStorageACT_Impl {
     fn IsDeviceRemovable(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnhancedStorageACT2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnhancedStorageACT2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageACT2_Impl, const OFFSET: isize>() -> IEnhancedStorageACT2_Vtbl {
         unsafe extern "system" fn GetDeviceName<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageACT2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszdevicename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -116,6 +119,8 @@ pub trait IEnhancedStorageACT3_Impl: Sized + IEnhancedStorageACT_Impl + IEnhance
     fn IsQueueFrozen(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetShellExtSupport(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnhancedStorageACT3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnhancedStorageACT3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageACT3_Impl, const OFFSET: isize>() -> IEnhancedStorageACT3_Vtbl {
@@ -165,6 +170,8 @@ pub trait IEnhancedStorageSilo_Impl: Sized {
     fn GetPortableDevice(&self) -> ::windows::core::Result<super::super::Devices::PortableDevices::IPortableDevice>;
     fn GetDevicePath(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Devices_PortableDevices")]
+impl ::windows::core::RuntimeName for IEnhancedStorageSilo {}
 #[cfg(feature = "Win32_Devices_PortableDevices")]
 impl IEnhancedStorageSilo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageSilo_Impl, const OFFSET: isize>() -> IEnhancedStorageSilo_Vtbl {
@@ -229,6 +236,7 @@ pub trait IEnhancedStorageSiloAction_Impl: Sized {
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnhancedStorageSiloAction {}
 impl IEnhancedStorageSiloAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageSiloAction_Impl, const OFFSET: isize>() -> IEnhancedStorageSiloAction_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IEnhancedStorageSiloAction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszactionname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -273,6 +281,7 @@ pub trait IEnumEnhancedStorageACT_Impl: Sized {
     fn GetACTs(&self, pppienhancedstorageacts: *mut *mut ::core::option::Option<IEnhancedStorageACT>, pcenhancedstorageacts: *mut u32) -> ::windows::core::Result<()>;
     fn GetMatchingACT(&self, szvolume: &::windows::core::PCWSTR) -> ::windows::core::Result<IEnhancedStorageACT>;
 }
+impl ::windows::core::RuntimeName for IEnumEnhancedStorageACT {}
 impl IEnumEnhancedStorageACT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumEnhancedStorageACT_Impl, const OFFSET: isize>() -> IEnumEnhancedStorageACT_Vtbl {
         unsafe extern "system" fn GetACTs<Identity: ::windows::core::IUnknownImpl, Impl: IEnumEnhancedStorageACT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pppienhancedstorageacts: *mut *mut ::windows::core::RawPtr, pcenhancedstorageacts: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
@@ -16,6 +16,8 @@ pub trait IFhConfigMgr_Impl: Sized {
     fn QueryProtectionStatus(&self, protectionstate: *mut u32, protecteduntiltime: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFhConfigMgr {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFhConfigMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFhConfigMgr_Impl, const OFFSET: isize>() -> IFhConfigMgr_Vtbl {
         unsafe extern "system" fn LoadConfiguration<Identity: ::windows::core::IUnknownImpl, Impl: IFhConfigMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -149,6 +151,8 @@ pub trait IFhReassociation_Impl: Sized {
     fn PerformReassociation(&self, overwriteifexists: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFhReassociation {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFhReassociation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFhReassociation_Impl, const OFFSET: isize>() -> IFhReassociation_Vtbl {
         unsafe extern "system" fn ValidateTarget<Identity: ::windows::core::IUnknownImpl, Impl: IFhReassociation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targeturl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, validationresult: *mut FH_DEVICE_VALIDATION_RESULT) -> ::windows::core::HRESULT {
@@ -201,6 +205,8 @@ pub trait IFhScopeIterator_Impl: Sized {
     fn GetItem(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFhScopeIterator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFhScopeIterator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFhScopeIterator_Impl, const OFFSET: isize>() -> IFhScopeIterator_Vtbl {
         unsafe extern "system" fn MoveToNextItem<Identity: ::windows::core::IUnknownImpl, Impl: IFhScopeIterator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -234,6 +240,8 @@ pub trait IFhTarget_Impl: Sized {
     fn GetStringProperty(&self, propertytype: FH_TARGET_PROPERTY_TYPE) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetNumericalProperty(&self, propertytype: FH_TARGET_PROPERTY_TYPE) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFhTarget {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFhTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFhTarget_Impl, const OFFSET: isize>() -> IFhTarget_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/impl.rs
@@ -1,6 +1,8 @@
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DIFsrmClassificationEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DIFsrmClassificationEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DIFsrmClassificationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DIFsrmClassificationEvents_Impl, const OFFSET: isize>() -> DIFsrmClassificationEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -13,6 +15,8 @@ impl DIFsrmClassificationEvents_Vtbl {
 pub trait IFsrmAccessDeniedRemediationClient_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Show(&self, parentwnd: usize, accesspath: &super::super::Foundation::BSTR, errortype: AdrClientErrorType, flags: i32, windowtitle: &super::super::Foundation::BSTR, windowmessage: &super::super::Foundation::BSTR) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmAccessDeniedRemediationClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmAccessDeniedRemediationClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmAccessDeniedRemediationClient_Impl, const OFFSET: isize>() -> IFsrmAccessDeniedRemediationClient_Vtbl {
@@ -41,6 +45,8 @@ pub trait IFsrmAction_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetRunLimitInterval(&self, minutes: i32) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmAction {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmAction_Impl, const OFFSET: isize>() -> IFsrmAction_Vtbl {
@@ -117,6 +123,8 @@ pub trait IFsrmActionCommand_Impl: Sized + super::super::System::Com::IDispatch_
     fn LogResult(&self) -> ::windows::core::Result<i16>;
     fn SetLogResult(&self, logresults: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmActionCommand {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmActionCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionCommand_Impl, const OFFSET: isize>() -> IFsrmActionCommand_Vtbl {
@@ -272,6 +280,8 @@ pub trait IFsrmActionEmail_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn SetMessageText(&self, messagetext: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmActionEmail {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmActionEmail_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionEmail_Impl, const OFFSET: isize>() -> IFsrmActionEmail_Vtbl {
         unsafe extern "system" fn MailFrom<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionEmail_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mailfrom: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -414,6 +424,8 @@ pub trait IFsrmActionEmail2_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetAttachmentFileListSize(&self, attachmentfilelistsize: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmActionEmail2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmActionEmail2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionEmail2_Impl, const OFFSET: isize>() -> IFsrmActionEmail2_Vtbl {
         unsafe extern "system" fn AttachmentFileListSize<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionEmail2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, attachmentfilelistsize: *mut i32) -> ::windows::core::HRESULT {
@@ -449,6 +461,8 @@ pub trait IFsrmActionEventLog_Impl: Sized + super::super::System::Com::IDispatch
     fn MessageText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetMessageText(&self, messagetext: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmActionEventLog {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmActionEventLog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionEventLog_Impl, const OFFSET: isize>() -> IFsrmActionEventLog_Vtbl {
@@ -504,6 +518,8 @@ pub trait IFsrmActionReport_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetMailTo(&self, mailto: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmActionReport {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmActionReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionReport_Impl, const OFFSET: isize>() -> IFsrmActionReport_Vtbl {
         unsafe extern "system" fn ReportTypes<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmActionReport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, reporttypes: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -556,6 +572,8 @@ pub trait IFsrmAutoApplyQuota_Impl: Sized + super::super::System::Com::IDispatch
     fn SetExcludeFolders(&self, folders: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn CommitAndUpdateDerived(&self, commitoptions: FsrmCommitOptions, applyoptions: FsrmTemplateApplyOptions) -> ::windows::core::Result<IFsrmDerivedObjectsResult>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmAutoApplyQuota {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmAutoApplyQuota_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmAutoApplyQuota_Impl, const OFFSET: isize>() -> IFsrmAutoApplyQuota_Vtbl {
@@ -627,6 +645,8 @@ pub trait IFsrmClassificationManager_Impl: Sized + super::super::System::Com::ID
     fn SetFileProperty(&self, filepath: &super::super::Foundation::BSTR, propertyname: &super::super::Foundation::BSTR, propertyvalue: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn ClearFileProperty(&self, filepath: &super::super::Foundation::BSTR, property: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmClassificationManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmClassificationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassificationManager_Impl, const OFFSET: isize>() -> IFsrmClassificationManager_Vtbl {
@@ -919,6 +939,8 @@ pub trait IFsrmClassificationManager2_Impl: Sized + super::super::System::Com::I
     fn ClassifyFiles(&self, filepaths: *const super::super::System::Com::SAFEARRAY, propertynames: *const super::super::System::Com::SAFEARRAY, propertyvalues: *const super::super::System::Com::SAFEARRAY, options: FsrmGetFilePropertyOptions) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmClassificationManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmClassificationManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassificationManager2_Impl, const OFFSET: isize>() -> IFsrmClassificationManager2_Vtbl {
         unsafe extern "system" fn ClassifyFiles<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassificationManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filepaths: *const super::super::System::Com::SAFEARRAY, propertynames: *const super::super::System::Com::SAFEARRAY, propertyvalues: *const super::super::System::Com::SAFEARRAY, options: FsrmGetFilePropertyOptions) -> ::windows::core::HRESULT {
@@ -941,6 +963,8 @@ pub trait IFsrmClassificationRule_Impl: Sized + super::super::System::Com::IDisp
     fn Value(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetValue(&self, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmClassificationRule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmClassificationRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassificationRule_Impl, const OFFSET: isize>() -> IFsrmClassificationRule_Vtbl {
@@ -1016,6 +1040,8 @@ pub trait IFsrmClassifierModuleDefinition_Impl: Sized + super::super::System::Co
     fn SetNeedsExplicitValue(&self, needsexplicitvalue: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmClassifierModuleDefinition {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmClassifierModuleDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassifierModuleDefinition_Impl, const OFFSET: isize>() -> IFsrmClassifierModuleDefinition_Vtbl {
         unsafe extern "system" fn PropertiesAffected<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassifierModuleDefinition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertiesaffected: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -1090,6 +1116,8 @@ pub trait IFsrmClassifierModuleImplementation_Impl: Sized + super::super::System
     fn OnEndFile(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmClassifierModuleImplementation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmClassifierModuleImplementation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassifierModuleImplementation_Impl, const OFFSET: isize>() -> IFsrmClassifierModuleImplementation_Vtbl {
         unsafe extern "system" fn LastModified<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmClassifierModuleImplementation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lastmodified: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1152,6 +1180,8 @@ pub trait IFsrmCollection_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn WaitForCompletion(&self, waitseconds: i32) -> ::windows::core::Result<i16>;
     fn GetById(&self, id: &::windows::core::GUID) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmCollection_Impl, const OFFSET: isize>() -> IFsrmCollection_Vtbl {
@@ -1246,6 +1276,8 @@ pub trait IFsrmCommittableCollection_Impl: Sized + super::super::System::Com::ID
     fn Commit(&self, options: FsrmCommitOptions) -> ::windows::core::Result<IFsrmCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmCommittableCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmCommittableCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmCommittableCollection_Impl, const OFFSET: isize>() -> IFsrmCommittableCollection_Vtbl {
         unsafe extern "system" fn Commit<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmCommittableCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: FsrmCommitOptions, results: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1270,6 +1302,8 @@ pub trait IFsrmDerivedObjectsResult_Impl: Sized + super::super::System::Com::IDi
     fn DerivedObjects(&self) -> ::windows::core::Result<IFsrmCollection>;
     fn Results(&self) -> ::windows::core::Result<IFsrmCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmDerivedObjectsResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmDerivedObjectsResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmDerivedObjectsResult_Impl, const OFFSET: isize>() -> IFsrmDerivedObjectsResult_Vtbl {
@@ -1314,6 +1348,8 @@ pub trait IFsrmExportImport_Impl: Sized + super::super::System::Com::IDispatch_I
     fn ExportQuotaTemplates(&self, filepath: &super::super::Foundation::BSTR, templatenamessafearray: *const super::super::System::Com::VARIANT, remotehost: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn ImportQuotaTemplates(&self, filepath: &super::super::Foundation::BSTR, templatenamessafearray: *const super::super::System::Com::VARIANT, remotehost: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFsrmCommittableCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmExportImport {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmExportImport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmExportImport_Impl, const OFFSET: isize>() -> IFsrmExportImport_Vtbl {
@@ -1385,6 +1421,8 @@ pub trait IFsrmFileCondition_Impl: Sized + super::super::System::Com::IDispatch_
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileCondition {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileCondition_Impl, const OFFSET: isize>() -> IFsrmFileCondition_Vtbl {
         unsafe extern "system" fn Type<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileCondition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut FsrmFileConditionType) -> ::windows::core::HRESULT {
@@ -1426,6 +1464,8 @@ pub trait IFsrmFileConditionProperty_Impl: Sized + super::super::System::Com::ID
     fn Value(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn SetValue(&self, newval: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileConditionProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileConditionProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileConditionProperty_Impl, const OFFSET: isize>() -> IFsrmFileConditionProperty_Vtbl {
@@ -1537,6 +1577,8 @@ pub trait IFsrmFileGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SetNonMembers(&self, nonmembers: &::core::option::Option<IFsrmMutableCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileGroup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileGroup_Impl, const OFFSET: isize>() -> IFsrmFileGroup_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1607,6 +1649,8 @@ pub trait IFsrmFileGroupImported_Impl: Sized + super::super::System::Com::IDispa
     fn SetOverwriteOnCommit(&self, overwrite: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileGroupImported {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileGroupImported_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileGroupImported_Impl, const OFFSET: isize>() -> IFsrmFileGroupImported_Vtbl {
         unsafe extern "system" fn OverwriteOnCommit<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileGroupImported_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, overwrite: *mut i16) -> ::windows::core::HRESULT {
@@ -1643,6 +1687,8 @@ pub trait IFsrmFileGroupManager_Impl: Sized + super::super::System::Com::IDispat
     fn ExportFileGroups(&self, filegroupnamesarray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ImportFileGroups(&self, serializedfilegroups: &super::super::Foundation::BSTR, filegroupnamesarray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<IFsrmCommittableCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileGroupManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileGroupManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileGroupManager_Impl, const OFFSET: isize>() -> IFsrmFileGroupManager_Vtbl {
@@ -1766,6 +1812,8 @@ pub trait IFsrmFileManagementJob_Impl: Sized + super::super::System::Com::IDispa
     fn CreatePropertyCondition(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFsrmPropertyCondition>;
     fn CreateCustomAction(&self) -> ::windows::core::Result<IFsrmActionCommand>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileManagementJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileManagementJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileManagementJob_Impl, const OFFSET: isize>() -> IFsrmFileManagementJob_Vtbl {
@@ -2248,6 +2296,8 @@ pub trait IFsrmFileManagementJobManager_Impl: Sized + super::super::System::Com:
     fn GetFileManagementJob(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<IFsrmFileManagementJob>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileManagementJobManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileManagementJobManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileManagementJobManager_Impl, const OFFSET: isize>() -> IFsrmFileManagementJobManager_Vtbl {
         unsafe extern "system" fn ActionVariables<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileManagementJobManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, variables: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -2327,6 +2377,8 @@ pub trait IFsrmFileScreen_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn UserAccount(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ApplyTemplate(&self, filescreentemplatename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreen {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreen_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreen_Impl, const OFFSET: isize>() -> IFsrmFileScreen_Vtbl {
@@ -2414,6 +2466,8 @@ pub trait IFsrmFileScreenBase_Impl: Sized + super::super::System::Com::IDispatch
     fn EnumActions(&self) -> ::windows::core::Result<IFsrmCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreenBase {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreenBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenBase_Impl, const OFFSET: isize>() -> IFsrmFileScreenBase_Vtbl {
         unsafe extern "system" fn BlockedFileGroups<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenBase_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, blocklist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2491,6 +2545,8 @@ pub trait IFsrmFileScreenException_Impl: Sized + super::super::System::Com::IDis
     fn SetAllowedFileGroups(&self, allowlist: &::core::option::Option<IFsrmMutableCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreenException {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreenException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenException_Impl, const OFFSET: isize>() -> IFsrmFileScreenException_Vtbl {
         unsafe extern "system" fn Path<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenException_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, path: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2543,6 +2599,8 @@ pub trait IFsrmFileScreenManager_Impl: Sized + super::super::System::Com::IDispa
     fn EnumFileScreenExceptions(&self, path: &super::super::Foundation::BSTR, options: FsrmEnumOptions) -> ::windows::core::Result<IFsrmCommittableCollection>;
     fn CreateFileScreenCollection(&self) -> ::windows::core::Result<IFsrmCommittableCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreenManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreenManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenManager_Impl, const OFFSET: isize>() -> IFsrmFileScreenManager_Vtbl {
@@ -2670,6 +2728,8 @@ pub trait IFsrmFileScreenTemplate_Impl: Sized + super::super::System::Com::IDisp
     fn CommitAndUpdateDerived(&self, commitoptions: FsrmCommitOptions, applyoptions: FsrmTemplateApplyOptions) -> ::windows::core::Result<IFsrmDerivedObjectsResult>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreenTemplate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreenTemplate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenTemplate_Impl, const OFFSET: isize>() -> IFsrmFileScreenTemplate_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenTemplate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2722,6 +2782,8 @@ pub trait IFsrmFileScreenTemplateImported_Impl: Sized + super::super::System::Co
     fn SetOverwriteOnCommit(&self, overwrite: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreenTemplateImported {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreenTemplateImported_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenTemplateImported_Impl, const OFFSET: isize>() -> IFsrmFileScreenTemplateImported_Vtbl {
         unsafe extern "system" fn OverwriteOnCommit<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenTemplateImported_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, overwrite: *mut i16) -> ::windows::core::HRESULT {
@@ -2758,6 +2820,8 @@ pub trait IFsrmFileScreenTemplateManager_Impl: Sized + super::super::System::Com
     fn ExportTemplates(&self, filescreentemplatenamesarray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ImportTemplates(&self, serializedfilescreentemplates: &super::super::Foundation::BSTR, filescreentemplatenamesarray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<IFsrmCommittableCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmFileScreenTemplateManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmFileScreenTemplateManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmFileScreenTemplateManager_Impl, const OFFSET: isize>() -> IFsrmFileScreenTemplateManager_Vtbl {
@@ -2837,6 +2901,8 @@ pub trait IFsrmMutableCollection_Impl: Sized + super::super::System::Com::IDispa
     fn Clone(&self) -> ::windows::core::Result<IFsrmMutableCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmMutableCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmMutableCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmMutableCollection_Impl, const OFFSET: isize>() -> IFsrmMutableCollection_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmMutableCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, item: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -2885,6 +2951,8 @@ pub trait IFsrmObject_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Delete(&self) -> ::windows::core::Result<()>;
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmObject_Impl, const OFFSET: isize>() -> IFsrmObject_Vtbl {
@@ -2943,6 +3011,8 @@ pub trait IFsrmPathMapper_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn GetSharePathsForLocalPath(&self, localpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPathMapper {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPathMapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPathMapper_Impl, const OFFSET: isize>() -> IFsrmPathMapper_Vtbl {
         unsafe extern "system" fn GetSharePathsForLocalPath<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPathMapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, localpath: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, sharepaths: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -2973,6 +3043,8 @@ pub trait IFsrmPipelineModuleConnector_Impl: Sized + super::super::System::Com::
     fn HostingProcessPid(&self) -> ::windows::core::Result<i32>;
     fn Bind(&self, moduledefinition: &::core::option::Option<IFsrmPipelineModuleDefinition>, moduleimplementation: &::core::option::Option<IFsrmPipelineModuleImplementation>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPipelineModuleConnector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPipelineModuleConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPipelineModuleConnector_Impl, const OFFSET: isize>() -> IFsrmPipelineModuleConnector_Vtbl {
@@ -3060,6 +3132,8 @@ pub trait IFsrmPipelineModuleDefinition_Impl: Sized + super::super::System::Com:
     fn Parameters(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn SetParameters(&self, parameters: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPipelineModuleDefinition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPipelineModuleDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPipelineModuleDefinition_Impl, const OFFSET: isize>() -> IFsrmPipelineModuleDefinition_Vtbl {
@@ -3251,6 +3325,8 @@ pub trait IFsrmPipelineModuleImplementation_Impl: Sized + super::super::System::
     fn OnUnload(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPipelineModuleImplementation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPipelineModuleImplementation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPipelineModuleImplementation_Impl, const OFFSET: isize>() -> IFsrmPipelineModuleImplementation_Vtbl {
         unsafe extern "system" fn OnLoad<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPipelineModuleImplementation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, moduledefinition: ::windows::core::RawPtr, moduleconnector: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3286,6 +3362,8 @@ pub trait IFsrmProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Sources(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn PropertyFlags(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmProperty_Impl, const OFFSET: isize>() -> IFsrmProperty_Vtbl {
@@ -3369,6 +3447,8 @@ pub trait IFsrmPropertyBag_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn AddMessage(&self, message: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetFileStreamInterface(&self, accessmode: FsrmFileStreamingMode, interfacetype: FsrmFileStreamingInterfaceType) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPropertyBag {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyBag_Impl, const OFFSET: isize>() -> IFsrmPropertyBag_Vtbl {
@@ -3626,6 +3706,8 @@ pub trait IFsrmPropertyBag2_Impl: Sized + super::super::System::Com::IDispatch_I
     fn GetUntrustedInFileProperties(&self) -> ::windows::core::Result<IFsrmCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPropertyBag2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPropertyBag2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyBag2_Impl, const OFFSET: isize>() -> IFsrmPropertyBag2_Vtbl {
         unsafe extern "system" fn GetFieldValue<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyBag2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, field: FsrmPropertyBagField, value: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -3670,6 +3752,8 @@ pub trait IFsrmPropertyCondition_Impl: Sized + super::super::System::Com::IDispa
     fn SetValue(&self, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPropertyCondition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPropertyCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyCondition_Impl, const OFFSET: isize>() -> IFsrmPropertyCondition_Vtbl {
@@ -3754,6 +3838,8 @@ pub trait IFsrmPropertyDefinition_Impl: Sized + super::super::System::Com::IDisp
     fn Parameters(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn SetParameters(&self, parameters: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPropertyDefinition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPropertyDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyDefinition_Impl, const OFFSET: isize>() -> IFsrmPropertyDefinition_Vtbl {
@@ -3864,6 +3950,8 @@ pub trait IFsrmPropertyDefinition2_Impl: Sized + super::super::System::Com::IDis
     fn ValueDefinitions(&self) -> ::windows::core::Result<IFsrmCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPropertyDefinition2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPropertyDefinition2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyDefinition2_Impl, const OFFSET: isize>() -> IFsrmPropertyDefinition2_Vtbl {
         unsafe extern "system" fn PropertyDefinitionFlags<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyDefinition2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertydefinitionflags: *mut i32) -> ::windows::core::HRESULT {
@@ -3936,6 +4024,8 @@ pub trait IFsrmPropertyDefinitionValue_Impl: Sized + super::super::System::Com::
     fn UniqueID(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmPropertyDefinitionValue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmPropertyDefinitionValue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyDefinitionValue_Impl, const OFFSET: isize>() -> IFsrmPropertyDefinitionValue_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmPropertyDefinitionValue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4002,6 +4092,8 @@ pub trait IFsrmQuota_Impl: Sized + super::super::System::Com::IDispatch_Impl + I
     fn ResetPeakUsage(&self) -> ::windows::core::Result<()>;
     fn RefreshUsageProperties(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuota {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuota_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuota_Impl, const OFFSET: isize>() -> IFsrmQuota_Vtbl {
@@ -4074,6 +4166,8 @@ pub trait IFsrmQuotaBase_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn CreateThresholdAction(&self, threshold: i32, actiontype: FsrmActionType) -> ::windows::core::Result<IFsrmAction>;
     fn EnumThresholdActions(&self, threshold: i32) -> ::windows::core::Result<IFsrmCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaBase {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaBase_Impl, const OFFSET: isize>() -> IFsrmQuotaBase_Vtbl {
@@ -4190,6 +4284,8 @@ pub trait IFsrmQuotaManager_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Scan(&self, strpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn CreateQuotaCollection(&self) -> ::windows::core::Result<IFsrmCommittableCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaManager_Impl, const OFFSET: isize>() -> IFsrmQuotaManager_Vtbl {
@@ -4344,6 +4440,8 @@ pub trait IFsrmQuotaManagerEx_Impl: Sized + super::super::System::Com::IDispatch
     fn IsAffectedByQuota(&self, path: &super::super::Foundation::BSTR, options: FsrmEnumOptions) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaManagerEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaManagerEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaManagerEx_Impl, const OFFSET: isize>() -> IFsrmQuotaManagerEx_Vtbl {
         unsafe extern "system" fn IsAffectedByQuota<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaManagerEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, path: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, options: FsrmEnumOptions, affected: *mut i16) -> ::windows::core::HRESULT {
@@ -4372,6 +4470,8 @@ pub trait IFsrmQuotaObject_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn MatchesSourceTemplate(&self) -> ::windows::core::Result<i16>;
     fn ApplyTemplate(&self, quotatemplatename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaObject_Impl, const OFFSET: isize>() -> IFsrmQuotaObject_Vtbl {
@@ -4457,6 +4557,8 @@ pub trait IFsrmQuotaTemplate_Impl: Sized + super::super::System::Com::IDispatch_
     fn CommitAndUpdateDerived(&self, commitoptions: FsrmCommitOptions, applyoptions: FsrmTemplateApplyOptions) -> ::windows::core::Result<IFsrmDerivedObjectsResult>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaTemplate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaTemplate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaTemplate_Impl, const OFFSET: isize>() -> IFsrmQuotaTemplate_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaTemplate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4509,6 +4611,8 @@ pub trait IFsrmQuotaTemplateImported_Impl: Sized + super::super::System::Com::ID
     fn SetOverwriteOnCommit(&self, overwrite: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaTemplateImported {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaTemplateImported_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaTemplateImported_Impl, const OFFSET: isize>() -> IFsrmQuotaTemplateImported_Vtbl {
         unsafe extern "system" fn OverwriteOnCommit<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaTemplateImported_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, overwrite: *mut i16) -> ::windows::core::HRESULT {
@@ -4545,6 +4649,8 @@ pub trait IFsrmQuotaTemplateManager_Impl: Sized + super::super::System::Com::IDi
     fn ExportTemplates(&self, quotatemplatenamesarray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ImportTemplates(&self, serializedquotatemplates: &super::super::Foundation::BSTR, quotatemplatenamesarray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<IFsrmCommittableCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmQuotaTemplateManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmQuotaTemplateManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmQuotaTemplateManager_Impl, const OFFSET: isize>() -> IFsrmQuotaTemplateManager_Vtbl {
@@ -4628,6 +4734,8 @@ pub trait IFsrmReport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetFilter(&self, filter: FsrmReportFilter, filtervalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmReport {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmReport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmReport_Impl, const OFFSET: isize>() -> IFsrmReport_Vtbl {
@@ -4743,6 +4851,8 @@ pub trait IFsrmReportJob_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn WaitForCompletion(&self, waitseconds: i32) -> ::windows::core::Result<i16>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmReportJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmReportJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmReportJob_Impl, const OFFSET: isize>() -> IFsrmReportJob_Vtbl {
@@ -4936,6 +5046,8 @@ pub trait IFsrmReportManager_Impl: Sized + super::super::System::Com::IDispatch_
     fn SetReportSizeLimit(&self, limit: FsrmReportLimit, limitvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmReportManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmReportManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmReportManager_Impl, const OFFSET: isize>() -> IFsrmReportManager_Vtbl {
         unsafe extern "system" fn EnumReportJobs<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmReportManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: FsrmEnumOptions, reportjobs: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5056,6 +5168,8 @@ pub trait IFsrmReportScheduler_Impl: Sized + super::super::System::Com::IDispatc
     fn DeleteScheduleTask(&self, taskname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmReportScheduler {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmReportScheduler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmReportScheduler_Impl, const OFFSET: isize>() -> IFsrmReportScheduler_Vtbl {
         unsafe extern "system" fn VerifyNamespaces<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmReportScheduler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, namespacessafearray: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -5105,6 +5219,8 @@ pub trait IFsrmRule_Impl: Sized + super::super::System::Com::IDispatch_Impl + IF
     fn SetParameters(&self, parameters: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn LastModified(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmRule {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmRule_Impl, const OFFSET: isize>() -> IFsrmRule_Vtbl {
@@ -5247,6 +5363,8 @@ pub trait IFsrmSetting_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetActionRunLimitInterval(&self, actiontype: FsrmActionType) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmSetting {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmSetting_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmSetting_Impl, const OFFSET: isize>() -> IFsrmSetting_Vtbl {
         unsafe extern "system" fn SmtpServer<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmSetting_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, smtpserver: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5381,6 +5499,8 @@ pub trait IFsrmStorageModuleDefinition_Impl: Sized + super::super::System::Com::
     fn SetUpdatesFileContent(&self, updatesfilecontent: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmStorageModuleDefinition {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmStorageModuleDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmStorageModuleDefinition_Impl, const OFFSET: isize>() -> IFsrmStorageModuleDefinition_Vtbl {
         unsafe extern "system" fn Capabilities<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmStorageModuleDefinition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, capabilities: *mut FsrmStorageModuleCaps) -> ::windows::core::HRESULT {
@@ -5451,6 +5571,8 @@ pub trait IFsrmStorageModuleImplementation_Impl: Sized + super::super::System::C
     fn LoadProperties(&self, propertybag: &::core::option::Option<IFsrmPropertyBag>) -> ::windows::core::Result<()>;
     fn SaveProperties(&self, propertybag: &::core::option::Option<IFsrmPropertyBag>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsrmStorageModuleImplementation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsrmStorageModuleImplementation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsrmStorageModuleImplementation_Impl, const OFFSET: isize>() -> IFsrmStorageModuleImplementation_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
@@ -23,6 +23,8 @@ pub trait IDiskQuotaControl_Impl: Sized + super::super::System::Com::IConnection
     fn ShutdownNameResolution(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDiskQuotaControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDiskQuotaControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaControl_Impl, const OFFSET: isize>() -> IDiskQuotaControl_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, breadwrite: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -192,6 +194,7 @@ impl IDiskQuotaControl_Vtbl {
 pub trait IDiskQuotaEvents_Impl: Sized {
     fn OnUserNameChanged(&self, puser: &::core::option::Option<IDiskQuotaUser>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDiskQuotaEvents {}
 impl IDiskQuotaEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaEvents_Impl, const OFFSET: isize>() -> IDiskQuotaEvents_Vtbl {
         unsafe extern "system" fn OnUserNameChanged<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puser: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -223,6 +226,8 @@ pub trait IDiskQuotaUser_Impl: Sized {
     fn Invalidate(&self) -> ::windows::core::Result<()>;
     fn GetAccountStatus(&self, pdwstatus: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDiskQuotaUser {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDiskQuotaUser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaUser_Impl, const OFFSET: isize>() -> IDiskQuotaUser_Vtbl {
@@ -330,6 +335,7 @@ pub trait IDiskQuotaUserBatch_Impl: Sized {
     fn RemoveAll(&self) -> ::windows::core::Result<()>;
     fn FlushToDisk(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDiskQuotaUserBatch {}
 impl IDiskQuotaUserBatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaUserBatch_Impl, const OFFSET: isize>() -> IDiskQuotaUserBatch_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: IDiskQuotaUserBatch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puser: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -370,6 +376,7 @@ pub trait IEnumDiskQuotaUsers_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDiskQuotaUsers>;
 }
+impl ::windows::core::RuntimeName for IEnumDiskQuotaUsers {}
 impl IEnumDiskQuotaUsers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDiskQuotaUsers_Impl, const OFFSET: isize>() -> IEnumDiskQuotaUsers_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDiskQuotaUsers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cusers: u32, rgusers: *mut ::windows::core::RawPtr, pcusersfetched: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
@@ -3,6 +3,8 @@ pub trait DDiscFormat2DataEvents_Impl: Sized + super::super::System::Com::IDispa
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DDiscFormat2DataEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DDiscFormat2DataEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DDiscFormat2DataEvents_Impl, const OFFSET: isize>() -> DDiscFormat2DataEvents_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: DDiscFormat2DataEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, object: ::windows::core::RawPtr, progress: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -20,6 +22,8 @@ impl DDiscFormat2DataEvents_Vtbl {
 pub trait DDiscFormat2EraseEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, elapsedseconds: i32, estimatedtotalseconds: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DDiscFormat2EraseEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DDiscFormat2EraseEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DDiscFormat2EraseEvents_Impl, const OFFSET: isize>() -> DDiscFormat2EraseEvents_Vtbl {
@@ -39,6 +43,8 @@ pub trait DDiscFormat2RawCDEvents_Impl: Sized + super::super::System::Com::IDisp
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DDiscFormat2RawCDEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DDiscFormat2RawCDEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DDiscFormat2RawCDEvents_Impl, const OFFSET: isize>() -> DDiscFormat2RawCDEvents_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: DDiscFormat2RawCDEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, object: ::windows::core::RawPtr, progress: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -56,6 +62,8 @@ impl DDiscFormat2RawCDEvents_Vtbl {
 pub trait DDiscFormat2TrackAtOnceEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DDiscFormat2TrackAtOnceEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DDiscFormat2TrackAtOnceEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DDiscFormat2TrackAtOnceEvents_Impl, const OFFSET: isize>() -> DDiscFormat2TrackAtOnceEvents_Vtbl {
@@ -75,6 +83,8 @@ pub trait DDiscMaster2Events_Impl: Sized + super::super::System::Com::IDispatch_
     fn NotifyDeviceAdded(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, uniqueid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn NotifyDeviceRemoved(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, uniqueid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DDiscMaster2Events {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DDiscMaster2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DDiscMaster2Events_Impl, const OFFSET: isize>() -> DDiscMaster2Events_Vtbl {
@@ -103,6 +113,8 @@ pub trait DFileSystemImageEvents_Impl: Sized + super::super::System::Com::IDispa
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, currentfile: &super::super::Foundation::BSTR, copiedsectors: i32, totalsectors: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DFileSystemImageEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DFileSystemImageEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DFileSystemImageEvents_Impl, const OFFSET: isize>() -> DFileSystemImageEvents_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: DFileSystemImageEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, object: ::windows::core::RawPtr, currentfile: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, copiedsectors: i32, totalsectors: i32) -> ::windows::core::HRESULT {
@@ -120,6 +132,8 @@ impl DFileSystemImageEvents_Vtbl {
 pub trait DFileSystemImageImportEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UpdateImport(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, filesystem: FsiFileSystems, currentitem: &super::super::Foundation::BSTR, importeddirectoryitems: i32, totaldirectoryitems: i32, importedfileitems: i32, totalfileitems: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DFileSystemImageImportEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DFileSystemImageImportEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DFileSystemImageImportEvents_Impl, const OFFSET: isize>() -> DFileSystemImageImportEvents_Vtbl {
@@ -139,6 +153,8 @@ pub trait DWriteEngine2Events_Impl: Sized + super::super::System::Com::IDispatch
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DWriteEngine2Events {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DWriteEngine2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DWriteEngine2Events_Impl, const OFFSET: isize>() -> DWriteEngine2Events_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: DWriteEngine2Events_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, object: ::windows::core::RawPtr, progress: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -157,6 +173,8 @@ pub trait IBlockRange_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartLba(&self) -> ::windows::core::Result<i32>;
     fn EndLba(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBlockRange {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBlockRange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBlockRange_Impl, const OFFSET: isize>() -> IBlockRange_Vtbl {
@@ -197,6 +215,8 @@ pub trait IBlockRangeList_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn BlockRanges(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBlockRangeList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBlockRangeList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBlockRangeList_Impl, const OFFSET: isize>() -> IBlockRangeList_Vtbl {
         unsafe extern "system" fn BlockRanges<Identity: ::windows::core::IUnknownImpl, Impl: IBlockRangeList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -228,6 +248,8 @@ pub trait IBootOptions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ImageSize(&self) -> ::windows::core::Result<u32>;
     fn AssignBootImage(&self, newval: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBootOptions {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBootOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBootOptions_Impl, const OFFSET: isize>() -> IBootOptions_Vtbl {
@@ -327,6 +349,7 @@ pub trait IBurnVerification_Impl: Sized {
     fn SetBurnVerificationLevel(&self, value: IMAPI_BURN_VERIFICATION_LEVEL) -> ::windows::core::Result<()>;
     fn BurnVerificationLevel(&self) -> ::windows::core::Result<IMAPI_BURN_VERIFICATION_LEVEL>;
 }
+impl ::windows::core::RuntimeName for IBurnVerification {}
 impl IBurnVerification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBurnVerification_Impl, const OFFSET: isize>() -> IBurnVerification_Vtbl {
         unsafe extern "system" fn SetBurnVerificationLevel<Identity: ::windows::core::IUnknownImpl, Impl: IBurnVerification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: IMAPI_BURN_VERIFICATION_LEVEL) -> ::windows::core::HRESULT {
@@ -363,6 +386,8 @@ pub trait IDiscFormat2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MediaHeuristicallyBlank(&self) -> ::windows::core::Result<i16>;
     fn SupportedMediaTypes(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2_Impl, const OFFSET: isize>() -> IDiscFormat2_Vtbl {
@@ -469,6 +494,8 @@ pub trait IDiscFormat2Data_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn CancelWrite(&self) -> ::windows::core::Result<()>;
     fn SetWriteSpeed(&self, requestedsectorspersecond: i32, rotationtypeispurecav: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2Data {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2Data_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2Data_Impl, const OFFSET: isize>() -> IDiscFormat2Data_Vtbl {
@@ -812,6 +839,8 @@ pub trait IDiscFormat2DataEventArgs_Impl: Sized + super::super::System::Com::IDi
     fn CurrentAction(&self) -> ::windows::core::Result<IMAPI_FORMAT2_DATA_WRITE_ACTION>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2DataEventArgs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2DataEventArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2DataEventArgs_Impl, const OFFSET: isize>() -> IDiscFormat2DataEventArgs_Vtbl {
         unsafe extern "system" fn ElapsedTime<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2DataEventArgs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i32) -> ::windows::core::HRESULT {
@@ -881,6 +910,8 @@ pub trait IDiscFormat2Erase_Impl: Sized + super::super::System::Com::IDispatch_I
     fn ClientName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn EraseMedia(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2Erase {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2Erase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2Erase_Impl, const OFFSET: isize>() -> IDiscFormat2Erase_Vtbl {
@@ -991,6 +1022,8 @@ pub trait IDiscFormat2RawCD_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SupportedWriteSpeeds(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn SupportedWriteSpeedDescriptors(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2RawCD {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2RawCD_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2RawCD_Impl, const OFFSET: isize>() -> IDiscFormat2RawCD_Vtbl {
@@ -1237,6 +1270,8 @@ pub trait IDiscFormat2RawCDEventArgs_Impl: Sized + super::super::System::Com::ID
     fn RemainingTime(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2RawCDEventArgs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2RawCDEventArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2RawCDEventArgs_Impl, const OFFSET: isize>() -> IDiscFormat2RawCDEventArgs_Vtbl {
         unsafe extern "system" fn CurrentAction<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2RawCDEventArgs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut IMAPI_FORMAT2_RAW_CD_WRITE_ACTION) -> ::windows::core::HRESULT {
@@ -1311,6 +1346,8 @@ pub trait IDiscFormat2TrackAtOnce_Impl: Sized + super::super::System::Com::IDisp
     fn SupportedWriteSpeeds(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn SupportedWriteSpeedDescriptors(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2TrackAtOnce {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2TrackAtOnce_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2TrackAtOnce_Impl, const OFFSET: isize>() -> IDiscFormat2TrackAtOnce_Vtbl {
@@ -1576,6 +1613,8 @@ pub trait IDiscFormat2TrackAtOnceEventArgs_Impl: Sized + super::super::System::C
     fn RemainingTime(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscFormat2TrackAtOnceEventArgs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscFormat2TrackAtOnceEventArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2TrackAtOnceEventArgs_Impl, const OFFSET: isize>() -> IDiscFormat2TrackAtOnceEventArgs_Vtbl {
         unsafe extern "system" fn CurrentTrackNumber<Identity: ::windows::core::IUnknownImpl, Impl: IDiscFormat2TrackAtOnceEventArgs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i32) -> ::windows::core::HRESULT {
@@ -1648,6 +1687,7 @@ pub trait IDiscMaster_Impl: Sized {
     fn RecordDisc(&self, bsimulate: u8, bejectafterburn: u8) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDiscMaster {}
 impl IDiscMaster_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscMaster_Impl, const OFFSET: isize>() -> IDiscMaster_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IDiscMaster_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1768,6 +1808,8 @@ pub trait IDiscMaster2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsSupportedEnvironment(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscMaster2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscMaster2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscMaster2_Impl, const OFFSET: isize>() -> IDiscMaster2_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IDiscMaster2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunk: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1837,6 +1879,7 @@ pub trait IDiscMasterProgressEvents_Impl: Sized {
     fn NotifyBurnComplete(&self, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn NotifyEraseComplete(&self, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDiscMasterProgressEvents {}
 impl IDiscMasterProgressEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscMasterProgressEvents_Impl, const OFFSET: isize>() -> IDiscMasterProgressEvents_Vtbl {
         unsafe extern "system" fn QueryCancel<Identity: ::windows::core::IUnknownImpl, Impl: IDiscMasterProgressEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbcancel: *mut u8) -> ::windows::core::HRESULT {
@@ -1925,6 +1968,8 @@ pub trait IDiscRecorder_Impl: Sized {
     fn Erase(&self, bfullerase: u8) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IDiscRecorder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IDiscRecorder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscRecorder_Impl, const OFFSET: isize>() -> IDiscRecorder_Vtbl {
@@ -2080,6 +2125,8 @@ pub trait IDiscRecorder2_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SupportedModePages(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn ExclusiveAccessOwner(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDiscRecorder2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDiscRecorder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscRecorder2_Impl, const OFFSET: isize>() -> IDiscRecorder2_Vtbl {
@@ -2323,6 +2370,8 @@ pub trait IDiscRecorder2Ex_Impl: Sized {
     fn GetMaximumPageAlignedTransferSize(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDiscRecorder2Ex {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDiscRecorder2Ex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDiscRecorder2Ex_Impl, const OFFSET: isize>() -> IDiscRecorder2Ex_Vtbl {
         unsafe extern "system" fn SendCommandNoData<Identity: ::windows::core::IUnknownImpl, Impl: IDiscRecorder2Ex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cdb: *const u8, cdbsize: u32, sensebuffer: *mut u8, timeout: u32) -> ::windows::core::HRESULT {
@@ -2465,6 +2514,7 @@ pub trait IEnumDiscMasterFormats_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDiscMasterFormats>;
 }
+impl ::windows::core::RuntimeName for IEnumDiscMasterFormats {}
 impl IEnumDiscMasterFormats_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDiscMasterFormats_Impl, const OFFSET: isize>() -> IEnumDiscMasterFormats_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDiscMasterFormats_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cformats: u32, lpiidformatid: *mut ::windows::core::GUID, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2511,6 +2561,7 @@ pub trait IEnumDiscRecorders_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDiscRecorders>;
 }
+impl ::windows::core::RuntimeName for IEnumDiscRecorders {}
 impl IEnumDiscRecorders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDiscRecorders_Impl, const OFFSET: isize>() -> IEnumDiscRecorders_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDiscRecorders_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crecorders: u32, pprecorder: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2559,6 +2610,8 @@ pub trait IEnumFsiItems_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumFsiItems>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumFsiItems {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumFsiItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFsiItems_Impl, const OFFSET: isize>() -> IEnumFsiItems_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFsiItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2606,6 +2659,8 @@ pub trait IEnumProgressItems_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumProgressItems>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumProgressItems {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumProgressItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumProgressItems_Impl, const OFFSET: isize>() -> IEnumProgressItems_Vtbl {
@@ -2700,6 +2755,8 @@ pub trait IFileSystemImage_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn MultisessionInterfaces(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn SetMultisessionInterfaces(&self, newval: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFileSystemImage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFileSystemImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImage_Impl, const OFFSET: isize>() -> IFileSystemImage_Vtbl {
@@ -3209,6 +3266,8 @@ pub trait IFileSystemImage2_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetBootImageOptionsArray(&self, newval: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFileSystemImage2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFileSystemImage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImage2_Impl, const OFFSET: isize>() -> IFileSystemImage2_Vtbl {
         unsafe extern "system" fn BootImageOptionsArray<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -3243,6 +3302,8 @@ pub trait IFileSystemImage3_Impl: Sized + super::super::System::Com::IDispatch_I
     fn SetCreateRedundantUdfMetadataFiles(&self, newval: i16) -> ::windows::core::Result<()>;
     fn ProbeSpecificFileSystem(&self, filesystemtoprobe: FsiFileSystems) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFileSystemImage3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFileSystemImage3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImage3_Impl, const OFFSET: isize>() -> IFileSystemImage3_Vtbl {
@@ -3292,6 +3353,8 @@ pub trait IFileSystemImageResult_Impl: Sized + super::super::System::Com::IDispa
     fn BlockSize(&self) -> ::windows::core::Result<i32>;
     fn DiscId(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFileSystemImageResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFileSystemImageResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImageResult_Impl, const OFFSET: isize>() -> IFileSystemImageResult_Vtbl {
@@ -3368,6 +3431,8 @@ pub trait IFileSystemImageResult2_Impl: Sized + super::super::System::Com::IDisp
     fn ModifiedBlocks(&self) -> ::windows::core::Result<IBlockRangeList>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFileSystemImageResult2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFileSystemImageResult2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImageResult2_Impl, const OFFSET: isize>() -> IFileSystemImageResult2_Vtbl {
         unsafe extern "system" fn ModifiedBlocks<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemImageResult2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3400,6 +3465,8 @@ pub trait IFsiDirectoryItem_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Remove(&self, path: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn RemoveTree(&self, path: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsiDirectoryItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsiDirectoryItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsiDirectoryItem_Impl, const OFFSET: isize>() -> IFsiDirectoryItem_Vtbl {
@@ -3500,6 +3567,8 @@ pub trait IFsiDirectoryItem2_Impl: Sized + super::super::System::Com::IDispatch_
     fn AddTreeWithNamedStreams(&self, sourcedirectory: &super::super::Foundation::BSTR, includebasedirectory: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsiDirectoryItem2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsiDirectoryItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsiDirectoryItem2_Impl, const OFFSET: isize>() -> IFsiDirectoryItem2_Vtbl {
         unsafe extern "system" fn AddTreeWithNamedStreams<Identity: ::windows::core::IUnknownImpl, Impl: IFsiDirectoryItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sourcedirectory: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, includebasedirectory: i16) -> ::windows::core::HRESULT {
@@ -3521,6 +3590,8 @@ pub trait IFsiFileItem_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn Data(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
     fn SetData(&self, newval: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsiFileItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsiFileItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsiFileItem_Impl, const OFFSET: isize>() -> IFsiFileItem_Vtbl {
@@ -3595,6 +3666,8 @@ pub trait IFsiFileItem2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn IsRealTime(&self) -> ::windows::core::Result<i16>;
     fn SetIsRealTime(&self, newval: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsiFileItem2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsiFileItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsiFileItem2_Impl, const OFFSET: isize>() -> IFsiFileItem2_Vtbl {
@@ -3675,6 +3748,8 @@ pub trait IFsiItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FileSystemName(&self, filesystem: FsiFileSystems) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn FileSystemPath(&self, filesystem: FsiFileSystems) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsiItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsiItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsiItem_Impl, const OFFSET: isize>() -> IFsiItem_Vtbl {
@@ -3814,6 +3889,8 @@ pub trait IFsiNamedStreams_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn EnumNamedStreams(&self) -> ::windows::core::Result<IEnumFsiItems>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFsiNamedStreams {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFsiNamedStreams_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFsiNamedStreams_Impl, const OFFSET: isize>() -> IFsiNamedStreams_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IFsiNamedStreams_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3881,6 +3958,8 @@ pub trait IIsoImageManager_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn Validate(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IIsoImageManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IIsoImageManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsoImageManager_Impl, const OFFSET: isize>() -> IIsoImageManager_Vtbl {
         unsafe extern "system" fn Path<Identity: ::windows::core::IUnknownImpl, Impl: IIsoImageManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3942,6 +4021,8 @@ pub trait IJolietDiscMaster_Impl: Sized {
     fn GetJolietProperties(&self) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::IPropertyStorage>;
     fn SetJolietProperties(&self, ppropstg: &::core::option::Option<super::super::System::Com::StructuredStorage::IPropertyStorage>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IJolietDiscMaster {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IJolietDiscMaster_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJolietDiscMaster_Impl, const OFFSET: isize>() -> IJolietDiscMaster_Vtbl {
@@ -4021,6 +4102,8 @@ pub trait IMultisession_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn ImportRecorder(&self) -> ::windows::core::Result<IDiscRecorder2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMultisession {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMultisession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultisession_Impl, const OFFSET: isize>() -> IMultisession_Vtbl {
         unsafe extern "system" fn IsSupportedOnCurrentMediaState<Identity: ::windows::core::IUnknownImpl, Impl: IMultisession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i16) -> ::windows::core::HRESULT {
@@ -4080,6 +4163,8 @@ pub trait IMultisessionRandomWrite_Impl: Sized + super::super::System::Com::IDis
     fn TotalSectorsOnMedia(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMultisessionRandomWrite {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMultisessionRandomWrite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultisessionRandomWrite_Impl, const OFFSET: isize>() -> IMultisessionRandomWrite_Vtbl {
         unsafe extern "system" fn WriteUnitSize<Identity: ::windows::core::IUnknownImpl, Impl: IMultisessionRandomWrite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i32) -> ::windows::core::HRESULT {
@@ -4134,6 +4219,8 @@ pub trait IMultisessionSequential_Impl: Sized + super::super::System::Com::IDisp
     fn NextWritableAddress(&self) -> ::windows::core::Result<i32>;
     fn FreeSectorsOnMedia(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMultisessionSequential {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMultisessionSequential_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultisessionSequential_Impl, const OFFSET: isize>() -> IMultisessionSequential_Vtbl {
@@ -4210,6 +4297,8 @@ pub trait IMultisessionSequential2_Impl: Sized + super::super::System::Com::IDis
     fn WriteUnitSize(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMultisessionSequential2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMultisessionSequential2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultisessionSequential2_Impl, const OFFSET: isize>() -> IMultisessionSequential2_Vtbl {
         unsafe extern "system" fn WriteUnitSize<Identity: ::windows::core::IUnknownImpl, Impl: IMultisessionSequential2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i32) -> ::windows::core::HRESULT {
@@ -4236,6 +4325,8 @@ pub trait IProgressItem_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn LastBlock(&self) -> ::windows::core::Result<u32>;
     fn BlockCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IProgressItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IProgressItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProgressItem_Impl, const OFFSET: isize>() -> IProgressItem_Vtbl {
@@ -4304,6 +4395,8 @@ pub trait IProgressItems_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn ProgressItemFromDescription(&self, description: &super::super::Foundation::BSTR) -> ::windows::core::Result<IProgressItem>;
     fn EnumProgressItems(&self) -> ::windows::core::Result<IEnumProgressItems>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IProgressItems {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IProgressItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProgressItems_Impl, const OFFSET: isize>() -> IProgressItems_Vtbl {
@@ -4409,6 +4502,8 @@ pub trait IRawCDImageCreator_Impl: Sized + super::super::System::Com::IDispatch_
     fn LastUsedUserSectorInImage(&self) -> ::windows::core::Result<i32>;
     fn ExpectedTableOfContents(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRawCDImageCreator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRawCDImageCreator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawCDImageCreator_Impl, const OFFSET: isize>() -> IRawCDImageCreator_Vtbl {
@@ -4623,6 +4718,8 @@ pub trait IRawCDImageTrackInfo_Impl: Sized + super::super::System::Com::IDispatc
     fn ClearTrackIndex(&self, lbaoffset: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRawCDImageTrackInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRawCDImageTrackInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawCDImageTrackInfo_Impl, const OFFSET: isize>() -> IRawCDImageTrackInfo_Vtbl {
         unsafe extern "system" fn StartingLba<Identity: ::windows::core::IUnknownImpl, Impl: IRawCDImageTrackInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i32) -> ::windows::core::HRESULT {
@@ -4769,6 +4866,7 @@ pub trait IRedbookDiscMaster_Impl: Sized {
     fn AddAudioTrackBlocks(&self, pby: *const u8, cb: i32) -> ::windows::core::Result<()>;
     fn CloseAudioTrack(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRedbookDiscMaster {}
 impl IRedbookDiscMaster_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRedbookDiscMaster_Impl, const OFFSET: isize>() -> IRedbookDiscMaster_Vtbl {
         unsafe extern "system" fn GetTotalAudioTracks<Identity: ::windows::core::IUnknownImpl, Impl: IRedbookDiscMaster_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pntracks: *mut i32) -> ::windows::core::HRESULT {
@@ -4865,6 +4963,8 @@ pub trait IStreamConcatenate_Impl: Sized + super::super::System::Com::ISequentia
     fn Append2(&self, streams: *const ::core::option::Option<super::super::System::Com::IStream>, streamcount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IStreamConcatenate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IStreamConcatenate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamConcatenate_Impl, const OFFSET: isize>() -> IStreamConcatenate_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IStreamConcatenate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stream1: ::windows::core::RawPtr, stream2: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4904,6 +5004,8 @@ pub trait IStreamInterleave_Impl: Sized + super::super::System::Com::ISequential
     fn Initialize(&self, streams: *const ::core::option::Option<super::super::System::Com::IStream>, interleavesizes: *const u32, streamcount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IStreamInterleave {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IStreamInterleave_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamInterleave_Impl, const OFFSET: isize>() -> IStreamInterleave_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IStreamInterleave_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, streams: *const ::windows::core::RawPtr, interleavesizes: *const u32, streamcount: u32) -> ::windows::core::HRESULT {
@@ -4924,6 +5026,8 @@ pub trait IStreamPseudoRandomBased_Impl: Sized + super::super::System::Com::ISeq
     fn put_ExtendedSeed(&self, values: *const u32, ecount: u32) -> ::windows::core::Result<()>;
     fn get_ExtendedSeed(&self, values: *mut *mut u32, ecount: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IStreamPseudoRandomBased {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IStreamPseudoRandomBased_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamPseudoRandomBased_Impl, const OFFSET: isize>() -> IStreamPseudoRandomBased_Vtbl {
@@ -4981,6 +5085,8 @@ pub trait IWriteEngine2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn BytesPerSector(&self) -> ::windows::core::Result<i32>;
     fn WriteInProgress(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWriteEngine2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWriteEngine2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWriteEngine2_Impl, const OFFSET: isize>() -> IWriteEngine2_Vtbl {
@@ -5117,6 +5223,8 @@ pub trait IWriteEngine2EventArgs_Impl: Sized + super::super::System::Com::IDispa
     fn FreeSystemBuffer(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWriteEngine2EventArgs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWriteEngine2EventArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWriteEngine2EventArgs_Impl, const OFFSET: isize>() -> IWriteEngine2EventArgs_Vtbl {
         unsafe extern "system" fn StartLba<Identity: ::windows::core::IUnknownImpl, Impl: IWriteEngine2EventArgs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut i32) -> ::windows::core::HRESULT {
@@ -5217,6 +5325,8 @@ pub trait IWriteSpeedDescriptor_Impl: Sized + super::super::System::Com::IDispat
     fn RotationTypeIsPureCAV(&self) -> ::windows::core::Result<i16>;
     fn WriteSpeed(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWriteSpeedDescriptor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWriteSpeedDescriptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWriteSpeedDescriptor_Impl, const OFFSET: isize>() -> IWriteSpeedDescriptor_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/impl.rs
@@ -7,6 +7,8 @@ pub trait IFilter_Impl: Sized {
     fn BindRegion(&self, origpos: &FILTERREGION, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> i32;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IFilter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilter_Impl, const OFFSET: isize>() -> IFilter_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, grfflags: u32, cattributes: u32, aattributes: *const FULLPROPSPEC, pflags: *mut u32) -> i32 {
@@ -51,6 +53,7 @@ pub trait IPhraseSink_Impl: Sized {
     fn PutSmallPhrase(&self, pwcnoun: &::windows::core::PCWSTR, cwcnoun: u32, pwcmodifier: &::windows::core::PCWSTR, cwcmodifier: u32, ulattachmenttype: u32) -> ::windows::core::Result<()>;
     fn PutPhrase(&self, pwcphrase: &::windows::core::PCWSTR, cwcphrase: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPhraseSink {}
 impl IPhraseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPhraseSink_Impl, const OFFSET: isize>() -> IPhraseSink_Vtbl {
         unsafe extern "system" fn PutSmallPhrase<Identity: ::windows::core::IUnknownImpl, Impl: IPhraseSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwcnoun: ::windows::core::PCWSTR, cwcnoun: u32, pwcmodifier: ::windows::core::PCWSTR, cwcmodifier: u32, ulattachmenttype: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
@@ -4,6 +4,7 @@ pub trait IEnumOfflineFilesItems_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumOfflineFilesItems>;
 }
+impl ::windows::core::RuntimeName for IEnumOfflineFilesItems {}
 impl IEnumOfflineFilesItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOfflineFilesItems_Impl, const OFFSET: isize>() -> IEnumOfflineFilesItems_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOfflineFilesItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -50,6 +51,7 @@ pub trait IEnumOfflineFilesSettings_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumOfflineFilesSettings>;
 }
+impl ::windows::core::RuntimeName for IEnumOfflineFilesSettings {}
 impl IEnumOfflineFilesSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOfflineFilesSettings_Impl, const OFFSET: isize>() -> IEnumOfflineFilesSettings_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOfflineFilesSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -110,6 +112,8 @@ pub trait IOfflineFilesCache_Impl: Sized {
     fn EnumSettingObjects(&self) -> ::windows::core::Result<IEnumOfflineFilesSettings>;
     fn IsPathCacheable(&self, pszpath: &::windows::core::PCWSTR, pbcacheable: *mut super::super::Foundation::BOOL, psharecachingmode: *mut OFFLINEFILES_CACHING_MODE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesCache {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesCache_Impl, const OFFSET: isize>() -> IOfflineFilesCache_Vtbl {
@@ -258,6 +262,8 @@ pub trait IOfflineFilesCache2_Impl: Sized + IOfflineFilesCache_Impl {
     fn RenameItemEx(&self, pszpathoriginal: &::windows::core::PCWSTR, pszpathnew: &::windows::core::PCWSTR, breplaceifexists: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesCache2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesCache2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesCache2_Impl, const OFFSET: isize>() -> IOfflineFilesCache2_Vtbl {
         unsafe extern "system" fn RenameItemEx<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesCache2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpathoriginal: ::windows::core::PCWSTR, pszpathnew: ::windows::core::PCWSTR, breplaceifexists: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -280,6 +286,8 @@ pub trait IOfflineFilesChangeInfo_Impl: Sized {
     fn IsLocallyModifiedAttributes(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn IsLocallyModifiedTime(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesChangeInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesChangeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesChangeInfo_Impl, const OFFSET: isize>() -> IOfflineFilesChangeInfo_Vtbl {
@@ -365,6 +373,8 @@ pub trait IOfflineFilesConnectionInfo_Impl: Sized {
     fn TransitionOffline(&self, hwndparent: super::super::Foundation::HWND, dwflags: u32, bforceopenfilesclosed: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesConnectionInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesConnectionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesConnectionInfo_Impl, const OFFSET: isize>() -> IOfflineFilesConnectionInfo_Vtbl {
         unsafe extern "system" fn GetConnectState<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesConnectionInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnectstate: *mut OFFLINEFILES_CONNECT_STATE, pofflinereason: *mut OFFLINEFILES_OFFLINE_REASON) -> ::windows::core::HRESULT {
@@ -408,6 +418,8 @@ impl IOfflineFilesConnectionInfo_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesDirectoryItem_Impl: Sized + IOfflineFilesItem_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesDirectoryItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesDirectoryItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesDirectoryItem_Impl, const OFFSET: isize>() -> IOfflineFilesDirectoryItem_Vtbl {
         Self { base__: IOfflineFilesItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -420,6 +432,7 @@ pub trait IOfflineFilesDirtyInfo_Impl: Sized {
     fn LocalDirtyByteCount(&self) -> ::windows::core::Result<i64>;
     fn RemoteDirtyByteCount(&self) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IOfflineFilesDirtyInfo {}
 impl IOfflineFilesDirtyInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesDirtyInfo_Impl, const OFFSET: isize>() -> IOfflineFilesDirtyInfo_Vtbl {
         unsafe extern "system" fn LocalDirtyByteCount<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesDirtyInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdirtybytecount: *mut i64) -> ::windows::core::HRESULT {
@@ -459,6 +472,8 @@ pub trait IOfflineFilesErrorInfo_Impl: Sized {
     fn GetRawData(&self) -> ::windows::core::Result<*mut super::super::System::Com::BYTE_BLOB>;
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOfflineFilesErrorInfo {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOfflineFilesErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesErrorInfo_Impl, const OFFSET: isize>() -> IOfflineFilesErrorInfo_Vtbl {
@@ -522,6 +537,8 @@ pub trait IOfflineFilesEvents_Impl: Sized {
     fn DataLost(&self) -> ::windows::core::Result<()>;
     fn Ping(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents_Impl, const OFFSET: isize>() -> IOfflineFilesEvents_Vtbl {
@@ -696,6 +713,8 @@ pub trait IOfflineFilesEvents2_Impl: Sized + IOfflineFilesEvents_Impl {
     fn SettingsChangesApplied(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesEvents2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesEvents2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents2_Impl, const OFFSET: isize>() -> IOfflineFilesEvents2_Vtbl {
         unsafe extern "system" fn ItemReconnectBegin<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -767,6 +786,8 @@ pub trait IOfflineFilesEvents3_Impl: Sized + IOfflineFilesEvents_Impl + IOffline
     fn PrefetchFileEnd(&self, pszpath: &::windows::core::PCWSTR, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesEvents3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesEvents3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents3_Impl, const OFFSET: isize>() -> IOfflineFilesEvents3_Vtbl {
         unsafe extern "system" fn TransparentCacheItemNotify<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, eventtype: OFFLINEFILES_EVENTS, itemtype: OFFLINEFILES_ITEM_TYPE, bmodifieddata: super::super::Foundation::BOOL, bmodifiedattributes: super::super::Foundation::BOOL, pzsoldpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -801,6 +822,8 @@ pub trait IOfflineFilesEvents4_Impl: Sized + IOfflineFilesEvents_Impl + IOffline
     fn PrefetchCloseHandleEnd(&self, dwclosedhandlecount: u32, dwopenhandlecount: u32, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesEvents4 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesEvents4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents4_Impl, const OFFSET: isize>() -> IOfflineFilesEvents4_Vtbl {
         unsafe extern "system" fn PrefetchCloseHandleBegin<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEvents4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -828,6 +851,7 @@ pub trait IOfflineFilesEventsFilter_Impl: Sized {
     fn GetIncludedEvents(&self, celements: u32, prgevents: *mut OFFLINEFILES_EVENTS, pcevents: *mut u32) -> ::windows::core::Result<()>;
     fn GetExcludedEvents(&self, celements: u32, prgevents: *mut OFFLINEFILES_EVENTS, pcevents: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOfflineFilesEventsFilter {}
 impl IOfflineFilesEventsFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEventsFilter_Impl, const OFFSET: isize>() -> IOfflineFilesEventsFilter_Vtbl {
         unsafe extern "system" fn GetPathFilter<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesEventsFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszfilter: *mut ::windows::core::PWSTR, pmatch: *mut OFFLINEFILES_PATHFILTER_MATCH) -> ::windows::core::HRESULT {
@@ -861,6 +885,8 @@ pub trait IOfflineFilesFileItem_Impl: Sized + IOfflineFilesItem_Impl {
     fn IsSparse(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn IsEncrypted(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesFileItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesFileItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesFileItem_Impl, const OFFSET: isize>() -> IOfflineFilesFileItem_Vtbl {
@@ -902,6 +928,8 @@ pub trait IOfflineFilesFileSysInfo_Impl: Sized {
     fn GetTimes(&self, copy: OFFLINEFILES_ITEM_COPY, pftcreationtime: *mut super::super::Foundation::FILETIME, pftlastwritetime: *mut super::super::Foundation::FILETIME, pftchangetime: *mut super::super::Foundation::FILETIME, pftlastaccesstime: *mut super::super::Foundation::FILETIME) -> ::windows::core::Result<()>;
     fn GetFileSize(&self, copy: OFFLINEFILES_ITEM_COPY) -> ::windows::core::Result<i64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesFileSysInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesFileSysInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesFileSysInfo_Impl, const OFFSET: isize>() -> IOfflineFilesFileSysInfo_Vtbl {
@@ -948,6 +976,8 @@ pub trait IOfflineFilesGhostInfo_Impl: Sized {
     fn IsGhosted(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesGhostInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesGhostInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesGhostInfo_Impl, const OFFSET: isize>() -> IOfflineFilesGhostInfo_Vtbl {
         unsafe extern "system" fn IsGhosted<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesGhostInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbghosted: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -975,6 +1005,8 @@ pub trait IOfflineFilesItem_Impl: Sized {
     fn Refresh(&self, dwqueryflags: u32) -> ::windows::core::Result<()>;
     fn IsMarkedForDeletion(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesItem_Impl, const OFFSET: isize>() -> IOfflineFilesItem_Vtbl {
@@ -1044,6 +1076,7 @@ pub trait IOfflineFilesItemContainer_Impl: Sized {
     fn EnumItems(&self, dwqueryflags: u32) -> ::windows::core::Result<IEnumOfflineFilesItems>;
     fn EnumItemsEx(&self, pincludefilefilter: &::core::option::Option<IOfflineFilesItemFilter>, pincludedirfilter: &::core::option::Option<IOfflineFilesItemFilter>, pexcludefilefilter: &::core::option::Option<IOfflineFilesItemFilter>, pexcludedirfilter: &::core::option::Option<IOfflineFilesItemFilter>, dwenumflags: u32, dwqueryflags: u32) -> ::windows::core::Result<IEnumOfflineFilesItems>;
 }
+impl ::windows::core::RuntimeName for IOfflineFilesItemContainer {}
 impl IOfflineFilesItemContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesItemContainer_Impl, const OFFSET: isize>() -> IOfflineFilesItemContainer_Vtbl {
         unsafe extern "system" fn EnumItems<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesItemContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwqueryflags: u32, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1085,6 +1118,8 @@ pub trait IOfflineFilesItemFilter_Impl: Sized {
     fn GetPatternFilter(&self, pszpattern: ::windows::core::PWSTR, cchpattern: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesItemFilter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesItemFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesItemFilter_Impl, const OFFSET: isize>() -> IOfflineFilesItemFilter_Vtbl {
         unsafe extern "system" fn GetFilterFlags<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesItemFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pullflags: *mut u64, pullmask: *mut u64) -> ::windows::core::HRESULT {
@@ -1121,6 +1156,8 @@ pub trait IOfflineFilesPinInfo_Impl: Sized {
     fn IsPinnedForComputer(&self, pbpinnedforcomputer: *mut super::super::Foundation::BOOL, pbinherit: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn IsPinnedForFolderRedirection(&self, pbpinnedforfolderredirection: *mut super::super::Foundation::BOOL, pbinherit: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesPinInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesPinInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesPinInfo_Impl, const OFFSET: isize>() -> IOfflineFilesPinInfo_Vtbl {
@@ -1173,6 +1210,8 @@ pub trait IOfflineFilesPinInfo2_Impl: Sized + IOfflineFilesPinInfo_Impl {
     fn IsPartlyPinned(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesPinInfo2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesPinInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesPinInfo2_Impl, const OFFSET: isize>() -> IOfflineFilesPinInfo2_Vtbl {
         unsafe extern "system" fn IsPartlyPinned<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesPinInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbpartlypinned: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1198,6 +1237,8 @@ pub trait IOfflineFilesProgress_Impl: Sized {
     fn QueryAbort(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn End(&self, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesProgress {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesProgress_Impl, const OFFSET: isize>() -> IOfflineFilesProgress_Vtbl {
@@ -1242,6 +1283,8 @@ impl IOfflineFilesProgress_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesServerItem_Impl: Sized + IOfflineFilesItem_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesServerItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesServerItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesServerItem_Impl, const OFFSET: isize>() -> IOfflineFilesServerItem_Vtbl {
         Self { base__: IOfflineFilesItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1262,6 +1305,8 @@ pub trait IOfflineFilesSetting_Impl: Sized {
     fn GetPolicyScope(&self) -> ::windows::core::Result<u32>;
     fn GetValue(&self, pvarvalue: *mut super::super::System::Com::VARIANT, pbsetbypolicy: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOfflineFilesSetting {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOfflineFilesSetting_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSetting_Impl, const OFFSET: isize>() -> IOfflineFilesSetting_Vtbl {
@@ -1358,6 +1403,8 @@ pub trait IOfflineFilesShareInfo_Impl: Sized {
     fn IsShareDfsJunction(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesShareInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesShareInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesShareInfo_Impl, const OFFSET: isize>() -> IOfflineFilesShareInfo_Vtbl {
         unsafe extern "system" fn GetShareItem<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesShareInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppshareitem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1407,6 +1454,8 @@ impl IOfflineFilesShareInfo_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesShareItem_Impl: Sized + IOfflineFilesItem_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesShareItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesShareItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesShareItem_Impl, const OFFSET: isize>() -> IOfflineFilesShareItem_Vtbl {
         Self { base__: IOfflineFilesItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1420,6 +1469,8 @@ pub trait IOfflineFilesSimpleProgress_Impl: Sized + IOfflineFilesProgress_Impl {
     fn ItemBegin(&self, pszfile: &::windows::core::PCWSTR) -> ::windows::core::Result<OFFLINEFILES_OP_RESPONSE>;
     fn ItemResult(&self, pszfile: &::windows::core::PCWSTR, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<OFFLINEFILES_OP_RESPONSE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesSimpleProgress {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesSimpleProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSimpleProgress_Impl, const OFFSET: isize>() -> IOfflineFilesSimpleProgress_Vtbl {
@@ -1460,6 +1511,8 @@ pub trait IOfflineFilesSuspend_Impl: Sized {
     fn SuspendRoot(&self, bsuspend: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesSuspend {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesSuspend_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSuspend_Impl, const OFFSET: isize>() -> IOfflineFilesSuspend_Vtbl {
         unsafe extern "system" fn SuspendRoot<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSuspend_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bsuspend: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1478,6 +1531,8 @@ pub trait IOfflineFilesSuspendInfo_Impl: Sized {
     fn IsSuspended(&self, pbsuspended: *mut super::super::Foundation::BOOL, pbsuspendedroot: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesSuspendInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesSuspendInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSuspendInfo_Impl, const OFFSET: isize>() -> IOfflineFilesSuspendInfo_Vtbl {
         unsafe extern "system" fn IsSuspended<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSuspendInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbsuspended: *mut super::super::Foundation::BOOL, pbsuspendedroot: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1494,6 +1549,7 @@ impl IOfflineFilesSuspendInfo_Vtbl {
 pub trait IOfflineFilesSyncConflictHandler_Impl: Sized {
     fn ResolveConflict(&self, pszpath: &::windows::core::PCWSTR, fstateknown: u32, state: OFFLINEFILES_SYNC_STATE, fchangedetails: u32, pconflictresolution: *mut OFFLINEFILES_SYNC_CONFLICT_RESOLVE, ppsznewname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOfflineFilesSyncConflictHandler {}
 impl IOfflineFilesSyncConflictHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncConflictHandler_Impl, const OFFSET: isize>() -> IOfflineFilesSyncConflictHandler_Vtbl {
         unsafe extern "system" fn ResolveConflict<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncConflictHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, fstateknown: u32, state: OFFLINEFILES_SYNC_STATE, fchangedetails: u32, pconflictresolution: *mut OFFLINEFILES_SYNC_CONFLICT_RESOLVE, ppsznewname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1517,6 +1573,8 @@ pub trait IOfflineFilesSyncErrorInfo_Impl: Sized + IOfflineFilesErrorInfo_Impl {
     fn GetRemoteInfo(&self) -> ::windows::core::Result<IOfflineFilesSyncErrorItemInfo>;
     fn GetOriginalInfo(&self) -> ::windows::core::Result<IOfflineFilesSyncErrorItemInfo>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOfflineFilesSyncErrorInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOfflineFilesSyncErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncErrorInfo_Impl, const OFFSET: isize>() -> IOfflineFilesSyncErrorInfo_Vtbl {
@@ -1607,6 +1665,8 @@ pub trait IOfflineFilesSyncErrorItemInfo_Impl: Sized {
     fn GetFileSize(&self) -> ::windows::core::Result<i64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesSyncErrorItemInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesSyncErrorItemInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncErrorItemInfo_Impl, const OFFSET: isize>() -> IOfflineFilesSyncErrorItemInfo_Vtbl {
         unsafe extern "system" fn GetFileAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncErrorItemInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwattributes: *mut u32) -> ::windows::core::HRESULT {
@@ -1653,6 +1713,8 @@ pub trait IOfflineFilesSyncProgress_Impl: Sized + IOfflineFilesProgress_Impl {
     fn SyncItemResult(&self, pszfile: &::windows::core::PCWSTR, hrresult: ::windows::core::HRESULT, perrorinfo: &::core::option::Option<IOfflineFilesSyncErrorInfo>) -> ::windows::core::Result<OFFLINEFILES_OP_RESPONSE>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesSyncProgress {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesSyncProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncProgress_Impl, const OFFSET: isize>() -> IOfflineFilesSyncProgress_Vtbl {
         unsafe extern "system" fn SyncItemBegin<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesSyncProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PCWSTR, presponse: *mut OFFLINEFILES_OP_RESPONSE) -> ::windows::core::HRESULT {
@@ -1691,6 +1753,8 @@ impl IOfflineFilesSyncProgress_Vtbl {
 pub trait IOfflineFilesTransparentCacheInfo_Impl: Sized {
     fn IsTransparentlyCached(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOfflineFilesTransparentCacheInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOfflineFilesTransparentCacheInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOfflineFilesTransparentCacheInfo_Impl, const OFFSET: isize>() -> IOfflineFilesTransparentCacheInfo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
@@ -2,6 +2,7 @@ pub trait IAppxBlockMapBlock_Impl: Sized {
     fn GetHash(&self, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetCompressedSize(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAppxBlockMapBlock {}
 impl IAppxBlockMapBlock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapBlock_Impl, const OFFSET: isize>() -> IAppxBlockMapBlock_Vtbl {
         unsafe extern "system" fn GetHash<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapBlock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -36,6 +37,8 @@ pub trait IAppxBlockMapBlocksEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxBlockMapBlocksEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxBlockMapBlocksEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapBlocksEnumerator_Impl, const OFFSET: isize>() -> IAppxBlockMapBlocksEnumerator_Vtbl {
@@ -91,6 +94,8 @@ pub trait IAppxBlockMapFile_Impl: Sized {
     fn GetUncompressedSize(&self) -> ::windows::core::Result<u64>;
     fn ValidateFileHash(&self, filestream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxBlockMapFile {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxBlockMapFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapFile_Impl, const OFFSET: isize>() -> IAppxBlockMapFile_Vtbl {
@@ -169,6 +174,8 @@ pub trait IAppxBlockMapFilesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxBlockMapFilesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxBlockMapFilesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapFilesEnumerator_Impl, const OFFSET: isize>() -> IAppxBlockMapFilesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapFilesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, file: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -222,6 +229,8 @@ pub trait IAppxBlockMapReader_Impl: Sized {
     fn GetHashMethod(&self) -> ::windows::core::Result<super::super::super::System::Com::IUri>;
     fn GetStream(&self) -> ::windows::core::Result<super::super::super::System::Com::IStream>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxBlockMapReader {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAppxBlockMapReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBlockMapReader_Impl, const OFFSET: isize>() -> IAppxBlockMapReader_Vtbl {
@@ -288,6 +297,8 @@ pub trait IAppxBundleFactory_Impl: Sized {
     fn CreateBundleManifestReader(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<IAppxBundleManifestReader>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxBundleFactory {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxBundleFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleFactory_Impl, const OFFSET: isize>() -> IAppxBundleFactory_Vtbl {
         unsafe extern "system" fn CreateBundleWriter<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, outputstream: ::windows::core::RawPtr, bundleversion: u64, bundlewriter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -339,6 +350,7 @@ pub trait IAppxBundleManifestOptionalBundleInfo_Impl: Sized {
     fn GetFileName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetPackageInfoItems(&self) -> ::windows::core::Result<IAppxBundleManifestPackageInfoEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxBundleManifestOptionalBundleInfo {}
 impl IAppxBundleManifestOptionalBundleInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestOptionalBundleInfo_Impl, const OFFSET: isize>() -> IAppxBundleManifestOptionalBundleInfo_Vtbl {
         unsafe extern "system" fn GetPackageId<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestOptionalBundleInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packageid: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -391,6 +403,8 @@ pub trait IAppxBundleManifestOptionalBundleInfoEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxBundleManifestOptionalBundleInfoEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestOptionalBundleInfoEnumerator_Impl, const OFFSET: isize>() -> IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
@@ -446,6 +460,7 @@ pub trait IAppxBundleManifestPackageInfo_Impl: Sized {
     fn GetSize(&self) -> ::windows::core::Result<u64>;
     fn GetResources(&self) -> ::windows::core::Result<IAppxManifestQualifiedResourcesEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxBundleManifestPackageInfo {}
 impl IAppxBundleManifestPackageInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo_Impl, const OFFSET: isize>() -> IAppxBundleManifestPackageInfo_Vtbl {
         unsafe extern "system" fn GetPackageType<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagetype: *mut APPX_BUNDLE_PAYLOAD_PACKAGE_TYPE) -> ::windows::core::HRESULT {
@@ -535,6 +550,8 @@ pub trait IAppxBundleManifestPackageInfo2_Impl: Sized {
     fn GetIsDefaultApplicablePackage(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxBundleManifestPackageInfo2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxBundleManifestPackageInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo2_Impl, const OFFSET: isize>() -> IAppxBundleManifestPackageInfo2_Vtbl {
         unsafe extern "system" fn GetIsPackageReference<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ispackagereference: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -584,6 +601,7 @@ impl IAppxBundleManifestPackageInfo2_Vtbl {
 pub trait IAppxBundleManifestPackageInfo3_Impl: Sized {
     fn GetTargetDeviceFamilies(&self) -> ::windows::core::Result<IAppxManifestTargetDeviceFamiliesEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxBundleManifestPackageInfo3 {}
 impl IAppxBundleManifestPackageInfo3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo3_Impl, const OFFSET: isize>() -> IAppxBundleManifestPackageInfo3_Vtbl {
         unsafe extern "system" fn GetTargetDeviceFamilies<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetdevicefamilies: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -607,6 +625,8 @@ impl IAppxBundleManifestPackageInfo3_Vtbl {
 pub trait IAppxBundleManifestPackageInfo4_Impl: Sized {
     fn GetIsStub(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxBundleManifestPackageInfo4 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxBundleManifestPackageInfo4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfo4_Impl, const OFFSET: isize>() -> IAppxBundleManifestPackageInfo4_Vtbl {
@@ -633,6 +653,8 @@ pub trait IAppxBundleManifestPackageInfoEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxBundleManifestPackageInfoEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxBundleManifestPackageInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestPackageInfoEnumerator_Impl, const OFFSET: isize>() -> IAppxBundleManifestPackageInfoEnumerator_Vtbl {
@@ -687,6 +709,8 @@ pub trait IAppxBundleManifestReader_Impl: Sized {
     fn GetStream(&self) -> ::windows::core::Result<super::super::super::System::Com::IStream>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxBundleManifestReader {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxBundleManifestReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestReader_Impl, const OFFSET: isize>() -> IAppxBundleManifestReader_Vtbl {
         unsafe extern "system" fn GetPackageId<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packageid: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -736,6 +760,7 @@ impl IAppxBundleManifestReader_Vtbl {
 pub trait IAppxBundleManifestReader2_Impl: Sized {
     fn GetOptionalBundles(&self) -> ::windows::core::Result<IAppxBundleManifestOptionalBundleInfoEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxBundleManifestReader2 {}
 impl IAppxBundleManifestReader2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestReader2_Impl, const OFFSET: isize>() -> IAppxBundleManifestReader2_Vtbl {
         unsafe extern "system" fn GetOptionalBundles<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleManifestReader2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, optionalbundles: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -762,6 +787,7 @@ pub trait IAppxBundleReader_Impl: Sized {
     fn GetPayloadPackages(&self) -> ::windows::core::Result<IAppxFilesEnumerator>;
     fn GetPayloadPackage(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<IAppxFile>;
 }
+impl ::windows::core::RuntimeName for IAppxBundleReader {}
 impl IAppxBundleReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleReader_Impl, const OFFSET: isize>() -> IAppxBundleReader_Vtbl {
         unsafe extern "system" fn GetFootprintFile<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filetype: APPX_BUNDLE_FOOTPRINT_FILE_TYPE, footprintfile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -838,6 +864,8 @@ pub trait IAppxBundleWriter_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxBundleWriter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxBundleWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleWriter_Impl, const OFFSET: isize>() -> IAppxBundleWriter_Vtbl {
         unsafe extern "system" fn AddPayloadPackage<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, packagestream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -865,6 +893,8 @@ pub trait IAppxBundleWriter2_Impl: Sized {
     fn AddExternalPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxBundleWriter2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxBundleWriter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleWriter2_Impl, const OFFSET: isize>() -> IAppxBundleWriter2_Vtbl {
         unsafe extern "system" fn AddExternalPackageReference<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleWriter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, inputstream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -886,6 +916,8 @@ pub trait IAppxBundleWriter3_Impl: Sized {
     fn AddPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
     fn Close(&self, hashmethodstring: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxBundleWriter3 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAppxBundleWriter3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleWriter3_Impl, const OFFSET: isize>() -> IAppxBundleWriter3_Vtbl {
@@ -915,6 +947,8 @@ pub trait IAppxBundleWriter4_Impl: Sized {
     fn AddPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn AddExternalPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxBundleWriter4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxBundleWriter4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxBundleWriter4_Impl, const OFFSET: isize>() -> IAppxBundleWriter4_Vtbl {
@@ -948,6 +982,7 @@ pub trait IAppxContentGroup_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetFiles(&self) -> ::windows::core::Result<IAppxContentGroupFilesEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxContentGroup {}
 impl IAppxContentGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroup_Impl, const OFFSET: isize>() -> IAppxContentGroup_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, groupname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -988,6 +1023,8 @@ pub trait IAppxContentGroupFilesEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxContentGroupFilesEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxContentGroupFilesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroupFilesEnumerator_Impl, const OFFSET: isize>() -> IAppxContentGroupFilesEnumerator_Vtbl {
@@ -1039,6 +1076,7 @@ pub trait IAppxContentGroupMapReader_Impl: Sized {
     fn GetRequiredGroup(&self) -> ::windows::core::Result<IAppxContentGroup>;
     fn GetAutomaticGroups(&self) -> ::windows::core::Result<IAppxContentGroupsEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxContentGroupMapReader {}
 impl IAppxContentGroupMapReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroupMapReader_Impl, const OFFSET: isize>() -> IAppxContentGroupMapReader_Vtbl {
         unsafe extern "system" fn GetRequiredGroup<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroupMapReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requiredgroup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1078,6 +1116,7 @@ pub trait IAppxContentGroupMapWriter_Impl: Sized {
     fn AddAutomaticFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAppxContentGroupMapWriter {}
 impl IAppxContentGroupMapWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroupMapWriter_Impl, const OFFSET: isize>() -> IAppxContentGroupMapWriter_Vtbl {
         unsafe extern "system" fn AddAutomaticGroup<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroupMapWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, groupname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1112,6 +1151,8 @@ pub trait IAppxContentGroupsEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxContentGroupsEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxContentGroupsEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxContentGroupsEnumerator_Impl, const OFFSET: isize>() -> IAppxContentGroupsEnumerator_Vtbl {
@@ -1165,6 +1206,8 @@ pub trait IAppxEncryptedBundleWriter_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxEncryptedBundleWriter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxEncryptedBundleWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedBundleWriter_Impl, const OFFSET: isize>() -> IAppxEncryptedBundleWriter_Vtbl {
         unsafe extern "system" fn AddPayloadPackageEncrypted<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedBundleWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, packagestream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1192,6 +1235,8 @@ pub trait IAppxEncryptedBundleWriter2_Impl: Sized {
     fn AddExternalPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxEncryptedBundleWriter2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxEncryptedBundleWriter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedBundleWriter2_Impl, const OFFSET: isize>() -> IAppxEncryptedBundleWriter2_Vtbl {
         unsafe extern "system" fn AddExternalPackageReference<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedBundleWriter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, inputstream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1213,6 +1258,8 @@ pub trait IAppxEncryptedBundleWriter3_Impl: Sized {
     fn AddPayloadPackageEncrypted(&self, filename: &::windows::core::PCWSTR, packagestream: &::core::option::Option<super::super::super::System::Com::IStream>, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn AddExternalPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxEncryptedBundleWriter3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxEncryptedBundleWriter3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedBundleWriter3_Impl, const OFFSET: isize>() -> IAppxEncryptedBundleWriter3_Vtbl {
@@ -1242,6 +1289,8 @@ pub trait IAppxEncryptedPackageWriter_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxEncryptedPackageWriter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxEncryptedPackageWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedPackageWriter_Impl, const OFFSET: isize>() -> IAppxEncryptedPackageWriter_Vtbl {
         unsafe extern "system" fn AddPayloadFileEncrypted<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedPackageWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, compressionoption: APPX_COMPRESSION_OPTION, inputstream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1269,6 +1318,8 @@ pub trait IAppxEncryptedPackageWriter2_Impl: Sized {
     fn AddPayloadFilesEncrypted(&self, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxEncryptedPackageWriter2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxEncryptedPackageWriter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedPackageWriter2_Impl, const OFFSET: isize>() -> IAppxEncryptedPackageWriter2_Vtbl {
         unsafe extern "system" fn AddPayloadFilesEncrypted<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptedPackageWriter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::HRESULT {
@@ -1293,6 +1344,8 @@ pub trait IAppxEncryptionFactory_Impl: Sized {
     fn CreateEncryptedBundleWriter(&self, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, bundleversion: u64, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<IAppxEncryptedBundleWriter>;
     fn CreateEncryptedBundleReader(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, keyinfo: *const APPX_KEY_INFO) -> ::windows::core::Result<IAppxBundleReader>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxEncryptionFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxEncryptionFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptionFactory_Impl, const OFFSET: isize>() -> IAppxEncryptionFactory_Vtbl {
@@ -1381,6 +1434,8 @@ pub trait IAppxEncryptionFactory2_Impl: Sized {
     fn CreateEncryptedPackageWriter(&self, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, manifeststream: &::core::option::Option<super::super::super::System::Com::IStream>, contentgroupmapstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<IAppxEncryptedPackageWriter>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxEncryptionFactory2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxEncryptionFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptionFactory2_Impl, const OFFSET: isize>() -> IAppxEncryptionFactory2_Vtbl {
         unsafe extern "system" fn CreateEncryptedPackageWriter<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptionFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, outputstream: ::windows::core::RawPtr, manifeststream: ::windows::core::RawPtr, contentgroupmapstream: ::windows::core::RawPtr, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS, packagewriter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1410,6 +1465,8 @@ pub trait IAppxEncryptionFactory3_Impl: Sized {
     fn EncryptBundle(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<()>;
     fn CreateEncryptedBundleWriter(&self, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, bundleversion: u64, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<IAppxEncryptedBundleWriter>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxEncryptionFactory3 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAppxEncryptionFactory3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptionFactory3_Impl, const OFFSET: isize>() -> IAppxEncryptionFactory3_Vtbl {
@@ -1462,6 +1519,8 @@ pub trait IAppxEncryptionFactory4_Impl: Sized {
     fn EncryptPackage(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS, memorylimit: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxEncryptionFactory4 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxEncryptionFactory4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptionFactory4_Impl, const OFFSET: isize>() -> IAppxEncryptionFactory4_Vtbl {
         unsafe extern "system" fn EncryptPackage<Identity: ::windows::core::IUnknownImpl, Impl: IAppxEncryptionFactory4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputstream: ::windows::core::RawPtr, outputstream: ::windows::core::RawPtr, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS, memorylimit: u64) -> ::windows::core::HRESULT {
@@ -1483,6 +1542,8 @@ pub trait IAppxFactory_Impl: Sized {
     fn CreateBlockMapReader(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<IAppxBlockMapReader>;
     fn CreateValidatedBlockMapReader(&self, blockmapstream: &::core::option::Option<super::super::super::System::Com::IStream>, signaturefilename: &::windows::core::PCWSTR) -> ::windows::core::Result<IAppxBlockMapReader>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxFactory_Impl, const OFFSET: isize>() -> IAppxFactory_Vtbl {
@@ -1561,6 +1622,8 @@ pub trait IAppxFactory2_Impl: Sized {
     fn CreateContentGroupMapWriter(&self, stream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<IAppxContentGroupMapWriter>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxFactory2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxFactory2_Impl, const OFFSET: isize>() -> IAppxFactory2_Vtbl {
         unsafe extern "system" fn CreateContentGroupMapReader<Identity: ::windows::core::IUnknownImpl, Impl: IAppxFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputstream: ::windows::core::RawPtr, contentgroupmapreader: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1615,6 +1678,8 @@ pub trait IAppxFile_Impl: Sized {
     fn GetSize(&self) -> ::windows::core::Result<u64>;
     fn GetStream(&self) -> ::windows::core::Result<super::super::super::System::Com::IStream>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxFile {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAppxFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxFile_Impl, const OFFSET: isize>() -> IAppxFile_Vtbl {
@@ -1693,6 +1758,8 @@ pub trait IAppxFilesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxFilesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxFilesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxFilesEnumerator_Impl, const OFFSET: isize>() -> IAppxFilesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxFilesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, file: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1743,6 +1810,7 @@ pub trait IAppxManifestApplication_Impl: Sized {
     fn GetStringValue(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetAppUserModelId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestApplication {}
 impl IAppxManifestApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestApplication_Impl, const OFFSET: isize>() -> IAppxManifestApplication_Vtbl {
         unsafe extern "system" fn GetStringValue<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1783,6 +1851,8 @@ pub trait IAppxManifestApplicationsEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestApplicationsEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestApplicationsEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestApplicationsEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestApplicationsEnumerator_Vtbl {
@@ -1837,6 +1907,8 @@ pub trait IAppxManifestCapabilitiesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestCapabilitiesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestCapabilitiesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestCapabilitiesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestCapabilitiesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestCapabilitiesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, capability: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1890,6 +1962,8 @@ pub trait IAppxManifestDeviceCapabilitiesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestDeviceCapabilitiesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDeviceCapabilitiesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDeviceCapabilitiesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, devicecapability: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1941,6 +2015,7 @@ pub trait IAppxManifestDriverConstraint_Impl: Sized {
     fn GetMinVersion(&self) -> ::windows::core::Result<u64>;
     fn GetMinDate(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestDriverConstraint {}
 impl IAppxManifestDriverConstraint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverConstraint_Impl, const OFFSET: isize>() -> IAppxManifestDriverConstraint_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverConstraint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1993,6 +2068,8 @@ pub trait IAppxManifestDriverConstraintsEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestDriverConstraintsEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestDriverConstraintsEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverConstraintsEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestDriverConstraintsEnumerator_Vtbl {
@@ -2047,6 +2124,8 @@ pub trait IAppxManifestDriverDependenciesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestDriverDependenciesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverDependenciesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestDriverDependenciesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverDependenciesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, driverdependency: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2096,6 +2175,7 @@ impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
 pub trait IAppxManifestDriverDependency_Impl: Sized {
     fn GetDriverConstraints(&self) -> ::windows::core::Result<IAppxManifestDriverConstraintsEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestDriverDependency {}
 impl IAppxManifestDriverDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverDependency_Impl, const OFFSET: isize>() -> IAppxManifestDriverDependency_Vtbl {
         unsafe extern "system" fn GetDriverConstraints<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestDriverDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, driverconstraints: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2121,6 +2201,8 @@ pub trait IAppxManifestHostRuntimeDependenciesEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestHostRuntimeDependenciesEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestHostRuntimeDependenciesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
@@ -2173,6 +2255,7 @@ pub trait IAppxManifestHostRuntimeDependency_Impl: Sized {
     fn GetPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetMinVersion(&self) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestHostRuntimeDependency {}
 impl IAppxManifestHostRuntimeDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestHostRuntimeDependency_Impl, const OFFSET: isize>() -> IAppxManifestHostRuntimeDependency_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestHostRuntimeDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2222,6 +2305,7 @@ impl IAppxManifestHostRuntimeDependency_Vtbl {
 pub trait IAppxManifestHostRuntimeDependency2_Impl: Sized {
     fn GetPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestHostRuntimeDependency2 {}
 impl IAppxManifestHostRuntimeDependency2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestHostRuntimeDependency2_Impl, const OFFSET: isize>() -> IAppxManifestHostRuntimeDependency2_Vtbl {
         unsafe extern "system" fn GetPackageFamilyName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestHostRuntimeDependency2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagefamilyname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2247,6 +2331,8 @@ pub trait IAppxManifestMainPackageDependenciesEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestMainPackageDependenciesEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestMainPackageDependenciesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
@@ -2299,6 +2385,7 @@ pub trait IAppxManifestMainPackageDependency_Impl: Sized {
     fn GetPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestMainPackageDependency {}
 impl IAppxManifestMainPackageDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestMainPackageDependency_Impl, const OFFSET: isize>() -> IAppxManifestMainPackageDependency_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestMainPackageDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2352,6 +2439,8 @@ pub trait IAppxManifestOSPackageDependenciesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestOSPackageDependenciesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestOSPackageDependenciesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestOSPackageDependenciesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ospackagedependency: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2402,6 +2491,7 @@ pub trait IAppxManifestOSPackageDependency_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetVersion(&self) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestOSPackageDependency {}
 impl IAppxManifestOSPackageDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestOSPackageDependency_Impl, const OFFSET: isize>() -> IAppxManifestOSPackageDependency_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestOSPackageDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2441,6 +2531,8 @@ pub trait IAppxManifestOptionalPackageInfo_Impl: Sized {
     fn GetIsOptionalPackage(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn GetMainPackageName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestOptionalPackageInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestOptionalPackageInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestOptionalPackageInfo_Impl, const OFFSET: isize>() -> IAppxManifestOptionalPackageInfo_Vtbl {
@@ -2482,6 +2574,8 @@ pub trait IAppxManifestPackageDependenciesEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestPackageDependenciesEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestPackageDependenciesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageDependenciesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestPackageDependenciesEnumerator_Vtbl {
@@ -2534,6 +2628,7 @@ pub trait IAppxManifestPackageDependency_Impl: Sized {
     fn GetPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetMinVersion(&self) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestPackageDependency {}
 impl IAppxManifestPackageDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageDependency_Impl, const OFFSET: isize>() -> IAppxManifestPackageDependency_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2583,6 +2678,7 @@ impl IAppxManifestPackageDependency_Vtbl {
 pub trait IAppxManifestPackageDependency2_Impl: Sized + IAppxManifestPackageDependency_Impl {
     fn GetMaxMajorVersionTested(&self) -> ::windows::core::Result<u16>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestPackageDependency2 {}
 impl IAppxManifestPackageDependency2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageDependency2_Impl, const OFFSET: isize>() -> IAppxManifestPackageDependency2_Vtbl {
         unsafe extern "system" fn GetMaxMajorVersionTested<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageDependency2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxmajorversiontested: *mut u16) -> ::windows::core::HRESULT {
@@ -2609,6 +2705,8 @@ impl IAppxManifestPackageDependency2_Vtbl {
 pub trait IAppxManifestPackageDependency3_Impl: Sized {
     fn GetIsOptional(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestPackageDependency3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestPackageDependency3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageDependency3_Impl, const OFFSET: isize>() -> IAppxManifestPackageDependency3_Vtbl {
@@ -2640,6 +2738,8 @@ pub trait IAppxManifestPackageId_Impl: Sized {
     fn GetPackageFullName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestPackageId {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestPackageId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageId_Impl, const OFFSET: isize>() -> IAppxManifestPackageId_Vtbl {
@@ -2752,6 +2852,8 @@ pub trait IAppxManifestPackageId2_Impl: Sized + IAppxManifestPackageId_Impl {
     fn GetArchitecture2(&self) -> ::windows::core::Result<APPX_PACKAGE_ARCHITECTURE2>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestPackageId2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestPackageId2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageId2_Impl, const OFFSET: isize>() -> IAppxManifestPackageId2_Vtbl {
         unsafe extern "system" fn GetArchitecture2<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestPackageId2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, architecture: *mut APPX_PACKAGE_ARCHITECTURE2) -> ::windows::core::HRESULT {
@@ -2776,6 +2878,8 @@ pub trait IAppxManifestProperties_Impl: Sized {
     fn GetBoolValue(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn GetStringValue(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestProperties {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestProperties_Impl, const OFFSET: isize>() -> IAppxManifestProperties_Vtbl {
@@ -2816,6 +2920,7 @@ pub trait IAppxManifestQualifiedResource_Impl: Sized {
     fn GetScale(&self) -> ::windows::core::Result<u32>;
     fn GetDXFeatureLevel(&self) -> ::windows::core::Result<DX_FEATURE_LEVEL>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestQualifiedResource {}
 impl IAppxManifestQualifiedResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestQualifiedResource_Impl, const OFFSET: isize>() -> IAppxManifestQualifiedResource_Vtbl {
         unsafe extern "system" fn GetLanguage<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestQualifiedResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, language: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2868,6 +2973,8 @@ pub trait IAppxManifestQualifiedResourcesEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestQualifiedResourcesEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestQualifiedResourcesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestQualifiedResourcesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestQualifiedResourcesEnumerator_Vtbl {
@@ -2927,6 +3034,8 @@ pub trait IAppxManifestReader_Impl: Sized {
     fn GetApplications(&self) -> ::windows::core::Result<IAppxManifestApplicationsEnumerator>;
     fn GetStream(&self) -> ::windows::core::Result<super::super::super::System::Com::IStream>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxManifestReader {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAppxManifestReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader_Impl, const OFFSET: isize>() -> IAppxManifestReader_Vtbl {
@@ -3051,6 +3160,8 @@ pub trait IAppxManifestReader2_Impl: Sized + IAppxManifestReader_Impl {
     fn GetQualifiedResources(&self) -> ::windows::core::Result<IAppxManifestQualifiedResourcesEnumerator>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxManifestReader2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxManifestReader2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader2_Impl, const OFFSET: isize>() -> IAppxManifestReader2_Vtbl {
         unsafe extern "system" fn GetQualifiedResources<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resources: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3075,6 +3186,8 @@ pub trait IAppxManifestReader3_Impl: Sized + IAppxManifestReader_Impl + IAppxMan
     fn GetCapabilitiesByCapabilityClass(&self, capabilityclass: APPX_CAPABILITY_CLASS_TYPE) -> ::windows::core::Result<IAppxManifestCapabilitiesEnumerator>;
     fn GetTargetDeviceFamilies(&self) -> ::windows::core::Result<IAppxManifestTargetDeviceFamiliesEnumerator>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxManifestReader3 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAppxManifestReader3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader3_Impl, const OFFSET: isize>() -> IAppxManifestReader3_Vtbl {
@@ -3115,6 +3228,8 @@ pub trait IAppxManifestReader4_Impl: Sized + IAppxManifestReader_Impl + IAppxMan
     fn GetOptionalPackageInfo(&self) -> ::windows::core::Result<IAppxManifestOptionalPackageInfo>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxManifestReader4 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxManifestReader4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader4_Impl, const OFFSET: isize>() -> IAppxManifestReader4_Vtbl {
         unsafe extern "system" fn GetOptionalPackageInfo<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, optionalpackageinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3137,6 +3252,7 @@ impl IAppxManifestReader4_Vtbl {
 pub trait IAppxManifestReader5_Impl: Sized {
     fn GetMainPackageDependencies(&self) -> ::windows::core::Result<IAppxManifestMainPackageDependenciesEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestReader5 {}
 impl IAppxManifestReader5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader5_Impl, const OFFSET: isize>() -> IAppxManifestReader5_Vtbl {
         unsafe extern "system" fn GetMainPackageDependencies<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mainpackagedependencies: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3163,6 +3279,8 @@ impl IAppxManifestReader5_Vtbl {
 pub trait IAppxManifestReader6_Impl: Sized {
     fn GetIsNonQualifiedResourcePackage(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestReader6 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestReader6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader6_Impl, const OFFSET: isize>() -> IAppxManifestReader6_Vtbl {
@@ -3191,6 +3309,7 @@ pub trait IAppxManifestReader7_Impl: Sized {
     fn GetOSPackageDependencies(&self) -> ::windows::core::Result<IAppxManifestOSPackageDependenciesEnumerator>;
     fn GetHostRuntimeDependencies(&self) -> ::windows::core::Result<IAppxManifestHostRuntimeDependenciesEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestReader7 {}
 impl IAppxManifestReader7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader7_Impl, const OFFSET: isize>() -> IAppxManifestReader7_Vtbl {
         unsafe extern "system" fn GetDriverDependencies<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestReader7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, driverdependencies: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3243,6 +3362,8 @@ pub trait IAppxManifestResourcesEnumerator_Impl: Sized {
     fn GetHasCurrent(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestResourcesEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestResourcesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestResourcesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestResourcesEnumerator_Vtbl {
@@ -3297,6 +3418,8 @@ pub trait IAppxManifestTargetDeviceFamiliesEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAppxManifestTargetDeviceFamiliesEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestTargetDeviceFamiliesEnumerator_Impl, const OFFSET: isize>() -> IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestTargetDeviceFamiliesEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetdevicefamily: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3348,6 +3471,7 @@ pub trait IAppxManifestTargetDeviceFamily_Impl: Sized {
     fn GetMinVersion(&self) -> ::windows::core::Result<u64>;
     fn GetMaxVersionTested(&self) -> ::windows::core::Result<u64>;
 }
+impl ::windows::core::RuntimeName for IAppxManifestTargetDeviceFamily {}
 impl IAppxManifestTargetDeviceFamily_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestTargetDeviceFamily_Impl, const OFFSET: isize>() -> IAppxManifestTargetDeviceFamily_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IAppxManifestTargetDeviceFamily_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -3404,6 +3528,8 @@ pub trait IAppxPackageEditor_Impl: Sized {
     fn UpdatePackageManifest(&self, packagestream: &::core::option::Option<super::super::super::System::Com::IStream>, updatedmanifeststream: &::core::option::Option<super::super::super::System::Com::IStream>, ispackageencrypted: super::super::super::Foundation::BOOL, options: APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAppxPackageEditor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAppxPackageEditor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageEditor_Impl, const OFFSET: isize>() -> IAppxPackageEditor_Vtbl {
         unsafe extern "system" fn SetWorkingDirectory<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageEditor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, workingdirectory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -3457,6 +3583,7 @@ pub trait IAppxPackageReader_Impl: Sized {
     fn GetPayloadFiles(&self) -> ::windows::core::Result<IAppxFilesEnumerator>;
     fn GetManifest(&self) -> ::windows::core::Result<IAppxManifestReader>;
 }
+impl ::windows::core::RuntimeName for IAppxPackageReader {}
 impl IAppxPackageReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageReader_Impl, const OFFSET: isize>() -> IAppxPackageReader_Vtbl {
         unsafe extern "system" fn GetBlockMap<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, blockmapreader: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3533,6 +3660,8 @@ pub trait IAppxPackageWriter_Impl: Sized {
     fn Close(&self, manifest: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxPackageWriter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxPackageWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageWriter_Impl, const OFFSET: isize>() -> IAppxPackageWriter_Vtbl {
         unsafe extern "system" fn AddPayloadFile<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, contenttype: ::windows::core::PCWSTR, compressionoption: APPX_COMPRESSION_OPTION, inputstream: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3560,6 +3689,8 @@ pub trait IAppxPackageWriter2_Impl: Sized {
     fn Close(&self, manifest: &::core::option::Option<super::super::super::System::Com::IStream>, contentgroupmap: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxPackageWriter2 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxPackageWriter2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageWriter2_Impl, const OFFSET: isize>() -> IAppxPackageWriter2_Vtbl {
         unsafe extern "system" fn Close<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageWriter2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, manifest: ::windows::core::RawPtr, contentgroupmap: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3578,6 +3709,8 @@ pub trait IAppxPackageWriter3_Impl: Sized {
     fn AddPayloadFiles(&self, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAppxPackageWriter3 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAppxPackageWriter3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageWriter3_Impl, const OFFSET: isize>() -> IAppxPackageWriter3_Vtbl {
         unsafe extern "system" fn AddPayloadFiles<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackageWriter3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::HRESULT {
@@ -3595,6 +3728,7 @@ pub trait IAppxPackagingDiagnosticEventSink_Impl: Sized {
     fn ReportContextChange(&self, changetype: APPX_PACKAGING_CONTEXT_CHANGE_TYPE, contextid: i32, contextname: &::windows::core::PCSTR, contextmessage: &::windows::core::PCWSTR, detailsmessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ReportError(&self, errormessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAppxPackagingDiagnosticEventSink {}
 impl IAppxPackagingDiagnosticEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackagingDiagnosticEventSink_Impl, const OFFSET: isize>() -> IAppxPackagingDiagnosticEventSink_Vtbl {
         unsafe extern "system" fn ReportContextChange<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackagingDiagnosticEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, changetype: APPX_PACKAGING_CONTEXT_CHANGE_TYPE, contextid: i32, contextname: ::windows::core::PCSTR, contextmessage: ::windows::core::PCWSTR, detailsmessage: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -3620,6 +3754,7 @@ impl IAppxPackagingDiagnosticEventSink_Vtbl {
 pub trait IAppxPackagingDiagnosticEventSinkManager_Impl: Sized {
     fn SetSinkForProcess(&self, sink: &::core::option::Option<IAppxPackagingDiagnosticEventSink>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAppxPackagingDiagnosticEventSinkManager {}
 impl IAppxPackagingDiagnosticEventSinkManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackagingDiagnosticEventSinkManager_Impl, const OFFSET: isize>() -> IAppxPackagingDiagnosticEventSinkManager_Vtbl {
         unsafe extern "system" fn SetSinkForProcess<Identity: ::windows::core::IUnknownImpl, Impl: IAppxPackagingDiagnosticEventSinkManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3637,6 +3772,7 @@ pub trait IAppxSourceContentGroupMapReader_Impl: Sized {
     fn GetRequiredGroup(&self) -> ::windows::core::Result<IAppxContentGroup>;
     fn GetAutomaticGroups(&self) -> ::windows::core::Result<IAppxContentGroupsEnumerator>;
 }
+impl ::windows::core::RuntimeName for IAppxSourceContentGroupMapReader {}
 impl IAppxSourceContentGroupMapReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppxSourceContentGroupMapReader_Impl, const OFFSET: isize>() -> IAppxSourceContentGroupMapReader_Vtbl {
         unsafe extern "system" fn GetRequiredGroup<Identity: ::windows::core::IUnknownImpl, Impl: IAppxSourceContentGroupMapReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requiredgroup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
@@ -6,6 +6,8 @@ pub trait IOpcCertificateEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcCertificateEnumerator>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
+impl ::windows::core::RuntimeName for IOpcCertificateEnumerator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl IOpcCertificateEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcCertificateEnumerator_Impl, const OFFSET: isize>() -> IOpcCertificateEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcCertificateEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -52,6 +54,8 @@ pub trait IOpcCertificateSet_Impl: Sized {
     fn Remove(&self, certificate: *const super::super::super::Security::Cryptography::CERT_CONTEXT) -> ::windows::core::Result<()>;
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcCertificateEnumerator>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
+impl ::windows::core::RuntimeName for IOpcCertificateSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 impl IOpcCertificateSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcCertificateSet_Impl, const OFFSET: isize>() -> IOpcCertificateSet_Vtbl {
@@ -105,6 +109,8 @@ pub trait IOpcDigitalSignature_Impl: Sized {
     fn GetCustomObjectEnumerator(&self) -> ::windows::core::Result<IOpcSignatureCustomObjectEnumerator>;
     fn GetSignatureXml(&self, signaturexml: *mut *mut u8, count: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcDigitalSignature {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcDigitalSignature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcDigitalSignature_Impl, const OFFSET: isize>() -> IOpcDigitalSignature_Vtbl {
@@ -274,6 +280,8 @@ pub trait IOpcDigitalSignatureEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcDigitalSignatureEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcDigitalSignatureEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpcDigitalSignatureEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcDigitalSignatureEnumerator_Impl, const OFFSET: isize>() -> IOpcDigitalSignatureEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcDigitalSignatureEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -343,6 +351,8 @@ pub trait IOpcDigitalSignatureManager_Impl: Sized {
     fn Sign(&self, certificate: *const super::super::super::Security::Cryptography::CERT_CONTEXT, signingoptions: &::core::option::Option<IOpcSigningOptions>) -> ::windows::core::Result<IOpcDigitalSignature>;
     fn ReplaceSignatureXml(&self, signaturepartname: &::core::option::Option<IOpcPartUri>, newsignaturexml: *const u8, count: u32) -> ::windows::core::Result<IOpcDigitalSignature>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOpcDigitalSignatureManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_System_Com"))]
 impl IOpcDigitalSignatureManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcDigitalSignatureManager_Impl, const OFFSET: isize>() -> IOpcDigitalSignatureManager_Vtbl {
@@ -443,6 +453,8 @@ pub trait IOpcFactory_Impl: Sized {
     fn CreateDigitalSignatureManager(&self, package: &::core::option::Option<IOpcPackage>) -> ::windows::core::Result<IOpcDigitalSignatureManager>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOpcFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Com"))]
 impl IOpcFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcFactory_Impl, const OFFSET: isize>() -> IOpcFactory_Vtbl {
         unsafe extern "system" fn CreatePackageRootUri<Identity: ::windows::core::IUnknownImpl, Impl: IOpcFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rooturi: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -535,6 +547,7 @@ pub trait IOpcPackage_Impl: Sized {
     fn GetPartSet(&self) -> ::windows::core::Result<IOpcPartSet>;
     fn GetRelationshipSet(&self) -> ::windows::core::Result<IOpcRelationshipSet>;
 }
+impl ::windows::core::RuntimeName for IOpcPackage {}
 impl IOpcPackage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPackage_Impl, const OFFSET: isize>() -> IOpcPackage_Vtbl {
         unsafe extern "system" fn GetPartSet<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPackage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, partset: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -577,6 +590,8 @@ pub trait IOpcPart_Impl: Sized {
     fn GetContentType(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetCompressionOptions(&self) -> ::windows::core::Result<OPC_COMPRESSION_OPTIONS>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcPart {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcPart_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPart_Impl, const OFFSET: isize>() -> IOpcPart_Vtbl {
@@ -656,6 +671,8 @@ pub trait IOpcPartEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcPartEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcPartEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpcPartEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPartEnumerator_Impl, const OFFSET: isize>() -> IOpcPartEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPartEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -722,6 +739,8 @@ pub trait IOpcPartSet_Impl: Sized {
     fn PartExists(&self, name: &::core::option::Option<IOpcPartUri>) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcPartEnumerator>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOpcPartSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOpcPartSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPartSet_Impl, const OFFSET: isize>() -> IOpcPartSet_Vtbl {
@@ -794,6 +813,8 @@ pub trait IOpcPartUri_Impl: Sized + super::super::super::System::Com::IUri_Impl 
     fn IsRelationshipsPartUri(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOpcPartUri {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOpcPartUri_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPartUri_Impl, const OFFSET: isize>() -> IOpcPartUri_Vtbl {
         unsafe extern "system" fn ComparePartUri<Identity: ::windows::core::IUnknownImpl, Impl: IOpcPartUri_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parturi: ::windows::core::RawPtr, comparisonresult: *mut i32) -> ::windows::core::HRESULT {
@@ -848,6 +869,8 @@ pub trait IOpcRelationship_Impl: Sized {
     fn GetTargetUri(&self) -> ::windows::core::Result<super::super::super::System::Com::IUri>;
     fn GetTargetMode(&self) -> ::windows::core::Result<OPC_URI_TARGET_MODE>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcRelationship {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcRelationship_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationship_Impl, const OFFSET: isize>() -> IOpcRelationship_Vtbl {
@@ -927,6 +950,8 @@ pub trait IOpcRelationshipEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcRelationshipEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcRelationshipEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpcRelationshipEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipEnumerator_Impl, const OFFSET: isize>() -> IOpcRelationshipEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -989,6 +1014,7 @@ pub trait IOpcRelationshipSelector_Impl: Sized {
     fn GetSelectorType(&self) -> ::windows::core::Result<OPC_RELATIONSHIP_SELECTOR>;
     fn GetSelectionCriterion(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IOpcRelationshipSelector {}
 impl IOpcRelationshipSelector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipSelector_Impl, const OFFSET: isize>() -> IOpcRelationshipSelector_Vtbl {
         unsafe extern "system" fn GetSelectorType<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipSelector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, selector: *mut OPC_RELATIONSHIP_SELECTOR) -> ::windows::core::HRESULT {
@@ -1030,6 +1056,8 @@ pub trait IOpcRelationshipSelectorEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IOpcRelationshipSelector>;
     fn Clone(&self) -> ::windows::core::Result<IOpcRelationshipSelectorEnumerator>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcRelationshipSelectorEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOpcRelationshipSelectorEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipSelectorEnumerator_Impl, const OFFSET: isize>() -> IOpcRelationshipSelectorEnumerator_Vtbl {
@@ -1094,6 +1122,7 @@ pub trait IOpcRelationshipSelectorSet_Impl: Sized {
     fn Delete(&self, relationshipselector: &::core::option::Option<IOpcRelationshipSelector>) -> ::windows::core::Result<()>;
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcRelationshipSelectorEnumerator>;
 }
+impl ::windows::core::RuntimeName for IOpcRelationshipSelectorSet {}
 impl IOpcRelationshipSelectorSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipSelectorSet_Impl, const OFFSET: isize>() -> IOpcRelationshipSelectorSet_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipSelectorSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, selector: OPC_RELATIONSHIP_SELECTOR, selectioncriterion: ::windows::core::PCWSTR, relationshipselector: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1144,6 +1173,8 @@ pub trait IOpcRelationshipSet_Impl: Sized {
     fn GetEnumeratorForType(&self, relationshiptype: &::windows::core::PCWSTR) -> ::windows::core::Result<IOpcRelationshipEnumerator>;
     fn GetRelationshipsContentStream(&self) -> ::windows::core::Result<super::super::super::System::Com::IStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOpcRelationshipSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOpcRelationshipSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcRelationshipSet_Impl, const OFFSET: isize>() -> IOpcRelationshipSet_Vtbl {
@@ -1236,6 +1267,7 @@ impl IOpcRelationshipSet_Vtbl {
 pub trait IOpcSignatureCustomObject_Impl: Sized {
     fn GetXml(&self, xmlmarkup: *mut *mut u8, count: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOpcSignatureCustomObject {}
 impl IOpcSignatureCustomObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureCustomObject_Impl, const OFFSET: isize>() -> IOpcSignatureCustomObject_Vtbl {
         unsafe extern "system" fn GetXml<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureCustomObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xmlmarkup: *mut *mut u8, count: *mut u32) -> ::windows::core::HRESULT {
@@ -1256,6 +1288,8 @@ pub trait IOpcSignatureCustomObjectEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IOpcSignatureCustomObject>;
     fn Clone(&self) -> ::windows::core::Result<IOpcSignatureCustomObjectEnumerator>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcSignatureCustomObjectEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOpcSignatureCustomObjectEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureCustomObjectEnumerator_Impl, const OFFSET: isize>() -> IOpcSignatureCustomObjectEnumerator_Vtbl {
@@ -1320,6 +1354,7 @@ pub trait IOpcSignatureCustomObjectSet_Impl: Sized {
     fn Delete(&self, customobject: &::core::option::Option<IOpcSignatureCustomObject>) -> ::windows::core::Result<()>;
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcSignatureCustomObjectEnumerator>;
 }
+impl ::windows::core::RuntimeName for IOpcSignatureCustomObjectSet {}
 impl IOpcSignatureCustomObjectSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureCustomObjectSet_Impl, const OFFSET: isize>() -> IOpcSignatureCustomObjectSet_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureCustomObjectSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xmlmarkup: *const u8, count: u32, customobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1368,6 +1403,8 @@ pub trait IOpcSignaturePartReference_Impl: Sized {
     fn GetDigestValue(&self, digestvalue: *mut *mut u8, count: *mut u32) -> ::windows::core::Result<()>;
     fn GetTransformMethod(&self) -> ::windows::core::Result<OPC_CANONICALIZATION_METHOD>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSignaturePartReference {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcSignaturePartReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignaturePartReference_Impl, const OFFSET: isize>() -> IOpcSignaturePartReference_Vtbl {
@@ -1441,6 +1478,8 @@ pub trait IOpcSignaturePartReferenceEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcSignaturePartReferenceEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcSignaturePartReferenceEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpcSignaturePartReferenceEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignaturePartReferenceEnumerator_Impl, const OFFSET: isize>() -> IOpcSignaturePartReferenceEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignaturePartReferenceEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1506,6 +1545,8 @@ pub trait IOpcSignaturePartReferenceSet_Impl: Sized {
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcSignaturePartReferenceEnumerator>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSignaturePartReferenceSet {}
+#[cfg(feature = "Win32_System_Com")]
 impl IOpcSignaturePartReferenceSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignaturePartReferenceSet_Impl, const OFFSET: isize>() -> IOpcSignaturePartReferenceSet_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignaturePartReferenceSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parturi: ::windows::core::RawPtr, digestmethod: ::windows::core::PCWSTR, transformmethod: OPC_CANONICALIZATION_METHOD, partreference: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1555,6 +1596,8 @@ pub trait IOpcSignatureReference_Impl: Sized {
     fn GetDigestMethod(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetDigestValue(&self, digestvalue: *mut *mut u8, count: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSignatureReference {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcSignatureReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureReference_Impl, const OFFSET: isize>() -> IOpcSignatureReference_Vtbl {
@@ -1640,6 +1683,8 @@ pub trait IOpcSignatureReferenceEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcSignatureReferenceEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcSignatureReferenceEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpcSignatureReferenceEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureReferenceEnumerator_Impl, const OFFSET: isize>() -> IOpcSignatureReferenceEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureReferenceEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1705,6 +1750,8 @@ pub trait IOpcSignatureReferenceSet_Impl: Sized {
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcSignatureReferenceEnumerator>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSignatureReferenceSet {}
+#[cfg(feature = "Win32_System_Com")]
 impl IOpcSignatureReferenceSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureReferenceSet_Impl, const OFFSET: isize>() -> IOpcSignatureReferenceSet_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureReferenceSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, referenceuri: ::windows::core::RawPtr, referenceid: ::windows::core::PCWSTR, r#type: ::windows::core::PCWSTR, digestmethod: ::windows::core::PCWSTR, transformmethod: OPC_CANONICALIZATION_METHOD, reference: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1754,6 +1801,8 @@ pub trait IOpcSignatureRelationshipReference_Impl: Sized {
     fn GetRelationshipSigningOption(&self) -> ::windows::core::Result<OPC_RELATIONSHIPS_SIGNING_OPTION>;
     fn GetRelationshipSelectorEnumerator(&self) -> ::windows::core::Result<IOpcRelationshipSelectorEnumerator>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSignatureRelationshipReference {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcSignatureRelationshipReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureRelationshipReference_Impl, const OFFSET: isize>() -> IOpcSignatureRelationshipReference_Vtbl {
@@ -1839,6 +1888,8 @@ pub trait IOpcSignatureRelationshipReferenceEnumerator_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IOpcSignatureRelationshipReferenceEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpcSignatureRelationshipReferenceEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureRelationshipReferenceEnumerator_Impl, const OFFSET: isize>() -> IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
         unsafe extern "system" fn MoveNext<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureRelationshipReferenceEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1904,6 +1955,8 @@ pub trait IOpcSignatureRelationshipReferenceSet_Impl: Sized {
     fn Delete(&self, relationshipreference: &::core::option::Option<IOpcSignatureRelationshipReference>) -> ::windows::core::Result<()>;
     fn GetEnumerator(&self) -> ::windows::core::Result<IOpcSignatureRelationshipReferenceEnumerator>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSignatureRelationshipReferenceSet {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcSignatureRelationshipReferenceSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSignatureRelationshipReferenceSet_Impl, const OFFSET: isize>() -> IOpcSignatureRelationshipReferenceSet_Vtbl {
@@ -1977,6 +2030,8 @@ pub trait IOpcSigningOptions_Impl: Sized {
     fn GetSignaturePartName(&self) -> ::windows::core::Result<IOpcPartUri>;
     fn SetSignaturePartName(&self, signaturepartname: &::core::option::Option<IOpcPartUri>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOpcSigningOptions {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOpcSigningOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcSigningOptions_Impl, const OFFSET: isize>() -> IOpcSigningOptions_Vtbl {
@@ -2162,6 +2217,8 @@ pub trait IOpcUri_Impl: Sized + super::super::super::System::Com::IUri_Impl {
     fn GetRelativeUri(&self, targetparturi: &::core::option::Option<IOpcPartUri>) -> ::windows::core::Result<super::super::super::System::Com::IUri>;
     fn CombinePartUri(&self, relativeuri: &::core::option::Option<super::super::super::System::Com::IUri>) -> ::windows::core::Result<IOpcPartUri>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOpcUri {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOpcUri_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpcUri_Impl, const OFFSET: isize>() -> IOpcUri_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
@@ -4,6 +4,7 @@ pub trait IEnumVdsObject_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumVdsObject>;
 }
+impl ::windows::core::RuntimeName for IEnumVdsObject {}
 impl IEnumVdsObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumVdsObject_Impl, const OFFSET: isize>() -> IEnumVdsObject_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumVdsObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppobjectarray: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -48,6 +49,7 @@ pub trait IVdsAdmin_Impl: Sized {
     fn RegisterProvider(&self, providerid: &::windows::core::GUID, providerclsid: &::windows::core::GUID, pwszname: &::windows::core::PCWSTR, r#type: VDS_PROVIDER_TYPE, pwszmachinename: &::windows::core::PCWSTR, pwszversion: &::windows::core::PCWSTR, guidversionid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn UnregisterProvider(&self, providerid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsAdmin {}
 impl IVdsAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsAdmin_Impl, const OFFSET: isize>() -> IVdsAdmin_Vtbl {
         unsafe extern "system" fn RegisterProvider<Identity: ::windows::core::IUnknownImpl, Impl: IVdsAdmin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID, providerclsid: ::windows::core::GUID, pwszname: ::windows::core::PCWSTR, r#type: VDS_PROVIDER_TYPE, pwszmachinename: ::windows::core::PCWSTR, pwszversion: ::windows::core::PCWSTR, guidversionid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -73,6 +75,7 @@ impl IVdsAdmin_Vtbl {
 pub trait IVdsAdviseSink_Impl: Sized {
     fn OnNotify(&self, lnumberofnotifications: i32, pnotificationarray: *const VDS_NOTIFICATION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsAdviseSink {}
 impl IVdsAdviseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsAdviseSink_Impl, const OFFSET: isize>() -> IVdsAdviseSink_Vtbl {
         unsafe extern "system" fn OnNotify<Identity: ::windows::core::IUnknownImpl, Impl: IVdsAdviseSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnumberofnotifications: i32, pnotificationarray: *const VDS_NOTIFICATION) -> ::windows::core::HRESULT {
@@ -91,6 +94,7 @@ pub trait IVdsAsync_Impl: Sized {
     fn Wait(&self, phrresult: *mut ::windows::core::HRESULT, pasyncout: *mut VDS_ASYNC_OUTPUT) -> ::windows::core::Result<()>;
     fn QueryStatus(&self, phrresult: *mut ::windows::core::HRESULT, pulpercentcompleted: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsAsync {}
 impl IVdsAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsAsync_Impl, const OFFSET: isize>() -> IVdsAsync_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: IVdsAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -129,6 +133,7 @@ pub trait IVdsController_Impl: Sized {
     fn QueryAssociatedLuns(&self) -> ::windows::core::Result<IEnumVdsObject>;
     fn SetStatus(&self, status: VDS_CONTROLLER_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsController {}
 impl IVdsController_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsController_Impl, const OFFSET: isize>() -> IVdsController_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IVdsController_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontrollerprop: *mut VDS_CONTROLLER_PROP) -> ::windows::core::HRESULT {
@@ -214,6 +219,7 @@ impl IVdsController_Vtbl {
 pub trait IVdsControllerControllerPort_Impl: Sized {
     fn QueryControllerPorts(&self) -> ::windows::core::Result<IEnumVdsObject>;
 }
+impl ::windows::core::RuntimeName for IVdsControllerControllerPort {}
 impl IVdsControllerControllerPort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsControllerControllerPort_Impl, const OFFSET: isize>() -> IVdsControllerControllerPort_Vtbl {
         unsafe extern "system" fn QueryControllerPorts<Identity: ::windows::core::IUnknownImpl, Impl: IVdsControllerControllerPort_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -240,6 +246,7 @@ pub trait IVdsControllerPort_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn SetStatus(&self, status: VDS_PORT_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsControllerPort {}
 impl IVdsControllerPort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsControllerPort_Impl, const OFFSET: isize>() -> IVdsControllerPort_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IVdsControllerPort_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pportprop: *mut VDS_PORT_PROP) -> ::windows::core::HRESULT {
@@ -308,6 +315,8 @@ pub trait IVdsDrive_Impl: Sized {
     fn SetStatus(&self, status: VDS_DRIVE_STATUS) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsDrive {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVdsDrive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsDrive_Impl, const OFFSET: isize>() -> IVdsDrive_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IVdsDrive_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdriveprop: *mut VDS_DRIVE_PROP) -> ::windows::core::HRESULT {
@@ -369,6 +378,7 @@ impl IVdsDrive_Vtbl {
 pub trait IVdsDrive2_Impl: Sized {
     fn GetProperties2(&self) -> ::windows::core::Result<VDS_DRIVE_PROP2>;
 }
+impl ::windows::core::RuntimeName for IVdsDrive2 {}
 impl IVdsDrive2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsDrive2_Impl, const OFFSET: isize>() -> IVdsDrive2_Vtbl {
         unsafe extern "system" fn GetProperties2<Identity: ::windows::core::IUnknownImpl, Impl: IVdsDrive2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdriveprop2: *mut VDS_DRIVE_PROP2) -> ::windows::core::HRESULT {
@@ -393,6 +403,7 @@ pub trait IVdsHwProvider_Impl: Sized {
     fn Reenumerate(&self) -> ::windows::core::Result<()>;
     fn Refresh(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsHwProvider {}
 impl IVdsHwProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProvider_Impl, const OFFSET: isize>() -> IVdsHwProvider_Vtbl {
         unsafe extern "system" fn QuerySubSystems<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -432,6 +443,8 @@ pub trait IVdsHwProviderPrivate_Impl: Sized {
     fn QueryIfCreatedLun(&self, pwszdevicepath: &::windows::core::PCWSTR, pvdsluninformation: *const VDS_LUN_INFORMATION) -> ::windows::core::Result<::windows::core::GUID>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsHwProviderPrivate {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVdsHwProviderPrivate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderPrivate_Impl, const OFFSET: isize>() -> IVdsHwProviderPrivate_Vtbl {
         unsafe extern "system" fn QueryIfCreatedLun<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderPrivate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszdevicepath: ::windows::core::PCWSTR, pvdsluninformation: *const VDS_LUN_INFORMATION, plunid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -454,6 +467,7 @@ impl IVdsHwProviderPrivate_Vtbl {
 pub trait IVdsHwProviderPrivateMpio_Impl: Sized {
     fn SetAllPathStatusesFromHbaPort(&self, hbaportprop: &VDS_HBAPORT_PROP, status: VDS_PATH_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsHwProviderPrivateMpio {}
 impl IVdsHwProviderPrivateMpio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderPrivateMpio_Impl, const OFFSET: isize>() -> IVdsHwProviderPrivateMpio_Vtbl {
         unsafe extern "system" fn SetAllPathStatusesFromHbaPort<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderPrivateMpio_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hbaportprop: VDS_HBAPORT_PROP, status: VDS_PATH_STATUS) -> ::windows::core::HRESULT {
@@ -476,6 +490,8 @@ pub trait IVdsHwProviderStoragePools_Impl: Sized {
     fn CreateLunInStoragePool(&self, r#type: VDS_LUN_TYPE, ullsizeinbytes: u64, storagepoolid: &::windows::core::GUID, pwszunmaskinglist: &::windows::core::PCWSTR, phints2: *const VDS_HINTS2) -> ::windows::core::Result<IVdsAsync>;
     fn QueryMaxLunCreateSizeInStoragePool(&self, r#type: VDS_LUN_TYPE, storagepoolid: &::windows::core::GUID, phints2: *const VDS_HINTS2) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsHwProviderStoragePools {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsHwProviderStoragePools_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderStoragePools_Impl, const OFFSET: isize>() -> IVdsHwProviderStoragePools_Vtbl {
@@ -526,6 +542,7 @@ impl IVdsHwProviderStoragePools_Vtbl {
 pub trait IVdsHwProviderType_Impl: Sized {
     fn GetProviderType(&self) -> ::windows::core::Result<VDS_HWPROVIDER_TYPE>;
 }
+impl ::windows::core::RuntimeName for IVdsHwProviderType {}
 impl IVdsHwProviderType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderType_Impl, const OFFSET: isize>() -> IVdsHwProviderType_Vtbl {
         unsafe extern "system" fn GetProviderType<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut VDS_HWPROVIDER_TYPE) -> ::windows::core::HRESULT {
@@ -548,6 +565,7 @@ impl IVdsHwProviderType_Vtbl {
 pub trait IVdsHwProviderType2_Impl: Sized {
     fn GetProviderType2(&self) -> ::windows::core::Result<VDS_HWPROVIDER_TYPE>;
 }
+impl ::windows::core::RuntimeName for IVdsHwProviderType2 {}
 impl IVdsHwProviderType2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderType2_Impl, const OFFSET: isize>() -> IVdsHwProviderType2_Vtbl {
         unsafe extern "system" fn GetProviderType2<Identity: ::windows::core::IUnknownImpl, Impl: IVdsHwProviderType2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut VDS_HWPROVIDER_TYPE) -> ::windows::core::HRESULT {
@@ -576,6 +594,7 @@ pub trait IVdsIscsiPortal_Impl: Sized {
     fn GetIpsecSecurity(&self, pinitiatorportaladdress: *const VDS_IPADDRESS) -> ::windows::core::Result<u64>;
     fn SetIpsecSecurity(&self, pinitiatorportaladdress: *const VDS_IPADDRESS, ullsecurityflags: u64, pipseckey: *const VDS_ISCSI_IPSEC_KEY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsIscsiPortal {}
 impl IVdsIscsiPortal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsIscsiPortal_Impl, const OFFSET: isize>() -> IVdsIscsiPortal_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IVdsIscsiPortal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pportalprop: *mut VDS_ISCSI_PORTAL_PROP) -> ::windows::core::HRESULT {
@@ -660,6 +679,7 @@ pub trait IVdsIscsiPortalGroup_Impl: Sized {
     fn RemovePortal(&self, portalid: &::windows::core::GUID) -> ::windows::core::Result<IVdsAsync>;
     fn Delete(&self) -> ::windows::core::Result<IVdsAsync>;
 }
+impl ::windows::core::RuntimeName for IVdsIscsiPortalGroup {}
 impl IVdsIscsiPortalGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsIscsiPortalGroup_Impl, const OFFSET: isize>() -> IVdsIscsiPortalGroup_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IVdsIscsiPortalGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pportalgroupprop: *mut VDS_ISCSI_PORTALGROUP_PROP) -> ::windows::core::HRESULT {
@@ -755,6 +775,8 @@ pub trait IVdsIscsiTarget_Impl: Sized {
     fn RememberInitiatorSharedSecret(&self, pwszinitiatorname: &::windows::core::PCWSTR, pinitiatorsharedsecret: *const VDS_ISCSI_SHARED_SECRET) -> ::windows::core::Result<()>;
     fn GetConnectedInitiators(&self, pppwszinitiatorlist: *mut *mut ::windows::core::PWSTR, plnumberofinitiators: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsIscsiTarget {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsIscsiTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsIscsiTarget_Impl, const OFFSET: isize>() -> IVdsIscsiTarget_Vtbl {
@@ -882,6 +904,8 @@ pub trait IVdsLun_Impl: Sized {
     fn SetStatus(&self, status: VDS_LUN_STATUS) -> ::windows::core::Result<()>;
     fn QueryMaxLunExtendSize(&self, pdriveidarray: *const ::windows::core::GUID, lnumberofdrives: i32) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsLun {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsLun_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLun_Impl, const OFFSET: isize>() -> IVdsLun_Vtbl {
@@ -1073,6 +1097,8 @@ pub trait IVdsLun2_Impl: Sized {
     fn ApplyHints2(&self, phints2: *const VDS_HINTS2) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsLun2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVdsLun2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLun2_Impl, const OFFSET: isize>() -> IVdsLun2_Vtbl {
         unsafe extern "system" fn QueryHints2<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLun2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phints2: *mut VDS_HINTS2) -> ::windows::core::HRESULT {
@@ -1105,6 +1131,7 @@ pub trait IVdsLunControllerPorts_Impl: Sized {
     fn AssociateControllerPorts(&self, pactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofactivecontrollerports: i32, pinactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofinactivecontrollerports: i32) -> ::windows::core::Result<()>;
     fn QueryActiveControllerPorts(&self) -> ::windows::core::Result<IEnumVdsObject>;
 }
+impl ::windows::core::RuntimeName for IVdsLunControllerPorts {}
 impl IVdsLunControllerPorts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunControllerPorts_Impl, const OFFSET: isize>() -> IVdsLunControllerPorts_Vtbl {
         unsafe extern "system" fn AssociateControllerPorts<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunControllerPorts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofactivecontrollerports: i32, pinactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofinactivecontrollerports: i32) -> ::windows::core::HRESULT {
@@ -1137,6 +1164,7 @@ pub trait IVdsLunIscsi_Impl: Sized {
     fn AssociateTargets(&self, ptargetidarray: *const ::windows::core::GUID, lnumberoftargets: i32) -> ::windows::core::Result<()>;
     fn QueryAssociatedTargets(&self) -> ::windows::core::Result<IEnumVdsObject>;
 }
+impl ::windows::core::RuntimeName for IVdsLunIscsi {}
 impl IVdsLunIscsi_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunIscsi_Impl, const OFFSET: isize>() -> IVdsLunIscsi_Vtbl {
         unsafe extern "system" fn AssociateTargets<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunIscsi_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptargetidarray: *const ::windows::core::GUID, lnumberoftargets: i32) -> ::windows::core::HRESULT {
@@ -1172,6 +1200,8 @@ pub trait IVdsLunMpio_Impl: Sized {
     fn SetLoadBalancePolicy(&self, policy: VDS_LOADBALANCE_POLICY_ENUM, ppaths: *const VDS_PATH_POLICY, lnumberofpaths: i32) -> ::windows::core::Result<()>;
     fn GetSupportedLbPolicies(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsLunMpio {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsLunMpio_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunMpio_Impl, const OFFSET: isize>() -> IVdsLunMpio_Vtbl {
@@ -1216,6 +1246,7 @@ impl IVdsLunMpio_Vtbl {
 pub trait IVdsLunNaming_Impl: Sized {
     fn SetFriendlyName(&self, pwszfriendlyname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsLunNaming {}
 impl IVdsLunNaming_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunNaming_Impl, const OFFSET: isize>() -> IVdsLunNaming_Vtbl {
         unsafe extern "system" fn SetFriendlyName<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunNaming_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfriendlyname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1232,6 +1263,7 @@ impl IVdsLunNaming_Vtbl {
 pub trait IVdsLunNumber_Impl: Sized {
     fn GetLunNumber(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IVdsLunNumber {}
 impl IVdsLunNumber_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunNumber_Impl, const OFFSET: isize>() -> IVdsLunNumber_Vtbl {
         unsafe extern "system" fn GetLunNumber<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunNumber_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pullunnumber: *mut u32) -> ::windows::core::HRESULT {
@@ -1259,6 +1291,8 @@ pub trait IVdsLunPlex_Impl: Sized {
     fn QueryHints(&self) -> ::windows::core::Result<VDS_HINTS>;
     fn ApplyHints(&self, phints: *const VDS_HINTS) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsLunPlex {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsLunPlex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsLunPlex_Impl, const OFFSET: isize>() -> IVdsLunPlex_Vtbl {
@@ -1323,6 +1357,7 @@ pub trait IVdsMaintenance_Impl: Sized {
     fn StopMaintenance(&self, operation: VDS_MAINTENANCE_OPERATION) -> ::windows::core::Result<()>;
     fn PulseMaintenance(&self, operation: VDS_MAINTENANCE_OPERATION, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsMaintenance {}
 impl IVdsMaintenance_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsMaintenance_Impl, const OFFSET: isize>() -> IVdsMaintenance_Vtbl {
         unsafe extern "system" fn StartMaintenance<Identity: ::windows::core::IUnknownImpl, Impl: IVdsMaintenance_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, operation: VDS_MAINTENANCE_OPERATION) -> ::windows::core::HRESULT {
@@ -1354,6 +1389,7 @@ impl IVdsMaintenance_Vtbl {
 pub trait IVdsProvider_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_PROVIDER_PROP>;
 }
+impl ::windows::core::RuntimeName for IVdsProvider {}
 impl IVdsProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsProvider_Impl, const OFFSET: isize>() -> IVdsProvider_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IVdsProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pproviderprop: *mut VDS_PROVIDER_PROP) -> ::windows::core::HRESULT {
@@ -1379,6 +1415,8 @@ pub trait IVdsProviderPrivate_Impl: Sized {
     fn OnLoad(&self, pwszmachinename: &::windows::core::PCWSTR, pcallbackobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn OnUnload(&self, bforceunload: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsProviderPrivate {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsProviderPrivate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsProviderPrivate_Impl, const OFFSET: isize>() -> IVdsProviderPrivate_Vtbl {
@@ -1417,6 +1455,7 @@ impl IVdsProviderPrivate_Vtbl {
 pub trait IVdsProviderSupport_Impl: Sized {
     fn GetVersionSupport(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IVdsProviderSupport {}
 impl IVdsProviderSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsProviderSupport_Impl, const OFFSET: isize>() -> IVdsProviderSupport_Vtbl {
         unsafe extern "system" fn GetVersionSupport<Identity: ::windows::core::IUnknownImpl, Impl: IVdsProviderSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulversionsupport: *mut u32) -> ::windows::core::HRESULT {
@@ -1445,6 +1484,8 @@ pub trait IVdsStoragePool_Impl: Sized {
     fn QueryAllocatedLuns(&self) -> ::windows::core::Result<IEnumVdsObject>;
     fn QueryAllocatedStoragePools(&self) -> ::windows::core::Result<IEnumVdsObject>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsStoragePool {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsStoragePool_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsStoragePool_Impl, const OFFSET: isize>() -> IVdsStoragePool_Vtbl {
@@ -1537,6 +1578,8 @@ pub trait IVdsSubSystem_Impl: Sized {
     fn SetStatus(&self, status: VDS_SUB_SYSTEM_STATUS) -> ::windows::core::Result<()>;
     fn QueryMaxLunCreateSize(&self, r#type: VDS_LUN_TYPE, pdriveidarray: *const ::windows::core::GUID, lnumberofdrives: i32, phints: *const VDS_HINTS) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsSubSystem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVdsSubSystem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystem_Impl, const OFFSET: isize>() -> IVdsSubSystem_Vtbl {
@@ -1676,6 +1719,8 @@ pub trait IVdsSubSystem2_Impl: Sized {
     fn QueryMaxLunCreateSize2(&self, r#type: VDS_LUN_TYPE, pdriveidarray: *const ::windows::core::GUID, lnumberofdrives: i32, phints2: *const VDS_HINTS2) -> ::windows::core::Result<u64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVdsSubSystem2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVdsSubSystem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystem2_Impl, const OFFSET: isize>() -> IVdsSubSystem2_Vtbl {
         unsafe extern "system" fn GetProperties2<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psubsystemprop2: *mut VDS_SUB_SYSTEM_PROP2) -> ::windows::core::HRESULT {
@@ -1737,6 +1782,7 @@ impl IVdsSubSystem2_Vtbl {
 pub trait IVdsSubSystemInterconnect_Impl: Sized {
     fn GetSupportedInterconnects(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IVdsSubSystemInterconnect {}
 impl IVdsSubSystemInterconnect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystemInterconnect_Impl, const OFFSET: isize>() -> IVdsSubSystemInterconnect_Vtbl {
         unsafe extern "system" fn GetSupportedInterconnects<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystemInterconnect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulsupportedinterconnectsflag: *mut u32) -> ::windows::core::HRESULT {
@@ -1762,6 +1808,7 @@ pub trait IVdsSubSystemIscsi_Impl: Sized {
     fn CreateTarget(&self, pwsziscsiname: &::windows::core::PCWSTR, pwszfriendlyname: &::windows::core::PCWSTR) -> ::windows::core::Result<IVdsAsync>;
     fn SetIpsecGroupPresharedKey(&self, pipseckey: *const VDS_ISCSI_IPSEC_KEY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsSubSystemIscsi {}
 impl IVdsSubSystemIscsi_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystemIscsi_Impl, const OFFSET: isize>() -> IVdsSubSystemIscsi_Vtbl {
         unsafe extern "system" fn QueryTargets<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystemIscsi_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1817,6 +1864,7 @@ impl IVdsSubSystemIscsi_Vtbl {
 pub trait IVdsSubSystemNaming_Impl: Sized {
     fn SetFriendlyName(&self, pwszfriendlyname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVdsSubSystemNaming {}
 impl IVdsSubSystemNaming_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystemNaming_Impl, const OFFSET: isize>() -> IVdsSubSystemNaming_Vtbl {
         unsafe extern "system" fn SetFriendlyName<Identity: ::windows::core::IUnknownImpl, Impl: IVdsSubSystemNaming_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfriendlyname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
@@ -4,6 +4,7 @@ pub trait IVssAdmin_Impl: Sized {
     fn QueryProviders(&self) -> ::windows::core::Result<IVssEnumObject>;
     fn AbortAllSnapshotsInProgress(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssAdmin {}
 impl IVssAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssAdmin_Impl, const OFFSET: isize>() -> IVssAdmin_Vtbl {
         unsafe extern "system" fn RegisterProvider<Identity: ::windows::core::IUnknownImpl, Impl: IVssAdmin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pproviderid: ::windows::core::GUID, classid: ::windows::core::GUID, pwszprovidername: *const u16, eprovidertype: VSS_PROVIDER_TYPE, pwszproviderversion: *const u16, providerversionid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -49,6 +50,7 @@ pub trait IVssAdminEx_Impl: Sized + IVssAdmin_Impl {
     fn GetProviderContext(&self, providerid: &::windows::core::GUID) -> ::windows::core::Result<i32>;
     fn SetProviderContext(&self, providerid: &::windows::core::GUID, lcontext: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssAdminEx {}
 impl IVssAdminEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssAdminEx_Impl, const OFFSET: isize>() -> IVssAdminEx_Vtbl {
         unsafe extern "system" fn GetProviderCapability<Identity: ::windows::core::IUnknownImpl, Impl: IVssAdminEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pproviderid: ::windows::core::GUID, plloriginalcapabilitymask: *mut u64) -> ::windows::core::HRESULT {
@@ -94,6 +96,7 @@ pub trait IVssAsync_Impl: Sized {
     fn Wait(&self, dwmilliseconds: u32) -> ::windows::core::Result<()>;
     fn QueryStatus(&self, phrresult: *mut ::windows::core::HRESULT, preserved: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssAsync {}
 impl IVssAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssAsync_Impl, const OFFSET: isize>() -> IVssAsync_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: IVssAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -163,6 +166,8 @@ pub trait IVssComponent_Impl: Sized {
     fn GetDifferencedFilesCount(&self, pcdifferencedfiles: *mut u32) -> ::windows::core::Result<()>;
     fn GetDifferencedFile(&self, idifferencedfile: u32, pbstrpath: *mut super::super::Foundation::BSTR, pbstrfilespec: *mut super::super::Foundation::BSTR, pbrecursive: *mut super::super::Foundation::BOOL, pbstrlsnstring: *mut super::super::Foundation::BSTR, pftlastmodifytime: *mut super::super::Foundation::FILETIME) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssComponent {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVssComponent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssComponent_Impl, const OFFSET: isize>() -> IVssComponent_Vtbl {
@@ -425,6 +430,8 @@ pub trait IVssComponentEx_Impl: Sized + IVssComponent_Impl {
     fn GetRestoreName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssComponentEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVssComponentEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssComponentEx_Impl, const OFFSET: isize>() -> IVssComponentEx_Vtbl {
         unsafe extern "system" fn SetPrepareForBackupFailureMsg<Identity: ::windows::core::IUnknownImpl, Impl: IVssComponentEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszfailuremsg: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -507,6 +514,8 @@ pub trait IVssComponentEx2_Impl: Sized + IVssComponent_Impl + IVssComponentEx_Im
     fn GetFailure(&self, phr: *mut ::windows::core::HRESULT, phrapplication: *mut ::windows::core::HRESULT, pbstrapplicationmessage: *mut super::super::Foundation::BSTR, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssComponentEx2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVssComponentEx2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssComponentEx2_Impl, const OFFSET: isize>() -> IVssComponentEx2_Vtbl {
         unsafe extern "system" fn SetFailure<Identity: ::windows::core::IUnknownImpl, Impl: IVssComponentEx2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, hrapplication: ::windows::core::HRESULT, wszapplicationmessage: ::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -539,6 +548,8 @@ pub trait IVssCreateExpressWriterMetadata_Impl: Sized {
     fn SetBackupSchema(&self, dwschemamask: u32) -> ::windows::core::Result<()>;
     fn SaveAsXML(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssCreateExpressWriterMetadata {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVssCreateExpressWriterMetadata_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssCreateExpressWriterMetadata_Impl, const OFFSET: isize>() -> IVssCreateExpressWriterMetadata_Vtbl {
@@ -615,6 +626,8 @@ pub trait IVssCreateWriterMetadata_Impl: Sized {
     fn GetDocument(&self) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMDocument>;
     fn SaveAsXML(&self, pbstrxml: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IVssCreateWriterMetadata {}
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IVssCreateWriterMetadata_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>() -> IVssCreateWriterMetadata_Vtbl {
@@ -713,6 +726,7 @@ pub trait IVssDifferentialSoftwareSnapshotMgmt_Impl: Sized {
     fn QueryDiffAreasOnVolume(&self, pwszvolumename: *const u16) -> ::windows::core::Result<IVssEnumMgmtObject>;
     fn QueryDiffAreasForSnapshot(&self, snapshotid: &::windows::core::GUID) -> ::windows::core::Result<IVssEnumMgmtObject>;
 }
+impl ::windows::core::RuntimeName for IVssDifferentialSoftwareSnapshotMgmt {}
 impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssDifferentialSoftwareSnapshotMgmt_Impl, const OFFSET: isize>() -> IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
         unsafe extern "system" fn AddDiffArea<Identity: ::windows::core::IUnknownImpl, Impl: IVssDifferentialSoftwareSnapshotMgmt_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64) -> ::windows::core::HRESULT {
@@ -791,6 +805,8 @@ pub trait IVssDifferentialSoftwareSnapshotMgmt2_Impl: Sized + IVssDifferentialSo
     fn SetSnapshotPriority(&self, idsnapshot: &::windows::core::GUID, priority: u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssDifferentialSoftwareSnapshotMgmt2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVssDifferentialSoftwareSnapshotMgmt2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssDifferentialSoftwareSnapshotMgmt2_Impl, const OFFSET: isize>() -> IVssDifferentialSoftwareSnapshotMgmt2_Vtbl {
         unsafe extern "system" fn ChangeDiffAreaMaximumSizeEx<Identity: ::windows::core::IUnknownImpl, Impl: IVssDifferentialSoftwareSnapshotMgmt2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64, bvolatile: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -839,6 +855,8 @@ pub trait IVssDifferentialSoftwareSnapshotMgmt3_Impl: Sized + IVssDifferentialSo
     fn DeleteUnusedDiffAreas(&self, pwszdiffareavolumename: *const u16) -> ::windows::core::Result<()>;
     fn QuerySnapshotDeltaBitmap(&self, idsnapshotolder: &::windows::core::GUID, idsnapshotyounger: &::windows::core::GUID, pcblocksizeperbit: *mut u32, pcbitmaplength: *mut u32, ppbbitmap: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssDifferentialSoftwareSnapshotMgmt3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVssDifferentialSoftwareSnapshotMgmt3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssDifferentialSoftwareSnapshotMgmt3_Impl, const OFFSET: isize>() -> IVssDifferentialSoftwareSnapshotMgmt3_Vtbl {
@@ -892,6 +910,7 @@ pub trait IVssEnumMgmtObject_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self, ppenum: *mut ::core::option::Option<IVssEnumMgmtObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssEnumMgmtObject {}
 impl IVssEnumMgmtObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssEnumMgmtObject_Impl, const OFFSET: isize>() -> IVssEnumMgmtObject_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IVssEnumMgmtObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut VSS_MGMT_OBJECT_PROP, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -932,6 +951,7 @@ pub trait IVssEnumObject_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self, ppenum: *mut ::core::option::Option<IVssEnumObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssEnumObject {}
 impl IVssEnumObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssEnumObject_Impl, const OFFSET: isize>() -> IVssEnumObject_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IVssEnumObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut VSS_OBJECT_PROP, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -972,6 +992,7 @@ pub trait IVssExpressWriter_Impl: Sized {
     fn Register(&self) -> ::windows::core::Result<()>;
     fn Unregister(&self, writerid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssExpressWriter {}
 impl IVssExpressWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssExpressWriter_Impl, const OFFSET: isize>() -> IVssExpressWriter_Vtbl {
         unsafe extern "system" fn CreateMetadata<Identity: ::windows::core::IUnknownImpl, Impl: IVssExpressWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, writerid: ::windows::core::GUID, writername: ::windows::core::PCWSTR, usagetype: VSS_USAGE_TYPE, versionmajor: u32, versionminor: u32, reserved: u32, ppmetadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1023,6 +1044,8 @@ pub trait IVssFileShareSnapshotProvider_Impl: Sized {
     fn IsPathSnapshotted(&self, pwszsharepath: *const u16, pbsnapshotspresent: *mut super::super::Foundation::BOOL, plsnapshotcompatibility: *mut i32) -> ::windows::core::Result<()>;
     fn SetSnapshotProperty(&self, snapshotid: &::windows::core::GUID, esnapshotpropertyid: VSS_SNAPSHOT_PROPERTY_ID, vproperty: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVssFileShareSnapshotProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVssFileShareSnapshotProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssFileShareSnapshotProvider_Impl, const OFFSET: isize>() -> IVssFileShareSnapshotProvider_Vtbl {
@@ -1110,6 +1133,8 @@ pub trait IVssHardwareSnapshotProvider_Impl: Sized {
     fn OnLunEmpty(&self, wszdevicename: *const u16, pinformation: *const super::VirtualDiskService::VDS_LUN_INFORMATION) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
+impl ::windows::core::RuntimeName for IVssHardwareSnapshotProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
 impl IVssHardwareSnapshotProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssHardwareSnapshotProvider_Impl, const OFFSET: isize>() -> IVssHardwareSnapshotProvider_Vtbl {
         unsafe extern "system" fn AreLunsSupported<Identity: ::windows::core::IUnknownImpl, Impl: IVssHardwareSnapshotProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lluncount: i32, lcontext: i32, rgwszdevices: *const *const u16, pluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION, pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1163,6 +1188,8 @@ pub trait IVssHardwareSnapshotProviderEx_Impl: Sized + IVssHardwareSnapshotProvi
     fn ResyncLuns(&self, psourceluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, ptargetluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, dwcount: u32) -> ::windows::core::Result<IVssAsync>;
     fn OnReuseLuns(&self, psnapshotluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, poriginalluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, dwcount: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
+impl ::windows::core::RuntimeName for IVssHardwareSnapshotProviderEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
 impl IVssHardwareSnapshotProviderEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssHardwareSnapshotProviderEx_Impl, const OFFSET: isize>() -> IVssHardwareSnapshotProviderEx_Vtbl {
@@ -1219,6 +1246,7 @@ pub trait IVssProviderCreateSnapshotSet_Impl: Sized {
     fn PostFinalCommitSnapshots(&self, snapshotsetid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn AbortSnapshots(&self, snapshotsetid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVssProviderCreateSnapshotSet {}
 impl IVssProviderCreateSnapshotSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssProviderCreateSnapshotSet_Impl, const OFFSET: isize>() -> IVssProviderCreateSnapshotSet_Vtbl {
         unsafe extern "system" fn EndPrepareSnapshots<Identity: ::windows::core::IUnknownImpl, Impl: IVssProviderCreateSnapshotSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, snapshotsetid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1277,6 +1305,8 @@ pub trait IVssProviderNotifications_Impl: Sized {
     fn OnUnload(&self, bforceunload: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssProviderNotifications {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVssProviderNotifications_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssProviderNotifications_Impl, const OFFSET: isize>() -> IVssProviderNotifications_Vtbl {
         unsafe extern "system" fn OnLoad<Identity: ::windows::core::IUnknownImpl, Impl: IVssProviderNotifications_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1304,6 +1334,7 @@ pub trait IVssSnapshotMgmt_Impl: Sized {
     fn QueryVolumesSupportedForSnapshots(&self, providerid: &::windows::core::GUID, lcontext: i32) -> ::windows::core::Result<IVssEnumMgmtObject>;
     fn QuerySnapshotsByVolume(&self, pwszvolumename: *const u16, providerid: &::windows::core::GUID) -> ::windows::core::Result<IVssEnumObject>;
 }
+impl ::windows::core::RuntimeName for IVssSnapshotMgmt {}
 impl IVssSnapshotMgmt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssSnapshotMgmt_Impl, const OFFSET: isize>() -> IVssSnapshotMgmt_Vtbl {
         unsafe extern "system" fn GetProviderMgmtInterface<Identity: ::windows::core::IUnknownImpl, Impl: IVssSnapshotMgmt_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID, interfaceid: *const ::windows::core::GUID, ppitf: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1353,6 +1384,7 @@ impl IVssSnapshotMgmt_Vtbl {
 pub trait IVssSnapshotMgmt2_Impl: Sized {
     fn GetMinDiffAreaSize(&self) -> ::windows::core::Result<i64>;
 }
+impl ::windows::core::RuntimeName for IVssSnapshotMgmt2 {}
 impl IVssSnapshotMgmt2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssSnapshotMgmt2_Impl, const OFFSET: isize>() -> IVssSnapshotMgmt2_Vtbl {
         unsafe extern "system" fn GetMinDiffAreaSize<Identity: ::windows::core::IUnknownImpl, Impl: IVssSnapshotMgmt2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pllmindiffareasize: *mut i64) -> ::windows::core::HRESULT {
@@ -1385,6 +1417,8 @@ pub trait IVssSoftwareSnapshotProvider_Impl: Sized {
     fn RevertToSnapshot(&self, snapshotid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn QueryRevertStatus(&self, pwszvolume: *const u16) -> ::windows::core::Result<IVssAsync>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IVssSoftwareSnapshotProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IVssSoftwareSnapshotProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssSoftwareSnapshotProvider_Impl, const OFFSET: isize>() -> IVssSoftwareSnapshotProvider_Vtbl {
@@ -1487,6 +1521,8 @@ pub trait IVssWMDependency_Impl: Sized {
     fn GetComponentName(&self, pbstrcomponentname: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssWMDependency {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVssWMDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssWMDependency_Impl, const OFFSET: isize>() -> IVssWMDependency_Vtbl {
         unsafe extern "system" fn GetWriterId<Identity: ::windows::core::IUnknownImpl, Impl: IVssWMDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwriterid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1523,6 +1559,8 @@ pub trait IVssWMFiledesc_Impl: Sized {
     fn GetAlternateLocation(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetBackupTypeMask(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVssWMFiledesc {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVssWMFiledesc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssWMFiledesc_Impl, const OFFSET: isize>() -> IVssWMFiledesc_Vtbl {
@@ -1599,6 +1637,7 @@ pub trait IVssWriterComponents_Impl: Sized {
     fn GetWriterInfo(&self, pidinstance: *mut ::windows::core::GUID, pidwriter: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetComponent(&self, icomponent: u32) -> ::windows::core::Result<IVssComponent>;
 }
+impl ::windows::core::RuntimeName for IVssWriterComponents {}
 impl IVssWriterComponents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssWriterComponents_Impl, const OFFSET: isize>() -> IVssWriterComponents_Vtbl {
         unsafe extern "system" fn GetComponentCount<Identity: ::windows::core::IUnknownImpl, Impl: IVssWriterComponents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pccomponents: *mut u32) -> ::windows::core::HRESULT {
@@ -1656,6 +1695,7 @@ pub trait IVssWriterImpl_Impl: Sized {
     fn GetSessionId(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn IsWriterShuttingDown(&self) -> bool;
 }
+impl ::windows::core::RuntimeName for IVssWriterImpl {}
 impl IVssWriterImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVssWriterImpl_Impl, const OFFSET: isize>() -> IVssWriterImpl_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IVssWriterImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, writerid: ::windows::core::GUID, wszwritername: ::windows::core::PCWSTR, wszwriterinstancename: ::windows::core::PCWSTR, dwmajorversion: u32, dwminorversion: u32, ut: VSS_USAGE_TYPE, st: VSS_SOURCE_TYPE, nlevel: VSS_APPLICATION_LEVEL, dwtimeout: u32, aws: VSS_ALTERNATE_WRITER_STATE, biothrottlingonly: u8) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
@@ -3,6 +3,8 @@ pub trait IPrintDocumentPackageStatusEvent_Impl: Sized + super::super::super::Sy
     fn PackageStatusUpdated(&self, packagestatus: *const PrintDocumentPackageStatus) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrintDocumentPackageStatusEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrintDocumentPackageStatusEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDocumentPackageStatusEvent_Impl, const OFFSET: isize>() -> IPrintDocumentPackageStatusEvent_Vtbl {
         unsafe extern "system" fn PackageStatusUpdated<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDocumentPackageStatusEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagestatus: *const PrintDocumentPackageStatus) -> ::windows::core::HRESULT {
@@ -24,6 +26,7 @@ pub trait IPrintDocumentPackageTarget_Impl: Sized {
     fn GetPackageTarget(&self, guidtargettype: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvtarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrintDocumentPackageTarget {}
 impl IPrintDocumentPackageTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDocumentPackageTarget_Impl, const OFFSET: isize>() -> IPrintDocumentPackageTarget_Vtbl {
         unsafe extern "system" fn GetPackageTargetTypes<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDocumentPackageTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetcount: *mut u32, targettypes: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -57,6 +60,8 @@ pub trait IPrintDocumentPackageTargetFactory_Impl: Sized {
     fn CreateDocumentPackageTargetForPrintJob(&self, printername: &::windows::core::PCWSTR, jobname: &::windows::core::PCWSTR, joboutputstream: &::core::option::Option<super::super::super::System::Com::IStream>, jobprintticketstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<IPrintDocumentPackageTarget>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IPrintDocumentPackageTargetFactory {}
+#[cfg(feature = "Win32_System_Com")]
 impl IPrintDocumentPackageTargetFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDocumentPackageTargetFactory_Impl, const OFFSET: isize>() -> IPrintDocumentPackageTargetFactory_Vtbl {
         unsafe extern "system" fn CreateDocumentPackageTargetForPrintJob<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDocumentPackageTargetFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, printername: ::windows::core::PCWSTR, jobname: ::windows::core::PCWSTR, joboutputstream: ::windows::core::RawPtr, jobprintticketstream: ::windows::core::RawPtr, docpackagetarget: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -83,6 +88,7 @@ pub trait IXpsPrintJob_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn GetJobStatus(&self) -> ::windows::core::Result<XPS_JOB_STATUS>;
 }
+impl ::windows::core::RuntimeName for IXpsPrintJob {}
 impl IXpsPrintJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsPrintJob_Impl, const OFFSET: isize>() -> IXpsPrintJob_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: IXpsPrintJob_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -115,6 +121,8 @@ impl IXpsPrintJob_Vtbl {
 pub trait IXpsPrintJobStream_Impl: Sized + super::super::super::System::Com::ISequentialStream_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IXpsPrintJobStream {}
 #[cfg(feature = "Win32_System_Com")]
 impl IXpsPrintJobStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsPrintJobStream_Impl, const OFFSET: isize>() -> IXpsPrintJobStream_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
@@ -5,6 +5,8 @@ pub trait IXpsDocumentPackageTarget_Impl: Sized {
     fn GetXpsType(&self) -> ::windows::core::Result<XPS_DOCUMENT_TYPE>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsDocumentPackageTarget {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsDocumentPackageTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentPackageTarget_Impl, const OFFSET: isize>() -> IXpsDocumentPackageTarget_Vtbl {
         unsafe extern "system" fn GetXpsOMPackageWriter<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentPackageTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documentsequencepartname: ::windows::core::RawPtr, discardcontrolpartname: ::windows::core::RawPtr, packagewriter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -57,6 +59,8 @@ pub trait IXpsDocumentPackageTarget3D_Impl: Sized {
     fn GetXpsOMFactory(&self) -> ::windows::core::Result<IXpsOMObjectFactory>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsDocumentPackageTarget3D {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsDocumentPackageTarget3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentPackageTarget3D_Impl, const OFFSET: isize>() -> IXpsDocumentPackageTarget3D_Vtbl {
         unsafe extern "system" fn GetXpsOMPackageWriter3D<Identity: ::windows::core::IUnknownImpl, Impl: IXpsDocumentPackageTarget3D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documentsequencepartname: ::windows::core::RawPtr, discardcontrolpartname: ::windows::core::RawPtr, modelpartname: ::windows::core::RawPtr, modeldata: ::windows::core::RawPtr, packagewriter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -95,6 +99,7 @@ pub trait IXpsOMBrush_Impl: Sized + IXpsOMShareable_Impl {
     fn GetOpacity(&self) -> ::windows::core::Result<f32>;
     fn SetOpacity(&self, opacity: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMBrush {}
 impl IXpsOMBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMBrush_Impl, const OFFSET: isize>() -> IXpsOMBrush_Vtbl {
         unsafe extern "system" fn GetOpacity<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, opacity: *mut f32) -> ::windows::core::HRESULT {
@@ -139,6 +144,8 @@ pub trait IXpsOMCanvas_Impl: Sized + IXpsOMShareable_Impl + IXpsOMVisual_Impl {
     fn SetDictionaryResource(&self, remotedictionaryresource: &::core::option::Option<IXpsOMRemoteDictionaryResource>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMCanvas>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMCanvas {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXpsOMCanvas_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMCanvas_Impl, const OFFSET: isize>() -> IXpsOMCanvas_Vtbl {
@@ -282,6 +289,8 @@ pub trait IXpsOMColorProfileResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMResou
     fn SetContent(&self, sourcestream: &::core::option::Option<super::super::System::Com::IStream>, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMColorProfileResource {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMColorProfileResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMColorProfileResource_Impl, const OFFSET: isize>() -> IXpsOMColorProfileResource_Vtbl {
         unsafe extern "system" fn GetStream<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMColorProfileResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -320,6 +329,8 @@ pub trait IXpsOMColorProfileResourceCollection_Impl: Sized {
     fn Append(&self, object: &::core::option::Option<IXpsOMColorProfileResource>) -> ::windows::core::Result<()>;
     fn GetByPartName(&self, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMColorProfileResource>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMColorProfileResourceCollection {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMColorProfileResourceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMColorProfileResourceCollection_Impl, const OFFSET: isize>() -> IXpsOMColorProfileResourceCollection_Vtbl {
@@ -428,6 +439,8 @@ pub trait IXpsOMCoreProperties_Impl: Sized + IXpsOMPart_Impl {
     fn SetVersion(&self, version: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMCoreProperties>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMCoreProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMCoreProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMCoreProperties_Impl, const OFFSET: isize>() -> IXpsOMCoreProperties_Vtbl {
@@ -759,6 +772,7 @@ pub trait IXpsOMDashCollection_Impl: Sized {
     fn SetAt(&self, index: u32, dash: *const XPS_DASH) -> ::windows::core::Result<()>;
     fn Append(&self, dash: *const XPS_DASH) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMDashCollection {}
 impl IXpsOMDashCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDashCollection_Impl, const OFFSET: isize>() -> IXpsOMDashCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDashCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -829,6 +843,7 @@ pub trait IXpsOMDictionary_Impl: Sized {
     fn SetAt(&self, index: u32, key: &::windows::core::PCWSTR, entry: &::core::option::Option<IXpsOMShareable>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMDictionary>;
 }
+impl ::windows::core::RuntimeName for IXpsOMDictionary {}
 impl IXpsOMDictionary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDictionary_Impl, const OFFSET: isize>() -> IXpsOMDictionary_Vtbl {
         unsafe extern "system" fn GetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDictionary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, owner: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -941,6 +956,8 @@ pub trait IXpsOMDocument_Impl: Sized + IXpsOMPart_Impl {
     fn Clone(&self) -> ::windows::core::Result<IXpsOMDocument>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMDocument {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocument_Impl, const OFFSET: isize>() -> IXpsOMDocument_Vtbl {
         unsafe extern "system" fn GetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocument_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documentsequence: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1043,6 +1060,7 @@ pub trait IXpsOMDocumentCollection_Impl: Sized {
     fn SetAt(&self, index: u32, document: &::core::option::Option<IXpsOMDocument>) -> ::windows::core::Result<()>;
     fn Append(&self, document: &::core::option::Option<IXpsOMDocument>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMDocumentCollection {}
 impl IXpsOMDocumentCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocumentCollection_Impl, const OFFSET: isize>() -> IXpsOMDocumentCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocumentCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -1109,6 +1127,8 @@ pub trait IXpsOMDocumentSequence_Impl: Sized + IXpsOMPart_Impl {
     fn SetPrintTicketResource(&self, printticketresource: &::core::option::Option<IXpsOMPrintTicketResource>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMDocumentSequence {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMDocumentSequence_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocumentSequence_Impl, const OFFSET: isize>() -> IXpsOMDocumentSequence_Vtbl {
         unsafe extern "system" fn GetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocumentSequence_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, package: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1168,6 +1188,8 @@ pub trait IXpsOMDocumentStructureResource_Impl: Sized + IXpsOMPart_Impl + IXpsOM
     fn SetContent(&self, sourcestream: &::core::option::Option<super::super::System::Com::IStream>, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMDocumentStructureResource {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMDocumentStructureResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocumentStructureResource_Impl, const OFFSET: isize>() -> IXpsOMDocumentStructureResource_Vtbl {
         unsafe extern "system" fn GetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMDocumentStructureResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, owner: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1214,6 +1236,8 @@ pub trait IXpsOMFontResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMResource_Impl
     fn SetContent(&self, sourcestream: &::core::option::Option<super::super::System::Com::IStream>, embeddingoption: XPS_FONT_EMBEDDING, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
     fn GetEmbeddingOption(&self) -> ::windows::core::Result<XPS_FONT_EMBEDDING>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMFontResource {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMFontResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMFontResource_Impl, const OFFSET: isize>() -> IXpsOMFontResource_Vtbl {
@@ -1265,6 +1289,8 @@ pub trait IXpsOMFontResourceCollection_Impl: Sized {
     fn RemoveAt(&self, index: u32) -> ::windows::core::Result<()>;
     fn GetByPartName(&self, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMFontResource>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMFontResourceCollection {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMFontResourceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMFontResourceCollection_Impl, const OFFSET: isize>() -> IXpsOMFontResourceCollection_Vtbl {
@@ -1347,6 +1373,7 @@ pub trait IXpsOMGeometry_Impl: Sized + IXpsOMShareable_Impl {
     fn SetTransformLookup(&self, lookup: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMGeometry>;
 }
+impl ::windows::core::RuntimeName for IXpsOMGeometry {}
 impl IXpsOMGeometry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGeometry_Impl, const OFFSET: isize>() -> IXpsOMGeometry_Vtbl {
         unsafe extern "system" fn GetFigures<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGeometry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, figures: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1465,6 +1492,8 @@ pub trait IXpsOMGeometryFigure_Impl: Sized {
     fn GetSegmentStrokePattern(&self) -> ::windows::core::Result<XPS_SEGMENT_STROKE_PATTERN>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMGeometryFigure>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXpsOMGeometryFigure {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXpsOMGeometryFigure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGeometryFigure_Impl, const OFFSET: isize>() -> IXpsOMGeometryFigure_Vtbl {
@@ -1622,6 +1651,7 @@ pub trait IXpsOMGeometryFigureCollection_Impl: Sized {
     fn SetAt(&self, index: u32, geometryfigure: &::core::option::Option<IXpsOMGeometryFigure>) -> ::windows::core::Result<()>;
     fn Append(&self, geometryfigure: &::core::option::Option<IXpsOMGeometryFigure>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMGeometryFigureCollection {}
 impl IXpsOMGeometryFigureCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGeometryFigureCollection_Impl, const OFFSET: isize>() -> IXpsOMGeometryFigureCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGeometryFigureCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -1710,6 +1740,8 @@ pub trait IXpsOMGlyphs_Impl: Sized + IXpsOMShareable_Impl + IXpsOMVisual_Impl {
     fn GetGlyphsEditor(&self) -> ::windows::core::Result<IXpsOMGlyphsEditor>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMGlyphs>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMGlyphs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXpsOMGlyphs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGlyphs_Impl, const OFFSET: isize>() -> IXpsOMGlyphs_Vtbl {
@@ -2007,6 +2039,8 @@ pub trait IXpsOMGlyphsEditor_Impl: Sized {
     fn SetDeviceFontName(&self, devicefontname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXpsOMGlyphsEditor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IXpsOMGlyphsEditor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGlyphsEditor_Impl, const OFFSET: isize>() -> IXpsOMGlyphsEditor_Vtbl {
         unsafe extern "system" fn ApplyEdits<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGlyphsEditor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2179,6 +2213,7 @@ pub trait IXpsOMGradientBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMBrush_I
     fn GetColorInterpolationMode(&self) -> ::windows::core::Result<XPS_COLOR_INTERPOLATION>;
     fn SetColorInterpolationMode(&self, colorinterpolationmode: XPS_COLOR_INTERPOLATION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMGradientBrush {}
 impl IXpsOMGradientBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGradientBrush_Impl, const OFFSET: isize>() -> IXpsOMGradientBrush_Vtbl {
         unsafe extern "system" fn GetGradientStops<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGradientBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gradientstops: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2293,6 +2328,7 @@ pub trait IXpsOMGradientStop_Impl: Sized {
     fn SetColor(&self, color: *const XPS_COLOR, colorprofile: &::core::option::Option<IXpsOMColorProfileResource>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMGradientStop>;
 }
+impl ::windows::core::RuntimeName for IXpsOMGradientStop {}
 impl IXpsOMGradientStop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGradientStop_Impl, const OFFSET: isize>() -> IXpsOMGradientStop_Vtbl {
         unsafe extern "system" fn GetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGradientStop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, owner: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2365,6 +2401,7 @@ pub trait IXpsOMGradientStopCollection_Impl: Sized {
     fn SetAt(&self, index: u32, stop: &::core::option::Option<IXpsOMGradientStop>) -> ::windows::core::Result<()>;
     fn Append(&self, stop: &::core::option::Option<IXpsOMGradientStop>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMGradientStopCollection {}
 impl IXpsOMGradientStopCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGradientStopCollection_Impl, const OFFSET: isize>() -> IXpsOMGradientStopCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMGradientStopCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -2430,6 +2467,7 @@ pub trait IXpsOMImageBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMBrush_Impl
     fn SetColorProfileResource(&self, colorprofileresource: &::core::option::Option<IXpsOMColorProfileResource>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMImageBrush>;
 }
+impl ::windows::core::RuntimeName for IXpsOMImageBrush {}
 impl IXpsOMImageBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMImageBrush_Impl, const OFFSET: isize>() -> IXpsOMImageBrush_Vtbl {
         unsafe extern "system" fn GetImageResource<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMImageBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, imageresource: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2495,6 +2533,8 @@ pub trait IXpsOMImageResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMResource_Imp
     fn GetImageType(&self) -> ::windows::core::Result<XPS_IMAGE_TYPE>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMImageResource {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMImageResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMImageResource_Impl, const OFFSET: isize>() -> IXpsOMImageResource_Vtbl {
         unsafe extern "system" fn GetStream<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMImageResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, readerstream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2545,6 +2585,8 @@ pub trait IXpsOMImageResourceCollection_Impl: Sized {
     fn Append(&self, object: &::core::option::Option<IXpsOMImageResource>) -> ::windows::core::Result<()>;
     fn GetByPartName(&self, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMImageResource>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMImageResourceCollection {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMImageResourceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMImageResourceCollection_Impl, const OFFSET: isize>() -> IXpsOMImageResourceCollection_Vtbl {
@@ -2623,6 +2665,7 @@ pub trait IXpsOMLinearGradientBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMB
     fn SetEndPoint(&self, endpoint: *const XPS_POINT) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMLinearGradientBrush>;
 }
+impl ::windows::core::RuntimeName for IXpsOMLinearGradientBrush {}
 impl IXpsOMLinearGradientBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMLinearGradientBrush_Impl, const OFFSET: isize>() -> IXpsOMLinearGradientBrush_Vtbl {
         unsafe extern "system" fn GetStartPoint<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMLinearGradientBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, startpoint: *mut XPS_POINT) -> ::windows::core::HRESULT {
@@ -2686,6 +2729,7 @@ pub trait IXpsOMMatrixTransform_Impl: Sized + IXpsOMShareable_Impl {
     fn SetMatrix(&self, matrix: *const XPS_MATRIX) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMMatrixTransform>;
 }
+impl ::windows::core::RuntimeName for IXpsOMMatrixTransform {}
 impl IXpsOMMatrixTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMMatrixTransform_Impl, const OFFSET: isize>() -> IXpsOMMatrixTransform_Vtbl {
         unsafe extern "system" fn GetMatrix<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMMatrixTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, matrix: *mut XPS_MATRIX) -> ::windows::core::HRESULT {
@@ -2730,6 +2774,7 @@ pub trait IXpsOMNameCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IXpsOMNameCollection {}
 impl IXpsOMNameCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMNameCollection_Impl, const OFFSET: isize>() -> IXpsOMNameCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMNameCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -2804,6 +2849,8 @@ pub trait IXpsOMObjectFactory_Impl: Sized {
     fn CreatePartUri(&self, uri: &::windows::core::PCWSTR) -> ::windows::core::Result<super::Packaging::Opc::IOpcPartUri>;
     fn CreateReadOnlyStreamOnFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMObjectFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMObjectFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMObjectFactory_Impl, const OFFSET: isize>() -> IXpsOMObjectFactory_Vtbl {
@@ -3275,6 +3322,8 @@ pub trait IXpsOMObjectFactory1_Impl: Sized + IXpsOMObjectFactory_Impl {
     fn CreateRemoteDictionaryResourceFromStream1(&self, dictionarymarkupstream: &::core::option::Option<super::super::System::Com::IStream>, parturi: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, resources: &::core::option::Option<IXpsOMPartResources>) -> ::windows::core::Result<IXpsOMRemoteDictionaryResource>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMObjectFactory1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMObjectFactory1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMObjectFactory1_Impl, const OFFSET: isize>() -> IXpsOMObjectFactory1_Vtbl {
         unsafe extern "system" fn GetDocumentTypeFromFile<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMObjectFactory1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, documenttype: *mut XPS_DOCUMENT_TYPE) -> ::windows::core::HRESULT {
@@ -3443,6 +3492,8 @@ pub trait IXpsOMPackage_Impl: Sized {
     fn WriteToStream(&self, stream: &::core::option::Option<super::super::System::Com::ISequentialStream>, optimizemarkupsize: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPackage {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPackage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackage_Impl, const OFFSET: isize>() -> IXpsOMPackage_Vtbl {
         unsafe extern "system" fn GetDocumentSequence<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documentsequence: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3544,6 +3595,8 @@ pub trait IXpsOMPackage1_Impl: Sized + IXpsOMPackage_Impl {
     fn WriteToStream1(&self, outputstream: &::core::option::Option<super::super::System::Com::ISequentialStream>, optimizemarkupsize: super::super::Foundation::BOOL, documenttype: XPS_DOCUMENT_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPackage1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPackage1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackage1_Impl, const OFFSET: isize>() -> IXpsOMPackage1_Vtbl {
         unsafe extern "system" fn GetDocumentType<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackage1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documenttype: *mut XPS_DOCUMENT_TYPE) -> ::windows::core::HRESULT {
@@ -3583,6 +3636,8 @@ pub trait IXpsOMPackageTarget_Impl: Sized {
     fn CreateXpsOMPackageWriter(&self, documentsequencepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, documentsequenceprintticket: &::core::option::Option<IXpsOMPrintTicketResource>, discardcontrolpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMPackageWriter>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPackageTarget {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPackageTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackageTarget_Impl, const OFFSET: isize>() -> IXpsOMPackageTarget_Vtbl {
         unsafe extern "system" fn CreateXpsOMPackageWriter<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackageTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documentsequencepartname: ::windows::core::RawPtr, documentsequenceprintticket: ::windows::core::RawPtr, discardcontrolpartname: ::windows::core::RawPtr, packagewriter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3610,6 +3665,8 @@ pub trait IXpsOMPackageWriter_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn IsClosed(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPackageWriter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPackageWriter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackageWriter_Impl, const OFFSET: isize>() -> IXpsOMPackageWriter_Vtbl {
@@ -3663,6 +3720,8 @@ pub trait IXpsOMPackageWriter3D_Impl: Sized + IXpsOMPackageWriter_Impl {
     fn SetModelPrintTicket(&self, printticketpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, printticketdata: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPackageWriter3D {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPackageWriter3D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackageWriter3D_Impl, const OFFSET: isize>() -> IXpsOMPackageWriter3D_Vtbl {
         unsafe extern "system" fn AddModelTexture<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPackageWriter3D_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, texturepartname: ::windows::core::RawPtr, texturedata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3710,6 +3769,8 @@ pub trait IXpsOMPage_Impl: Sized + IXpsOMPart_Impl {
     fn GenerateUnusedLookupKey(&self, r#type: XPS_OBJECT_TYPE) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMPage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPage_Impl, const OFFSET: isize>() -> IXpsOMPage_Vtbl {
@@ -3937,6 +3998,8 @@ pub trait IXpsOMPage1_Impl: Sized + IXpsOMPart_Impl + IXpsOMPage_Impl {
     fn Write1(&self, stream: &::core::option::Option<super::super::System::Com::ISequentialStream>, optimizemarkupsize: super::super::Foundation::BOOL, documenttype: XPS_DOCUMENT_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPage1 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPage1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPage1_Impl, const OFFSET: isize>() -> IXpsOMPage1_Vtbl {
         unsafe extern "system" fn GetDocumentType<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPage1_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, documenttype: *mut XPS_DOCUMENT_TYPE) -> ::windows::core::HRESULT {
@@ -3985,6 +4048,8 @@ pub trait IXpsOMPageReference_Impl: Sized {
     fn HasRestrictedFonts(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMPageReference>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXpsOMPageReference {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXpsOMPageReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPageReference_Impl, const OFFSET: isize>() -> IXpsOMPageReference_Vtbl {
@@ -4172,6 +4237,7 @@ pub trait IXpsOMPageReferenceCollection_Impl: Sized {
     fn SetAt(&self, index: u32, pagereference: &::core::option::Option<IXpsOMPageReference>) -> ::windows::core::Result<()>;
     fn Append(&self, pagereference: &::core::option::Option<IXpsOMPageReference>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMPageReferenceCollection {}
 impl IXpsOMPageReferenceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPageReferenceCollection_Impl, const OFFSET: isize>() -> IXpsOMPageReferenceCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPageReferenceCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -4236,6 +4302,8 @@ pub trait IXpsOMPart_Impl: Sized {
     fn SetPartName(&self, parturi: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPart {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPart_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPart_Impl, const OFFSET: isize>() -> IXpsOMPart_Vtbl {
         unsafe extern "system" fn GetPartName<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPart_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parturi: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4270,6 +4338,7 @@ pub trait IXpsOMPartResources_Impl: Sized {
     fn GetColorProfileResources(&self) -> ::windows::core::Result<IXpsOMColorProfileResourceCollection>;
     fn GetRemoteDictionaryResources(&self) -> ::windows::core::Result<IXpsOMRemoteDictionaryResourceCollection>;
 }
+impl ::windows::core::RuntimeName for IXpsOMPartResources {}
 impl IXpsOMPartResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPartResources_Impl, const OFFSET: isize>() -> IXpsOMPartResources_Vtbl {
         unsafe extern "system" fn GetFontResources<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPartResources_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fontresources: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4337,6 +4406,8 @@ pub trait IXpsOMPartUriCollection_Impl: Sized {
     fn SetAt(&self, index: u32, parturi: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
     fn Append(&self, parturi: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPartUriCollection {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPartUriCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPartUriCollection_Impl, const OFFSET: isize>() -> IXpsOMPartUriCollection_Vtbl {
@@ -4436,6 +4507,8 @@ pub trait IXpsOMPath_Impl: Sized + IXpsOMShareable_Impl + IXpsOMVisual_Impl {
     fn SetFillBrushLookup(&self, lookup: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMPath>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPath {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXpsOMPath_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPath_Impl, const OFFSET: isize>() -> IXpsOMPath_Vtbl {
@@ -4801,6 +4874,8 @@ pub trait IXpsOMPrintTicketResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMResour
     fn SetContent(&self, sourcestream: &::core::option::Option<super::super::System::Com::IStream>, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMPrintTicketResource {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMPrintTicketResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPrintTicketResource_Impl, const OFFSET: isize>() -> IXpsOMPrintTicketResource_Vtbl {
         unsafe extern "system" fn GetStream<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMPrintTicketResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4838,6 +4913,7 @@ pub trait IXpsOMRadialGradientBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMB
     fn SetGradientOrigin(&self, origin: *const XPS_POINT) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMRadialGradientBrush>;
 }
+impl ::windows::core::RuntimeName for IXpsOMRadialGradientBrush {}
 impl IXpsOMRadialGradientBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMRadialGradientBrush_Impl, const OFFSET: isize>() -> IXpsOMRadialGradientBrush_Vtbl {
         unsafe extern "system" fn GetCenter<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMRadialGradientBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, center: *mut XPS_POINT) -> ::windows::core::HRESULT {
@@ -4920,6 +4996,8 @@ pub trait IXpsOMRemoteDictionaryResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMR
     fn SetDictionary(&self, dictionary: &::core::option::Option<IXpsOMDictionary>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMRemoteDictionaryResource {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMRemoteDictionaryResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMRemoteDictionaryResource_Impl, const OFFSET: isize>() -> IXpsOMRemoteDictionaryResource_Vtbl {
         unsafe extern "system" fn GetDictionary<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMRemoteDictionaryResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dictionary: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4953,6 +5031,8 @@ pub trait IXpsOMRemoteDictionaryResource1_Impl: Sized + IXpsOMPart_Impl + IXpsOM
     fn GetDocumentType(&self) -> ::windows::core::Result<XPS_DOCUMENT_TYPE>;
     fn Write1(&self, stream: &::core::option::Option<super::super::System::Com::ISequentialStream>, documenttype: XPS_DOCUMENT_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMRemoteDictionaryResource1 {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMRemoteDictionaryResource1_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMRemoteDictionaryResource1_Impl, const OFFSET: isize>() -> IXpsOMRemoteDictionaryResource1_Vtbl {
@@ -4992,6 +5072,8 @@ pub trait IXpsOMRemoteDictionaryResourceCollection_Impl: Sized {
     fn Append(&self, object: &::core::option::Option<IXpsOMRemoteDictionaryResource>) -> ::windows::core::Result<()>;
     fn GetByPartName(&self, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMRemoteDictionaryResource>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMRemoteDictionaryResourceCollection {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMRemoteDictionaryResourceCollection_Impl, const OFFSET: isize>() -> IXpsOMRemoteDictionaryResourceCollection_Vtbl {
@@ -5066,6 +5148,8 @@ impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMResource_Impl: Sized + IXpsOMPart_Impl {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMResource {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMResource_Impl, const OFFSET: isize>() -> IXpsOMResource_Vtbl {
         Self { base__: IXpsOMPart_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -5078,6 +5162,7 @@ pub trait IXpsOMShareable_Impl: Sized {
     fn GetOwner(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetType(&self) -> ::windows::core::Result<XPS_OBJECT_TYPE>;
 }
+impl ::windows::core::RuntimeName for IXpsOMShareable {}
 impl IXpsOMShareable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMShareable_Impl, const OFFSET: isize>() -> IXpsOMShareable_Vtbl {
         unsafe extern "system" fn GetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMShareable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, owner: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5118,6 +5203,8 @@ pub trait IXpsOMSignatureBlockResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMRes
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
     fn SetContent(&self, sourcestream: &::core::option::Option<super::super::System::Com::IStream>, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMSignatureBlockResource {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMSignatureBlockResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMSignatureBlockResource_Impl, const OFFSET: isize>() -> IXpsOMSignatureBlockResource_Vtbl {
@@ -5169,6 +5256,8 @@ pub trait IXpsOMSignatureBlockResourceCollection_Impl: Sized {
     fn Append(&self, signatureblockresource: &::core::option::Option<IXpsOMSignatureBlockResource>) -> ::windows::core::Result<()>;
     fn GetByPartName(&self, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMSignatureBlockResource>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMSignatureBlockResourceCollection {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMSignatureBlockResourceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMSignatureBlockResourceCollection_Impl, const OFFSET: isize>() -> IXpsOMSignatureBlockResourceCollection_Vtbl {
@@ -5245,6 +5334,7 @@ pub trait IXpsOMSolidColorBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMBrush
     fn SetColor(&self, color: *const XPS_COLOR, colorprofile: &::core::option::Option<IXpsOMColorProfileResource>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMSolidColorBrush>;
 }
+impl ::windows::core::RuntimeName for IXpsOMSolidColorBrush {}
 impl IXpsOMSolidColorBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMSolidColorBrush_Impl, const OFFSET: isize>() -> IXpsOMSolidColorBrush_Vtbl {
         unsafe extern "system" fn GetColor<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMSolidColorBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, color: *mut XPS_COLOR, colorprofile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5285,6 +5375,8 @@ pub trait IXpsOMStoryFragmentsResource_Impl: Sized + IXpsOMPart_Impl + IXpsOMRes
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
     fn SetContent(&self, sourcestream: &::core::option::Option<super::super::System::Com::IStream>, partname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMStoryFragmentsResource {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMStoryFragmentsResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMStoryFragmentsResource_Impl, const OFFSET: isize>() -> IXpsOMStoryFragmentsResource_Vtbl {
@@ -5331,6 +5423,8 @@ pub trait IXpsOMThumbnailGenerator_Impl: Sized {
     fn GenerateThumbnail(&self, page: &::core::option::Option<IXpsOMPage>, thumbnailtype: XPS_IMAGE_TYPE, thumbnailsize: XPS_THUMBNAIL_SIZE, imageresourcepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMImageResource>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMThumbnailGenerator {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsOMThumbnailGenerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMThumbnailGenerator_Impl, const OFFSET: isize>() -> IXpsOMThumbnailGenerator_Vtbl {
         unsafe extern "system" fn GenerateThumbnail<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMThumbnailGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, page: ::windows::core::RawPtr, thumbnailtype: XPS_IMAGE_TYPE, thumbnailsize: XPS_THUMBNAIL_SIZE, imageresourcepartname: ::windows::core::RawPtr, imageresource: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5363,6 +5457,7 @@ pub trait IXpsOMTileBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMBrush_Impl 
     fn GetTileMode(&self) -> ::windows::core::Result<XPS_TILE_MODE>;
     fn SetTileMode(&self, tilemode: XPS_TILE_MODE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMTileBrush {}
 impl IXpsOMTileBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMTileBrush_Impl, const OFFSET: isize>() -> IXpsOMTileBrush_Vtbl {
         unsafe extern "system" fn GetTransform<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMTileBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, transform: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5503,6 +5598,8 @@ pub trait IXpsOMVisual_Impl: Sized + IXpsOMShareable_Impl {
     fn GetLanguage(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn SetLanguage(&self, language: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsOMVisual {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IXpsOMVisual_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMVisual_Impl, const OFFSET: isize>() -> IXpsOMVisual_Vtbl {
@@ -5756,6 +5853,7 @@ pub trait IXpsOMVisualBrush_Impl: Sized + IXpsOMShareable_Impl + IXpsOMBrush_Imp
     fn SetVisualLookup(&self, lookup: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IXpsOMVisualBrush>;
 }
+impl ::windows::core::RuntimeName for IXpsOMVisualBrush {}
 impl IXpsOMVisualBrush_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMVisualBrush_Impl, const OFFSET: isize>() -> IXpsOMVisualBrush_Vtbl {
         unsafe extern "system" fn GetVisual<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMVisualBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, visual: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5834,6 +5932,7 @@ pub trait IXpsOMVisualCollection_Impl: Sized {
     fn SetAt(&self, index: u32, object: &::core::option::Option<IXpsOMVisual>) -> ::windows::core::Result<()>;
     fn Append(&self, object: &::core::option::Option<IXpsOMVisual>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsOMVisualCollection {}
 impl IXpsOMVisualCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMVisualCollection_Impl, const OFFSET: isize>() -> IXpsOMVisualCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsOMVisualCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -5907,6 +6006,8 @@ pub trait IXpsSignature_Impl: Sized {
     fn GetSignatureXml(&self, signaturexml: *mut *mut u8, count: *mut u32) -> ::windows::core::Result<()>;
     fn SetSignatureXml(&self, signaturexml: *const u8, count: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsSignature {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsSignature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignature_Impl, const OFFSET: isize>() -> IXpsSignature_Vtbl {
@@ -6053,6 +6154,8 @@ pub trait IXpsSignatureBlock_Impl: Sized {
     fn CreateRequest(&self, requestid: &::windows::core::PCWSTR) -> ::windows::core::Result<IXpsSignatureRequest>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsSignatureBlock {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsSignatureBlock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureBlock_Impl, const OFFSET: isize>() -> IXpsSignatureBlock_Vtbl {
         unsafe extern "system" fn GetRequests<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureBlock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requests: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6128,6 +6231,7 @@ pub trait IXpsSignatureBlockCollection_Impl: Sized {
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsSignatureBlock>;
     fn RemoveAt(&self, index: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsSignatureBlockCollection {}
 impl IXpsSignatureBlockCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureBlockCollection_Impl, const OFFSET: isize>() -> IXpsSignatureBlockCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureBlockCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -6173,6 +6277,7 @@ pub trait IXpsSignatureCollection_Impl: Sized {
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsSignature>;
     fn RemoveAt(&self, index: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsSignatureCollection {}
 impl IXpsSignatureCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureCollection_Impl, const OFFSET: isize>() -> IXpsSignatureCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -6227,6 +6332,8 @@ pub trait IXpsSignatureManager_Impl: Sized {
     fn SavePackageToFile(&self, filename: &::windows::core::PCWSTR, securityattributes: *const super::super::Security::SECURITY_ATTRIBUTES, flagsandattributes: u32) -> ::windows::core::Result<()>;
     fn SavePackageToStream(&self, stream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsSignatureManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsSignatureManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureManager_Impl, const OFFSET: isize>() -> IXpsSignatureManager_Vtbl {
@@ -6356,6 +6463,8 @@ pub trait IXpsSignatureRequest_Impl: Sized {
     fn GetSignature(&self) -> ::windows::core::Result<IXpsSignature>;
 }
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsSignatureRequest {}
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsSignatureRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureRequest_Impl, const OFFSET: isize>() -> IXpsSignatureRequest_Vtbl {
         unsafe extern "system" fn GetIntent<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, intent: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -6479,6 +6588,7 @@ pub trait IXpsSignatureRequestCollection_Impl: Sized {
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsSignatureRequest>;
     fn RemoveAt(&self, index: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXpsSignatureRequestCollection {}
 impl IXpsSignatureRequestCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureRequestCollection_Impl, const OFFSET: isize>() -> IXpsSignatureRequestCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSignatureRequestCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -6539,6 +6649,8 @@ pub trait IXpsSigningOptions_Impl: Sized {
     fn GetFlags(&self) -> ::windows::core::Result<XPS_SIGN_FLAGS>;
     fn SetFlags(&self, flags: XPS_SIGN_FLAGS) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IXpsSigningOptions {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 impl IXpsSigningOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXpsSigningOptions_Impl, const OFFSET: isize>() -> IXpsSigningOptions_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
@@ -6,6 +6,8 @@ pub trait IABContainer_Impl: Sized + IMAPIProp_Impl + IMAPIContainer_Impl {
     fn ResolveNames(&self, lpproptagarray: *const SPropTagArray, ulflags: u32, lpadrlist: *const ADRLIST) -> ::windows::core::Result<_flaglist>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IABContainer {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IABContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IABContainer_Impl, const OFFSET: isize>() -> IABContainer_Vtbl {
         unsafe extern "system" fn CreateEntry<Identity: ::windows::core::IUnknownImpl, Impl: IABContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbentryid: u32, lpentryid: *const ENTRYID, ulcreateflags: u32, lppmapipropentry: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -73,6 +75,8 @@ pub trait IAddrBook_Impl: Sized + IMAPIProp_Impl {
     fn SetSearchPath(&self, ulflags: u32, lpsearchpath: *mut SRowSet) -> ::windows::core::Result<()>;
     fn PrepareRecips(&self, ulflags: u32, lpproptagarray: *mut SPropTagArray, lpreciplist: *mut ADRLIST) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAddrBook {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAddrBook_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAddrBook_Impl, const OFFSET: isize>() -> IAddrBook_Vtbl {
@@ -195,6 +199,8 @@ impl IAddrBook_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAttach_Impl: Sized + IMAPIProp_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAttach {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAttach_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAttach_Impl, const OFFSET: isize>() -> IAttach_Vtbl {
         Self { base__: IMAPIProp_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -210,6 +216,8 @@ pub trait IDistList_Impl: Sized + IMAPIProp_Impl + IMAPIContainer_Impl {
     fn DeleteEntries(&self, lpentries: *const SBinaryArray, ulflags: u32) -> ::windows::core::Result<()>;
     fn ResolveNames(&self, lpproptagarray: *const SPropTagArray, ulflags: u32, lpadrlist: *const ADRLIST) -> ::windows::core::Result<_flaglist>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDistList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDistList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDistList_Impl, const OFFSET: isize>() -> IDistList_Vtbl {
@@ -262,6 +270,8 @@ pub trait IMAPIAdviseSink_Impl: Sized {
     fn OnNotify(&self, cnotif: u32, lpnotifications: *mut NOTIFICATION) -> u32;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMAPIAdviseSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMAPIAdviseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIAdviseSink_Impl, const OFFSET: isize>() -> IMAPIAdviseSink_Vtbl {
         unsafe extern "system" fn OnNotify<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIAdviseSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cnotif: u32, lpnotifications: *mut NOTIFICATION) -> u32 {
@@ -283,6 +293,8 @@ pub trait IMAPIContainer_Impl: Sized + IMAPIProp_Impl {
     fn SetSearchCriteria(&self, lprestriction: *const SRestriction, lpcontainerlist: *const SBinaryArray, ulsearchflags: u32) -> ::windows::core::Result<()>;
     fn GetSearchCriteria(&self, ulflags: u32, lpprestriction: *mut *mut SRestriction, lppcontainerlist: *mut *mut SBinaryArray, lpulsearchstate: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMAPIContainer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMAPIContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIContainer_Impl, const OFFSET: isize>() -> IMAPIContainer_Vtbl {
@@ -341,6 +353,7 @@ pub trait IMAPIControl_Impl: Sized {
     fn Activate(&self, ulflags: u32, uluiparam: usize) -> ::windows::core::Result<()>;
     fn GetState(&self, ulflags: u32, lpulstate: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMAPIControl {}
 impl IMAPIControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIControl_Impl, const OFFSET: isize>() -> IMAPIControl_Vtbl {
         unsafe extern "system" fn GetLastError<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT {
@@ -389,6 +402,8 @@ pub trait IMAPIFolder_Impl: Sized + IMAPIProp_Impl + IMAPIContainer_Impl {
     fn SaveContentsSort(&self, lpsortcriteria: *const SSortOrderSet, ulflags: u32) -> ::windows::core::Result<()>;
     fn EmptyFolder(&self, uluiparam: usize, lpprogress: &::core::option::Option<IMAPIProgress>, ulflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMAPIFolder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMAPIFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIFolder_Impl, const OFFSET: isize>() -> IMAPIFolder_Vtbl {
@@ -491,6 +506,7 @@ pub trait IMAPIProgress_Impl: Sized {
     fn GetMin(&self, lpulmin: *mut u32) -> ::windows::core::Result<()>;
     fn SetLimits(&self, lpulmin: *mut u32, lpulmax: *mut u32, lpulflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMAPIProgress {}
 impl IMAPIProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIProgress_Impl, const OFFSET: isize>() -> IMAPIProgress_Vtbl {
         unsafe extern "system" fn Progress<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulvalue: u32, ulcount: u32, ultotal: u32) -> ::windows::core::HRESULT {
@@ -545,6 +561,8 @@ pub trait IMAPIProp_Impl: Sized {
     fn GetNamesFromIDs(&self, lppproptags: *mut *mut SPropTagArray, lppropsetguid: *mut ::windows::core::GUID, ulflags: u32, lpcpropnames: *mut u32, lppppropnames: *mut *mut *mut MAPINAMEID) -> ::windows::core::Result<()>;
     fn GetIDsFromNames(&self, cpropnames: u32, lpppropnames: *mut *mut MAPINAMEID, ulflags: u32, lppproptags: *mut *mut SPropTagArray) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMAPIProp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMAPIProp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIProp_Impl, const OFFSET: isize>() -> IMAPIProp_Vtbl {
@@ -630,6 +648,8 @@ pub trait IMAPIStatus_Impl: Sized + IMAPIProp_Impl {
     fn FlushQueues(&self, uluiparam: usize, cbtargettransport: u32, lptargettransport: *const ENTRYID, ulflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMAPIStatus {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMAPIStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIStatus_Impl, const OFFSET: isize>() -> IMAPIStatus_Vtbl {
         unsafe extern "system" fn ValidateState<Identity: ::windows::core::IUnknownImpl, Impl: IMAPIStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uluiparam: usize, ulflags: u32) -> ::windows::core::HRESULT {
@@ -690,6 +710,8 @@ pub trait IMAPITable_Impl: Sized {
     fn GetCollapseState(&self, ulflags: u32, cbinstancekey: u32, lpbinstancekey: *mut u8, lpcbcollapsestate: *mut u32, lppbcollapsestate: *mut *mut u8) -> ::windows::core::Result<()>;
     fn SetCollapseState(&self, ulflags: u32, cbcollapsestate: u32, pbcollapsestate: *mut u8, lpbklocation: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMAPITable {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMAPITable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMAPITable_Impl, const OFFSET: isize>() -> IMAPITable_Vtbl {
@@ -842,6 +864,8 @@ impl IMAPITable_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMailUser_Impl: Sized + IMAPIProp_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMailUser {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMailUser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMailUser_Impl, const OFFSET: isize>() -> IMailUser_Vtbl {
         Self { base__: IMAPIProp_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -861,6 +885,8 @@ pub trait IMessage_Impl: Sized + IMAPIProp_Impl {
     fn SubmitMessage(&self, ulflags: u32) -> ::windows::core::Result<()>;
     fn SetReadFlag(&self, ulflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMessage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMessage_Impl, const OFFSET: isize>() -> IMessage_Vtbl {
@@ -954,6 +980,8 @@ pub trait IMsgStore_Impl: Sized + IMAPIProp_Impl {
     fn FinishedMsg(&self, ulflags: u32, cbentryid: u32, lpentryid: *const ENTRYID) -> ::windows::core::Result<()>;
     fn NotifyNewMail(&self, lpnotification: *const NOTIFICATION) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMsgStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMsgStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsgStore_Impl, const OFFSET: isize>() -> IMsgStore_Vtbl {
@@ -1070,6 +1098,8 @@ impl IMsgStore_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IProfSect_Impl: Sized + IMAPIProp_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IProfSect {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IProfSect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProfSect_Impl, const OFFSET: isize>() -> IProfSect_Vtbl {
         Self { base__: IMAPIProp_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1085,6 +1115,8 @@ pub trait IPropData_Impl: Sized + IMAPIProp_Impl {
     fn HrGetPropAccess(&self, lppproptagarray: *mut *mut SPropTagArray, lprgulaccess: *mut *mut u32) -> ::windows::core::Result<()>;
     fn HrAddObjProps(&self, lppproptagarray: *mut SPropTagArray, lprgulaccess: *mut *mut SPropProblemArray) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPropData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPropData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropData_Impl, const OFFSET: isize>() -> IPropData_Vtbl {
@@ -1128,6 +1160,8 @@ pub trait IProviderAdmin_Impl: Sized {
     fn DeleteProvider(&self, lpuid: *const MAPIUID) -> ::windows::core::Result<()>;
     fn OpenProfileSection(&self, lpuid: *const MAPIUID, lpinterface: *const ::windows::core::GUID, ulflags: u32) -> ::windows::core::Result<IProfSect>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IProviderAdmin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IProviderAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProviderAdmin_Impl, const OFFSET: isize>() -> IProviderAdmin_Vtbl {
@@ -1206,6 +1240,8 @@ pub trait ITableData_Impl: Sized {
     fn HrDeleteRows(&self, ulflags: u32, lprowsettodelete: *mut SRowSet, crowsdeleted: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITableData {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITableData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableData_Impl, const OFFSET: isize>() -> ITableData_Vtbl {
         unsafe extern "system" fn HrGetView<Identity: ::windows::core::IUnknownImpl, Impl: ITableData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpssortorderset: *mut SSortOrderSet, lpfcallerrelease: *mut ::windows::core::RawPtr, ulcallerdata: u32, lppmapitable: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1275,6 +1311,8 @@ pub trait IWABExtInit_Impl: Sized {
     fn Initialize(&self, lpwabextdisplay: *mut WABEXTDISPLAY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWABExtInit {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWABExtInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWABExtInit_Impl, const OFFSET: isize>() -> IWABExtInit_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWABExtInit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpwabextdisplay: *mut WABEXTDISPLAY) -> ::windows::core::HRESULT {
@@ -1307,6 +1345,8 @@ pub trait IWABOBJECT__Impl: Sized {
     fn GetMe(&self, lpiab: &::core::option::Option<IAddrBook>, ulflags: u32, lpdwaction: *mut u32, lpsbeid: *mut SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn SetMe(&self, lpiab: &::core::option::Option<IAddrBook>, ulflags: u32, sbeid: &SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWABOBJECT_ {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWABOBJECT__Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWABOBJECT__Impl, const OFFSET: isize>() -> IWABOBJECT__Vtbl {
@@ -1441,6 +1481,8 @@ pub trait IWABObject_Impl: Sized {
     fn GetMe(&self, lpiab: &::core::option::Option<IAddrBook>, ulflags: u32, lpdwaction: *mut u32, lpsbeid: *mut SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn SetMe(&self, lpiab: &::core::option::Option<IAddrBook>, ulflags: u32, sbeid: &SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWABObject {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWABObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWABObject_Impl, const OFFSET: isize>() -> IWABObject_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
@@ -2,6 +2,7 @@ pub trait IAmsiStream_Impl: Sized {
     fn GetAttribute(&self, attribute: AMSI_ATTRIBUTE, datasize: u32, data: *mut u8, retdata: *mut u32) -> ::windows::core::Result<()>;
     fn Read(&self, position: u64, size: u32, buffer: *mut u8, readsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAmsiStream {}
 impl IAmsiStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAmsiStream_Impl, const OFFSET: isize>() -> IAmsiStream_Vtbl {
         unsafe extern "system" fn GetAttribute<Identity: ::windows::core::IUnknownImpl, Impl: IAmsiStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, attribute: AMSI_ATTRIBUTE, datasize: u32, data: *mut u8, retdata: *mut u32) -> ::windows::core::HRESULT {
@@ -28,6 +29,7 @@ pub trait IAntimalware_Impl: Sized {
     fn Scan(&self, stream: &::core::option::Option<IAmsiStream>, result: *mut AMSI_RESULT, provider: *mut ::core::option::Option<IAntimalwareProvider>) -> ::windows::core::Result<()>;
     fn CloseSession(&self, session: u64);
 }
+impl ::windows::core::RuntimeName for IAntimalware {}
 impl IAntimalware_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalware_Impl, const OFFSET: isize>() -> IAntimalware_Vtbl {
         unsafe extern "system" fn Scan<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalware_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stream: ::windows::core::RawPtr, result: *mut AMSI_RESULT, provider: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -53,6 +55,7 @@ impl IAntimalware_Vtbl {
 pub trait IAntimalware2_Impl: Sized + IAntimalware_Impl {
     fn Notify(&self, buffer: *const ::core::ffi::c_void, length: u32, contentname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR) -> ::windows::core::Result<AMSI_RESULT>;
 }
+impl ::windows::core::RuntimeName for IAntimalware2 {}
 impl IAntimalware2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalware2_Impl, const OFFSET: isize>() -> IAntimalware2_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalware2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer: *const ::core::ffi::c_void, length: u32, contentname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, presult: *mut AMSI_RESULT) -> ::windows::core::HRESULT {
@@ -77,6 +80,7 @@ pub trait IAntimalwareProvider_Impl: Sized {
     fn CloseSession(&self, session: u64);
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IAntimalwareProvider {}
 impl IAntimalwareProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalwareProvider_Impl, const OFFSET: isize>() -> IAntimalwareProvider_Vtbl {
         unsafe extern "system" fn Scan<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalwareProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stream: ::windows::core::RawPtr, result: *mut AMSI_RESULT) -> ::windows::core::HRESULT {
@@ -120,6 +124,7 @@ impl IAntimalwareProvider_Vtbl {
 pub trait IAntimalwareProvider2_Impl: Sized + IAntimalwareProvider_Impl {
     fn Notify(&self, buffer: *const ::core::ffi::c_void, length: u32, contentname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR) -> ::windows::core::Result<AMSI_RESULT>;
 }
+impl ::windows::core::RuntimeName for IAntimalwareProvider2 {}
 impl IAntimalwareProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalwareProvider2_Impl, const OFFSET: isize>() -> IAntimalwareProvider2_Vtbl {
         unsafe extern "system" fn Notify<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalwareProvider2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer: *const ::core::ffi::c_void, length: u32, contentname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, presult: *mut AMSI_RESULT) -> ::windows::core::HRESULT {
@@ -144,6 +149,8 @@ pub trait IAntimalwareUacProvider_Impl: Sized {
     fn UacScan(&self, context: *const AMSI_UAC_REQUEST_CONTEXT) -> ::windows::core::Result<AMSI_RESULT>;
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAntimalwareUacProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAntimalwareUacProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAntimalwareUacProvider_Impl, const OFFSET: isize>() -> IAntimalwareUacProvider_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
@@ -5,6 +5,7 @@ pub trait IAssemblyCache_Impl: Sized {
     fn Reserved(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn InstallAssembly(&self, dwflags: u32, pszmanifestfilepath: &::windows::core::PCWSTR, prefdata: *mut FUSION_INSTALL_REFERENCE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAssemblyCache {}
 impl IAssemblyCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyCache_Impl, const OFFSET: isize>() -> IAssemblyCache_Vtbl {
         unsafe extern "system" fn UninstallAssembly<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyCache_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pszassemblyname: ::windows::core::PCWSTR, prefdata: *mut FUSION_INSTALL_REFERENCE, puldisposition: *mut IASSEMBLYCACHE_UNINSTALL_DISPOSITION) -> ::windows::core::HRESULT {
@@ -58,6 +59,8 @@ pub trait IAssemblyCacheItem_Impl: Sized {
     fn AbortItem(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAssemblyCacheItem {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAssemblyCacheItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyCacheItem_Impl, const OFFSET: isize>() -> IAssemblyCacheItem_Vtbl {
         unsafe extern "system" fn CreateStream<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyCacheItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, pszstreamname: ::windows::core::PCWSTR, dwformat: u32, dwformatflags: u32, ppistream: *mut ::windows::core::RawPtr, pulimaxsize: *mut u64) -> ::windows::core::HRESULT {
@@ -97,6 +100,7 @@ pub trait IAssemblyName_Impl: Sized {
     fn IsEqual(&self, pname: &::core::option::Option<IAssemblyName>, dwcmpflags: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IAssemblyName>;
 }
+impl ::windows::core::RuntimeName for IAssemblyName {}
 impl IAssemblyName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyName_Impl, const OFFSET: isize>() -> IAssemblyName_Vtbl {
         unsafe extern "system" fn SetProperty<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertyid: u32, pvproperty: *mut ::core::ffi::c_void, cbproperty: u32) -> ::windows::core::HRESULT {
@@ -175,6 +179,8 @@ pub trait IEnumMsmDependency_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumMsmDependency>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumMsmDependency {}
+#[cfg(feature = "Win32_System_Com")]
 impl IEnumMsmDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMsmDependency_Impl, const OFFSET: isize>() -> IEnumMsmDependency_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMsmDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cfetch: u32, rgmsmdependencies: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -222,6 +228,8 @@ pub trait IEnumMsmError_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumMsmError>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumMsmError {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumMsmError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMsmError_Impl, const OFFSET: isize>() -> IEnumMsmError_Vtbl {
@@ -271,6 +279,8 @@ pub trait IEnumMsmString_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumMsmString>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumMsmString {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumMsmString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMsmString_Impl, const OFFSET: isize>() -> IEnumMsmString_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMsmString_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cfetch: u32, rgbstrstrings: *mut super::super::Foundation::BSTR, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -317,6 +327,8 @@ pub trait IMsmDependencies_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self, count: *mut i32) -> ::windows::core::Result<()>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmDependencies {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmDependencies_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmDependencies_Impl, const OFFSET: isize>() -> IMsmDependencies_Vtbl {
@@ -365,6 +377,8 @@ pub trait IMsmDependency_Impl: Sized + super::Com::IDispatch_Impl {
     fn Version(&self, version: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmDependency {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmDependency_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmDependency_Impl, const OFFSET: isize>() -> IMsmDependency_Vtbl {
         unsafe extern "system" fn Module<Identity: ::windows::core::IUnknownImpl, Impl: IMsmDependency_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, module: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -403,6 +417,8 @@ pub trait IMsmError_Impl: Sized + super::Com::IDispatch_Impl {
     fn ModuleTable(&self, errortable: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn ModuleKeys(&self) -> ::windows::core::Result<IMsmStrings>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmError {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmError_Impl, const OFFSET: isize>() -> IMsmError_Vtbl {
@@ -475,6 +491,8 @@ pub trait IMsmErrors_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmErrors {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmErrors_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmErrors_Impl, const OFFSET: isize>() -> IMsmErrors_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IMsmErrors_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, item: i32, r#return: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -520,6 +538,8 @@ pub trait IMsmGetFiles_Impl: Sized + super::Com::IDispatch_Impl {
     fn ModuleFiles(&self) -> ::windows::core::Result<IMsmStrings>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmGetFiles {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmGetFiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmGetFiles_Impl, const OFFSET: isize>() -> IMsmGetFiles_Vtbl {
         unsafe extern "system" fn ModuleFiles<Identity: ::windows::core::IUnknownImpl, Impl: IMsmGetFiles_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, files: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -555,6 +575,8 @@ pub trait IMsmMerge_Impl: Sized + super::Com::IDispatch_Impl {
     fn ExtractCAB(&self, filename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn ExtractFiles(&self, path: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmMerge {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmMerge_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmMerge_Impl, const OFFSET: isize>() -> IMsmMerge_Vtbl {
@@ -663,6 +685,8 @@ pub trait IMsmStrings_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMsmStrings {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMsmStrings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMsmStrings_Impl, const OFFSET: isize>() -> IMsmStrings_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IMsmStrings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, item: i32, r#return: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -755,6 +779,8 @@ pub trait IPMApplicationInfo_Impl: Sized {
     fn set_IsMdilMaintenanceNeeded(&self, fismdilmaintenanceneeded: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn set_Title(&self, apptitle: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMApplicationInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMApplicationInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMApplicationInfo_Impl, const OFFSET: isize>() -> IPMApplicationInfo_Vtbl {
@@ -1309,6 +1335,7 @@ impl IPMApplicationInfo_Vtbl {
 pub trait IPMApplicationInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMApplicationInfo>;
 }
+impl ::windows::core::RuntimeName for IPMApplicationInfoEnumerator {}
 impl IPMApplicationInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMApplicationInfoEnumerator_Impl, const OFFSET: isize>() -> IPMApplicationInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMApplicationInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppappinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1345,6 +1372,8 @@ pub trait IPMBackgroundServiceAgentInfo_Impl: Sized {
     fn set_IsScheduled(&self, isscheduled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn set_IsScheduleAllowed(&self, isscheduleallowed: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMBackgroundServiceAgentInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMBackgroundServiceAgentInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMBackgroundServiceAgentInfo_Impl, const OFFSET: isize>() -> IPMBackgroundServiceAgentInfo_Vtbl {
@@ -1479,6 +1508,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
 pub trait IPMBackgroundServiceAgentInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMBackgroundServiceAgentInfo>;
 }
+impl ::windows::core::RuntimeName for IPMBackgroundServiceAgentInfoEnumerator {}
 impl IPMBackgroundServiceAgentInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMBackgroundServiceAgentInfoEnumerator_Impl, const OFFSET: isize>() -> IPMBackgroundServiceAgentInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMBackgroundServiceAgentInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbsainfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1507,6 +1537,8 @@ pub trait IPMBackgroundWorkerInfo_Impl: Sized {
     fn ExpectedRuntime(&self) -> ::windows::core::Result<u32>;
     fn IsBootWorker(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMBackgroundWorkerInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMBackgroundWorkerInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMBackgroundWorkerInfo_Impl, const OFFSET: isize>() -> IPMBackgroundWorkerInfo_Vtbl {
@@ -1581,6 +1613,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
 pub trait IPMBackgroundWorkerInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMBackgroundWorkerInfo>;
 }
+impl ::windows::core::RuntimeName for IPMBackgroundWorkerInfoEnumerator {}
 impl IPMBackgroundWorkerInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMBackgroundWorkerInfoEnumerator_Impl, const OFFSET: isize>() -> IPMBackgroundWorkerInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMBackgroundWorkerInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbwinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1638,6 +1671,8 @@ pub trait IPMDeploymentManager_Impl: Sized {
     fn AddLicenseForAppx(&self, productid: &::windows::core::GUID, pblicense: *const u8, cblicense: u32, pbplayreadyheader: *const u8, cbplayreadyheader: u32) -> ::windows::core::Result<()>;
     fn FixJunctionsForAppsOnSDCard(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPMDeploymentManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPMDeploymentManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMDeploymentManager_Impl, const OFFSET: isize>() -> IPMDeploymentManager_Vtbl {
@@ -1897,6 +1932,8 @@ pub trait IPMEnumerationManager_Impl: Sized {
     fn get_StartAppEnumeratorBlob(&self, filter: &PM_ENUM_FILTER, pcapps: *mut u32, ppappblobs: *mut *mut PM_STARTAPPBLOB) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMEnumerationManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPMEnumerationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMEnumerationManager_Impl, const OFFSET: isize>() -> IPMEnumerationManager_Vtbl {
         unsafe extern "system" fn get_AllApplications<Identity: ::windows::core::IUnknownImpl, Impl: IPMEnumerationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppappenum: *mut ::windows::core::RawPtr, filter: ::core::mem::ManuallyDrop<PM_ENUM_FILTER>) -> ::windows::core::HRESULT {
@@ -2074,6 +2111,8 @@ pub trait IPMExtensionCachedFileUpdaterInfo_Impl: Sized {
     fn SupportsUpdates(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionCachedFileUpdaterInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionCachedFileUpdaterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionCachedFileUpdaterInfo_Impl, const OFFSET: isize>() -> IPMExtensionCachedFileUpdaterInfo_Vtbl {
         unsafe extern "system" fn SupportsUpdates<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionCachedFileUpdaterInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psupportsupdates: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2098,6 +2137,8 @@ pub trait IPMExtensionContractInfo_Impl: Sized {
     fn get_InvocationInfo(&self, paumid: *mut super::super::Foundation::BSTR, pargs: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionContractInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionContractInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionContractInfo_Impl, const OFFSET: isize>() -> IPMExtensionContractInfo_Vtbl {
         unsafe extern "system" fn get_InvocationInfo<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionContractInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, paumid: *mut super::super::Foundation::BSTR, pargs: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2121,6 +2162,8 @@ pub trait IPMExtensionFileExtensionInfo_Impl: Sized {
     fn get_InvocationInfo(&self, pimageurn: *mut super::super::Foundation::BSTR, pparameters: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_AllFileTypes(&self, pcbtypes: *mut u32, pptypes: *mut *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionFileExtensionInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionFileExtensionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionFileExtensionInfo_Impl, const OFFSET: isize>() -> IPMExtensionFileExtensionInfo_Vtbl {
@@ -2180,6 +2223,8 @@ pub trait IPMExtensionFileOpenPickerInfo_Impl: Sized {
     fn SupportsAllFileTypes(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionFileOpenPickerInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionFileOpenPickerInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionFileOpenPickerInfo_Impl, const OFFSET: isize>() -> IPMExtensionFileOpenPickerInfo_Vtbl {
         unsafe extern "system" fn get_AllFileTypes<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionFileOpenPickerInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pctypes: *mut u32, pptypes: *mut *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2213,6 +2258,8 @@ pub trait IPMExtensionFileSavePickerInfo_Impl: Sized {
     fn get_AllFileTypes(&self, pctypes: *mut u32, pptypes: *mut *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SupportsAllFileTypes(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionFileSavePickerInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionFileSavePickerInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionFileSavePickerInfo_Impl, const OFFSET: isize>() -> IPMExtensionFileSavePickerInfo_Vtbl {
@@ -2251,6 +2298,8 @@ pub trait IPMExtensionInfo_Impl: Sized {
     fn ExtraFile(&self, pfilepath: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_InvocationInfo(&self, pimageurn: *mut super::super::Foundation::BSTR, pparameters: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionInfo_Impl, const OFFSET: isize>() -> IPMExtensionInfo_Vtbl {
@@ -2307,6 +2356,7 @@ impl IPMExtensionInfo_Vtbl {
 pub trait IPMExtensionInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMExtensionInfo>;
 }
+impl ::windows::core::RuntimeName for IPMExtensionInfoEnumerator {}
 impl IPMExtensionInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionInfoEnumerator_Impl, const OFFSET: isize>() -> IPMExtensionInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppextensioninfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2331,6 +2381,8 @@ pub trait IPMExtensionProtocolInfo_Impl: Sized {
     fn Protocol(&self, pprotocol: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn get_InvocationInfo(&self, pimageurn: *mut super::super::Foundation::BSTR, pparameters: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionProtocolInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionProtocolInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionProtocolInfo_Impl, const OFFSET: isize>() -> IPMExtensionProtocolInfo_Vtbl {
@@ -2360,6 +2412,8 @@ pub trait IPMExtensionShareTargetInfo_Impl: Sized {
     fn get_AllDataFormats(&self, pcdataformats: *mut u32, ppdataformats: *mut *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SupportsAllFileTypes(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMExtensionShareTargetInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMExtensionShareTargetInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMExtensionShareTargetInfo_Impl, const OFFSET: isize>() -> IPMExtensionShareTargetInfo_Vtbl {
@@ -2422,6 +2476,8 @@ pub trait IPMLiveTileJobInfo_Impl: Sized {
     fn DownloadState(&self) -> ::windows::core::Result<u32>;
     fn set_DownloadState(&self, uldownloadstate: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMLiveTileJobInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMLiveTileJobInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMLiveTileJobInfo_Impl, const OFFSET: isize>() -> IPMLiveTileJobInfo_Vtbl {
@@ -2640,6 +2696,7 @@ impl IPMLiveTileJobInfo_Vtbl {
 pub trait IPMLiveTileJobInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMLiveTileJobInfo>;
 }
+impl ::windows::core::RuntimeName for IPMLiveTileJobInfoEnumerator {}
 impl IPMLiveTileJobInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMLiveTileJobInfoEnumerator_Impl, const OFFSET: isize>() -> IPMLiveTileJobInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMLiveTileJobInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pplivetilejobinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2683,6 +2740,8 @@ pub trait IPMTaskInfo_Impl: Sized {
     fn BackgroundExecutionAbilities(&self, pbackgroundexecutionabilities: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn IsOptedForExtendedMem(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMTaskInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMTaskInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMTaskInfo_Impl, const OFFSET: isize>() -> IPMTaskInfo_Vtbl {
@@ -2895,6 +2954,7 @@ impl IPMTaskInfo_Vtbl {
 pub trait IPMTaskInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMTaskInfo>;
 }
+impl ::windows::core::RuntimeName for IPMTaskInfoEnumerator {}
 impl IPMTaskInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMTaskInfoEnumerator_Impl, const OFFSET: isize>() -> IPMTaskInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMTaskInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptaskinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2941,6 +3001,8 @@ pub trait IPMTileInfo_Impl: Sized {
     fn set_IsRestoring(&self, restoring: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn set_IsAutoRestoreDisabled(&self, autorestoredisabled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMTileInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMTileInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMTileInfo_Impl, const OFFSET: isize>() -> IPMTileInfo_Vtbl {
@@ -3177,6 +3239,7 @@ impl IPMTileInfo_Vtbl {
 pub trait IPMTileInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMTileInfo>;
 }
+impl ::windows::core::RuntimeName for IPMTileInfoEnumerator {}
 impl IPMTileInfoEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMTileInfoEnumerator_Impl, const OFFSET: isize>() -> IPMTileInfoEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMTileInfoEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptileinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3199,6 +3262,7 @@ impl IPMTileInfoEnumerator_Vtbl {
 pub trait IPMTilePropertyEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMTilePropertyInfo>;
 }
+impl ::windows::core::RuntimeName for IPMTilePropertyEnumerator {}
 impl IPMTilePropertyEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMTilePropertyEnumerator_Impl, const OFFSET: isize>() -> IPMTilePropertyEnumerator_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IPMTilePropertyEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pppropinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3224,6 +3288,8 @@ pub trait IPMTilePropertyInfo_Impl: Sized {
     fn PropertyValue(&self, ppropvalue: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn set_Property(&self, propvalue: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPMTilePropertyInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPMTilePropertyInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPMTilePropertyInfo_Impl, const OFFSET: isize>() -> IPMTilePropertyInfo_Vtbl {
@@ -3269,6 +3335,8 @@ pub trait IValidate_Impl: Sized {
     fn SetStatus(&self, pstatusfunction: &LPEVALCOMCALLBACK, pcontext: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Validate(&self, wzices: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IValidate {}
 #[cfg(feature = "Win32_Foundation")]
 impl IValidate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IValidate_Impl, const OFFSET: isize>() -> IValidate_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
@@ -3,6 +3,8 @@ pub trait IAccessibleWinSAT_Impl: Sized + super::Com::IDispatch_Impl + super::su
     fn SetAccessiblityData(&self, wsname: &::windows::core::PCWSTR, wsvalue: &::windows::core::PCWSTR, wsdesc: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Accessibility"))]
+impl ::windows::core::RuntimeName for IAccessibleWinSAT {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Accessibility"))]
 impl IAccessibleWinSAT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleWinSAT_Impl, const OFFSET: isize>() -> IAccessibleWinSAT_Vtbl {
         unsafe extern "system" fn SetAccessiblityData<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleWinSAT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wsname: ::windows::core::PCWSTR, wsvalue: ::windows::core::PCWSTR, wsdesc: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -25,6 +27,8 @@ pub trait IInitiateWinSATAssessment_Impl: Sized {
     fn InitiateFormalAssessment(&self, pcallbacks: &::core::option::Option<IWinSATInitiateEvents>, callerhwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn CancelAssessment(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInitiateWinSATAssessment {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInitiateWinSATAssessment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitiateWinSATAssessment_Impl, const OFFSET: isize>() -> IInitiateWinSATAssessment_Vtbl {
@@ -60,6 +64,8 @@ pub trait IProvideWinSATAssessmentInfo_Impl: Sized + super::Com::IDispatch_Impl 
     fn Title(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Description(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IProvideWinSATAssessmentInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IProvideWinSATAssessmentInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideWinSATAssessmentInfo_Impl, const OFFSET: isize>() -> IProvideWinSATAssessmentInfo_Vtbl {
@@ -115,6 +121,8 @@ pub trait IProvideWinSATResultsInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn SystemRating(&self) -> ::windows::core::Result<f32>;
     fn RatingStateDesc(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IProvideWinSATResultsInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IProvideWinSATResultsInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideWinSATResultsInfo_Impl, const OFFSET: isize>() -> IProvideWinSATResultsInfo_Vtbl {
@@ -191,6 +199,8 @@ pub trait IProvideWinSATVisuals_Impl: Sized {
     fn get_Bitmap(&self, bitmapsize: WINSAT_BITMAP_SIZE, state: WINSAT_ASSESSMENT_STATE, rating: f32) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IProvideWinSATVisuals {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IProvideWinSATVisuals_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideWinSATVisuals_Impl, const OFFSET: isize>() -> IProvideWinSATVisuals_Vtbl {
         unsafe extern "system" fn get_Bitmap<Identity: ::windows::core::IUnknownImpl, Impl: IProvideWinSATVisuals_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bitmapsize: WINSAT_BITMAP_SIZE, state: WINSAT_ASSESSMENT_STATE, rating: f32, pbitmap: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT {
@@ -215,6 +225,8 @@ pub trait IQueryAllWinSATAssessments_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_AllXML(&self, xpath: &super::super::Foundation::BSTR, namespaces: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMNodeList>;
 }
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IQueryAllWinSATAssessments {}
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IQueryAllWinSATAssessments_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryAllWinSATAssessments_Impl, const OFFSET: isize>() -> IQueryAllWinSATAssessments_Vtbl {
         unsafe extern "system" fn get_AllXML<Identity: ::windows::core::IUnknownImpl, Impl: IQueryAllWinSATAssessments_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xpath: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, namespaces: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppdomnodelist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -237,6 +249,7 @@ impl IQueryAllWinSATAssessments_Vtbl {
 pub trait IQueryOEMWinSATCustomization_Impl: Sized {
     fn GetOEMPrePopulationInfo(&self) -> ::windows::core::Result<WINSAT_OEM_DATA_TYPE>;
 }
+impl ::windows::core::RuntimeName for IQueryOEMWinSATCustomization {}
 impl IQueryOEMWinSATCustomization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryOEMWinSATCustomization_Impl, const OFFSET: isize>() -> IQueryOEMWinSATCustomization_Vtbl {
         unsafe extern "system" fn GetOEMPrePopulationInfo<Identity: ::windows::core::IUnknownImpl, Impl: IQueryOEMWinSATCustomization_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, state: *mut WINSAT_OEM_DATA_TYPE) -> ::windows::core::HRESULT {
@@ -261,6 +274,8 @@ pub trait IQueryRecentWinSATAssessment_Impl: Sized + super::Com::IDispatch_Impl 
     fn get_XML(&self, xpath: &super::super::Foundation::BSTR, namespaces: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMNodeList>;
     fn Info(&self) -> ::windows::core::Result<IProvideWinSATResultsInfo>;
 }
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IQueryRecentWinSATAssessment {}
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IQueryRecentWinSATAssessment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryRecentWinSATAssessment_Impl, const OFFSET: isize>() -> IQueryRecentWinSATAssessment_Vtbl {
@@ -300,6 +315,7 @@ pub trait IWinSATInitiateEvents_Impl: Sized {
     fn WinSATComplete(&self, hresult: ::windows::core::HRESULT, strdescription: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn WinSATUpdate(&self, ucurrenttick: u32, uticktotal: u32, strcurrentstate: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinSATInitiateEvents {}
 impl IWinSATInitiateEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinSATInitiateEvents_Impl, const OFFSET: isize>() -> IWinSATInitiateEvents_Vtbl {
         unsafe extern "system" fn WinSATComplete<Identity: ::windows::core::IUnknownImpl, Impl: IWinSATInitiateEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, strdescription: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
@@ -21,6 +21,8 @@ pub trait ICallFrame_Impl: Sized {
     fn Invoke(&self, pvreceiver: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICallFrame {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ICallFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallFrame_Impl, const OFFSET: isize>() -> ICallFrame_Vtbl {
         unsafe extern "system" fn GetInfo<Identity: ::windows::core::IUnknownImpl, Impl: ICallFrame_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *mut CALLFRAMEINFO) -> ::windows::core::HRESULT {
@@ -184,6 +186,7 @@ impl ICallFrame_Vtbl {
 pub trait ICallFrameEvents_Impl: Sized {
     fn OnCall(&self, pframe: &::core::option::Option<ICallFrame>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICallFrameEvents {}
 impl ICallFrameEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallFrameEvents_Impl, const OFFSET: isize>() -> ICallFrameEvents_Vtbl {
         unsafe extern "system" fn OnCall<Identity: ::windows::core::IUnknownImpl, Impl: ICallFrameEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pframe: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -201,6 +204,8 @@ impl ICallFrameEvents_Vtbl {
 pub trait ICallFrameWalker_Impl: Sized {
     fn OnWalkInterface(&self, iid: *const ::windows::core::GUID, ppvinterface: *const *const ::core::ffi::c_void, fin: super::super::super::Foundation::BOOL, fout: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICallFrameWalker {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICallFrameWalker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallFrameWalker_Impl, const OFFSET: isize>() -> ICallFrameWalker_Vtbl {
@@ -222,6 +227,8 @@ pub trait ICallIndirect_Impl: Sized {
     fn GetStackSize(&self, imethod: u32) -> ::windows::core::Result<u32>;
     fn GetIID(&self, piid: *mut ::windows::core::GUID, pfderivesfromidispatch: *mut super::super::super::Foundation::BOOL, pcmethod: *mut u32, pwszinterface: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICallIndirect {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICallIndirect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallIndirect_Impl, const OFFSET: isize>() -> ICallIndirect_Vtbl {
@@ -269,6 +276,8 @@ pub trait ICallInterceptor_Impl: Sized + ICallIndirect_Impl {
     fn GetRegisteredSink(&self) -> ::windows::core::Result<ICallFrameEvents>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICallInterceptor {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICallInterceptor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallInterceptor_Impl, const OFFSET: isize>() -> ICallInterceptor_Vtbl {
         unsafe extern "system" fn RegisterSink<Identity: ::windows::core::IUnknownImpl, Impl: ICallInterceptor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -303,6 +312,8 @@ pub trait ICallUnmarshal_Impl: Sized {
     fn ReleaseMarshalData(&self, imethod: u32, pbuffer: *const ::core::ffi::c_void, cbbuffer: u32, ibfirstrelease: u32, datarep: u32, pcontext: *const CALLFRAME_MARSHALCONTEXT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICallUnmarshal {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICallUnmarshal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallUnmarshal_Impl, const OFFSET: isize>() -> ICallUnmarshal_Vtbl {
         unsafe extern "system" fn Unmarshal<Identity: ::windows::core::IUnknownImpl, Impl: ICallUnmarshal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, imethod: u32, pbuffer: *const ::core::ffi::c_void, cbbuffer: u32, fforcebuffercopy: super::super::super::Foundation::BOOL, datarep: u32, pcontext: *const CALLFRAME_MARSHALCONTEXT, pcbunmarshalled: *mut u32, ppframe: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -329,6 +340,7 @@ pub trait IInterfaceRelated_Impl: Sized {
     fn SetIID(&self, iid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetIID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IInterfaceRelated {}
 impl IInterfaceRelated_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInterfaceRelated_Impl, const OFFSET: isize>() -> IInterfaceRelated_Vtbl {
         unsafe extern "system" fn SetIID<Identity: ::windows::core::IUnknownImpl, Impl: IInterfaceRelated_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/ChannelCredentials/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/ChannelCredentials/impl.rs
@@ -12,6 +12,8 @@ pub trait IChannelCredentials_Impl: Sized + super::IDispatch_Impl {
     fn SetIssuedToken(&self, localissueraddres: &super::super::super::Foundation::BSTR, localissuerbindingtype: &super::super::super::Foundation::BSTR, localissuerbinding: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IChannelCredentials {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IChannelCredentials_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChannelCredentials_Impl, const OFFSET: isize>() -> IChannelCredentials_Vtbl {
         unsafe extern "system" fn SetWindowsCredential<Identity: ::windows::core::IUnknownImpl, Impl: IChannelCredentials_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, domain: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, username: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, password: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, impersonationlevel: i32, allowntlm: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
@@ -1,4 +1,5 @@
 pub trait IDontSupportEventSubscription_Impl: Sized {}
+impl ::windows::core::RuntimeName for IDontSupportEventSubscription {}
 impl IDontSupportEventSubscription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDontSupportEventSubscription_Impl, const OFFSET: isize>() -> IDontSupportEventSubscription_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -13,6 +14,7 @@ pub trait IEnumEventObject_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, cskipelem: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumEventObject {}
 impl IEnumEventObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumEventObject_Impl, const OFFSET: isize>() -> IEnumEventObject_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumEventObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppinterface: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -70,6 +72,8 @@ pub trait IEventClass_Impl: Sized + super::IDispatch_Impl {
     fn TypeLib(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn SetTypeLib(&self, bstrtypelib: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventClass {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventClass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventClass_Impl, const OFFSET: isize>() -> IEventClass_Vtbl {
@@ -219,6 +223,8 @@ pub trait IEventClass2_Impl: Sized + super::IDispatch_Impl + IEventClass_Impl {
     fn SetFireInParallel(&self, ffireinparallel: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventClass2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventClass2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventClass2_Impl, const OFFSET: isize>() -> IEventClass2_Vtbl {
         unsafe extern "system" fn PublisherID<Identity: ::windows::core::IUnknownImpl, Impl: IEventClass2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrpublisherid: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -310,6 +316,8 @@ pub trait IEventControl_Impl: Sized + super::IDispatch_Impl {
     fn SetDefaultQuery(&self, methodname: &super::super::super::Foundation::BSTR, criteria: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventControl_Impl, const OFFSET: isize>() -> IEventControl_Vtbl {
         unsafe extern "system" fn SetPublisherFilter<Identity: ::windows::core::IUnknownImpl, Impl: IEventControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, methodname: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, ppublisherfilter: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -375,6 +383,8 @@ pub trait IEventObjectChange_Impl: Sized {
     fn ChangedPublisher(&self, changetype: EOC_ChangeType, bstrpublisherid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEventObjectChange {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEventObjectChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventObjectChange_Impl, const OFFSET: isize>() -> IEventObjectChange_Vtbl {
         unsafe extern "system" fn ChangedSubscription<Identity: ::windows::core::IUnknownImpl, Impl: IEventObjectChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, changetype: EOC_ChangeType, bstrsubscriptionid: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -409,6 +419,8 @@ pub trait IEventObjectChange2_Impl: Sized {
     fn ChangedEventClass(&self, pinfo: *const COMEVENTSYSCHANGEINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEventObjectChange2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEventObjectChange2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventObjectChange2_Impl, const OFFSET: isize>() -> IEventObjectChange2_Vtbl {
         unsafe extern "system" fn ChangedSubscription<Identity: ::windows::core::IUnknownImpl, Impl: IEventObjectChange2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMEVENTSYSCHANGEINFO) -> ::windows::core::HRESULT {
@@ -440,6 +452,8 @@ pub trait IEventObjectCollection_Impl: Sized + super::IDispatch_Impl {
     fn Add(&self, item: *const super::VARIANT, objectid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Remove(&self, objectid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventObjectCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventObjectCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventObjectCollection_Impl, const OFFSET: isize>() -> IEventObjectCollection_Vtbl {
@@ -519,6 +533,8 @@ pub trait IEventProperty_Impl: Sized + super::IDispatch_Impl {
     fn SetValue(&self, propertyvalue: *const super::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventProperty_Impl, const OFFSET: isize>() -> IEventProperty_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IEventProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertyname: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -582,6 +598,8 @@ pub trait IEventPublisher_Impl: Sized + super::IDispatch_Impl {
     fn RemoveDefaultProperty(&self, bstrpropertyname: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetDefaultPropertyCollection(&self) -> ::windows::core::Result<IEventObjectCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventPublisher {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventPublisher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventPublisher_Impl, const OFFSET: isize>() -> IEventPublisher_Vtbl {
@@ -756,6 +774,8 @@ pub trait IEventSubscription_Impl: Sized + super::IDispatch_Impl {
     fn InterfaceID(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn SetInterfaceID(&self, bstrinterfaceid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventSubscription {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventSubscription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventSubscription_Impl, const OFFSET: isize>() -> IEventSubscription_Vtbl {
@@ -1083,6 +1103,8 @@ pub trait IEventSystem_Impl: Sized + super::IDispatch_Impl {
     fn RemoveS(&self, progid: &super::super::super::Foundation::BSTR, querycriteria: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventSystem {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IEventSystem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventSystem_Impl, const OFFSET: isize>() -> IEventSystem_Vtbl {
         unsafe extern "system" fn Query<Identity: ::windows::core::IUnknownImpl, Impl: IEventSystem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, progid: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, querycriteria: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, errorindex: *mut i32, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1152,6 +1174,8 @@ pub trait IFiringControl_Impl: Sized + super::IDispatch_Impl {
     fn FireSubscription(&self, subscription: &::core::option::Option<IEventSubscription>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFiringControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IFiringControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFiringControl_Impl, const OFFSET: isize>() -> IFiringControl_Vtbl {
         unsafe extern "system" fn FireSubscription<Identity: ::windows::core::IUnknownImpl, Impl: IFiringControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, subscription: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1175,6 +1199,8 @@ pub trait IMultiInterfaceEventControl_Impl: Sized {
     fn FireInParallel(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn SetFireInParallel(&self, ffireinparallel: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMultiInterfaceEventControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMultiInterfaceEventControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiInterfaceEventControl_Impl, const OFFSET: isize>() -> IMultiInterfaceEventControl_Vtbl {
@@ -1258,6 +1284,8 @@ pub trait IMultiInterfacePublisherFilter_Impl: Sized {
     fn PrepareToFire(&self, iid: *const ::windows::core::GUID, methodname: &super::super::super::Foundation::BSTR, firingcontrol: &::core::option::Option<IFiringControl>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMultiInterfacePublisherFilter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMultiInterfacePublisherFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiInterfacePublisherFilter_Impl, const OFFSET: isize>() -> IMultiInterfacePublisherFilter_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IMultiInterfacePublisherFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peic: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1285,6 +1313,8 @@ pub trait IPublisherFilter_Impl: Sized {
     fn Initialize(&self, methodname: &super::super::super::Foundation::BSTR, dispuserdefined: &::core::option::Option<super::IDispatch>) -> ::windows::core::Result<()>;
     fn PrepareToFire(&self, methodname: &super::super::super::Foundation::BSTR, firingcontrol: &::core::option::Option<IFiringControl>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPublisherFilter {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPublisherFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPublisherFilter_Impl, const OFFSET: isize>() -> IPublisherFilter_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
@@ -6,6 +6,7 @@ pub trait IMarshal_Impl: Sized {
     fn ReleaseMarshalData(&self, pstm: &::core::option::Option<super::IStream>) -> ::windows::core::Result<()>;
     fn DisconnectObject(&self, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMarshal {}
 impl IMarshal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMarshal_Impl, const OFFSET: isize>() -> IMarshal_Vtbl {
         unsafe extern "system" fn GetUnmarshalClass<Identity: ::windows::core::IUnknownImpl, Impl: IMarshal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pv: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, mshlflags: u32, pcid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -53,6 +54,7 @@ impl IMarshal_Vtbl {
     }
 }
 pub trait IMarshal2_Impl: Sized + IMarshal_Impl {}
+impl ::windows::core::RuntimeName for IMarshal2 {}
 impl IMarshal2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMarshal2_Impl, const OFFSET: isize>() -> IMarshal2_Vtbl {
         Self { base__: IMarshal_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -65,6 +67,8 @@ impl IMarshal2_Vtbl {
 pub trait IMarshalingStream_Impl: Sized + super::ISequentialStream_Impl + super::IStream_Impl {
     fn GetMarshalingContextAttribute(&self, attribute: super::CO_MARSHALING_CONTEXT_ATTRIBUTES) -> ::windows::core::Result<usize>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IMarshalingStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IMarshalingStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMarshalingStream_Impl, const OFFSET: isize>() -> IMarshalingStream_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
@@ -3,6 +3,7 @@ pub trait IDirectWriterLock_Impl: Sized {
     fn ReleaseWriteAccess(&self) -> ::windows::core::Result<()>;
     fn HaveWriteAccess(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirectWriterLock {}
 impl IDirectWriterLock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirectWriterLock_Impl, const OFFSET: isize>() -> IDirectWriterLock_Vtbl {
         unsafe extern "system" fn WaitForWriteAccess<Identity: ::windows::core::IUnknownImpl, Impl: IDirectWriterLock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtimeout: u32) -> ::windows::core::HRESULT {
@@ -38,6 +39,8 @@ pub trait IEnumSTATPROPSETSTG_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSTATPROPSETSTG>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumSTATPROPSETSTG {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnumSTATPROPSETSTG_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATPROPSETSTG_Impl, const OFFSET: isize>() -> IEnumSTATPROPSETSTG_Vtbl {
@@ -85,6 +88,7 @@ pub trait IEnumSTATPROPSTG_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSTATPROPSTG>;
 }
+impl ::windows::core::RuntimeName for IEnumSTATPROPSTG {}
 impl IEnumSTATPROPSTG_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATPROPSTG_Impl, const OFFSET: isize>() -> IEnumSTATPROPSTG_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATPROPSTG_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut STATPROPSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -133,6 +137,8 @@ pub trait IEnumSTATSTG_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumSTATSTG>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumSTATSTG {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumSTATSTG_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATSTG_Impl, const OFFSET: isize>() -> IEnumSTATSTG_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATSTG_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut super::STATSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -180,6 +186,8 @@ pub trait IFillLockBytes_Impl: Sized {
     fn SetFillSize(&self, ulsize: u64) -> ::windows::core::Result<()>;
     fn Terminate(&self, bcanceled: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFillLockBytes {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFillLockBytes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFillLockBytes_Impl, const OFFSET: isize>() -> IFillLockBytes_Vtbl {
@@ -234,6 +242,7 @@ pub trait ILayoutStorage_Impl: Sized {
     fn ReLayoutDocfile(&self, pwcsnewdfname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ReLayoutDocfileOnILockBytes(&self, pilockbytes: &::core::option::Option<ILockBytes>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILayoutStorage {}
 impl ILayoutStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILayoutStorage_Impl, const OFFSET: isize>() -> ILayoutStorage_Vtbl {
         unsafe extern "system" fn LayoutScript<Identity: ::windows::core::IUnknownImpl, Impl: ILayoutStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstoragelayout: *const super::StorageLayout, nentries: u32, glfinterleavedflag: u32) -> ::windows::core::HRESULT {
@@ -284,6 +293,8 @@ pub trait ILockBytes_Impl: Sized {
     fn UnlockRegion(&self, liboffset: u64, cb: u64, dwlocktype: u32) -> ::windows::core::Result<()>;
     fn Stat(&self, pstatstg: *mut super::STATSTG, grfstatflag: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ILockBytes {}
 #[cfg(feature = "Win32_Foundation")]
 impl ILockBytes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILockBytes_Impl, const OFFSET: isize>() -> ILockBytes_Vtbl {
@@ -353,6 +364,8 @@ pub trait IPersistStorage_Impl: Sized + super::IPersist_Impl {
     fn HandsOffStorage(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPersistStorage {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPersistStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistStorage_Impl, const OFFSET: isize>() -> IPersistStorage_Vtbl {
         unsafe extern "system" fn IsDirty<Identity: ::windows::core::IUnknownImpl, Impl: IPersistStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -405,6 +418,8 @@ pub trait IPropertyBag_Impl: Sized {
     fn Write(&self, pszpropname: &::windows::core::PCWSTR, pvar: *const super::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPropertyBag {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyBag_Impl, const OFFSET: isize>() -> IPropertyBag_Vtbl {
         unsafe extern "system" fn Read<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyBag_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpropname: ::windows::core::PCWSTR, pvar: *mut super::VARIANT, perrorlog: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -431,6 +446,8 @@ pub trait IPropertyBag2_Impl: Sized {
     fn GetPropertyInfo(&self, iproperty: u32, cproperties: u32, ppropbag: *mut PROPBAG2, pcproperties: *mut u32) -> ::windows::core::Result<()>;
     fn LoadObject(&self, pstrname: &::windows::core::PCWSTR, dwhint: u32, punkobject: &::core::option::Option<::windows::core::IUnknown>, perrlog: &::core::option::Option<super::IErrorLog>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPropertyBag2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IPropertyBag2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyBag2_Impl, const OFFSET: isize>() -> IPropertyBag2_Vtbl {
@@ -484,6 +501,7 @@ pub trait IPropertySetStorage_Impl: Sized {
     fn Delete(&self, rfmtid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Enum(&self) -> ::windows::core::Result<IEnumSTATPROPSETSTG>;
 }
+impl ::windows::core::RuntimeName for IPropertySetStorage {}
 impl IPropertySetStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySetStorage_Impl, const OFFSET: isize>() -> IPropertySetStorage_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySetStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rfmtid: *const ::windows::core::GUID, pclsid: *const ::windows::core::GUID, grfflags: u32, grfmode: u32, ppprstg: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -551,6 +569,8 @@ pub trait IPropertyStorage_Impl: Sized {
     fn SetClass(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Stat(&self) -> ::windows::core::Result<STATPROPSETSTG>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPropertyStorage {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPropertyStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStorage_Impl, const OFFSET: isize>() -> IPropertyStorage_Vtbl {
@@ -649,6 +669,7 @@ impl IPropertyStorage_Vtbl {
 pub trait IRootStorage_Impl: Sized {
     fn SwitchToFile(&self, pszfile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRootStorage {}
 impl IRootStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRootStorage_Impl, const OFFSET: isize>() -> IRootStorage_Vtbl {
         unsafe extern "system" fn SwitchToFile<Identity: ::windows::core::IUnknownImpl, Impl: IRootStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -680,6 +701,8 @@ pub trait IStorage_Impl: Sized {
     fn SetStateBits(&self, grfstatebits: u32, grfmask: u32) -> ::windows::core::Result<()>;
     fn Stat(&self, pstatstg: *mut super::STATSTG, grfstatflag: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStorage {}
 #[cfg(feature = "Win32_Foundation")]
 impl IStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorage_Impl, const OFFSET: isize>() -> IStorage_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/UI/impl.rs
@@ -3,6 +3,8 @@ pub trait IDummyHICONIncluder_Impl: Sized {
     fn Dummy(&self, h1: super::super::super::UI::WindowsAndMessaging::HICON, h2: super::super::super::Graphics::Gdi::HDC) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDummyHICONIncluder {}
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDummyHICONIncluder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDummyHICONIncluder_Impl, const OFFSET: isize>() -> IDummyHICONIncluder_Vtbl {
         unsafe extern "system" fn Dummy<Identity: ::windows::core::IUnknownImpl, Impl: IDummyHICONIncluder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, h1: super::super::super::UI::WindowsAndMessaging::HICON, h2: super::super::super::Graphics::Gdi::HDC) -> ::windows::core::HRESULT {
@@ -21,6 +23,8 @@ pub trait IThumbnailExtractor_Impl: Sized {
     fn ExtractThumbnail(&self, pstg: &::core::option::Option<super::StructuredStorage::IStorage>, ullength: u32, ulheight: u32, puloutputlength: *mut u32, puloutputheight: *mut u32, phoutputbitmap: *mut super::super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::Result<()>;
     fn OnFileUpdated(&self, pstg: &::core::option::Option<super::StructuredStorage::IStorage>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IThumbnailExtractor {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IThumbnailExtractor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailExtractor_Impl, const OFFSET: isize>() -> IThumbnailExtractor_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
@@ -1,6 +1,7 @@
 pub trait IBindCallbackRedirect_Impl: Sized {
     fn Redirect(&self, lpcurl: &::windows::core::PCWSTR) -> ::windows::core::Result<i16>;
 }
+impl ::windows::core::RuntimeName for IBindCallbackRedirect {}
 impl IBindCallbackRedirect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindCallbackRedirect_Impl, const OFFSET: isize>() -> IBindCallbackRedirect_Vtbl {
         unsafe extern "system" fn Redirect<Identity: ::windows::core::IUnknownImpl, Impl: IBindCallbackRedirect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpcurl: ::windows::core::PCWSTR, vbcancel: *mut i16) -> ::windows::core::HRESULT {
@@ -23,6 +24,7 @@ impl IBindCallbackRedirect_Vtbl {
 pub trait IBindHttpSecurity_Impl: Sized {
     fn GetIgnoreCertMask(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBindHttpSecurity {}
 impl IBindHttpSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindHttpSecurity_Impl, const OFFSET: isize>() -> IBindHttpSecurity_Vtbl {
         unsafe extern "system" fn GetIgnoreCertMask<Identity: ::windows::core::IUnknownImpl, Impl: IBindHttpSecurity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwignorecertmask: *mut u32) -> ::windows::core::HRESULT {
@@ -45,6 +47,7 @@ impl IBindHttpSecurity_Vtbl {
 pub trait IBindProtocol_Impl: Sized {
     fn CreateBinding(&self, szurl: &::windows::core::PCWSTR, pbc: &::core::option::Option<super::IBindCtx>) -> ::windows::core::Result<super::IBinding>;
 }
+impl ::windows::core::RuntimeName for IBindProtocol {}
 impl IBindProtocol_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindProtocol_Impl, const OFFSET: isize>() -> IBindProtocol_Vtbl {
         unsafe extern "system" fn CreateBinding<Identity: ::windows::core::IUnknownImpl, Impl: IBindProtocol_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szurl: ::windows::core::PCWSTR, pbc: ::windows::core::RawPtr, ppb: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -68,6 +71,7 @@ pub trait ICatalogFileInfo_Impl: Sized {
     fn GetCatalogFile(&self) -> ::windows::core::Result<::windows::core::PSTR>;
     fn GetJavaTrust(&self, ppjavatrust: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICatalogFileInfo {}
 impl ICatalogFileInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICatalogFileInfo_Impl, const OFFSET: isize>() -> ICatalogFileInfo_Vtbl {
         unsafe extern "system" fn GetCatalogFile<Identity: ::windows::core::IUnknownImpl, Impl: ICatalogFileInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszcatalogfile: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT {
@@ -101,6 +105,8 @@ pub trait ICodeInstall_Impl: Sized + IWindowForBindingUI_Impl {
     fn OnCodeInstallProblem(&self, ulstatuscode: u32, szdestination: &::windows::core::PCWSTR, szsource: &::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICodeInstall {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICodeInstall_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICodeInstall_Impl, const OFFSET: isize>() -> ICodeInstall_Vtbl {
         unsafe extern "system" fn OnCodeInstallProblem<Identity: ::windows::core::IUnknownImpl, Impl: ICodeInstall_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulstatuscode: u32, szdestination: ::windows::core::PCWSTR, szsource: ::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -119,6 +125,7 @@ pub trait IDataFilter_Impl: Sized {
     fn DoDecode(&self, dwflags: u32, linbuffersize: i32, pbinbuffer: *const u8, loutbuffersize: i32, pboutbuffer: *mut u8, linbytesavailable: i32, plinbytesread: *mut i32, ploutbyteswritten: *mut i32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn SetEncodingLevel(&self, dwenclevel: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDataFilter {}
 impl IDataFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataFilter_Impl, const OFFSET: isize>() -> IDataFilter_Vtbl {
         unsafe extern "system" fn DoEncode<Identity: ::windows::core::IUnknownImpl, Impl: IDataFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, linbuffersize: i32, pbinbuffer: *const u8, loutbuffersize: i32, pboutbuffer: *mut u8, linbytesavailable: i32, plinbytesread: *mut i32, ploutbyteswritten: *mut i32, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -151,6 +158,7 @@ pub trait IEncodingFilterFactory_Impl: Sized {
     fn FindBestFilter(&self, pwzcodein: &::windows::core::PCWSTR, pwzcodeout: &::windows::core::PCWSTR, info: &DATAINFO) -> ::windows::core::Result<IDataFilter>;
     fn GetDefaultFilter(&self, pwzcodein: &::windows::core::PCWSTR, pwzcodeout: &::windows::core::PCWSTR) -> ::windows::core::Result<IDataFilter>;
 }
+impl ::windows::core::RuntimeName for IEncodingFilterFactory {}
 impl IEncodingFilterFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEncodingFilterFactory_Impl, const OFFSET: isize>() -> IEncodingFilterFactory_Vtbl {
         unsafe extern "system" fn FindBestFilter<Identity: ::windows::core::IUnknownImpl, Impl: IEncodingFilterFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzcodein: ::windows::core::PCWSTR, pwzcodeout: ::windows::core::PCWSTR, info: DATAINFO, ppdf: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -190,6 +198,8 @@ pub trait IGetBindHandle_Impl: Sized {
     fn GetBindHandle(&self, enumrequestedhandle: BINDHANDLETYPES) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGetBindHandle {}
+#[cfg(feature = "Win32_Foundation")]
 impl IGetBindHandle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetBindHandle_Impl, const OFFSET: isize>() -> IGetBindHandle_Vtbl {
         unsafe extern "system" fn GetBindHandle<Identity: ::windows::core::IUnknownImpl, Impl: IGetBindHandle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumrequestedhandle: BINDHANDLETYPES, prethandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -213,6 +223,7 @@ pub trait IHttpNegotiate_Impl: Sized {
     fn BeginningTransaction(&self, szurl: &::windows::core::PCWSTR, szheaders: &::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn OnResponse(&self, dwresponsecode: u32, szresponseheaders: &::windows::core::PCWSTR, szrequestheaders: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IHttpNegotiate {}
 impl IHttpNegotiate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHttpNegotiate_Impl, const OFFSET: isize>() -> IHttpNegotiate_Vtbl {
         unsafe extern "system" fn BeginningTransaction<Identity: ::windows::core::IUnknownImpl, Impl: IHttpNegotiate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szurl: ::windows::core::PCWSTR, szheaders: ::windows::core::PCWSTR, dwreserved: u32, pszadditionalheaders: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -250,6 +261,7 @@ impl IHttpNegotiate_Vtbl {
 pub trait IHttpNegotiate2_Impl: Sized + IHttpNegotiate_Impl {
     fn GetRootSecurityId(&self, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IHttpNegotiate2 {}
 impl IHttpNegotiate2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHttpNegotiate2_Impl, const OFFSET: isize>() -> IHttpNegotiate2_Vtbl {
         unsafe extern "system" fn GetRootSecurityId<Identity: ::windows::core::IUnknownImpl, Impl: IHttpNegotiate2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::HRESULT {
@@ -266,6 +278,7 @@ impl IHttpNegotiate2_Vtbl {
 pub trait IHttpNegotiate3_Impl: Sized + IHttpNegotiate_Impl + IHttpNegotiate2_Impl {
     fn GetSerializedClientCertContext(&self, ppbcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IHttpNegotiate3 {}
 impl IHttpNegotiate3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHttpNegotiate3_Impl, const OFFSET: isize>() -> IHttpNegotiate3_Vtbl {
         unsafe extern "system" fn GetSerializedClientCertContext<Identity: ::windows::core::IUnknownImpl, Impl: IHttpNegotiate3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::HRESULT {
@@ -287,6 +300,8 @@ pub trait IHttpSecurity_Impl: Sized + IWindowForBindingUI_Impl {
     fn OnSecurityProblem(&self, dwproblem: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IHttpSecurity {}
+#[cfg(feature = "Win32_Foundation")]
 impl IHttpSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHttpSecurity_Impl, const OFFSET: isize>() -> IHttpSecurity_Vtbl {
         unsafe extern "system" fn OnSecurityProblem<Identity: ::windows::core::IUnknownImpl, Impl: IHttpSecurity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwproblem: u32) -> ::windows::core::HRESULT {
@@ -301,6 +316,7 @@ impl IHttpSecurity_Vtbl {
     }
 }
 pub trait IInternet_Impl: Sized {}
+impl ::windows::core::RuntimeName for IInternet {}
 impl IInternet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternet_Impl, const OFFSET: isize>() -> IInternet_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -314,6 +330,8 @@ pub trait IInternetBindInfo_Impl: Sized {
     fn GetBindInfo(&self, grfbindf: *mut u32, pbindinfo: *mut super::BINDINFO) -> ::windows::core::Result<()>;
     fn GetBindString(&self, ulstringtype: u32, ppwzstr: *mut ::windows::core::PWSTR, cel: u32, pcelfetched: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IInternetBindInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 impl IInternetBindInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetBindInfo_Impl, const OFFSET: isize>() -> IInternetBindInfo_Vtbl {
@@ -342,6 +360,8 @@ pub trait IInternetBindInfoEx_Impl: Sized + IInternetBindInfo_Impl {
     fn GetBindInfoEx(&self, grfbindf: *mut u32, pbindinfo: *mut super::BINDINFO, grfbindf2: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IInternetBindInfoEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 impl IInternetBindInfoEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetBindInfoEx_Impl, const OFFSET: isize>() -> IInternetBindInfoEx_Vtbl {
         unsafe extern "system" fn GetBindInfoEx<Identity: ::windows::core::IUnknownImpl, Impl: IInternetBindInfoEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, grfbindf: *mut u32, pbindinfo: *mut super::BINDINFO, grfbindf2: *mut u32, pdwreserved: *mut u32) -> ::windows::core::HRESULT {
@@ -360,6 +380,7 @@ pub trait IInternetHostSecurityManager_Impl: Sized {
     fn ProcessUrlAction(&self, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn QueryCustomPolicy(&self, guidkey: *const ::windows::core::GUID, pppolicy: *mut *mut u8, pcbpolicy: *mut u32, pcontext: *const u8, cbcontext: u32, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetHostSecurityManager {}
 impl IInternetHostSecurityManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetHostSecurityManager_Impl, const OFFSET: isize>() -> IInternetHostSecurityManager_Vtbl {
         unsafe extern "system" fn GetSecurityId<Identity: ::windows::core::IUnknownImpl, Impl: IInternetHostSecurityManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::HRESULT {
@@ -392,6 +413,7 @@ pub trait IInternetPriority_Impl: Sized {
     fn SetPriority(&self, npriority: i32) -> ::windows::core::Result<()>;
     fn GetPriority(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IInternetPriority {}
 impl IInternetPriority_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetPriority_Impl, const OFFSET: isize>() -> IInternetPriority_Vtbl {
         unsafe extern "system" fn SetPriority<Identity: ::windows::core::IUnknownImpl, Impl: IInternetPriority_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, npriority: i32) -> ::windows::core::HRESULT {
@@ -427,6 +449,8 @@ pub trait IInternetProtocol_Impl: Sized + IInternetProtocolRoot_Impl {
     fn LockRequest(&self, dwoptions: u32) -> ::windows::core::Result<()>;
     fn UnlockRequest(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetProtocol {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInternetProtocol_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocol_Impl, const OFFSET: isize>() -> IInternetProtocol_Vtbl {
@@ -473,6 +497,8 @@ pub trait IInternetProtocolEx_Impl: Sized + IInternetProtocolRoot_Impl + IIntern
     fn StartEx(&self, puri: &::core::option::Option<super::IUri>, poiprotsink: &::core::option::Option<IInternetProtocolSink>, poibindinfo: &::core::option::Option<IInternetBindInfo>, grfpi: u32, dwreserved: super::super::super::Foundation::HANDLE_PTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetProtocolEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl IInternetProtocolEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolEx_Impl, const OFFSET: isize>() -> IInternetProtocolEx_Vtbl {
         unsafe extern "system" fn StartEx<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puri: ::windows::core::RawPtr, poiprotsink: ::windows::core::RawPtr, poibindinfo: ::windows::core::RawPtr, grfpi: u32, dwreserved: super::super::super::Foundation::HANDLE_PTR) -> ::windows::core::HRESULT {
@@ -492,6 +518,7 @@ pub trait IInternetProtocolInfo_Impl: Sized {
     fn CompareUrl(&self, pwzurl1: &::windows::core::PCWSTR, pwzurl2: &::windows::core::PCWSTR, dwcompareflags: u32) -> ::windows::core::Result<()>;
     fn QueryInfo(&self, pwzurl: &::windows::core::PCWSTR, oueryoption: QUERYOPTION, dwqueryflags: u32, pbuffer: *mut ::core::ffi::c_void, cbbuffer: u32, pcbbuf: *mut u32, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetProtocolInfo {}
 impl IInternetProtocolInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolInfo_Impl, const OFFSET: isize>() -> IInternetProtocolInfo_Vtbl {
         unsafe extern "system" fn ParseUrl<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzurl: ::windows::core::PCWSTR, parseaction: PARSEACTION, dwparseflags: u32, pwzresult: ::windows::core::PWSTR, cchresult: u32, pcchresult: *mut u32, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -535,6 +562,8 @@ pub trait IInternetProtocolRoot_Impl: Sized {
     fn Suspend(&self) -> ::windows::core::Result<()>;
     fn Resume(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetProtocolRoot {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInternetProtocolRoot_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolRoot_Impl, const OFFSET: isize>() -> IInternetProtocolRoot_Vtbl {
@@ -588,6 +617,7 @@ pub trait IInternetProtocolSink_Impl: Sized {
     fn ReportData(&self, grfbscf: u32, ulprogress: u32, ulprogressmax: u32) -> ::windows::core::Result<()>;
     fn ReportResult(&self, hrresult: ::windows::core::HRESULT, dwerror: u32, szresult: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetProtocolSink {}
 impl IInternetProtocolSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolSink_Impl, const OFFSET: isize>() -> IInternetProtocolSink_Vtbl {
         unsafe extern "system" fn Switch<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprotocoldata: *const PROTOCOLDATA) -> ::windows::core::HRESULT {
@@ -627,6 +657,7 @@ pub trait IInternetProtocolSinkStackable_Impl: Sized {
     fn CommitSwitch(&self) -> ::windows::core::Result<()>;
     fn RollbackSwitch(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetProtocolSinkStackable {}
 impl IInternetProtocolSinkStackable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolSinkStackable_Impl, const OFFSET: isize>() -> IInternetProtocolSinkStackable_Vtbl {
         unsafe extern "system" fn SwitchSink<Identity: ::windows::core::IUnknownImpl, Impl: IInternetProtocolSinkStackable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poiprotsink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -665,6 +696,7 @@ pub trait IInternetSecurityManager_Impl: Sized {
     fn SetZoneMapping(&self, dwzone: u32, lpszpattern: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetZoneMappings(&self, dwzone: u32, ppenumstring: *mut ::core::option::Option<super::IEnumString>, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetSecurityManager {}
 impl IInternetSecurityManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityManager_Impl, const OFFSET: isize>() -> IInternetSecurityManager_Vtbl {
         unsafe extern "system" fn SetSecuritySite<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psite: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -732,6 +764,7 @@ impl IInternetSecurityManager_Vtbl {
 pub trait IInternetSecurityManagerEx_Impl: Sized + IInternetSecurityManager_Impl {
     fn ProcessUrlActionEx(&self, pwszurl: &::windows::core::PCWSTR, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: u32, pdwoutflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetSecurityManagerEx {}
 impl IInternetSecurityManagerEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityManagerEx_Impl, const OFFSET: isize>() -> IInternetSecurityManagerEx_Vtbl {
         unsafe extern "system" fn ProcessUrlActionEx<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityManagerEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: u32, pdwoutflags: *mut u32) -> ::windows::core::HRESULT {
@@ -751,6 +784,7 @@ pub trait IInternetSecurityManagerEx2_Impl: Sized + IInternetSecurityManager_Imp
     fn GetSecurityIdEx2(&self, puri: &::core::option::Option<super::IUri>, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::Result<()>;
     fn QueryCustomPolicyEx2(&self, puri: &::core::option::Option<super::IUri>, guidkey: *const ::windows::core::GUID, pppolicy: *mut *mut u8, pcbpolicy: *mut u32, pcontext: *const u8, cbcontext: u32, dwreserved: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetSecurityManagerEx2 {}
 impl IInternetSecurityManagerEx2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityManagerEx2_Impl, const OFFSET: isize>() -> IInternetSecurityManagerEx2_Vtbl {
         unsafe extern "system" fn MapUrlToZoneEx2<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityManagerEx2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puri: ::windows::core::RawPtr, pdwzone: *mut u32, dwflags: u32, ppwszmappedurl: *mut ::windows::core::PWSTR, pdwoutflags: *mut u32) -> ::windows::core::HRESULT {
@@ -791,6 +825,8 @@ pub trait IInternetSecurityMgrSite_Impl: Sized {
     fn EnableModeless(&self, fenable: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetSecurityMgrSite {}
+#[cfg(feature = "Win32_Foundation")]
 impl IInternetSecurityMgrSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityMgrSite_Impl, const OFFSET: isize>() -> IInternetSecurityMgrSite_Vtbl {
         unsafe extern "system" fn GetWindow<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSecurityMgrSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -828,6 +864,7 @@ pub trait IInternetSession_Impl: Sized {
     fn SetSessionOption(&self, dwoption: u32, pbuffer: *const ::core::ffi::c_void, dwbufferlength: u32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn GetSessionOption(&self, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pdwbufferlength: *mut u32, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetSession {}
 impl IInternetSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSession_Impl, const OFFSET: isize>() -> IInternetSession_Vtbl {
         unsafe extern "system" fn RegisterNameSpace<Identity: ::windows::core::IUnknownImpl, Impl: IInternetSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcf: ::windows::core::RawPtr, rclsid: *const ::windows::core::GUID, pwzprotocol: ::windows::core::PCWSTR, cpatterns: u32, ppwzpatterns: *const ::windows::core::PWSTR, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -884,6 +921,7 @@ pub trait IInternetThreadSwitch_Impl: Sized {
     fn Prepare(&self) -> ::windows::core::Result<()>;
     fn Continue(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternetThreadSwitch {}
 impl IInternetThreadSwitch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetThreadSwitch_Impl, const OFFSET: isize>() -> IInternetThreadSwitch_Vtbl {
         unsafe extern "system" fn Prepare<Identity: ::windows::core::IUnknownImpl, Impl: IInternetThreadSwitch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -921,6 +959,8 @@ pub trait IInternetZoneManager_Impl: Sized {
     fn DestroyZoneEnumerator(&self, dwenum: u32) -> ::windows::core::Result<()>;
     fn CopyTemplatePoliciesToZone(&self, dwtemplate: u32, dwzone: u32, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetZoneManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInternetZoneManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetZoneManager_Impl, const OFFSET: isize>() -> IInternetZoneManager_Vtbl {
@@ -1016,6 +1056,8 @@ pub trait IInternetZoneManagerEx_Impl: Sized + IInternetZoneManager_Impl {
     fn SetZoneActionPolicyEx(&self, dwzone: u32, dwaction: u32, ppolicy: *const u8, cbpolicy: u32, urlzonereg: URLZONEREG, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetZoneManagerEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl IInternetZoneManagerEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetZoneManagerEx_Impl, const OFFSET: isize>() -> IInternetZoneManagerEx_Vtbl {
         unsafe extern "system" fn GetZoneActionPolicyEx<Identity: ::windows::core::IUnknownImpl, Impl: IInternetZoneManagerEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwzone: u32, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, urlzonereg: URLZONEREG, dwflags: u32) -> ::windows::core::HRESULT {
@@ -1045,6 +1087,8 @@ pub trait IInternetZoneManagerEx2_Impl: Sized + IInternetZoneManager_Impl + IInt
     fn GetIESecurityState(&self, frespectpolicy: super::super::super::Foundation::BOOL, pdwstate: *mut u32, pfpolicyencountered: *mut super::super::super::Foundation::BOOL, fnocache: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn FixUnsecureSettings(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInternetZoneManagerEx2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInternetZoneManagerEx2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternetZoneManagerEx2_Impl, const OFFSET: isize>() -> IInternetZoneManagerEx2_Vtbl {
@@ -1083,6 +1127,7 @@ impl IInternetZoneManagerEx2_Vtbl {
 pub trait IMonikerProp_Impl: Sized {
     fn PutProperty(&self, mkp: MONIKERPROPERTY, val: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMonikerProp {}
 impl IMonikerProp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMonikerProp_Impl, const OFFSET: isize>() -> IMonikerProp_Vtbl {
         unsafe extern "system" fn PutProperty<Identity: ::windows::core::IUnknownImpl, Impl: IMonikerProp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mkp: MONIKERPROPERTY, val: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1105,6 +1150,8 @@ pub trait IPersistMoniker_Impl: Sized {
     fn SaveCompleted(&self, pimkname: &::core::option::Option<super::IMoniker>, pibc: &::core::option::Option<super::IBindCtx>) -> ::windows::core::Result<()>;
     fn GetCurMoniker(&self) -> ::windows::core::Result<super::IMoniker>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPersistMoniker {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPersistMoniker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistMoniker_Impl, const OFFSET: isize>() -> IPersistMoniker_Vtbl {
@@ -1172,6 +1219,8 @@ pub trait ISoftDistExt_Impl: Sized {
     fn AsyncInstallDistributionUnit(&self, pbc: &::core::option::Option<super::IBindCtx>, pvreserved: *const ::core::ffi::c_void, flags: u32, lpcbh: *const CODEBASEHOLD) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Data_Xml_MsXml")]
+impl ::windows::core::RuntimeName for ISoftDistExt {}
+#[cfg(feature = "Win32_Data_Xml_MsXml")]
 impl ISoftDistExt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISoftDistExt_Impl, const OFFSET: isize>() -> ISoftDistExt_Vtbl {
         unsafe extern "system" fn ProcessSoftDist<Identity: ::windows::core::IUnknownImpl, Impl: ISoftDistExt_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szcdfurl: ::windows::core::PCWSTR, psoftdistelement: ::windows::core::RawPtr, lpsdi: *mut SOFTDISTINFO) -> ::windows::core::HRESULT {
@@ -1210,6 +1259,7 @@ pub trait IUriBuilderFactory_Impl: Sized {
     fn CreateIUriBuilder(&self, dwflags: u32, dwreserved: usize) -> ::windows::core::Result<super::IUriBuilder>;
     fn CreateInitializedIUriBuilder(&self, dwflags: u32, dwreserved: usize) -> ::windows::core::Result<super::IUriBuilder>;
 }
+impl ::windows::core::RuntimeName for IUriBuilderFactory {}
 impl IUriBuilderFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUriBuilderFactory_Impl, const OFFSET: isize>() -> IUriBuilderFactory_Vtbl {
         unsafe extern "system" fn CreateIUriBuilder<Identity: ::windows::core::IUnknownImpl, Impl: IUriBuilderFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, dwreserved: usize, ppiuribuilder: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1247,6 +1297,7 @@ impl IUriBuilderFactory_Vtbl {
 pub trait IUriContainer_Impl: Sized {
     fn GetIUri(&self) -> ::windows::core::Result<super::IUri>;
 }
+impl ::windows::core::RuntimeName for IUriContainer {}
 impl IUriContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUriContainer_Impl, const OFFSET: isize>() -> IUriContainer_Vtbl {
         unsafe extern "system" fn GetIUri<Identity: ::windows::core::IUnknownImpl, Impl: IUriContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppiuri: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1269,6 +1320,7 @@ impl IUriContainer_Vtbl {
 pub trait IWinInetCacheHints_Impl: Sized {
     fn SetCacheExtension(&self, pwzext: &::windows::core::PCWSTR, pszcachefile: *mut ::core::ffi::c_void, pcbcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinInetCacheHints {}
 impl IWinInetCacheHints_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetCacheHints_Impl, const OFFSET: isize>() -> IWinInetCacheHints_Vtbl {
         unsafe extern "system" fn SetCacheExtension<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetCacheHints_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzext: ::windows::core::PCWSTR, pszcachefile: *mut ::core::ffi::c_void, pcbcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::HRESULT {
@@ -1285,6 +1337,7 @@ impl IWinInetCacheHints_Vtbl {
 pub trait IWinInetCacheHints2_Impl: Sized + IWinInetCacheHints_Impl {
     fn SetCacheExtension2(&self, pwzext: &::windows::core::PCWSTR, pwzcachefile: ::windows::core::PWSTR, pcchcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinInetCacheHints2 {}
 impl IWinInetCacheHints2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetCacheHints2_Impl, const OFFSET: isize>() -> IWinInetCacheHints2_Vtbl {
         unsafe extern "system" fn SetCacheExtension2<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetCacheHints2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzext: ::windows::core::PCWSTR, pwzcachefile: ::windows::core::PWSTR, pcchcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::HRESULT {
@@ -1302,6 +1355,7 @@ pub trait IWinInetFileStream_Impl: Sized {
     fn SetHandleForUnlock(&self, hwininetlockhandle: usize, dwreserved: usize) -> ::windows::core::Result<()>;
     fn SetDeleteFile(&self, dwreserved: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinInetFileStream {}
 impl IWinInetFileStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetFileStream_Impl, const OFFSET: isize>() -> IWinInetFileStream_Vtbl {
         unsafe extern "system" fn SetHandleForUnlock<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetFileStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwininetlockhandle: usize, dwreserved: usize) -> ::windows::core::HRESULT {
@@ -1327,6 +1381,7 @@ impl IWinInetFileStream_Vtbl {
 pub trait IWinInetHttpInfo_Impl: Sized + IWinInetInfo_Impl {
     fn QueryInfo(&self, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32, pdwflags: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinInetHttpInfo {}
 impl IWinInetHttpInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetHttpInfo_Impl, const OFFSET: isize>() -> IWinInetHttpInfo_Vtbl {
         unsafe extern "system" fn QueryInfo<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetHttpInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32, pdwflags: *mut u32, pdwreserved: *mut u32) -> ::windows::core::HRESULT {
@@ -1343,6 +1398,7 @@ impl IWinInetHttpInfo_Vtbl {
 pub trait IWinInetHttpTimeouts_Impl: Sized {
     fn GetRequestTimeouts(&self, pdwconnecttimeout: *mut u32, pdwsendtimeout: *mut u32, pdwreceivetimeout: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinInetHttpTimeouts {}
 impl IWinInetHttpTimeouts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetHttpTimeouts_Impl, const OFFSET: isize>() -> IWinInetHttpTimeouts_Vtbl {
         unsafe extern "system" fn GetRequestTimeouts<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetHttpTimeouts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwconnecttimeout: *mut u32, pdwsendtimeout: *mut u32, pdwreceivetimeout: *mut u32) -> ::windows::core::HRESULT {
@@ -1359,6 +1415,7 @@ impl IWinInetHttpTimeouts_Vtbl {
 pub trait IWinInetInfo_Impl: Sized {
     fn QueryOption(&self, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWinInetInfo {}
 impl IWinInetInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetInfo_Impl, const OFFSET: isize>() -> IWinInetInfo_Vtbl {
         unsafe extern "system" fn QueryOption<Identity: ::windows::core::IUnknownImpl, Impl: IWinInetInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32) -> ::windows::core::HRESULT {
@@ -1376,6 +1433,8 @@ impl IWinInetInfo_Vtbl {
 pub trait IWindowForBindingUI_Impl: Sized {
     fn GetWindow(&self, rguidreason: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWindowForBindingUI {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWindowForBindingUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowForBindingUI_Impl, const OFFSET: isize>() -> IWindowForBindingUI_Vtbl {
@@ -1399,6 +1458,7 @@ impl IWindowForBindingUI_Vtbl {
 pub trait IWrappedProtocol_Impl: Sized {
     fn GetWrapperCode(&self, pncode: *mut i32, dwreserved: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWrappedProtocol {}
 impl IWrappedProtocol_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWrappedProtocol_Impl, const OFFSET: isize>() -> IWrappedProtocol_Vtbl {
         unsafe extern "system" fn GetWrapperCode<Identity: ::windows::core::IUnknownImpl, Impl: IWrappedProtocol_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pncode: *mut i32, dwreserved: usize) -> ::windows::core::HRESULT {
@@ -1417,6 +1477,7 @@ pub trait IZoneIdentifier_Impl: Sized {
     fn SetId(&self, dwzone: u32) -> ::windows::core::Result<()>;
     fn Remove(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IZoneIdentifier {}
 impl IZoneIdentifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IZoneIdentifier_Impl, const OFFSET: isize>() -> IZoneIdentifier_Vtbl {
         unsafe extern "system" fn GetId<Identity: ::windows::core::IUnknownImpl, Impl: IZoneIdentifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwzone: *mut u32) -> ::windows::core::HRESULT {
@@ -1459,6 +1520,7 @@ pub trait IZoneIdentifier2_Impl: Sized + IZoneIdentifier_Impl {
     fn SetAppZoneId(&self, zone: u32) -> ::windows::core::Result<()>;
     fn RemoveAppZoneId(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IZoneIdentifier2 {}
 impl IZoneIdentifier2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IZoneIdentifier2_Impl, const OFFSET: isize>() -> IZoneIdentifier2_Vtbl {
         unsafe extern "system" fn GetLastWriterPackageFamilyName<Identity: ::windows::core::IUnknownImpl, Impl: IZoneIdentifier2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagefamilyname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
@@ -12,6 +12,8 @@ pub trait AsyncIAdviseSink_Impl: Sized {
     fn Finish_OnClose(&self);
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for AsyncIAdviseSink {}
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl AsyncIAdviseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIAdviseSink_Impl, const OFFSET: isize>() -> AsyncIAdviseSink_Vtbl {
         unsafe extern "system" fn Begin_OnDataChange<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIAdviseSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pformatetc: *const FORMATETC, pstgmed: *const STGMEDIUM) {
@@ -88,6 +90,8 @@ pub trait AsyncIAdviseSink2_Impl: Sized + AsyncIAdviseSink_Impl {
     fn Finish_OnLinkSrcChange(&self);
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for AsyncIAdviseSink2 {}
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl AsyncIAdviseSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIAdviseSink2_Impl, const OFFSET: isize>() -> AsyncIAdviseSink2_Vtbl {
         unsafe extern "system" fn Begin_OnLinkSrcChange<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIAdviseSink2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmk: ::windows::core::RawPtr) {
@@ -114,6 +118,7 @@ pub trait AsyncIMultiQI_Impl: Sized {
     fn Begin_QueryMultipleInterfaces(&self, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::Result<()>;
     fn Finish_QueryMultipleInterfaces(&self, pmqis: *mut MULTI_QI) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIMultiQI {}
 impl AsyncIMultiQI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIMultiQI_Impl, const OFFSET: isize>() -> AsyncIMultiQI_Vtbl {
         unsafe extern "system" fn Begin_QueryMultipleInterfaces<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIMultiQI_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::HRESULT {
@@ -142,6 +147,7 @@ pub trait AsyncIPipeByte_Impl: Sized {
     fn Begin_Push(&self, buf: *const u8, csent: u32) -> ::windows::core::Result<()>;
     fn Finish_Push(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIPipeByte {}
 impl AsyncIPipeByte_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIPipeByte_Impl, const OFFSET: isize>() -> AsyncIPipeByte_Vtbl {
         unsafe extern "system" fn Begin_Pull<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIPipeByte_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32) -> ::windows::core::HRESULT {
@@ -182,6 +188,7 @@ pub trait AsyncIPipeDouble_Impl: Sized {
     fn Begin_Push(&self, buf: *const f64, csent: u32) -> ::windows::core::Result<()>;
     fn Finish_Push(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIPipeDouble {}
 impl AsyncIPipeDouble_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIPipeDouble_Impl, const OFFSET: isize>() -> AsyncIPipeDouble_Vtbl {
         unsafe extern "system" fn Begin_Pull<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIPipeDouble_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32) -> ::windows::core::HRESULT {
@@ -222,6 +229,7 @@ pub trait AsyncIPipeLong_Impl: Sized {
     fn Begin_Push(&self, buf: *const i32, csent: u32) -> ::windows::core::Result<()>;
     fn Finish_Push(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIPipeLong {}
 impl AsyncIPipeLong_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIPipeLong_Impl, const OFFSET: isize>() -> AsyncIPipeLong_Vtbl {
         unsafe extern "system" fn Begin_Pull<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIPipeLong_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crequest: u32) -> ::windows::core::HRESULT {
@@ -264,6 +272,7 @@ pub trait AsyncIUnknown_Impl: Sized {
     fn Begin_Release(&self) -> ::windows::core::Result<()>;
     fn Finish_Release(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for AsyncIUnknown {}
 impl AsyncIUnknown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIUnknown_Impl, const OFFSET: isize>() -> AsyncIUnknown_Vtbl {
         unsafe extern "system" fn Begin_QueryInterface<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIUnknown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -313,6 +322,7 @@ impl AsyncIUnknown_Vtbl {
 pub trait IActivationFilter_Impl: Sized {
     fn HandleActivation(&self, dwactivationtype: u32, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IActivationFilter {}
 impl IActivationFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActivationFilter_Impl, const OFFSET: isize>() -> IActivationFilter_Vtbl {
         unsafe extern "system" fn HandleActivation<Identity: ::windows::core::IUnknownImpl, Impl: IActivationFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwactivationtype: u32, rclsid: *const ::windows::core::GUID, preplacementclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -336,6 +346,7 @@ pub trait IAddrExclusionControl_Impl: Sized {
     fn GetCurrentAddrExclusionList(&self, riid: *const ::windows::core::GUID, ppenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn UpdateAddrExclusionList(&self, penumerator: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAddrExclusionControl {}
 impl IAddrExclusionControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAddrExclusionControl_Impl, const OFFSET: isize>() -> IAddrExclusionControl_Vtbl {
         unsafe extern "system" fn GetCurrentAddrExclusionList<Identity: ::windows::core::IUnknownImpl, Impl: IAddrExclusionControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -362,6 +373,7 @@ pub trait IAddrTrackingControl_Impl: Sized {
     fn EnableCOMDynamicAddrTracking(&self) -> ::windows::core::Result<()>;
     fn DisableCOMDynamicAddrTracking(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAddrTrackingControl {}
 impl IAddrTrackingControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAddrTrackingControl_Impl, const OFFSET: isize>() -> IAddrTrackingControl_Vtbl {
         unsafe extern "system" fn EnableCOMDynamicAddrTracking<Identity: ::windows::core::IUnknownImpl, Impl: IAddrTrackingControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -392,6 +404,8 @@ pub trait IAdviseSink_Impl: Sized {
     fn OnSave(&self);
     fn OnClose(&self);
 }
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IAdviseSink {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IAdviseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAdviseSink_Impl, const OFFSET: isize>() -> IAdviseSink_Vtbl {
@@ -438,6 +452,8 @@ pub trait IAdviseSink2_Impl: Sized + IAdviseSink_Impl {
     fn OnLinkSrcChange(&self, pmk: &::core::option::Option<IMoniker>);
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IAdviseSink2 {}
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IAdviseSink2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAdviseSink2_Impl, const OFFSET: isize>() -> IAdviseSink2_Vtbl {
         unsafe extern "system" fn OnLinkSrcChange<Identity: ::windows::core::IUnknownImpl, Impl: IAdviseSink2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmk: ::windows::core::RawPtr) {
@@ -452,6 +468,7 @@ impl IAdviseSink2_Vtbl {
     }
 }
 pub trait IAgileObject_Impl: Sized {}
+impl ::windows::core::RuntimeName for IAgileObject {}
 impl IAgileObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAgileObject_Impl, const OFFSET: isize>() -> IAgileObject_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -465,6 +482,7 @@ pub trait IAsyncManager_Impl: Sized {
     fn GetCallContext(&self, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetState(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IAsyncManager {}
 impl IAsyncManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncManager_Impl, const OFFSET: isize>() -> IAsyncManager_Vtbl {
         unsafe extern "system" fn CompleteCall<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -504,6 +522,7 @@ pub trait IAsyncRpcChannelBuffer_Impl: Sized + IRpcChannelBuffer_Impl + IRpcChan
     fn Receive(&self, pmsg: *mut RPCOLEMESSAGE, pulstatus: *mut u32) -> ::windows::core::Result<()>;
     fn GetDestCtxEx(&self, pmsg: *const RPCOLEMESSAGE, pdwdestcontext: *mut u32, ppvdestcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAsyncRpcChannelBuffer {}
 impl IAsyncRpcChannelBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncRpcChannelBuffer_Impl, const OFFSET: isize>() -> IAsyncRpcChannelBuffer_Vtbl {
         unsafe extern "system" fn Send<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncRpcChannelBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmsg: *mut RPCOLEMESSAGE, psync: ::windows::core::RawPtr, pulstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -537,6 +556,8 @@ pub trait IAuthenticate_Impl: Sized {
     fn Authenticate(&self, phwnd: *mut super::super::Foundation::HWND, pszusername: *mut ::windows::core::PWSTR, pszpassword: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAuthenticate {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAuthenticate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAuthenticate_Impl, const OFFSET: isize>() -> IAuthenticate_Vtbl {
         unsafe extern "system" fn Authenticate<Identity: ::windows::core::IUnknownImpl, Impl: IAuthenticate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::Foundation::HWND, pszusername: *mut ::windows::core::PWSTR, pszpassword: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -554,6 +575,8 @@ impl IAuthenticate_Vtbl {
 pub trait IAuthenticateEx_Impl: Sized + IAuthenticate_Impl {
     fn AuthenticateEx(&self, phwnd: *mut super::super::Foundation::HWND, pszusername: *mut ::windows::core::PWSTR, pszpassword: *mut ::windows::core::PWSTR, pauthinfo: *const AUTHENTICATEINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAuthenticateEx {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAuthenticateEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAuthenticateEx_Impl, const OFFSET: isize>() -> IAuthenticateEx_Vtbl {
@@ -580,6 +603,7 @@ pub trait IBindCtx_Impl: Sized {
     fn EnumObjectParam(&self) -> ::windows::core::Result<IEnumString>;
     fn RevokeObjectParam(&self, pszkey: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBindCtx {}
 impl IBindCtx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindCtx_Impl, const OFFSET: isize>() -> IBindCtx_Vtbl {
         unsafe extern "system" fn RegisterObjectBound<Identity: ::windows::core::IUnknownImpl, Impl: IBindCtx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -673,6 +697,7 @@ pub trait IBindHost_Impl: Sized {
     fn MonikerBindToStorage(&self, pmk: &::core::option::Option<IMoniker>, pbc: &::core::option::Option<IBindCtx>, pbsc: &::core::option::Option<IBindStatusCallback>, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn MonikerBindToObject(&self, pmk: &::core::option::Option<IMoniker>, pbc: &::core::option::Option<IBindCtx>, pbsc: &::core::option::Option<IBindStatusCallback>, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBindHost {}
 impl IBindHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindHost_Impl, const OFFSET: isize>() -> IBindHost_Vtbl {
         unsafe extern "system" fn CreateMoniker<Identity: ::windows::core::IUnknownImpl, Impl: IBindHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCWSTR, pbc: ::windows::core::RawPtr, ppmk: *mut ::windows::core::RawPtr, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -712,6 +737,8 @@ pub trait IBindStatusCallback_Impl: Sized {
     fn OnDataAvailable(&self, grfbscf: u32, dwsize: u32, pformatetc: *const FORMATETC, pstgmed: *const STGMEDIUM) -> ::windows::core::Result<()>;
     fn OnObjectAvailable(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IBindStatusCallback {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 impl IBindStatusCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindStatusCallback_Impl, const OFFSET: isize>() -> IBindStatusCallback_Vtbl {
@@ -782,6 +809,8 @@ pub trait IBindStatusCallbackEx_Impl: Sized + IBindStatusCallback_Impl {
     fn GetBindInfoEx(&self, grfbindf: *mut u32, pbindinfo: *mut BINDINFO, grfbindf2: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IBindStatusCallbackEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 impl IBindStatusCallbackEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindStatusCallbackEx_Impl, const OFFSET: isize>() -> IBindStatusCallbackEx_Vtbl {
         unsafe extern "system" fn GetBindInfoEx<Identity: ::windows::core::IUnknownImpl, Impl: IBindStatusCallbackEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, grfbindf: *mut u32, pbindinfo: *mut BINDINFO, grfbindf2: *mut u32, pdwreserved: *mut u32) -> ::windows::core::HRESULT {
@@ -803,6 +832,7 @@ pub trait IBinding_Impl: Sized {
     fn GetPriority(&self) -> ::windows::core::Result<i32>;
     fn GetBindResult(&self, pclsidprotocol: *mut ::windows::core::GUID, pdwresult: *mut u32, pszresult: *mut ::windows::core::PWSTR, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBinding {}
 impl IBinding_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBinding_Impl, const OFFSET: isize>() -> IBinding_Vtbl {
         unsafe extern "system" fn Abort<Identity: ::windows::core::IUnknownImpl, Impl: IBinding_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -859,6 +889,7 @@ pub trait IBlockingLock_Impl: Sized {
     fn Lock(&self, dwtimeout: u32) -> ::windows::core::Result<()>;
     fn Unlock(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBlockingLock {}
 impl IBlockingLock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBlockingLock_Impl, const OFFSET: isize>() -> IBlockingLock_Vtbl {
         unsafe extern "system" fn Lock<Identity: ::windows::core::IUnknownImpl, Impl: IBlockingLock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtimeout: u32) -> ::windows::core::HRESULT {
@@ -880,6 +911,7 @@ impl IBlockingLock_Vtbl {
 pub trait ICallFactory_Impl: Sized {
     fn CreateCall(&self, riid: *const ::windows::core::GUID, pctrlunk: &::core::option::Option<::windows::core::IUnknown>, riid2: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for ICallFactory {}
 impl ICallFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICallFactory_Impl, const OFFSET: isize>() -> ICallFactory_Vtbl {
         unsafe extern "system" fn CreateCall<Identity: ::windows::core::IUnknownImpl, Impl: ICallFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pctrlunk: *mut ::core::ffi::c_void, riid2: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -903,6 +935,7 @@ pub trait ICancelMethodCalls_Impl: Sized {
     fn Cancel(&self, ulseconds: u32) -> ::windows::core::Result<()>;
     fn TestCancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICancelMethodCalls {}
 impl ICancelMethodCalls_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICancelMethodCalls_Impl, const OFFSET: isize>() -> ICancelMethodCalls_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: ICancelMethodCalls_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulseconds: u32) -> ::windows::core::HRESULT {
@@ -933,6 +966,7 @@ pub trait ICatInformation_Impl: Sized {
     fn EnumImplCategoriesOfClass(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<IEnumGUID>;
     fn EnumReqCategoriesOfClass(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<IEnumGUID>;
 }
+impl ::windows::core::RuntimeName for ICatInformation {}
 impl ICatInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICatInformation_Impl, const OFFSET: isize>() -> ICatInformation_Vtbl {
         unsafe extern "system" fn EnumCategories<Identity: ::windows::core::IUnknownImpl, Impl: ICatInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lcid: u32, ppenumcategoryinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1017,6 +1051,7 @@ pub trait ICatRegister_Impl: Sized {
     fn RegisterClassReqCategories(&self, rclsid: *const ::windows::core::GUID, ccategories: u32, rgcatid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn UnRegisterClassReqCategories(&self, rclsid: *const ::windows::core::GUID, ccategories: u32, rgcatid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICatRegister {}
 impl ICatRegister_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICatRegister_Impl, const OFFSET: isize>() -> ICatRegister_Vtbl {
         unsafe extern "system" fn RegisterCategories<Identity: ::windows::core::IUnknownImpl, Impl: ICatRegister_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ccategories: u32, rgcategoryinfo: *const CATEGORYINFO) -> ::windows::core::HRESULT {
@@ -1071,6 +1106,7 @@ pub trait IChannelHook_Impl: Sized {
     fn ServerGetSize(&self, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, hrfault: ::windows::core::HRESULT, pdatasize: *mut u32);
     fn ServerFillBuffer(&self, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pdatasize: *mut u32, pdatabuffer: *const ::core::ffi::c_void, hrfault: ::windows::core::HRESULT);
 }
+impl ::windows::core::RuntimeName for IChannelHook {}
 impl IChannelHook_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChannelHook_Impl, const OFFSET: isize>() -> IChannelHook_Vtbl {
         unsafe extern "system" fn ClientGetSize<Identity: ::windows::core::IUnknownImpl, Impl: IChannelHook_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pdatasize: *mut u32) {
@@ -1120,6 +1156,7 @@ impl IChannelHook_Vtbl {
 pub trait IClassActivator_Impl: Sized {
     fn GetClassObject(&self, rclsid: *const ::windows::core::GUID, dwclasscontext: u32, locale: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IClassActivator {}
 impl IClassActivator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClassActivator_Impl, const OFFSET: isize>() -> IClassActivator_Vtbl {
         unsafe extern "system" fn GetClassObject<Identity: ::windows::core::IUnknownImpl, Impl: IClassActivator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, dwclasscontext: u32, locale: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1138,6 +1175,8 @@ pub trait IClassFactory_Impl: Sized {
     fn CreateInstance(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn LockServer(&self, flock: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IClassFactory {}
 #[cfg(feature = "Win32_Foundation")]
 impl IClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClassFactory_Impl, const OFFSET: isize>() -> IClassFactory_Vtbl {
@@ -1166,6 +1205,7 @@ pub trait IClientSecurity_Impl: Sized {
     fn SetBlanket(&self, pproxy: &::core::option::Option<::windows::core::IUnknown>, dwauthnsvc: u32, dwauthzsvc: u32, pserverprincname: &::windows::core::PCWSTR, dwauthnlevel: RPC_C_AUTHN_LEVEL, dwimplevel: RPC_C_IMP_LEVEL, pauthinfo: *const ::core::ffi::c_void, dwcapabilities: EOLE_AUTHENTICATION_CAPABILITIES) -> ::windows::core::Result<()>;
     fn CopyProxy(&self, pproxy: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IClientSecurity {}
 impl IClientSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClientSecurity_Impl, const OFFSET: isize>() -> IClientSecurity_Vtbl {
         unsafe extern "system" fn QueryBlanket<Identity: ::windows::core::IUnknownImpl, Impl: IClientSecurity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pproxy: *mut ::core::ffi::c_void, pauthnsvc: *mut u32, pauthzsvc: *mut u32, pserverprincname: *mut *mut u16, pauthnlevel: *mut RPC_C_AUTHN_LEVEL, pimplevel: *mut RPC_C_IMP_LEVEL, pauthinfo: *mut *mut ::core::ffi::c_void, pcapabilites: *mut EOLE_AUTHENTICATION_CAPABILITIES) -> ::windows::core::HRESULT {
@@ -1206,6 +1246,7 @@ pub trait IComThreadingInfo_Impl: Sized {
     fn GetCurrentLogicalThreadId(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetCurrentLogicalThreadId(&self, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComThreadingInfo {}
 impl IComThreadingInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComThreadingInfo_Impl, const OFFSET: isize>() -> IComThreadingInfo_Vtbl {
         unsafe extern "system" fn GetCurrentApartmentType<Identity: ::windows::core::IUnknownImpl, Impl: IComThreadingInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, papttype: *mut APTTYPE) -> ::windows::core::HRESULT {
@@ -1265,6 +1306,7 @@ pub trait IConnectionPoint_Impl: Sized {
     fn Unadvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
     fn EnumConnections(&self) -> ::windows::core::Result<IEnumConnections>;
 }
+impl ::windows::core::RuntimeName for IConnectionPoint {}
 impl IConnectionPoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConnectionPoint_Impl, const OFFSET: isize>() -> IConnectionPoint_Vtbl {
         unsafe extern "system" fn GetConnectionInterface<Identity: ::windows::core::IUnknownImpl, Impl: IConnectionPoint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1333,6 +1375,7 @@ pub trait IConnectionPointContainer_Impl: Sized {
     fn EnumConnectionPoints(&self) -> ::windows::core::Result<IEnumConnectionPoints>;
     fn FindConnectionPoint(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<IConnectionPoint>;
 }
+impl ::windows::core::RuntimeName for IConnectionPointContainer {}
 impl IConnectionPointContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConnectionPointContainer_Impl, const OFFSET: isize>() -> IConnectionPointContainer_Vtbl {
         unsafe extern "system" fn EnumConnectionPoints<Identity: ::windows::core::IUnknownImpl, Impl: IConnectionPointContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1370,6 +1413,7 @@ impl IConnectionPointContainer_Vtbl {
 pub trait IContextCallback_Impl: Sized {
     fn ContextCallback(&self, pfncallback: &PFNCONTEXTCALL, pparam: *const ComCallData, riid: *const ::windows::core::GUID, imethod: i32, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContextCallback {}
 impl IContextCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextCallback_Impl, const OFFSET: isize>() -> IContextCallback_Vtbl {
         unsafe extern "system" fn ContextCallback<Identity: ::windows::core::IUnknownImpl, Impl: IContextCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfncallback: ::windows::core::RawPtr, pparam: *const ComCallData, riid: *const ::windows::core::GUID, imethod: i32, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1389,6 +1433,7 @@ pub trait IDataAdviseHolder_Impl: Sized {
     fn EnumAdvise(&self) -> ::windows::core::Result<IEnumSTATDATA>;
     fn SendOnDataChange(&self, pdataobject: &::core::option::Option<IDataObject>, dwreserved: u32, advf: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDataAdviseHolder {}
 impl IDataAdviseHolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataAdviseHolder_Impl, const OFFSET: isize>() -> IDataAdviseHolder_Vtbl {
         unsafe extern "system" fn Advise<Identity: ::windows::core::IUnknownImpl, Impl: IDataAdviseHolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdataobject: ::windows::core::RawPtr, pfetc: *const FORMATETC, advf: u32, padvise: ::windows::core::RawPtr, pdwconnection: *mut u32) -> ::windows::core::HRESULT {
@@ -1447,6 +1492,8 @@ pub trait IDataObject_Impl: Sized {
     fn DUnadvise(&self, dwconnection: u32) -> ::windows::core::Result<()>;
     fn EnumDAdvise(&self) -> ::windows::core::Result<IEnumSTATDATA>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IDataObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IDataObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataObject_Impl, const OFFSET: isize>() -> IDataObject_Vtbl {
@@ -1544,6 +1591,8 @@ pub trait IDispatch_Impl: Sized {
     fn Invoke(&self, dispidmember: i32, riid: *const ::windows::core::GUID, lcid: u32, wflags: u16, pdispparams: *const DISPPARAMS, pvarresult: *mut VARIANT, pexcepinfo: *mut EXCEPINFO, puargerr: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDispatch {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDispatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispatch_Impl, const OFFSET: isize>() -> IDispatch_Vtbl {
         unsafe extern "system" fn GetTypeInfoCount<Identity: ::windows::core::IUnknownImpl, Impl: IDispatch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pctinfo: *mut u32) -> ::windows::core::HRESULT {
@@ -1596,6 +1645,7 @@ pub trait IEnumCATEGORYINFO_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumCATEGORYINFO>;
 }
+impl ::windows::core::RuntimeName for IEnumCATEGORYINFO {}
 impl IEnumCATEGORYINFO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCATEGORYINFO_Impl, const OFFSET: isize>() -> IEnumCATEGORYINFO_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumCATEGORYINFO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut CATEGORYINFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1642,6 +1692,7 @@ pub trait IEnumConnectionPoints_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumConnectionPoints>;
 }
+impl ::windows::core::RuntimeName for IEnumConnectionPoints {}
 impl IEnumConnectionPoints_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumConnectionPoints_Impl, const OFFSET: isize>() -> IEnumConnectionPoints_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumConnectionPoints_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cconnections: u32, ppcp: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1688,6 +1739,7 @@ pub trait IEnumConnections_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumConnections>;
 }
+impl ::windows::core::RuntimeName for IEnumConnections {}
 impl IEnumConnections_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumConnections_Impl, const OFFSET: isize>() -> IEnumConnections_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumConnections_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cconnections: u32, rgcd: *mut CONNECTDATA, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1734,6 +1786,7 @@ pub trait IEnumFORMATETC_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumFORMATETC>;
 }
+impl ::windows::core::RuntimeName for IEnumFORMATETC {}
 impl IEnumFORMATETC_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFORMATETC_Impl, const OFFSET: isize>() -> IEnumFORMATETC_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFORMATETC_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut FORMATETC, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1780,6 +1833,7 @@ pub trait IEnumGUID_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumGUID>;
 }
+impl ::windows::core::RuntimeName for IEnumGUID {}
 impl IEnumGUID_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumGUID_Impl, const OFFSET: isize>() -> IEnumGUID_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumGUID_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1826,6 +1880,7 @@ pub trait IEnumMoniker_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumMoniker>;
 }
+impl ::windows::core::RuntimeName for IEnumMoniker {}
 impl IEnumMoniker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMoniker_Impl, const OFFSET: isize>() -> IEnumMoniker_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumMoniker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1872,6 +1927,7 @@ pub trait IEnumSTATDATA_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSTATDATA>;
 }
+impl ::windows::core::RuntimeName for IEnumSTATDATA {}
 impl IEnumSTATDATA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATDATA_Impl, const OFFSET: isize>() -> IEnumSTATDATA_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSTATDATA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut STATDATA, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1918,6 +1974,7 @@ pub trait IEnumString_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumString>;
 }
+impl ::windows::core::RuntimeName for IEnumString {}
 impl IEnumString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumString_Impl, const OFFSET: isize>() -> IEnumString_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumString_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::PWSTR, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1964,6 +2021,7 @@ pub trait IEnumUnknown_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumUnknown>;
 }
+impl ::windows::core::RuntimeName for IEnumUnknown {}
 impl IEnumUnknown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumUnknown_Impl, const OFFSET: isize>() -> IEnumUnknown_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumUnknown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -2012,6 +2070,8 @@ pub trait IErrorInfo_Impl: Sized {
     fn GetHelpFile(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetHelpContext(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IErrorInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IErrorInfo_Impl, const OFFSET: isize>() -> IErrorInfo_Vtbl {
@@ -2088,6 +2148,8 @@ pub trait IErrorLog_Impl: Sized {
     fn AddError(&self, pszpropname: &::windows::core::PCWSTR, pexcepinfo: *const EXCEPINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IErrorLog {}
+#[cfg(feature = "Win32_Foundation")]
 impl IErrorLog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IErrorLog_Impl, const OFFSET: isize>() -> IErrorLog_Vtbl {
         unsafe extern "system" fn AddError<Identity: ::windows::core::IUnknownImpl, Impl: IErrorLog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpropname: ::windows::core::PCWSTR, pexcepinfo: *const EXCEPINFO) -> ::windows::core::HRESULT {
@@ -2106,6 +2168,8 @@ pub trait IExternalConnection_Impl: Sized {
     fn AddConnection(&self, extconn: u32, reserved: u32) -> u32;
     fn ReleaseConnection(&self, extconn: u32, reserved: u32, flastreleasecloses: super::super::Foundation::BOOL) -> u32;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IExternalConnection {}
 #[cfg(feature = "Win32_Foundation")]
 impl IExternalConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExternalConnection_Impl, const OFFSET: isize>() -> IExternalConnection_Vtbl {
@@ -2130,6 +2194,7 @@ impl IExternalConnection_Vtbl {
     }
 }
 pub trait IFastRundown_Impl: Sized {}
+impl ::windows::core::RuntimeName for IFastRundown {}
 impl IFastRundown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFastRundown_Impl, const OFFSET: isize>() -> IFastRundown_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -2141,6 +2206,7 @@ impl IFastRundown_Vtbl {
 pub trait IForegroundTransfer_Impl: Sized {
     fn AllowForegroundTransfer(&self, lpvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IForegroundTransfer {}
 impl IForegroundTransfer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IForegroundTransfer_Impl, const OFFSET: isize>() -> IForegroundTransfer_Vtbl {
         unsafe extern "system" fn AllowForegroundTransfer<Identity: ::windows::core::IUnknownImpl, Impl: IForegroundTransfer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpvreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2159,6 +2225,7 @@ pub trait IGlobalInterfaceTable_Impl: Sized {
     fn RevokeInterfaceFromGlobal(&self, dwcookie: u32) -> ::windows::core::Result<()>;
     fn GetInterfaceFromGlobal(&self, dwcookie: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGlobalInterfaceTable {}
 impl IGlobalInterfaceTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGlobalInterfaceTable_Impl, const OFFSET: isize>() -> IGlobalInterfaceTable_Vtbl {
         unsafe extern "system" fn RegisterInterfaceInGlobal<Identity: ::windows::core::IUnknownImpl, Impl: IGlobalInterfaceTable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -2197,6 +2264,7 @@ pub trait IGlobalOptions_Impl: Sized {
     fn Set(&self, dwproperty: GLOBALOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::Result<()>;
     fn Query(&self, dwproperty: GLOBALOPT_PROPERTIES) -> ::windows::core::Result<usize>;
 }
+impl ::windows::core::RuntimeName for IGlobalOptions {}
 impl IGlobalOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGlobalOptions_Impl, const OFFSET: isize>() -> IGlobalOptions_Vtbl {
         unsafe extern "system" fn Set<Identity: ::windows::core::IUnknownImpl, Impl: IGlobalOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwproperty: GLOBALOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::HRESULT {
@@ -2227,6 +2295,7 @@ pub trait IInitializeSpy_Impl: Sized {
     fn PreUninitialize(&self, dwcurthreadaptrefs: u32) -> ::windows::core::Result<()>;
     fn PostUninitialize(&self, dwnewthreadaptrefs: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInitializeSpy {}
 impl IInitializeSpy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeSpy_Impl, const OFFSET: isize>() -> IInitializeSpy_Vtbl {
         unsafe extern "system" fn PreInitialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeSpy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcoinit: u32, dwcurthreadaptrefs: u32) -> ::windows::core::HRESULT {
@@ -2264,6 +2333,7 @@ impl IInitializeSpy_Vtbl {
 pub trait IInternalUnknown_Impl: Sized {
     fn QueryInternalInterface(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternalUnknown {}
 impl IInternalUnknown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternalUnknown_Impl, const OFFSET: isize>() -> IInternalUnknown_Vtbl {
         unsafe extern "system" fn QueryInternalInterface<Identity: ::windows::core::IUnknownImpl, Impl: IInternalUnknown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2282,6 +2352,7 @@ pub trait IMachineGlobalObjectTable_Impl: Sized {
     fn GetObject(&self, clsid: *const ::windows::core::GUID, identifier: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn RevokeObject(&self, token: *const MachineGlobalObjectTableRegistrationToken__) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMachineGlobalObjectTable {}
 impl IMachineGlobalObjectTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMachineGlobalObjectTable_Impl, const OFFSET: isize>() -> IMachineGlobalObjectTable_Vtbl {
         unsafe extern "system" fn RegisterObject<Identity: ::windows::core::IUnknownImpl, Impl: IMachineGlobalObjectTable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, identifier: ::windows::core::PCWSTR, object: *mut ::core::ffi::c_void, token: *mut *mut MachineGlobalObjectTableRegistrationToken__) -> ::windows::core::HRESULT {
@@ -2324,6 +2395,7 @@ pub trait IMalloc_Impl: Sized {
     fn DidAlloc(&self, pv: *const ::core::ffi::c_void) -> i32;
     fn HeapMinimize(&self);
 }
+impl ::windows::core::RuntimeName for IMalloc {}
 impl IMalloc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMalloc_Impl, const OFFSET: isize>() -> IMalloc_Vtbl {
         unsafe extern "system" fn Alloc<Identity: ::windows::core::IUnknownImpl, Impl: IMalloc_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cb: usize) -> *mut ::core::ffi::c_void {
@@ -2385,6 +2457,8 @@ pub trait IMallocSpy_Impl: Sized {
     fn PreHeapMinimize(&self);
     fn PostHeapMinimize(&self);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMallocSpy {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMallocSpy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMallocSpy_Impl, const OFFSET: isize>() -> IMallocSpy_Vtbl {
@@ -2486,6 +2560,8 @@ pub trait IMoniker_Impl: Sized + IPersist_Impl + IPersistStream_Impl {
     fn ParseDisplayName(&self, pbc: &::core::option::Option<IBindCtx>, pmktoleft: &::core::option::Option<IMoniker>, pszdisplayname: &::windows::core::PCWSTR, pcheaten: *mut u32, ppmkout: *mut ::core::option::Option<IMoniker>) -> ::windows::core::Result<()>;
     fn IsSystemMoniker(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMoniker {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMoniker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMoniker_Impl, const OFFSET: isize>() -> IMoniker_Vtbl {
@@ -2644,6 +2720,7 @@ impl IMoniker_Vtbl {
 pub trait IMultiQI_Impl: Sized {
     fn QueryMultipleInterfaces(&self, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMultiQI {}
 impl IMultiQI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultiQI_Impl, const OFFSET: isize>() -> IMultiQI_Vtbl {
         unsafe extern "system" fn QueryMultipleInterfaces<Identity: ::windows::core::IUnknownImpl, Impl: IMultiQI_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::HRESULT {
@@ -2658,6 +2735,7 @@ impl IMultiQI_Vtbl {
     }
 }
 pub trait INoMarshal_Impl: Sized {}
+impl ::windows::core::RuntimeName for INoMarshal {}
 impl INoMarshal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INoMarshal_Impl, const OFFSET: isize>() -> INoMarshal_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -2670,6 +2748,7 @@ pub trait IOplockStorage_Impl: Sized {
     fn CreateStorageEx(&self, pwcsname: &::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn OpenStorageEx(&self, pwcsname: &::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOplockStorage {}
 impl IOplockStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOplockStorage_Impl, const OFFSET: isize>() -> IOplockStorage_Vtbl {
         unsafe extern "system" fn CreateStorageEx<Identity: ::windows::core::IUnknownImpl, Impl: IOplockStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwcsname: ::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2696,6 +2775,7 @@ pub trait IPSFactoryBuffer_Impl: Sized {
     fn CreateProxy(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppproxy: *mut ::core::option::Option<IRpcProxyBuffer>, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateStub(&self, riid: *const ::windows::core::GUID, punkserver: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IRpcStubBuffer>;
 }
+impl ::windows::core::RuntimeName for IPSFactoryBuffer {}
 impl IPSFactoryBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPSFactoryBuffer_Impl, const OFFSET: isize>() -> IPSFactoryBuffer_Vtbl {
         unsafe extern "system" fn CreateProxy<Identity: ::windows::core::IUnknownImpl, Impl: IPSFactoryBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppproxy: *mut ::windows::core::RawPtr, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2727,6 +2807,7 @@ impl IPSFactoryBuffer_Vtbl {
 pub trait IPersist_Impl: Sized {
     fn GetClassID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IPersist {}
 impl IPersist_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersist_Impl, const OFFSET: isize>() -> IPersist_Vtbl {
         unsafe extern "system" fn GetClassID<Identity: ::windows::core::IUnknownImpl, Impl: IPersist_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclassid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2754,6 +2835,8 @@ pub trait IPersistFile_Impl: Sized + IPersist_Impl {
     fn SaveCompleted(&self, pszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetCurFile(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPersistFile {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPersistFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistFile_Impl, const OFFSET: isize>() -> IPersistFile_Vtbl {
@@ -2810,6 +2893,8 @@ pub trait IPersistMemory_Impl: Sized + IPersist_Impl {
     fn InitNew(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPersistMemory {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPersistMemory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistMemory_Impl, const OFFSET: isize>() -> IPersistMemory_Vtbl {
         unsafe extern "system" fn IsDirty<Identity: ::windows::core::IUnknownImpl, Impl: IPersistMemory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2864,6 +2949,8 @@ pub trait IPersistStream_Impl: Sized + IPersist_Impl {
     fn GetSizeMax(&self) -> ::windows::core::Result<u64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPersistStream {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPersistStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistStream_Impl, const OFFSET: isize>() -> IPersistStream_Vtbl {
         unsafe extern "system" fn IsDirty<Identity: ::windows::core::IUnknownImpl, Impl: IPersistStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2912,6 +2999,8 @@ pub trait IPersistStreamInit_Impl: Sized + IPersist_Impl {
     fn GetSizeMax(&self) -> ::windows::core::Result<u64>;
     fn InitNew(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPersistStreamInit {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPersistStreamInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistStreamInit_Impl, const OFFSET: isize>() -> IPersistStreamInit_Vtbl {
@@ -2963,6 +3052,7 @@ pub trait IPipeByte_Impl: Sized {
     fn Pull(&self, buf: *mut u8, crequest: u32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, buf: *const u8, csent: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPipeByte {}
 impl IPipeByte_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPipeByte_Impl, const OFFSET: isize>() -> IPipeByte_Vtbl {
         unsafe extern "system" fn Pull<Identity: ::windows::core::IUnknownImpl, Impl: IPipeByte_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buf: *mut u8, crequest: u32, pcreturned: *mut u32) -> ::windows::core::HRESULT {
@@ -2985,6 +3075,7 @@ pub trait IPipeDouble_Impl: Sized {
     fn Pull(&self, buf: *mut f64, crequest: u32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, buf: *const f64, csent: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPipeDouble {}
 impl IPipeDouble_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPipeDouble_Impl, const OFFSET: isize>() -> IPipeDouble_Vtbl {
         unsafe extern "system" fn Pull<Identity: ::windows::core::IUnknownImpl, Impl: IPipeDouble_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buf: *mut f64, crequest: u32, pcreturned: *mut u32) -> ::windows::core::HRESULT {
@@ -3007,6 +3098,7 @@ pub trait IPipeLong_Impl: Sized {
     fn Pull(&self, buf: *mut i32, crequest: u32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, buf: *const i32, csent: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPipeLong {}
 impl IPipeLong_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPipeLong_Impl, const OFFSET: isize>() -> IPipeLong_Vtbl {
         unsafe extern "system" fn Pull<Identity: ::windows::core::IUnknownImpl, Impl: IPipeLong_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buf: *mut i32, crequest: u32, pcreturned: *mut u32) -> ::windows::core::HRESULT {
@@ -3028,6 +3120,7 @@ impl IPipeLong_Vtbl {
 pub trait IProcessInitControl_Impl: Sized {
     fn ResetInitializerTimeout(&self, dwsecondsremaining: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProcessInitControl {}
 impl IProcessInitControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProcessInitControl_Impl, const OFFSET: isize>() -> IProcessInitControl_Vtbl {
         unsafe extern "system" fn ResetInitializerTimeout<Identity: ::windows::core::IUnknownImpl, Impl: IProcessInitControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsecondsremaining: u32) -> ::windows::core::HRESULT {
@@ -3045,6 +3138,7 @@ pub trait IProcessLock_Impl: Sized {
     fn AddRefOnProcess(&self) -> u32;
     fn ReleaseRefOnProcess(&self) -> u32;
 }
+impl ::windows::core::RuntimeName for IProcessLock {}
 impl IProcessLock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProcessLock_Impl, const OFFSET: isize>() -> IProcessLock_Vtbl {
         unsafe extern "system" fn AddRefOnProcess<Identity: ::windows::core::IUnknownImpl, Impl: IProcessLock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -3072,6 +3166,8 @@ pub trait IProgressNotify_Impl: Sized {
     fn OnProgress(&self, dwprogresscurrent: u32, dwprogressmaximum: u32, faccurate: super::super::Foundation::BOOL, fowner: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IProgressNotify {}
+#[cfg(feature = "Win32_Foundation")]
 impl IProgressNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProgressNotify_Impl, const OFFSET: isize>() -> IProgressNotify_Vtbl {
         unsafe extern "system" fn OnProgress<Identity: ::windows::core::IUnknownImpl, Impl: IProgressNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwprogresscurrent: u32, dwprogressmaximum: u32, faccurate: super::super::Foundation::BOOL, fowner: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3088,6 +3184,7 @@ impl IProgressNotify_Vtbl {
 pub trait IROTData_Impl: Sized {
     fn GetComparisonData(&self, pbdata: *mut u8, cbmax: u32, pcbdata: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IROTData {}
 impl IROTData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IROTData_Impl, const OFFSET: isize>() -> IROTData_Vtbl {
         unsafe extern "system" fn GetComparisonData<Identity: ::windows::core::IUnknownImpl, Impl: IROTData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbdata: *mut u8, cbmax: u32, pcbdata: *mut u32) -> ::windows::core::HRESULT {
@@ -3104,6 +3201,7 @@ impl IROTData_Vtbl {
 pub trait IReleaseMarshalBuffers_Impl: Sized {
     fn ReleaseMarshalBuffer(&self, pmsg: *mut RPCOLEMESSAGE, dwflags: u32, pchnl: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReleaseMarshalBuffers {}
 impl IReleaseMarshalBuffers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReleaseMarshalBuffers_Impl, const OFFSET: isize>() -> IReleaseMarshalBuffers_Vtbl {
         unsafe extern "system" fn ReleaseMarshalBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IReleaseMarshalBuffers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmsg: *mut RPCOLEMESSAGE, dwflags: u32, pchnl: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3124,6 +3222,7 @@ pub trait IRpcChannelBuffer_Impl: Sized {
     fn GetDestCtx(&self, pdwdestcontext: *mut u32, ppvdestcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn IsConnected(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRpcChannelBuffer {}
 impl IRpcChannelBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcChannelBuffer_Impl, const OFFSET: isize>() -> IRpcChannelBuffer_Vtbl {
         unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IRpcChannelBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmessage: *mut RPCOLEMESSAGE, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -3167,6 +3266,7 @@ impl IRpcChannelBuffer_Vtbl {
 pub trait IRpcChannelBuffer2_Impl: Sized + IRpcChannelBuffer_Impl {
     fn GetProtocolVersion(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IRpcChannelBuffer2 {}
 impl IRpcChannelBuffer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcChannelBuffer2_Impl, const OFFSET: isize>() -> IRpcChannelBuffer2_Vtbl {
         unsafe extern "system" fn GetProtocolVersion<Identity: ::windows::core::IUnknownImpl, Impl: IRpcChannelBuffer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwversion: *mut u32) -> ::windows::core::HRESULT {
@@ -3195,6 +3295,7 @@ pub trait IRpcChannelBuffer3_Impl: Sized + IRpcChannelBuffer_Impl + IRpcChannelB
     fn GetState(&self, pmsg: *const RPCOLEMESSAGE) -> ::windows::core::Result<u32>;
     fn RegisterAsync(&self, pmsg: *mut RPCOLEMESSAGE, pasyncmgr: &::core::option::Option<IAsyncManager>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRpcChannelBuffer3 {}
 impl IRpcChannelBuffer3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcChannelBuffer3_Impl, const OFFSET: isize>() -> IRpcChannelBuffer3_Vtbl {
         unsafe extern "system" fn Send<Identity: ::windows::core::IUnknownImpl, Impl: IRpcChannelBuffer3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmsg: *mut RPCOLEMESSAGE, pulstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -3257,6 +3358,7 @@ pub trait IRpcHelper_Impl: Sized {
     fn GetDCOMProtocolVersion(&self) -> ::windows::core::Result<u32>;
     fn GetIIDFromOBJREF(&self, pobjref: *const ::core::ffi::c_void) -> ::windows::core::Result<*mut ::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IRpcHelper {}
 impl IRpcHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcHelper_Impl, const OFFSET: isize>() -> IRpcHelper_Vtbl {
         unsafe extern "system" fn GetDCOMProtocolVersion<Identity: ::windows::core::IUnknownImpl, Impl: IRpcHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcomversion: *mut u32) -> ::windows::core::HRESULT {
@@ -3295,6 +3397,7 @@ pub trait IRpcOptions_Impl: Sized {
     fn Set(&self, pprx: &::core::option::Option<::windows::core::IUnknown>, dwproperty: RPCOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::Result<()>;
     fn Query(&self, pprx: &::core::option::Option<::windows::core::IUnknown>, dwproperty: RPCOPT_PROPERTIES) -> ::windows::core::Result<usize>;
 }
+impl ::windows::core::RuntimeName for IRpcOptions {}
 impl IRpcOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcOptions_Impl, const OFFSET: isize>() -> IRpcOptions_Vtbl {
         unsafe extern "system" fn Set<Identity: ::windows::core::IUnknownImpl, Impl: IRpcOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprx: *mut ::core::ffi::c_void, dwproperty: RPCOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::HRESULT {
@@ -3323,6 +3426,7 @@ pub trait IRpcProxyBuffer_Impl: Sized {
     fn Connect(&self, prpcchannelbuffer: &::core::option::Option<IRpcChannelBuffer>) -> ::windows::core::Result<()>;
     fn Disconnect(&self);
 }
+impl ::windows::core::RuntimeName for IRpcProxyBuffer {}
 impl IRpcProxyBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcProxyBuffer_Impl, const OFFSET: isize>() -> IRpcProxyBuffer_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: IRpcProxyBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prpcchannelbuffer: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3354,6 +3458,7 @@ pub trait IRpcStubBuffer_Impl: Sized {
     fn DebugServerQueryInterface(&self, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn DebugServerRelease(&self, pv: *const ::core::ffi::c_void);
 }
+impl ::windows::core::RuntimeName for IRpcStubBuffer {}
 impl IRpcStubBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcStubBuffer_Impl, const OFFSET: isize>() -> IRpcStubBuffer_Vtbl {
         unsafe extern "system" fn Connect<Identity: ::windows::core::IUnknownImpl, Impl: IRpcStubBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkserver: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3409,6 +3514,7 @@ impl IRpcStubBuffer_Vtbl {
 pub trait IRpcSyntaxNegotiate_Impl: Sized {
     fn NegotiateSyntax(&self, pmsg: *mut RPCOLEMESSAGE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRpcSyntaxNegotiate {}
 impl IRpcSyntaxNegotiate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRpcSyntaxNegotiate_Impl, const OFFSET: isize>() -> IRpcSyntaxNegotiate_Vtbl {
         unsafe extern "system" fn NegotiateSyntax<Identity: ::windows::core::IUnknownImpl, Impl: IRpcSyntaxNegotiate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmsg: *mut RPCOLEMESSAGE) -> ::windows::core::HRESULT {
@@ -3430,6 +3536,8 @@ pub trait IRunnableObject_Impl: Sized {
     fn LockRunning(&self, flock: super::super::Foundation::BOOL, flastunlockcloses: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SetContainedObject(&self, fcontained: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRunnableObject {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRunnableObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRunnableObject_Impl, const OFFSET: isize>() -> IRunnableObject_Vtbl {
@@ -3487,6 +3595,8 @@ pub trait IRunningObjectTable_Impl: Sized {
     fn GetTimeOfLastChange(&self, pmkobjectname: &::core::option::Option<IMoniker>) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
     fn EnumRunning(&self) -> ::windows::core::Result<IEnumMoniker>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRunningObjectTable {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRunningObjectTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRunningObjectTable_Impl, const OFFSET: isize>() -> IRunningObjectTable_Vtbl {
@@ -3568,6 +3678,7 @@ pub trait ISequentialStream_Impl: Sized {
     fn Read(&self, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::HRESULT;
     fn Write(&self, pv: *const ::core::ffi::c_void, cb: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT;
 }
+impl ::windows::core::RuntimeName for ISequentialStream {}
 impl ISequentialStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISequentialStream_Impl, const OFFSET: isize>() -> ISequentialStream_Vtbl {
         unsafe extern "system" fn Read<Identity: ::windows::core::IUnknownImpl, Impl: ISequentialStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::HRESULT {
@@ -3593,6 +3704,8 @@ pub trait IServerSecurity_Impl: Sized {
     fn RevertToSelf(&self) -> ::windows::core::Result<()>;
     fn IsImpersonating(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IServerSecurity {}
 #[cfg(feature = "Win32_Foundation")]
 impl IServerSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServerSecurity_Impl, const OFFSET: isize>() -> IServerSecurity_Vtbl {
@@ -3631,6 +3744,7 @@ impl IServerSecurity_Vtbl {
 pub trait IServiceProvider_Impl: Sized {
     fn QueryService(&self, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceProvider {}
 impl IServiceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceProvider_Impl, const OFFSET: isize>() -> IServiceProvider_Vtbl {
         unsafe extern "system" fn QueryService<Identity: ::windows::core::IUnknownImpl, Impl: IServiceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3647,6 +3761,7 @@ impl IServiceProvider_Vtbl {
 pub trait IStdMarshalInfo_Impl: Sized {
     fn GetClassForHandler(&self, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStdMarshalInfo {}
 impl IStdMarshalInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStdMarshalInfo_Impl, const OFFSET: isize>() -> IStdMarshalInfo_Vtbl {
         unsafe extern "system" fn GetClassForHandler<Identity: ::windows::core::IUnknownImpl, Impl: IStdMarshalInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -3672,6 +3787,8 @@ pub trait IStream_Impl: Sized + ISequentialStream_Impl {
     fn Stat(&self, pstatstg: *mut STATSTG, grfstatflag: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IStream {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStream_Impl, const OFFSET: isize>() -> IStream_Vtbl {
@@ -3752,6 +3869,7 @@ impl IStream_Vtbl {
 pub trait ISupportErrorInfo_Impl: Sized {
     fn InterfaceSupportsErrorInfo(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISupportErrorInfo {}
 impl ISupportErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISupportErrorInfo_Impl, const OFFSET: isize>() -> ISupportErrorInfo_Vtbl {
         unsafe extern "system" fn InterfaceSupportsErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: ISupportErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -3772,6 +3890,7 @@ pub trait ISurrogate_Impl: Sized {
     fn LoadDllServer(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn FreeSurrogate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISurrogate {}
 impl ISurrogate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISurrogate_Impl, const OFFSET: isize>() -> ISurrogate_Vtbl {
         unsafe extern "system" fn LoadDllServer<Identity: ::windows::core::IUnknownImpl, Impl: ISurrogate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -3802,6 +3921,8 @@ pub trait ISurrogateService_Impl: Sized {
     fn CatalogRefresh(&self, ulreserved: u32) -> ::windows::core::Result<()>;
     fn ProcessShutdown(&self, shutdowntype: ShutdownType) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISurrogateService {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISurrogateService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISurrogateService_Impl, const OFFSET: isize>() -> ISurrogateService_Vtbl {
@@ -3854,6 +3975,7 @@ pub trait ISynchronize_Impl: Sized {
     fn Signal(&self) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISynchronize {}
 impl ISynchronize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronize_Impl, const OFFSET: isize>() -> ISynchronize_Vtbl {
         unsafe extern "system" fn Wait<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronize_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32, dwmilliseconds: u32) -> ::windows::core::HRESULT {
@@ -3886,6 +4008,7 @@ pub trait ISynchronizeContainer_Impl: Sized {
     fn AddSynchronize(&self, psync: &::core::option::Option<ISynchronize>) -> ::windows::core::Result<()>;
     fn WaitMultiple(&self, dwflags: u32, dwtimeout: u32) -> ::windows::core::Result<ISynchronize>;
 }
+impl ::windows::core::RuntimeName for ISynchronizeContainer {}
 impl ISynchronizeContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeContainer_Impl, const OFFSET: isize>() -> ISynchronizeContainer_Vtbl {
         unsafe extern "system" fn AddSynchronize<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psync: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3919,6 +4042,8 @@ pub trait ISynchronizeEvent_Impl: Sized + ISynchronizeHandle_Impl {
     fn SetEventHandle(&self, ph: *const super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISynchronizeEvent {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISynchronizeEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeEvent_Impl, const OFFSET: isize>() -> ISynchronizeEvent_Vtbl {
         unsafe extern "system" fn SetEventHandle<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ph: *const super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -3936,6 +4061,8 @@ impl ISynchronizeEvent_Vtbl {
 pub trait ISynchronizeHandle_Impl: Sized {
     fn GetHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISynchronizeHandle {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISynchronizeHandle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeHandle_Impl, const OFFSET: isize>() -> ISynchronizeHandle_Vtbl {
@@ -3959,6 +4086,7 @@ impl ISynchronizeHandle_Vtbl {
 pub trait ISynchronizeMutex_Impl: Sized + ISynchronize_Impl {
     fn ReleaseMutex(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISynchronizeMutex {}
 impl ISynchronizeMutex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeMutex_Impl, const OFFSET: isize>() -> ISynchronizeMutex_Vtbl {
         unsafe extern "system" fn ReleaseMutex<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizeMutex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3975,6 +4103,7 @@ impl ISynchronizeMutex_Vtbl {
 pub trait ITimeAndNoticeControl_Impl: Sized {
     fn SuppressChanges(&self, res1: u32, res2: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITimeAndNoticeControl {}
 impl ITimeAndNoticeControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITimeAndNoticeControl_Impl, const OFFSET: isize>() -> ITimeAndNoticeControl_Vtbl {
         unsafe extern "system" fn SuppressChanges<Identity: ::windows::core::IUnknownImpl, Impl: ITimeAndNoticeControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, res1: u32, res2: u32) -> ::windows::core::HRESULT {
@@ -3993,6 +4122,8 @@ pub trait ITypeComp_Impl: Sized {
     fn Bind(&self, szname: &::windows::core::PCWSTR, lhashval: u32, wflags: u16, pptinfo: *mut ::core::option::Option<ITypeInfo>, pdesckind: *mut DESCKIND, pbindptr: *mut BINDPTR) -> ::windows::core::Result<()>;
     fn BindType(&self, szname: &::windows::core::PCWSTR, lhashval: u32, pptinfo: *mut ::core::option::Option<ITypeInfo>, pptcomp: *mut ::core::option::Option<ITypeComp>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITypeComp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ITypeComp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeComp_Impl, const OFFSET: isize>() -> ITypeComp_Vtbl {
@@ -4038,6 +4169,8 @@ pub trait ITypeInfo_Impl: Sized {
     fn ReleaseFuncDesc(&self, pfuncdesc: *const FUNCDESC);
     fn ReleaseVarDesc(&self, pvardesc: *const VARDESC);
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITypeInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ITypeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeInfo_Impl, const OFFSET: isize>() -> ITypeInfo_Vtbl {
@@ -4229,6 +4362,8 @@ pub trait ITypeInfo2_Impl: Sized + ITypeInfo_Impl {
     fn GetAllVarCustData(&self, index: u32) -> ::windows::core::Result<CUSTDATA>;
     fn GetAllImplTypeCustData(&self, index: u32) -> ::windows::core::Result<CUSTDATA>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITypeInfo2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ITypeInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeInfo2_Impl, const OFFSET: isize>() -> ITypeInfo2_Vtbl {
@@ -4428,6 +4563,8 @@ pub trait ITypeLib_Impl: Sized {
     fn ReleaseTLibAttr(&self, ptlibattr: *const TLIBATTR);
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITypeLib {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITypeLib_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLib_Impl, const OFFSET: isize>() -> ITypeLib_Vtbl {
         unsafe extern "system" fn GetTypeInfoCount<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLib_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -4536,6 +4673,8 @@ pub trait ITypeLib2_Impl: Sized + ITypeLib_Impl {
     fn GetAllCustData(&self) -> ::windows::core::Result<CUSTDATA>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITypeLib2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl ITypeLib2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLib2_Impl, const OFFSET: isize>() -> ITypeLib2_Vtbl {
         unsafe extern "system" fn GetCustData<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLib2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pvarval: *mut VARIANT) -> ::windows::core::HRESULT {
@@ -4593,6 +4732,8 @@ pub trait ITypeLibRegistration_Impl: Sized {
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
     fn GetHelpDir(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITypeLibRegistration {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITypeLibRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLibRegistration_Impl, const OFFSET: isize>() -> ITypeLibRegistration_Vtbl {
@@ -4703,6 +4844,7 @@ impl ITypeLibRegistration_Vtbl {
 pub trait ITypeLibRegistrationReader_Impl: Sized {
     fn EnumTypeLibRegistrations(&self) -> ::windows::core::Result<IEnumUnknown>;
 }
+impl ::windows::core::RuntimeName for ITypeLibRegistrationReader {}
 impl ITypeLibRegistrationReader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLibRegistrationReader_Impl, const OFFSET: isize>() -> ITypeLibRegistrationReader_Vtbl {
         unsafe extern "system" fn EnumTypeLibRegistrations<Identity: ::windows::core::IUnknownImpl, Impl: ITypeLibRegistrationReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenumunknown: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4750,6 +4892,8 @@ pub trait IUri_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<u32>;
     fn IsEqual(&self, puri: &::core::option::Option<IUri>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUri {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUri_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUri_Impl, const OFFSET: isize>() -> IUri_Vtbl {
@@ -5070,6 +5214,8 @@ pub trait IUriBuilder_Impl: Sized {
     fn HasBeenModified(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUriBuilder {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUriBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUriBuilder_Impl, const OFFSET: isize>() -> IUriBuilder_Vtbl {
         unsafe extern "system" fn CreateUriSimple<Identity: ::windows::core::IUnknownImpl, Impl: IUriBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwallowencodingpropertymask: u32, dwreserved: usize, ppiuri: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5251,6 +5397,7 @@ impl IUriBuilder_Vtbl {
 pub trait IUrlMon_Impl: Sized {
     fn AsyncGetClassBits(&self, rclsid: *const ::windows::core::GUID, psztype: &::windows::core::PCWSTR, pszext: &::windows::core::PCWSTR, dwfileversionms: u32, dwfileversionls: u32, pszcodebase: &::windows::core::PCWSTR, pbc: &::core::option::Option<IBindCtx>, dwclasscontext: u32, riid: *const ::windows::core::GUID, flags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUrlMon {}
 impl IUrlMon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUrlMon_Impl, const OFFSET: isize>() -> IUrlMon_Vtbl {
         unsafe extern "system" fn AsyncGetClassBits<Identity: ::windows::core::IUnknownImpl, Impl: IUrlMon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, psztype: ::windows::core::PCWSTR, pszext: ::windows::core::PCWSTR, dwfileversionms: u32, dwfileversionls: u32, pszcodebase: ::windows::core::PCWSTR, pbc: ::windows::core::RawPtr, dwclasscontext: u32, riid: *const ::windows::core::GUID, flags: u32) -> ::windows::core::HRESULT {
@@ -5268,6 +5415,7 @@ pub trait IWaitMultiple_Impl: Sized {
     fn WaitMultiple(&self, timeout: u32) -> ::windows::core::Result<ISynchronize>;
     fn AddSynchronize(&self, psync: &::core::option::Option<ISynchronize>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWaitMultiple {}
 impl IWaitMultiple_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWaitMultiple_Impl, const OFFSET: isize>() -> IWaitMultiple_Vtbl {
         unsafe extern "system" fn WaitMultiple<Identity: ::windows::core::IUnknownImpl, Impl: IWaitMultiple_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timeout: u32, psync: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
@@ -7,6 +7,8 @@ pub trait ContextInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetContextId(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ContextInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ContextInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ContextInfo_Impl, const OFFSET: isize>() -> ContextInfo_Vtbl {
         unsafe extern "system" fn IsInTransaction<Identity: ::windows::core::IUnknownImpl, Impl: ContextInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbisintx: *mut i16) -> ::windows::core::HRESULT {
@@ -84,6 +86,8 @@ pub trait ContextInfo2_Impl: Sized + super::Com::IDispatch_Impl + ContextInfo_Im
     fn GetApplicationInstanceId(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ContextInfo2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ContextInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ContextInfo2_Impl, const OFFSET: isize>() -> ContextInfo2_Vtbl {
         unsafe extern "system" fn GetPartitionId<Identity: ::windows::core::IUnknownImpl, Impl: ContextInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, __midl__contextinfo20000: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -136,6 +140,8 @@ pub trait IAppDomainHelper_Impl: Sized + super::Com::IDispatch_Impl {
     fn DoCallback(&self, punkad: &::core::option::Option<::windows::core::IUnknown>, __midl__iappdomainhelper0001: isize, ppool: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAppDomainHelper {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAppDomainHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppDomainHelper_Impl, const OFFSET: isize>() -> IAppDomainHelper_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IAppDomainHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkad: *mut ::core::ffi::c_void, __midl__iappdomainhelper0000: isize, ppool: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -163,6 +169,8 @@ pub trait IAssemblyLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetModules(&self, applicationdir: &super::super::Foundation::BSTR, applicationname: &super::super::Foundation::BSTR, assemblyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<*mut super::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAssemblyLocator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAssemblyLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyLocator_Impl, const OFFSET: isize>() -> IAssemblyLocator_Vtbl {
         unsafe extern "system" fn GetModules<Identity: ::windows::core::IUnknownImpl, Impl: IAssemblyLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, applicationdir: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, applicationname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, assemblyname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pmodules: *mut *mut super::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -185,6 +193,7 @@ impl IAssemblyLocator_Vtbl {
 pub trait IAsyncErrorNotify_Impl: Sized {
     fn OnError(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAsyncErrorNotify {}
 impl IAsyncErrorNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncErrorNotify_Impl, const OFFSET: isize>() -> IAsyncErrorNotify_Vtbl {
         unsafe extern "system" fn OnError<Identity: ::windows::core::IUnknownImpl, Impl: IAsyncErrorNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -227,6 +236,8 @@ pub trait ICOMAdminCatalog_Impl: Sized + super::Com::IDispatch_Impl {
     fn InstallEventClass(&self, bstrapplidorname: &super::super::Foundation::BSTR, bstrdll: &super::super::Foundation::BSTR, bstrtlb: &super::super::Foundation::BSTR, bstrpsdll: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetEventClassesForIID(&self, bstriid: &super::super::Foundation::BSTR, ppsavarclsids: *mut *mut super::Com::SAFEARRAY, ppsavarprogids: *mut *mut super::Com::SAFEARRAY, ppsavardescriptions: *mut *mut super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICOMAdminCatalog {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICOMAdminCatalog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICOMAdminCatalog_Impl, const OFFSET: isize>() -> ICOMAdminCatalog_Vtbl {
@@ -464,6 +475,8 @@ pub trait ICOMAdminCatalog2_Impl: Sized + super::Com::IDispatch_Impl + ICOMAdmin
     fn QueryApplicationFile2(&self, bstrapplicationfile: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::Com::IDispatch>;
     fn GetComponentVersionCount(&self, bstrclsidorprogid: &super::super::Foundation::BSTR) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICOMAdminCatalog2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICOMAdminCatalog2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICOMAdminCatalog2_Impl, const OFFSET: isize>() -> ICOMAdminCatalog2_Vtbl {
@@ -751,6 +764,7 @@ pub trait ICOMLBArguments_Impl: Sized {
     fn GetMachineName(&self, cchsvr: u32, szservername: ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn SetMachineName(&self, cchsvr: u32, szservername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICOMLBArguments {}
 impl ICOMLBArguments_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICOMLBArguments_Impl, const OFFSET: isize>() -> ICOMLBArguments_Vtbl {
         unsafe extern "system" fn GetCLSID<Identity: ::windows::core::IUnknownImpl, Impl: ICOMLBArguments_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -804,6 +818,8 @@ pub trait ICatalogCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn PopulateByKey(&self, psakeys: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn PopulateByQuery(&self, bstrquerystring: &super::super::Foundation::BSTR, lquerytype: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICatalogCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICatalogCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICatalogCollection_Impl, const OFFSET: isize>() -> ICatalogCollection_Vtbl {
@@ -994,6 +1010,8 @@ pub trait ICatalogObject_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsPropertyWriteOnly(&self, bstrpropname: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICatalogObject {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICatalogObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICatalogObject_Impl, const OFFSET: isize>() -> ICatalogObject_Vtbl {
         unsafe extern "system" fn get_Value<Identity: ::windows::core::IUnknownImpl, Impl: ICatalogObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrpropname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pvarretval: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1085,6 +1103,7 @@ impl ICatalogObject_Vtbl {
 pub trait ICheckSxsConfig_Impl: Sized {
     fn IsSameSxsConfig(&self, wszsxsname: &::windows::core::PCWSTR, wszsxsdirectory: &::windows::core::PCWSTR, wszsxsappname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICheckSxsConfig {}
 impl ICheckSxsConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICheckSxsConfig_Impl, const OFFSET: isize>() -> ICheckSxsConfig_Vtbl {
         unsafe extern "system" fn IsSameSxsConfig<Identity: ::windows::core::IUnknownImpl, Impl: ICheckSxsConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszsxsname: ::windows::core::PCWSTR, wszsxsdirectory: ::windows::core::PCWSTR, wszsxsappname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1107,6 +1126,7 @@ pub trait IComActivityEvents_Impl: Sized {
     fn OnActivityLeave(&self, pinfo: *const COMSVCSEVENTINFO, guidcurrent: *const ::windows::core::GUID, guidleft: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnActivityLeaveSame(&self, pinfo: *const COMSVCSEVENTINFO, guidcurrent: *const ::windows::core::GUID, dwcalldepth: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComActivityEvents {}
 impl IComActivityEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComActivityEvents_Impl, const OFFSET: isize>() -> IComActivityEvents_Vtbl {
         unsafe extern "system" fn OnActivityCreate<Identity: ::windows::core::IUnknownImpl, Impl: IComActivityEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1168,6 +1188,8 @@ pub trait IComApp2Events_Impl: Sized {
     fn OnAppRecycle2(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID, guidprocess: &::windows::core::GUID, lreason: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComApp2Events {}
+#[cfg(feature = "Win32_Foundation")]
 impl IComApp2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComApp2Events_Impl, const OFFSET: isize>() -> IComApp2Events_Vtbl {
         unsafe extern "system" fn OnAppActivation2<Identity: ::windows::core::IUnknownImpl, Impl: IComApp2Events_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID, guidprocess: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1213,6 +1235,7 @@ pub trait IComAppEvents_Impl: Sized {
     fn OnAppShutdown(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnAppForceShutdown(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComAppEvents {}
 impl IComAppEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComAppEvents_Impl, const OFFSET: isize>() -> IComAppEvents_Vtbl {
         unsafe extern "system" fn OnAppActivation<Identity: ::windows::core::IUnknownImpl, Impl: IComAppEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1259,6 +1282,8 @@ pub trait IComCRMEvents_Impl: Sized {
     fn OnCRMForce(&self, pinfo: *const COMSVCSEVENTINFO, guidclerkclsid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnCRMDeliver(&self, pinfo: *const COMSVCSEVENTINFO, guidclerkclsid: &::windows::core::GUID, fvariants: super::super::Foundation::BOOL, dwrecordsize: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComCRMEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IComCRMEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComCRMEvents_Impl, const OFFSET: isize>() -> IComCRMEvents_Vtbl {
@@ -1363,6 +1388,7 @@ impl IComCRMEvents_Vtbl {
 pub trait IComExceptionEvents_Impl: Sized {
     fn OnExceptionUser(&self, pinfo: *const COMSVCSEVENTINFO, code: u32, address: u64, pszstacktrace: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComExceptionEvents {}
 impl IComExceptionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComExceptionEvents_Impl, const OFFSET: isize>() -> IComExceptionEvents_Vtbl {
         unsafe extern "system" fn OnExceptionUser<Identity: ::windows::core::IUnknownImpl, Impl: IComExceptionEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, code: u32, address: u64, pszstacktrace: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1379,6 +1405,7 @@ impl IComExceptionEvents_Vtbl {
 pub trait IComIdentityEvents_Impl: Sized {
     fn OnIISRequestInfo(&self, pinfo: *const COMSVCSEVENTINFO, objid: u64, pszclientip: &::windows::core::PCWSTR, pszserverip: &::windows::core::PCWSTR, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComIdentityEvents {}
 impl IComIdentityEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComIdentityEvents_Impl, const OFFSET: isize>() -> IComIdentityEvents_Vtbl {
         unsafe extern "system" fn OnIISRequestInfo<Identity: ::windows::core::IUnknownImpl, Impl: IComIdentityEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, objid: u64, pszclientip: ::windows::core::PCWSTR, pszserverip: ::windows::core::PCWSTR, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1396,6 +1423,7 @@ pub trait IComInstance2Events_Impl: Sized {
     fn OnObjectCreate2(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnObjectDestroy2(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComInstance2Events {}
 impl IComInstance2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComInstance2Events_Impl, const OFFSET: isize>() -> IComInstance2Events_Vtbl {
         unsafe extern "system" fn OnObjectCreate2<Identity: ::windows::core::IUnknownImpl, Impl: IComInstance2Events_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1422,6 +1450,7 @@ pub trait IComInstanceEvents_Impl: Sized {
     fn OnObjectCreate(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64) -> ::windows::core::Result<()>;
     fn OnObjectDestroy(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComInstanceEvents {}
 impl IComInstanceEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComInstanceEvents_Impl, const OFFSET: isize>() -> IComInstanceEvents_Vtbl {
         unsafe extern "system" fn OnObjectCreate<Identity: ::windows::core::IUnknownImpl, Impl: IComInstanceEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64) -> ::windows::core::HRESULT {
@@ -1452,6 +1481,8 @@ pub trait IComLTxEvents_Impl: Sized {
     fn OnLtxTransactionCommit(&self, pinfo: *const COMSVCSEVENTINFO, guidltx: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnLtxTransactionPromote(&self, pinfo: *const COMSVCSEVENTINFO, guidltx: &::windows::core::GUID, txnid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComLTxEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IComLTxEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComLTxEvents_Impl, const OFFSET: isize>() -> IComLTxEvents_Vtbl {
@@ -1498,6 +1529,7 @@ pub trait IComMethod2Events_Impl: Sized {
     fn OnMethodReturn2(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnMethodException2(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComMethod2Events {}
 impl IComMethod2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComMethod2Events_Impl, const OFFSET: isize>() -> IComMethod2Events_Vtbl {
         unsafe extern "system" fn OnMethodCall2<Identity: ::windows::core::IUnknownImpl, Impl: IComMethod2Events_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32) -> ::windows::core::HRESULT {
@@ -1531,6 +1563,7 @@ pub trait IComMethodEvents_Impl: Sized {
     fn OnMethodReturn(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnMethodException(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComMethodEvents {}
 impl IComMethodEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComMethodEvents_Impl, const OFFSET: isize>() -> IComMethodEvents_Vtbl {
         unsafe extern "system" fn OnMethodCall<Identity: ::windows::core::IUnknownImpl, Impl: IComMethodEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32) -> ::windows::core::HRESULT {
@@ -1565,6 +1598,7 @@ pub trait IComMtaThreadPoolKnobs_Impl: Sized {
     fn MTASetThrottleValue(&self, dwthrottle: u32) -> ::windows::core::Result<()>;
     fn MTAGetThrottleValue(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IComMtaThreadPoolKnobs {}
 impl IComMtaThreadPoolKnobs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComMtaThreadPoolKnobs_Impl, const OFFSET: isize>() -> IComMtaThreadPoolKnobs_Vtbl {
         unsafe extern "system" fn MTASetMaxThreadCount<Identity: ::windows::core::IUnknownImpl, Impl: IComMtaThreadPoolKnobs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmaxthreads: u32) -> ::windows::core::HRESULT {
@@ -1614,6 +1648,7 @@ impl IComMtaThreadPoolKnobs_Vtbl {
 pub trait IComObjectConstruction2Events_Impl: Sized {
     fn OnObjectConstruct2(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: &::windows::core::PCWSTR, oid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComObjectConstruction2Events {}
 impl IComObjectConstruction2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectConstruction2Events_Impl, const OFFSET: isize>() -> IComObjectConstruction2Events_Vtbl {
         unsafe extern "system" fn OnObjectConstruct2<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectConstruction2Events_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: ::windows::core::PCWSTR, oid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1630,6 +1665,7 @@ impl IComObjectConstruction2Events_Vtbl {
 pub trait IComObjectConstructionEvents_Impl: Sized {
     fn OnObjectConstruct(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: &::windows::core::PCWSTR, oid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComObjectConstructionEvents {}
 impl IComObjectConstructionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectConstructionEvents_Impl, const OFFSET: isize>() -> IComObjectConstructionEvents_Vtbl {
         unsafe extern "system" fn OnObjectConstruct<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectConstructionEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: ::windows::core::PCWSTR, oid: u64) -> ::windows::core::HRESULT {
@@ -1651,6 +1687,7 @@ pub trait IComObjectEvents_Impl: Sized {
     fn OnSetComplete(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::Result<()>;
     fn OnSetAbort(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComObjectEvents {}
 impl IComObjectEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectEvents_Impl, const OFFSET: isize>() -> IComObjectEvents_Vtbl {
         unsafe extern "system" fn OnObjectActivate<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64, objectid: u64) -> ::windows::core::HRESULT {
@@ -1703,6 +1740,7 @@ pub trait IComObjectPool2Events_Impl: Sized {
     fn OnObjPoolRecycleToTx2(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, guidtx: *const ::windows::core::GUID, objid: u64) -> ::windows::core::Result<()>;
     fn OnObjPoolGetFromTx2(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, guidtx: *const ::windows::core::GUID, objid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComObjectPool2Events {}
 impl IComObjectPool2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectPool2Events_Impl, const OFFSET: isize>() -> IComObjectPool2Events_Vtbl {
         unsafe extern "system" fn OnObjPoolPutObject2<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectPool2Events_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, nreason: i32, dwavailable: u32, oid: u64) -> ::windows::core::HRESULT {
@@ -1743,6 +1781,7 @@ pub trait IComObjectPoolEvents_Impl: Sized {
     fn OnObjPoolRecycleToTx(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, guidtx: *const ::windows::core::GUID, objid: u64) -> ::windows::core::Result<()>;
     fn OnObjPoolGetFromTx(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, guidtx: *const ::windows::core::GUID, objid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComObjectPoolEvents {}
 impl IComObjectPoolEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectPoolEvents_Impl, const OFFSET: isize>() -> IComObjectPoolEvents_Vtbl {
         unsafe extern "system" fn OnObjPoolPutObject<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectPoolEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, nreason: i32, dwavailable: u32, oid: u64) -> ::windows::core::HRESULT {
@@ -1784,6 +1823,7 @@ pub trait IComObjectPoolEvents2_Impl: Sized {
     fn OnObjPoolTimeout(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, guidactivity: *const ::windows::core::GUID, dwtimeout: u32) -> ::windows::core::Result<()>;
     fn OnObjPoolCreatePool(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, dwmin: u32, dwmax: u32, dwtimeout: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComObjectPoolEvents2 {}
 impl IComObjectPoolEvents2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectPoolEvents2_Impl, const OFFSET: isize>() -> IComObjectPoolEvents2_Vtbl {
         unsafe extern "system" fn OnObjPoolCreateObject<Identity: ::windows::core::IUnknownImpl, Impl: IComObjectPoolEvents2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, dwobjscreated: u32, oid: u64) -> ::windows::core::HRESULT {
@@ -1833,6 +1873,7 @@ pub trait IComQCEvents_Impl: Sized {
     fn OnQCMoveToDeadQueue(&self, pinfo: *const COMSVCSEVENTINFO, guidmsgid: *const ::windows::core::GUID, guidworkflowid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnQCPlayback(&self, pinfo: *const COMSVCSEVENTINFO, objid: u64, guidmsgid: *const ::windows::core::GUID, guidworkflowid: *const ::windows::core::GUID, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComQCEvents {}
 impl IComQCEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComQCEvents_Impl, const OFFSET: isize>() -> IComQCEvents_Vtbl {
         unsafe extern "system" fn OnQCRecord<Identity: ::windows::core::IUnknownImpl, Impl: IComQCEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, objid: u64, szqueue: ::windows::core::PCWSTR, guidmsgid: *const ::windows::core::GUID, guidworkflowid: *const ::windows::core::GUID, msmqhr: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1894,6 +1935,8 @@ pub trait IComResourceEvents_Impl: Sized {
     fn OnResourceTrack(&self, pinfo: *const COMSVCSEVENTINFO, objectid: u64, psztype: &::windows::core::PCWSTR, resid: u64, enlisted: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComResourceEvents {}
+#[cfg(feature = "Win32_Foundation")]
 impl IComResourceEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComResourceEvents_Impl, const OFFSET: isize>() -> IComResourceEvents_Vtbl {
         unsafe extern "system" fn OnResourceCreate<Identity: ::windows::core::IUnknownImpl, Impl: IComResourceEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, objectid: u64, psztype: ::windows::core::PCWSTR, resid: u64, enlisted: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1940,6 +1983,8 @@ pub trait IComSecurityEvents_Impl: Sized {
     fn OnAuthenticateFail(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, objectid: u64, guidiid: *const ::windows::core::GUID, imeth: u32, cbbyteorig: u32, psidoriginaluser: *const u8, cbbytecur: u32, psidcurrentuser: *const u8, bcurrentuserinpersonatinginproc: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComSecurityEvents {}
+#[cfg(feature = "Win32_Foundation")]
 impl IComSecurityEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComSecurityEvents_Impl, const OFFSET: isize>() -> IComSecurityEvents_Vtbl {
         unsafe extern "system" fn OnAuthenticate<Identity: ::windows::core::IUnknownImpl, Impl: IComSecurityEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, objectid: u64, guidiid: *const ::windows::core::GUID, imeth: u32, cbbyteorig: u32, psidoriginaluser: *const u8, cbbytecur: u32, psidcurrentuser: *const u8, bcurrentuserinpersonatinginproc: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1975,6 +2020,7 @@ pub trait IComStaThreadPoolKnobs_Impl: Sized {
     fn GetQueueDepth(&self) -> ::windows::core::Result<u32>;
     fn SetQueueDepth(&self, dwqdepth: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComStaThreadPoolKnobs {}
 impl IComStaThreadPoolKnobs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComStaThreadPoolKnobs_Impl, const OFFSET: isize>() -> IComStaThreadPoolKnobs_Vtbl {
         unsafe extern "system" fn SetMinThreadCount<Identity: ::windows::core::IUnknownImpl, Impl: IComStaThreadPoolKnobs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, minthreads: u32) -> ::windows::core::HRESULT {
@@ -2101,6 +2147,8 @@ pub trait IComStaThreadPoolKnobs2_Impl: Sized + IComStaThreadPoolKnobs_Impl {
     fn SetWaitTimeForThreadCleanup(&self, dwthreadcleanupwaittime: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComStaThreadPoolKnobs2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IComStaThreadPoolKnobs2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComStaThreadPoolKnobs2_Impl, const OFFSET: isize>() -> IComStaThreadPoolKnobs2_Vtbl {
         unsafe extern "system" fn GetMaxCPULoad<Identity: ::windows::core::IUnknownImpl, Impl: IComStaThreadPoolKnobs2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwload: *mut u32) -> ::windows::core::HRESULT {
@@ -2214,6 +2262,7 @@ pub trait IComThreadEvents_Impl: Sized {
     fn OnThreadAssignApartment(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, aptid: u64) -> ::windows::core::Result<()>;
     fn OnThreadUnassignApartment(&self, pinfo: *const COMSVCSEVENTINFO, aptid: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComThreadEvents {}
 impl IComThreadEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComThreadEvents_Impl, const OFFSET: isize>() -> IComThreadEvents_Vtbl {
         unsafe extern "system" fn OnThreadStart<Identity: ::windows::core::IUnknownImpl, Impl: IComThreadEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, threadid: u64, dwthread: u32, dwtheadcnt: u32) -> ::windows::core::HRESULT {
@@ -2295,6 +2344,7 @@ pub trait IComTrackingInfoCollection_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<u32>;
     fn Item(&self, ulindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComTrackingInfoCollection {}
 impl IComTrackingInfoCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoCollection_Impl, const OFFSET: isize>() -> IComTrackingInfoCollection_Vtbl {
         unsafe extern "system" fn Type<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut TRACKING_COLL_TYPE) -> ::windows::core::HRESULT {
@@ -2338,6 +2388,7 @@ impl IComTrackingInfoCollection_Vtbl {
 pub trait IComTrackingInfoEvents_Impl: Sized {
     fn OnNewTrackingInfo(&self, ptoplevelcollection: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComTrackingInfoEvents {}
 impl IComTrackingInfoEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoEvents_Impl, const OFFSET: isize>() -> IComTrackingInfoEvents_Vtbl {
         unsafe extern "system" fn OnNewTrackingInfo<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptoplevelcollection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2355,6 +2406,8 @@ impl IComTrackingInfoEvents_Vtbl {
 pub trait IComTrackingInfoObject_Impl: Sized {
     fn GetValue(&self, szpropertyname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComTrackingInfoObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComTrackingInfoObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoObject_Impl, const OFFSET: isize>() -> IComTrackingInfoObject_Vtbl {
@@ -2379,6 +2432,7 @@ pub trait IComTrackingInfoProperties_Impl: Sized {
     fn PropCount(&self) -> ::windows::core::Result<u32>;
     fn GetPropName(&self, ulindex: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IComTrackingInfoProperties {}
 impl IComTrackingInfoProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoProperties_Impl, const OFFSET: isize>() -> IComTrackingInfoProperties_Vtbl {
         unsafe extern "system" fn PropCount<Identity: ::windows::core::IUnknownImpl, Impl: IComTrackingInfoProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT {
@@ -2420,6 +2474,8 @@ pub trait IComTransaction2Events_Impl: Sized {
     fn OnTransactionAbort2(&self, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnTransactionCommit2(&self, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComTransaction2Events {}
 #[cfg(feature = "Win32_Foundation")]
 impl IComTransaction2Events_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComTransaction2Events_Impl, const OFFSET: isize>() -> IComTransaction2Events_Vtbl {
@@ -2463,6 +2519,8 @@ pub trait IComTransactionEvents_Impl: Sized {
     fn OnTransactionCommit(&self, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IComTransactionEvents {}
+#[cfg(feature = "Win32_Foundation")]
 impl IComTransactionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComTransactionEvents_Impl, const OFFSET: isize>() -> IComTransactionEvents_Vtbl {
         unsafe extern "system" fn OnTransactionStart<Identity: ::windows::core::IUnknownImpl, Impl: IComTransactionEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, froot: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2502,6 +2560,8 @@ pub trait IComUserEvent_Impl: Sized {
     fn OnUserEvent(&self, pinfo: *const COMSVCSEVENTINFO, pvarevent: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComUserEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComUserEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComUserEvent_Impl, const OFFSET: isize>() -> IComUserEvent_Vtbl {
         unsafe extern "system" fn OnUserEvent<Identity: ::windows::core::IUnknownImpl, Impl: IComUserEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, pvarevent: *const super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2523,6 +2583,8 @@ pub trait IContextProperties_Impl: Sized {
     fn SetProperty(&self, name: &super::super::Foundation::BSTR, property: &super::Com::VARIANT) -> ::windows::core::Result<()>;
     fn RemoveProperty(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IContextProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IContextProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextProperties_Impl, const OFFSET: isize>() -> IContextProperties_Vtbl {
@@ -2576,6 +2638,8 @@ pub trait IContextSecurityPerimeter_Impl: Sized {
     fn SetPerimeterFlag(&self, fflag: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContextSecurityPerimeter {}
+#[cfg(feature = "Win32_Foundation")]
 impl IContextSecurityPerimeter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextSecurityPerimeter_Impl, const OFFSET: isize>() -> IContextSecurityPerimeter_Vtbl {
         unsafe extern "system" fn GetPerimeterFlag<Identity: ::windows::core::IUnknownImpl, Impl: IContextSecurityPerimeter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pflag: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2604,6 +2668,7 @@ pub trait IContextState_Impl: Sized {
     fn SetMyTransactionVote(&self, txvote: TransactionVote) -> ::windows::core::Result<()>;
     fn GetMyTransactionVote(&self, ptxvote: *mut TransactionVote) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContextState {}
 impl IContextState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextState_Impl, const OFFSET: isize>() -> IContextState_Vtbl {
         unsafe extern "system" fn SetDeactivateOnReturn<Identity: ::windows::core::IUnknownImpl, Impl: IContextState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bdeactivate: i16) -> ::windows::core::HRESULT {
@@ -2641,6 +2706,7 @@ impl IContextState_Vtbl {
 pub trait ICreateWithLocalTransaction_Impl: Sized {
     fn CreateInstanceWithSysTx(&self, ptransaction: &::core::option::Option<::windows::core::IUnknown>, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICreateWithLocalTransaction {}
 impl ICreateWithLocalTransaction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateWithLocalTransaction_Impl, const OFFSET: isize>() -> ICreateWithLocalTransaction_Vtbl {
         unsafe extern "system" fn CreateInstanceWithSysTx<Identity: ::windows::core::IUnknownImpl, Impl: ICreateWithLocalTransaction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2659,6 +2725,8 @@ pub trait ICreateWithTipTransactionEx_Impl: Sized {
     fn CreateInstance(&self, bstrtipurl: &super::super::Foundation::BSTR, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICreateWithTipTransactionEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICreateWithTipTransactionEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateWithTipTransactionEx_Impl, const OFFSET: isize>() -> ICreateWithTipTransactionEx_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: ICreateWithTipTransactionEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrtipurl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2676,6 +2744,8 @@ impl ICreateWithTipTransactionEx_Vtbl {
 pub trait ICreateWithTransactionEx_Impl: Sized {
     fn CreateInstance(&self, ptransaction: &::core::option::Option<super::DistributedTransactionCoordinator::ITransaction>, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
+impl ::windows::core::RuntimeName for ICreateWithTransactionEx {}
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 impl ICreateWithTransactionEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateWithTransactionEx_Impl, const OFFSET: isize>() -> ICreateWithTransactionEx_Vtbl {
@@ -2703,6 +2773,8 @@ pub trait ICrmCompensator_Impl: Sized {
     fn AbortRecord(&self, crmlogrec: &CrmLogRecordRead) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn EndAbort(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICrmCompensator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICrmCompensator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmCompensator_Impl, const OFFSET: isize>() -> ICrmCompensator_Vtbl {
@@ -2812,6 +2884,8 @@ pub trait ICrmCompensatorVariants_Impl: Sized {
     fn EndAbortVariants(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICrmCompensatorVariants {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICrmCompensatorVariants_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmCompensatorVariants_Impl, const OFFSET: isize>() -> ICrmCompensatorVariants_Vtbl {
         unsafe extern "system" fn SetLogControlVariants<Identity: ::windows::core::IUnknownImpl, Impl: ICrmCompensatorVariants_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plogcontrol: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2914,6 +2988,8 @@ pub trait ICrmFormatLogRecords_Impl: Sized {
     fn GetColumnVariants(&self, logrecord: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICrmFormatLogRecords {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICrmFormatLogRecords_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmFormatLogRecords_Impl, const OFFSET: isize>() -> ICrmFormatLogRecords_Vtbl {
         unsafe extern "system" fn GetColumnCount<Identity: ::windows::core::IUnknownImpl, Impl: ICrmFormatLogRecords_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcolumncount: *mut i32) -> ::windows::core::HRESULT {
@@ -2983,6 +3059,8 @@ pub trait ICrmLogControl_Impl: Sized {
     fn WriteLogRecord(&self, rgblob: *const super::Com::BLOB, cblob: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICrmLogControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICrmLogControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmLogControl_Impl, const OFFSET: isize>() -> ICrmLogControl_Vtbl {
         unsafe extern "system" fn TransactionUOW<Identity: ::windows::core::IUnknownImpl, Impl: ICrmLogControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3047,6 +3125,8 @@ pub trait ICrmMonitor_Impl: Sized {
     fn HoldClerk(&self, index: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICrmMonitor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICrmMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmMonitor_Impl, const OFFSET: isize>() -> ICrmMonitor_Vtbl {
         unsafe extern "system" fn GetClerks<Identity: ::windows::core::IUnknownImpl, Impl: ICrmMonitor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclerks: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3091,6 +3171,8 @@ pub trait ICrmMonitorClerks_Impl: Sized + super::Com::IDispatch_Impl {
     fn TransactionUOW(&self, index: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
     fn ActivityId(&self, index: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICrmMonitorClerks {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICrmMonitorClerks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmMonitorClerks_Impl, const OFFSET: isize>() -> ICrmMonitorClerks_Vtbl {
@@ -3195,6 +3277,8 @@ pub trait ICrmMonitorLogRecords_Impl: Sized {
     fn GetLogRecordVariants(&self, indexnumber: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICrmMonitorLogRecords {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICrmMonitorLogRecords_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICrmMonitorLogRecords_Impl, const OFFSET: isize>() -> ICrmMonitorLogRecords_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ICrmMonitorLogRecords_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -3269,6 +3353,8 @@ pub trait IDispenserDriver_Impl: Sized {
     fn DestroyResourceS(&self, resid: *mut u16) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDispenserDriver {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDispenserDriver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispenserDriver_Impl, const OFFSET: isize>() -> IDispenserDriver_Vtbl {
         unsafe extern "system" fn CreateResource<Identity: ::windows::core::IUnknownImpl, Impl: IDispenserDriver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, restypid: usize, presid: *mut usize, psecsfreebeforedestroy: *mut i32) -> ::windows::core::HRESULT {
@@ -3319,6 +3405,7 @@ pub trait IDispenserManager_Impl: Sized {
     fn RegisterDispenser(&self, __midl__idispensermanager0000: &::core::option::Option<IDispenserDriver>, szdispensername: &::windows::core::PCWSTR) -> ::windows::core::Result<IHolder>;
     fn GetContext(&self, __midl__idispensermanager0002: *mut usize, __midl__idispensermanager0003: *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDispenserManager {}
 impl IDispenserManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispenserManager_Impl, const OFFSET: isize>() -> IDispenserManager_Vtbl {
         unsafe extern "system" fn RegisterDispenser<Identity: ::windows::core::IUnknownImpl, Impl: IDispenserManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, __midl__idispensermanager0000: ::windows::core::RawPtr, szdispensername: ::windows::core::PCWSTR, __midl__idispensermanager0001: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3354,6 +3441,8 @@ pub trait IEnumNames_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumNames>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumNames {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnumNames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumNames_Impl, const OFFSET: isize>() -> IEnumNames_Vtbl {
@@ -3402,6 +3491,8 @@ pub trait IEventServerTrace_Impl: Sized + super::Com::IDispatch_Impl {
     fn EnumTraceGuid(&self, plcntguids: *mut i32, pbstrguidlist: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventServerTrace {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEventServerTrace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventServerTrace_Impl, const OFFSET: isize>() -> IEventServerTrace_Vtbl {
         unsafe extern "system" fn StartTraceGuid<Identity: ::windows::core::IUnknownImpl, Impl: IEventServerTrace_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrguidevent: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrguidfilter: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lpidfilter: i32) -> ::windows::core::HRESULT {
@@ -3440,6 +3531,8 @@ pub trait IGetAppTrackerData_Impl: Sized {
     fn GetTrackerDataAsCollectionObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetSuggestedPollingInterval(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGetAppTrackerData {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGetAppTrackerData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetAppTrackerData_Impl, const OFFSET: isize>() -> IGetAppTrackerData_Vtbl {
@@ -3512,6 +3605,8 @@ pub trait IGetContextProperties_Impl: Sized {
     fn EnumNames(&self) -> ::windows::core::Result<IEnumNames>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGetContextProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGetContextProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetContextProperties_Impl, const OFFSET: isize>() -> IGetContextProperties_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGetContextProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -3551,6 +3646,8 @@ pub trait IGetSecurityCallContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityCallContext(&self) -> ::windows::core::Result<ISecurityCallContext>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGetSecurityCallContext {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGetSecurityCallContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetSecurityCallContext_Impl, const OFFSET: isize>() -> IGetSecurityCallContext_Vtbl {
         unsafe extern "system" fn GetSecurityCallContext<Identity: ::windows::core::IUnknownImpl, Impl: IGetSecurityCallContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3581,6 +3678,8 @@ pub trait IHolder_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn RequestDestroyResource(&self, __midl__iholder0009: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IHolder {}
 #[cfg(feature = "Win32_Foundation")]
 impl IHolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHolder_Impl, const OFFSET: isize>() -> IHolder_Vtbl {
@@ -3647,6 +3746,8 @@ pub trait ILBEvents_Impl: Sized {
     fn EngineDefined(&self, bstrpropname: &super::super::Foundation::BSTR, varpropvalue: *const super::Com::VARIANT, bstrclsideng: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILBEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILBEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILBEvents_Impl, const OFFSET: isize>() -> ILBEvents_Vtbl {
         unsafe extern "system" fn TargetUp<Identity: ::windows::core::IUnknownImpl, Impl: ILBEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrservername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrclsideng: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -3682,6 +3783,7 @@ pub trait IMTSActivity_Impl: Sized {
     fn BindToCurrentThread(&self) -> ::windows::core::Result<()>;
     fn UnbindFromThread(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMTSActivity {}
 impl IMTSActivity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMTSActivity_Impl, const OFFSET: isize>() -> IMTSActivity_Vtbl {
         unsafe extern "system" fn SynchronousCall<Identity: ::windows::core::IUnknownImpl, Impl: IMTSActivity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcall: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3725,6 +3827,7 @@ impl IMTSActivity_Vtbl {
 pub trait IMTSCall_Impl: Sized {
     fn OnCall(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMTSCall {}
 impl IMTSCall_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMTSCall_Impl, const OFFSET: isize>() -> IMTSCall_Vtbl {
         unsafe extern "system" fn OnCall<Identity: ::windows::core::IUnknownImpl, Impl: IMTSCall_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3742,6 +3845,8 @@ impl IMTSCall_Vtbl {
 pub trait IMTSLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetEventDispatcher(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMTSLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMTSLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMTSLocator_Impl, const OFFSET: isize>() -> IMTSLocator_Vtbl {
@@ -3767,6 +3872,8 @@ pub trait IManagedActivationEvents_Impl: Sized {
     fn CreateManagedStub(&self, pinfo: &::core::option::Option<IManagedObjectInfo>, fdist: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn DestroyManagedStub(&self, pinfo: &::core::option::Option<IManagedObjectInfo>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IManagedActivationEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IManagedActivationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IManagedActivationEvents_Impl, const OFFSET: isize>() -> IManagedActivationEvents_Vtbl {
@@ -3797,6 +3904,8 @@ pub trait IManagedObjectInfo_Impl: Sized {
     fn SetInPool(&self, binpool: super::super::Foundation::BOOL, ppooledobj: &::core::option::Option<IManagedPooledObj>) -> ::windows::core::Result<()>;
     fn SetWrapperStrength(&self, bstrong: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IManagedObjectInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IManagedObjectInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IManagedObjectInfo_Impl, const OFFSET: isize>() -> IManagedObjectInfo_Vtbl {
@@ -3847,6 +3956,7 @@ impl IManagedObjectInfo_Vtbl {
 pub trait IManagedPoolAction_Impl: Sized {
     fn LastRelease(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IManagedPoolAction {}
 impl IManagedPoolAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IManagedPoolAction_Impl, const OFFSET: isize>() -> IManagedPoolAction_Vtbl {
         unsafe extern "system" fn LastRelease<Identity: ::windows::core::IUnknownImpl, Impl: IManagedPoolAction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3864,6 +3974,8 @@ impl IManagedPoolAction_Vtbl {
 pub trait IManagedPooledObj_Impl: Sized {
     fn SetHeld(&self, m_bheld: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IManagedPooledObj {}
 #[cfg(feature = "Win32_Foundation")]
 impl IManagedPooledObj_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IManagedPooledObj_Impl, const OFFSET: isize>() -> IManagedPooledObj_Vtbl {
@@ -3888,6 +4000,8 @@ pub trait IMessageMover_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetCommitBatchSize(&self, newval: i32) -> ::windows::core::Result<()>;
     fn MoveMessages(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMessageMover {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMessageMover_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMessageMover_Impl, const OFFSET: isize>() -> IMessageMover_Vtbl {
@@ -3974,6 +4088,8 @@ pub trait IMtsEventInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Value(&self, skey: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMtsEventInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMtsEventInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMtsEventInfo_Impl, const OFFSET: isize>() -> IMtsEventInfo_Vtbl {
         unsafe extern "system" fn Names<Identity: ::windows::core::IUnknownImpl, Impl: IMtsEventInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4053,6 +4169,8 @@ pub trait IMtsEvents_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetProcessID(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMtsEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMtsEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMtsEvents_Impl, const OFFSET: isize>() -> IMtsEvents_Vtbl {
         unsafe extern "system" fn PackageName<Identity: ::windows::core::IUnknownImpl, Impl: IMtsEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4124,6 +4242,8 @@ pub trait IMtsGrp_Impl: Sized + super::Com::IDispatch_Impl {
     fn Refresh(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMtsGrp {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMtsGrp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMtsGrp_Impl, const OFFSET: isize>() -> IMtsGrp_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IMtsGrp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -4173,6 +4293,7 @@ pub trait IObjPool_Impl: Sized {
     fn Reserved5(&self);
     fn Reserved6(&self);
 }
+impl ::windows::core::RuntimeName for IObjPool {}
 impl IObjPool_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjPool_Impl, const OFFSET: isize>() -> IObjPool_Vtbl {
         unsafe extern "system" fn Reserved1<Identity: ::windows::core::IUnknownImpl, Impl: IObjPool_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -4230,6 +4351,8 @@ pub trait IObjectConstruct_Impl: Sized {
     fn Construct(&self, pctorobj: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IObjectConstruct {}
+#[cfg(feature = "Win32_System_Com")]
 impl IObjectConstruct_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectConstruct_Impl, const OFFSET: isize>() -> IObjectConstruct_Vtbl {
         unsafe extern "system" fn Construct<Identity: ::windows::core::IUnknownImpl, Impl: IObjectConstruct_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pctorobj: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4247,6 +4370,8 @@ impl IObjectConstruct_Vtbl {
 pub trait IObjectConstructString_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConstructString(&self, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IObjectConstructString {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IObjectConstructString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectConstructString_Impl, const OFFSET: isize>() -> IObjectConstructString_Vtbl {
@@ -4272,6 +4397,8 @@ pub trait IObjectContext_Impl: Sized {
     fn IsSecurityEnabled(&self) -> super::super::Foundation::BOOL;
     fn IsCallerInRole(&self, bstrrole: &super::super::Foundation::BSTR, pfisinrole: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IObjectContext {}
 #[cfg(feature = "Win32_Foundation")]
 impl IObjectContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContext_Impl, const OFFSET: isize>() -> IObjectContext_Vtbl {
@@ -4334,6 +4461,7 @@ impl IObjectContext_Vtbl {
 pub trait IObjectContextActivity_Impl: Sized {
     fn GetActivityId(&self, pguid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectContextActivity {}
 impl IObjectContextActivity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextActivity_Impl, const OFFSET: isize>() -> IObjectContextActivity_Vtbl {
         unsafe extern "system" fn GetActivityId<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextActivity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -4355,6 +4483,8 @@ pub trait IObjectContextInfo_Impl: Sized {
     fn GetActivityId(&self, pguid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetContextId(&self, pguid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IObjectContextInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IObjectContextInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextInfo_Impl, const OFFSET: isize>() -> IObjectContextInfo_Vtbl {
@@ -4409,6 +4539,8 @@ pub trait IObjectContextInfo2_Impl: Sized + IObjectContextInfo_Impl {
     fn GetApplicationInstanceId(&self, pguid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IObjectContextInfo2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IObjectContextInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextInfo2_Impl, const OFFSET: isize>() -> IObjectContextInfo2_Vtbl {
         unsafe extern "system" fn GetPartitionId<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -4442,6 +4574,8 @@ pub trait IObjectContextTip_Impl: Sized {
     fn GetTipUrl(&self, ptipurl: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IObjectContextTip {}
+#[cfg(feature = "Win32_Foundation")]
 impl IObjectContextTip_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextTip_Impl, const OFFSET: isize>() -> IObjectContextTip_Vtbl {
         unsafe extern "system" fn GetTipUrl<Identity: ::windows::core::IUnknownImpl, Impl: IObjectContextTip_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptipurl: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4461,6 +4595,8 @@ pub trait IObjectControl_Impl: Sized {
     fn Deactivate(&self);
     fn CanBePooled(&self) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IObjectControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IObjectControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectControl_Impl, const OFFSET: isize>() -> IObjectControl_Vtbl {
@@ -4494,6 +4630,7 @@ pub trait IPlaybackControl_Impl: Sized {
     fn FinalClientRetry(&self) -> ::windows::core::Result<()>;
     fn FinalServerRetry(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPlaybackControl {}
 impl IPlaybackControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPlaybackControl_Impl, const OFFSET: isize>() -> IPlaybackControl_Vtbl {
         unsafe extern "system" fn FinalClientRetry<Identity: ::windows::core::IUnknownImpl, Impl: IPlaybackControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4521,6 +4658,8 @@ pub trait IPoolManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn ShutdownPool(&self, clsidorprogid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPoolManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPoolManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPoolManager_Impl, const OFFSET: isize>() -> IPoolManager_Vtbl {
         unsafe extern "system" fn ShutdownPool<Identity: ::windows::core::IUnknownImpl, Impl: IPoolManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsidorprogid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -4538,6 +4677,7 @@ pub trait IProcessInitializer_Impl: Sized {
     fn Startup(&self, punkprocesscontrol: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProcessInitializer {}
 impl IProcessInitializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProcessInitializer_Impl, const OFFSET: isize>() -> IProcessInitializer_Vtbl {
         unsafe extern "system" fn Startup<Identity: ::windows::core::IUnknownImpl, Impl: IProcessInitializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkprocesscontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4569,6 +4709,8 @@ pub trait ISecurityCallContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsSecurityEnabled(&self) -> ::windows::core::Result<i16>;
     fn IsUserInRole(&self, puser: *const super::Com::VARIANT, bstrrole: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISecurityCallContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISecurityCallContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityCallContext_Impl, const OFFSET: isize>() -> ISecurityCallContext_Vtbl {
@@ -4659,6 +4801,8 @@ pub trait ISecurityCallersColl_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISecurityCallersColl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISecurityCallersColl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityCallersColl_Impl, const OFFSET: isize>() -> ISecurityCallersColl_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityCallersColl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -4711,6 +4855,8 @@ pub trait ISecurityIdentityColl_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISecurityIdentityColl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISecurityIdentityColl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityIdentityColl_Impl, const OFFSET: isize>() -> ISecurityIdentityColl_Vtbl {
@@ -4767,6 +4913,8 @@ pub trait ISecurityProperty_Impl: Sized {
     fn ReleaseSID(&self, psid: super::super::Foundation::PSID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISecurityProperty {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISecurityProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityProperty_Impl, const OFFSET: isize>() -> ISecurityProperty_Vtbl {
         unsafe extern "system" fn GetDirectCreatorSID<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psid: *mut super::super::Foundation::PSID) -> ::windows::core::HRESULT {
@@ -4811,6 +4959,7 @@ pub trait ISelectCOMLBServer_Impl: Sized {
     fn Init(&self) -> ::windows::core::Result<()>;
     fn GetLBServer(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISelectCOMLBServer {}
 impl ISelectCOMLBServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISelectCOMLBServer_Impl, const OFFSET: isize>() -> ISelectCOMLBServer_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: ISelectCOMLBServer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4837,6 +4986,7 @@ pub trait ISendMethodEvents_Impl: Sized {
     fn SendMethodCall(&self, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32) -> ::windows::core::Result<()>;
     fn SendMethodReturn(&self, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32, hrcall: ::windows::core::HRESULT, hrserver: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISendMethodEvents {}
 impl ISendMethodEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISendMethodEvents_Impl, const OFFSET: isize>() -> ISendMethodEvents_Vtbl {
         unsafe extern "system" fn SendMethodCall<Identity: ::windows::core::IUnknownImpl, Impl: ISendMethodEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32) -> ::windows::core::HRESULT {
@@ -4865,6 +5015,7 @@ pub trait IServiceActivity_Impl: Sized {
     fn BindToCurrentThread(&self) -> ::windows::core::Result<()>;
     fn UnbindFromThread(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceActivity {}
 impl IServiceActivity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceActivity_Impl, const OFFSET: isize>() -> IServiceActivity_Vtbl {
         unsafe extern "system" fn SynchronousCall<Identity: ::windows::core::IUnknownImpl, Impl: IServiceActivity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piservicecall: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4902,6 +5053,7 @@ impl IServiceActivity_Vtbl {
 pub trait IServiceCall_Impl: Sized {
     fn OnCall(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceCall {}
 impl IServiceCall_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceCall_Impl, const OFFSET: isize>() -> IServiceCall_Vtbl {
         unsafe extern "system" fn OnCall<Identity: ::windows::core::IUnknownImpl, Impl: IServiceCall_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4918,6 +5070,7 @@ impl IServiceCall_Vtbl {
 pub trait IServiceComTIIntrinsicsConfig_Impl: Sized {
     fn ComTIIntrinsicsConfig(&self, comtiintrinsicsconfig: CSC_COMTIIntrinsicsConfig) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceComTIIntrinsicsConfig {}
 impl IServiceComTIIntrinsicsConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceComTIIntrinsicsConfig_Impl, const OFFSET: isize>() -> IServiceComTIIntrinsicsConfig_Vtbl {
         unsafe extern "system" fn ComTIIntrinsicsConfig<Identity: ::windows::core::IUnknownImpl, Impl: IServiceComTIIntrinsicsConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, comtiintrinsicsconfig: CSC_COMTIIntrinsicsConfig) -> ::windows::core::HRESULT {
@@ -4934,6 +5087,7 @@ impl IServiceComTIIntrinsicsConfig_Vtbl {
 pub trait IServiceIISIntrinsicsConfig_Impl: Sized {
     fn IISIntrinsicsConfig(&self, iisintrinsicsconfig: CSC_IISIntrinsicsConfig) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceIISIntrinsicsConfig {}
 impl IServiceIISIntrinsicsConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceIISIntrinsicsConfig_Impl, const OFFSET: isize>() -> IServiceIISIntrinsicsConfig_Vtbl {
         unsafe extern "system" fn IISIntrinsicsConfig<Identity: ::windows::core::IUnknownImpl, Impl: IServiceIISIntrinsicsConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iisintrinsicsconfig: CSC_IISIntrinsicsConfig) -> ::windows::core::HRESULT {
@@ -4950,6 +5104,7 @@ impl IServiceIISIntrinsicsConfig_Vtbl {
 pub trait IServiceInheritanceConfig_Impl: Sized {
     fn ContainingContextTreatment(&self, inheritanceconfig: CSC_InheritanceConfig) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceInheritanceConfig {}
 impl IServiceInheritanceConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceInheritanceConfig_Impl, const OFFSET: isize>() -> IServiceInheritanceConfig_Vtbl {
         unsafe extern "system" fn ContainingContextTreatment<Identity: ::windows::core::IUnknownImpl, Impl: IServiceInheritanceConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inheritanceconfig: CSC_InheritanceConfig) -> ::windows::core::HRESULT {
@@ -4970,6 +5125,7 @@ pub trait IServicePartitionConfig_Impl: Sized {
     fn PartitionConfig(&self, partitionconfig: CSC_PartitionConfig) -> ::windows::core::Result<()>;
     fn PartitionID(&self, guidpartitionid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServicePartitionConfig {}
 impl IServicePartitionConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServicePartitionConfig_Impl, const OFFSET: isize>() -> IServicePartitionConfig_Vtbl {
         unsafe extern "system" fn PartitionConfig<Identity: ::windows::core::IUnknownImpl, Impl: IServicePartitionConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, partitionconfig: CSC_PartitionConfig) -> ::windows::core::HRESULT {
@@ -4997,6 +5153,7 @@ pub trait IServicePool_Impl: Sized {
     fn GetObject(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServicePool {}
 impl IServicePool_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServicePool_Impl, const OFFSET: isize>() -> IServicePool_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IServicePool_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppoolconfig: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5038,6 +5195,8 @@ pub trait IServicePoolConfig_Impl: Sized {
     fn SetClassFactory(&self, pfactory: &::core::option::Option<super::Com::IClassFactory>) -> ::windows::core::Result<()>;
     fn ClassFactory(&self) -> ::windows::core::Result<super::Com::IClassFactory>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IServicePoolConfig {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IServicePoolConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServicePoolConfig_Impl, const OFFSET: isize>() -> IServicePoolConfig_Vtbl {
@@ -5120,6 +5279,7 @@ pub trait IServiceSxsConfig_Impl: Sized {
     fn SxsName(&self, szsxsname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SxsDirectory(&self, szsxsdirectory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceSxsConfig {}
 impl IServiceSxsConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceSxsConfig_Impl, const OFFSET: isize>() -> IServiceSxsConfig_Vtbl {
         unsafe extern "system" fn SxsConfig<Identity: ::windows::core::IUnknownImpl, Impl: IServiceSxsConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scsconfig: CSC_SxsConfig) -> ::windows::core::HRESULT {
@@ -5151,6 +5311,7 @@ impl IServiceSxsConfig_Vtbl {
 pub trait IServiceSynchronizationConfig_Impl: Sized {
     fn ConfigureSynchronization(&self, synchconfig: CSC_SynchronizationConfig) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceSynchronizationConfig {}
 impl IServiceSynchronizationConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceSynchronizationConfig_Impl, const OFFSET: isize>() -> IServiceSynchronizationConfig_Vtbl {
         unsafe extern "system" fn ConfigureSynchronization<Identity: ::windows::core::IUnknownImpl, Impl: IServiceSynchronizationConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, synchconfig: CSC_SynchronizationConfig) -> ::windows::core::HRESULT {
@@ -5169,6 +5330,8 @@ pub trait IServiceSysTxnConfig_Impl: Sized + IServiceTransactionConfigBase_Impl 
     fn ConfigureBYOTSysTxn(&self, ptxproxy: &::core::option::Option<ITransactionProxy>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
+impl ::windows::core::RuntimeName for IServiceSysTxnConfig {}
+#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 impl IServiceSysTxnConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceSysTxnConfig_Impl, const OFFSET: isize>() -> IServiceSysTxnConfig_Vtbl {
         unsafe extern "system" fn ConfigureBYOTSysTxn<Identity: ::windows::core::IUnknownImpl, Impl: IServiceSysTxnConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptxproxy: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5186,6 +5349,7 @@ pub trait IServiceThreadPoolConfig_Impl: Sized {
     fn SelectThreadPool(&self, threadpool: CSC_ThreadPool) -> ::windows::core::Result<()>;
     fn SetBindingInfo(&self, binding: CSC_Binding) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceThreadPoolConfig {}
 impl IServiceThreadPoolConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceThreadPoolConfig_Impl, const OFFSET: isize>() -> IServiceThreadPoolConfig_Vtbl {
         unsafe extern "system" fn SelectThreadPool<Identity: ::windows::core::IUnknownImpl, Impl: IServiceThreadPoolConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, threadpool: CSC_ThreadPool) -> ::windows::core::HRESULT {
@@ -5211,6 +5375,7 @@ impl IServiceThreadPoolConfig_Vtbl {
 pub trait IServiceTrackerConfig_Impl: Sized {
     fn TrackerConfig(&self, trackerconfig: CSC_TrackerConfig, sztrackerappname: &::windows::core::PCWSTR, sztrackerctxname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceTrackerConfig {}
 impl IServiceTrackerConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceTrackerConfig_Impl, const OFFSET: isize>() -> IServiceTrackerConfig_Vtbl {
         unsafe extern "system" fn TrackerConfig<Identity: ::windows::core::IUnknownImpl, Impl: IServiceTrackerConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, trackerconfig: CSC_TrackerConfig, sztrackerappname: ::windows::core::PCWSTR, sztrackerctxname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -5228,6 +5393,8 @@ impl IServiceTrackerConfig_Vtbl {
 pub trait IServiceTransactionConfig_Impl: Sized + IServiceTransactionConfigBase_Impl {
     fn ConfigureBYOT(&self, pitxbyot: &::core::option::Option<super::DistributedTransactionCoordinator::ITransaction>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
+impl ::windows::core::RuntimeName for IServiceTransactionConfig {}
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 impl IServiceTransactionConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceTransactionConfig_Impl, const OFFSET: isize>() -> IServiceTransactionConfig_Vtbl {
@@ -5249,6 +5416,7 @@ pub trait IServiceTransactionConfigBase_Impl: Sized {
     fn BringYourOwnTransaction(&self, sztipurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn NewTransactionDescription(&self, sztxdesc: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IServiceTransactionConfigBase {}
 impl IServiceTransactionConfigBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IServiceTransactionConfigBase_Impl, const OFFSET: isize>() -> IServiceTransactionConfigBase_Vtbl {
         unsafe extern "system" fn ConfigureTransaction<Identity: ::windows::core::IUnknownImpl, Impl: IServiceTransactionConfigBase_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, transactionconfig: CSC_TransactionConfig) -> ::windows::core::HRESULT {
@@ -5295,6 +5463,8 @@ pub trait ISharedProperty_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetValue(&self, val: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISharedProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISharedProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISharedProperty_Impl, const OFFSET: isize>() -> ISharedProperty_Vtbl {
         unsafe extern "system" fn Value<Identity: ::windows::core::IUnknownImpl, Impl: ISharedProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -5330,6 +5500,8 @@ pub trait ISharedPropertyGroup_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateProperty(&self, name: &super::super::Foundation::BSTR, fexists: *mut i16, ppprop: *mut ::core::option::Option<ISharedProperty>) -> ::windows::core::Result<()>;
     fn get_Property(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<ISharedProperty>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISharedPropertyGroup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISharedPropertyGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISharedPropertyGroup_Impl, const OFFSET: isize>() -> ISharedPropertyGroup_Vtbl {
@@ -5384,6 +5556,8 @@ pub trait ISharedPropertyGroupManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISharedPropertyGroupManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISharedPropertyGroupManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISharedPropertyGroupManager_Impl, const OFFSET: isize>() -> ISharedPropertyGroupManager_Vtbl {
         unsafe extern "system" fn CreatePropertyGroup<Identity: ::windows::core::IUnknownImpl, Impl: ISharedPropertyGroupManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, dwisomode: *mut i32, dwrelmode: *mut i32, fexists: *mut i16, ppgroup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5430,6 +5604,8 @@ pub trait ISystemAppEventData_Impl: Sized {
     fn OnDataChanged(&self, dwpid: u32, dwmask: u32, dwnumbersinks: u32, bstrdwmethodmask: &super::super::Foundation::BSTR, dwreason: u32, u64tracehandle: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISystemAppEventData {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISystemAppEventData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISystemAppEventData_Impl, const OFFSET: isize>() -> ISystemAppEventData_Vtbl {
         unsafe extern "system" fn Startup<Identity: ::windows::core::IUnknownImpl, Impl: ISystemAppEventData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5464,6 +5640,7 @@ pub trait IThreadPoolKnobs_Impl: Sized {
     fn SetMinThreads(&self, lcminthreads: i32) -> ::windows::core::Result<()>;
     fn SetQueueDepth(&self, lcqueuedepth: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IThreadPoolKnobs {}
 impl IThreadPoolKnobs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThreadPoolKnobs_Impl, const OFFSET: isize>() -> IThreadPoolKnobs_Vtbl {
         unsafe extern "system" fn GetMaxThreads<Identity: ::windows::core::IUnknownImpl, Impl: IThreadPoolKnobs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcmaxthreads: *mut i32) -> ::windows::core::HRESULT {
@@ -5541,6 +5718,8 @@ pub trait ITransactionContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn Abort(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITransactionContext {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITransactionContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionContext_Impl, const OFFSET: isize>() -> ITransactionContext_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszprogid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pobject: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -5580,6 +5759,7 @@ pub trait ITransactionContextEx_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
     fn Abort(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionContextEx {}
 impl ITransactionContextEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionContextEx_Impl, const OFFSET: isize>() -> ITransactionContextEx_Vtbl {
         unsafe extern "system" fn CreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionContextEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5628,6 +5808,7 @@ pub trait ITransactionProperty_Impl: Sized {
     fn Reserved16(&self);
     fn Reserved17(&self);
 }
+impl ::windows::core::RuntimeName for ITransactionProperty {}
 impl ITransactionProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionProperty_Impl, const OFFSET: isize>() -> ITransactionProperty_Vtbl {
         unsafe extern "system" fn Reserved1<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -5763,6 +5944,8 @@ pub trait ITransactionProxy_Impl: Sized {
     fn IsReusable(&self, pfisreusable: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_DistributedTransactionCoordinator"))]
+impl ::windows::core::RuntimeName for ITransactionProxy {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_DistributedTransactionCoordinator"))]
 impl ITransactionProxy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionProxy_Impl, const OFFSET: isize>() -> ITransactionProxy_Vtbl {
         unsafe extern "system" fn Commit<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionProxy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -5831,6 +6014,7 @@ pub trait ITransactionResourcePool_Impl: Sized {
     fn PutResource(&self, ppool: &::core::option::Option<IObjPool>, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetResource(&self, ppool: &::core::option::Option<IObjPool>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for ITransactionResourcePool {}
 impl ITransactionResourcePool_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionResourcePool_Impl, const OFFSET: isize>() -> ITransactionResourcePool_Vtbl {
         unsafe extern "system" fn PutResource<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionResourcePool_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppool: ::windows::core::RawPtr, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5863,6 +6047,7 @@ pub trait ITransactionStatus_Impl: Sized {
     fn SetTransactionStatus(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn GetTransactionStatus(&self, phrstatus: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionStatus {}
 impl ITransactionStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionStatus_Impl, const OFFSET: isize>() -> ITransactionStatus_Vtbl {
         unsafe extern "system" fn SetTransactionStatus<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -5888,6 +6073,7 @@ impl ITransactionStatus_Vtbl {
 pub trait ITxProxyHolder_Impl: Sized {
     fn GetIdentifier(&self, pguidltx: *mut ::windows::core::GUID);
 }
+impl ::windows::core::RuntimeName for ITxProxyHolder {}
 impl ITxProxyHolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITxProxyHolder_Impl, const OFFSET: isize>() -> ITxProxyHolder_Vtbl {
         unsafe extern "system" fn GetIdentifier<Identity: ::windows::core::IUnknownImpl, Impl: ITxProxyHolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidltx: *mut ::windows::core::GUID) {
@@ -5917,6 +6103,8 @@ pub trait ObjectContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn Security(&self) -> ::windows::core::Result<SecurityProperty>;
     fn ContextInfo(&self) -> ::windows::core::Result<ContextInfo>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ObjectContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ObjectContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ObjectContext_Impl, const OFFSET: isize>() -> ObjectContext_Vtbl {
@@ -6065,6 +6253,7 @@ pub trait ObjectControl_Impl: Sized {
     fn Deactivate(&self) -> ::windows::core::Result<()>;
     fn CanBePooled(&self, pbpoolable: *mut i16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ObjectControl {}
 impl ObjectControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ObjectControl_Impl, const OFFSET: isize>() -> ObjectControl_Vtbl {
         unsafe extern "system" fn Activate<Identity: ::windows::core::IUnknownImpl, Impl: ObjectControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6100,6 +6289,8 @@ pub trait SecurityProperty_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetOriginalCallerName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetOriginalCreatorName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for SecurityProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl SecurityProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: SecurityProperty_Impl, const OFFSET: isize>() -> SecurityProperty_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
@@ -3,6 +3,7 @@ pub trait IContact_Impl: Sized {
     fn GetPath(&self, pszpath: &::windows::core::PWSTR, cchpath: u32, pdwcchpathrequired: *mut u32) -> ::windows::core::Result<()>;
     fn CommitChanges(&self, dwcommitflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContact {}
 impl IContact_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContact_Impl, const OFFSET: isize>() -> IContact_Vtbl {
         unsafe extern "system" fn GetContactID<Identity: ::windows::core::IUnknownImpl, Impl: IContact_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcontactid: ::windows::core::PWSTR, cchcontactid: u32, pdwcchcontactidrequired: *mut u32) -> ::windows::core::HRESULT {
@@ -42,6 +43,7 @@ pub trait IContactAggregationAggregate_Impl: Sized {
     fn SetFavoriteOrder(&self, favoriteorder: u32) -> ::windows::core::Result<()>;
     fn Id(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationAggregate {}
 impl IContactAggregationAggregate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationAggregate_Impl, const OFFSET: isize>() -> IContactAggregationAggregate_Vtbl {
         unsafe extern "system" fn Save<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationAggregate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -142,6 +144,7 @@ pub trait IContactAggregationAggregateCollection_Impl: Sized {
     fn FindNext(&self) -> ::windows::core::Result<IContactAggregationAggregate>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationAggregateCollection {}
 impl IContactAggregationAggregateCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationAggregateCollection_Impl, const OFFSET: isize>() -> IContactAggregationAggregateCollection_Vtbl {
         unsafe extern "system" fn FindFirst<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationAggregateCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppaggregate: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -221,6 +224,8 @@ pub trait IContactAggregationContact_Impl: Sized {
     fn SyncIdentityHash(&self) -> ::windows::core::Result<*mut CONTACT_AGGREGATION_BLOB>;
     fn SetSyncIdentityHash(&self, psyncidentityhash: *const CONTACT_AGGREGATION_BLOB) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContactAggregationContact {}
 #[cfg(feature = "Win32_Foundation")]
 impl IContactAggregationContact_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationContact_Impl, const OFFSET: isize>() -> IContactAggregationContact_Vtbl {
@@ -401,6 +406,7 @@ pub trait IContactAggregationContactCollection_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn FindFirstByRemoteId(&self, psourcetype: &::windows::core::PCWSTR, paccountid: &::windows::core::PCWSTR, premoteobjectid: *const CONTACT_AGGREGATION_BLOB) -> ::windows::core::Result<IContactAggregationContact>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationContactCollection {}
 impl IContactAggregationContactCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationContactCollection_Impl, const OFFSET: isize>() -> IContactAggregationContactCollection_Vtbl {
         unsafe extern "system" fn FindFirst<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationContactCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppitem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -483,6 +489,7 @@ pub trait IContactAggregationGroup_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn SetName(&self, pname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationGroup {}
 impl IContactAggregationGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationGroup_Impl, const OFFSET: isize>() -> IContactAggregationGroup_Vtbl {
         unsafe extern "system" fn Delete<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -583,6 +590,7 @@ pub trait IContactAggregationGroupCollection_Impl: Sized {
     fn FindNext(&self) -> ::windows::core::Result<IContactAggregationGroup>;
     fn Count(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationGroupCollection {}
 impl IContactAggregationGroupCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationGroupCollection_Impl, const OFFSET: isize>() -> IContactAggregationGroupCollection_Vtbl {
         unsafe extern "system" fn FindFirst<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationGroupCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppgroup: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -661,6 +669,8 @@ pub trait IContactAggregationLink_Impl: Sized {
     fn SyncIdentityHash(&self) -> ::windows::core::Result<*mut CONTACT_AGGREGATION_BLOB>;
     fn SetSyncIdentityHash(&self, psyncidentityhash: *const CONTACT_AGGREGATION_BLOB) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContactAggregationLink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IContactAggregationLink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationLink_Impl, const OFFSET: isize>() -> IContactAggregationLink_Vtbl {
@@ -828,6 +838,7 @@ pub trait IContactAggregationLinkCollection_Impl: Sized {
     fn FindNext(&self) -> ::windows::core::Result<IContactAggregationLink>;
     fn Count(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationLinkCollection {}
 impl IContactAggregationLinkCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationLinkCollection_Impl, const OFFSET: isize>() -> IContactAggregationLinkCollection_Vtbl {
         unsafe extern "system" fn FindFirst<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationLinkCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppservercontactlink: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -904,6 +915,8 @@ pub trait IContactAggregationManager_Impl: Sized {
     fn ServerPersons(&self) -> ::windows::core::Result<IContactAggregationServerPersonCollection>;
     fn get_ServerContactLinks(&self, ppersonitemid: &::windows::core::PCWSTR) -> ::windows::core::Result<IContactAggregationLinkCollection>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContactAggregationManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IContactAggregationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationManager_Impl, const OFFSET: isize>() -> IContactAggregationManager_Vtbl {
@@ -1103,6 +1116,8 @@ pub trait IContactAggregationServerPerson_Impl: Sized {
     fn ObjectId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn SetObjectId(&self, pobjectid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContactAggregationServerPerson {}
 #[cfg(feature = "Win32_Foundation")]
 impl IContactAggregationServerPerson_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationServerPerson_Impl, const OFFSET: isize>() -> IContactAggregationServerPerson_Vtbl {
@@ -1326,6 +1341,7 @@ pub trait IContactAggregationServerPersonCollection_Impl: Sized {
     fn FindNext(&self) -> ::windows::core::Result<IContactAggregationServerPerson>;
     fn Count(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IContactAggregationServerPersonCollection {}
 impl IContactAggregationServerPersonCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationServerPersonCollection_Impl, const OFFSET: isize>() -> IContactAggregationServerPersonCollection_Vtbl {
         unsafe extern "system" fn FindFirst<Identity: ::windows::core::IUnknownImpl, Impl: IContactAggregationServerPersonCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppserverperson: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1413,6 +1429,7 @@ pub trait IContactCollection_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<()>;
     fn GetCurrent(&self) -> ::windows::core::Result<IContact>;
 }
+impl ::windows::core::RuntimeName for IContactCollection {}
 impl IContactCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactCollection_Impl, const OFFSET: isize>() -> IContactCollection_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IContactCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1455,6 +1472,7 @@ pub trait IContactManager_Impl: Sized {
     fn SetMeContact(&self, pmecontact: &::core::option::Option<IContact>) -> ::windows::core::Result<()>;
     fn GetContactCollection(&self) -> ::windows::core::Result<IContactCollection>;
 }
+impl ::windows::core::RuntimeName for IContactManager {}
 impl IContactManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactManager_Impl, const OFFSET: isize>() -> IContactManager_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IContactManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszappname: ::windows::core::PCWSTR, pszappversion: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1535,6 +1553,8 @@ pub trait IContactProperties_Impl: Sized {
     fn DeleteLabels(&self, pszarrayelementname: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetPropertyCollection(&self, pppropertycollection: *mut ::core::option::Option<IContactPropertyCollection>, dwflags: u32, pszmultivaluename: &::windows::core::PCWSTR, dwlabelcount: u32, ppszlabels: *const ::windows::core::PWSTR, fanylabelmatches: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IContactProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IContactProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactProperties_Impl, const OFFSET: isize>() -> IContactProperties_Vtbl {
@@ -1634,6 +1654,8 @@ pub trait IContactPropertyCollection_Impl: Sized {
     fn GetPropertyModificationDate(&self, pftmodificationdate: *mut super::super::Foundation::FILETIME) -> ::windows::core::Result<()>;
     fn GetPropertyArrayElementID(&self, pszarrayelementid: &::windows::core::PWSTR, ccharrayelementid: u32, pdwccharrayelementidrequired: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContactPropertyCollection {}
 #[cfg(feature = "Win32_Foundation")]
 impl IContactPropertyCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactPropertyCollection_Impl, const OFFSET: isize>() -> IContactPropertyCollection_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/impl.rs
@@ -6,6 +6,8 @@ pub trait IWdsTransportCacheable_Impl: Sized + super::Com::IDispatch_Impl {
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportCacheable {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportCacheable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportCacheable_Impl, const OFFSET: isize>() -> IWdsTransportCacheable_Vtbl {
         unsafe extern "system" fn Dirty<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportCacheable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbdirty: *mut i16) -> ::windows::core::HRESULT {
@@ -61,6 +63,8 @@ pub trait IWdsTransportClient_Impl: Sized + super::Com::IDispatch_Impl {
     fn UserIdentity(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Disconnect(&self, disconnectiontype: WDSTRANSPORT_DISCONNECT_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportClient_Impl, const OFFSET: isize>() -> IWdsTransportClient_Vtbl {
@@ -217,6 +221,8 @@ pub trait IWdsTransportCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportCollection_Impl, const OFFSET: isize>() -> IWdsTransportCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcount: *mut u32) -> ::windows::core::HRESULT {
@@ -275,6 +281,8 @@ pub trait IWdsTransportConfigurationManager_Impl: Sized + super::Com::IDispatch_
     fn RestartWdsTransportServices(&self) -> ::windows::core::Result<()>;
     fn NotifyWdsTransportServices(&self, servicenotification: WDSTRANSPORT_SERVICE_NOTIFICATION) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportConfigurationManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportConfigurationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportConfigurationManager_Impl, const OFFSET: isize>() -> IWdsTransportConfigurationManager_Vtbl {
@@ -363,6 +371,8 @@ pub trait IWdsTransportConfigurationManager2_Impl: Sized + super::Com::IDispatch
     fn MulticastSessionPolicy(&self) -> ::windows::core::Result<IWdsTransportMulticastSessionPolicy>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportConfigurationManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportConfigurationManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportConfigurationManager2_Impl, const OFFSET: isize>() -> IWdsTransportConfigurationManager2_Vtbl {
         unsafe extern "system" fn MulticastSessionPolicy<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportConfigurationManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwdstransportmulticastsessionpolicy: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -393,6 +403,8 @@ pub trait IWdsTransportContent_Impl: Sized + super::Com::IDispatch_Impl {
     fn RetrieveSessions(&self) -> ::windows::core::Result<IWdsTransportCollection>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportContent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportContent_Impl, const OFFSET: isize>() -> IWdsTransportContent_Vtbl {
@@ -466,6 +478,8 @@ pub trait IWdsTransportContentProvider_Impl: Sized + super::Com::IDispatch_Impl 
     fn InitializationRoutine(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportContentProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportContentProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportContentProvider_Impl, const OFFSET: isize>() -> IWdsTransportContentProvider_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportContentProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbszname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -532,6 +546,8 @@ pub trait IWdsTransportDiagnosticsPolicy_Impl: Sized + super::Com::IDispatch_Imp
     fn SetComponents(&self, ulcomponents: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportDiagnosticsPolicy {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportDiagnosticsPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportDiagnosticsPolicy_Impl, const OFFSET: isize>() -> IWdsTransportDiagnosticsPolicy_Vtbl {
         unsafe extern "system" fn Enabled<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportDiagnosticsPolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbenabled: *mut i16) -> ::windows::core::HRESULT {
@@ -583,6 +599,8 @@ pub trait IWdsTransportManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetWdsTransportServer(&self, bszservername: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWdsTransportServer>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportManager_Impl, const OFFSET: isize>() -> IWdsTransportManager_Vtbl {
         unsafe extern "system" fn GetWdsTransportServer<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bszservername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppwdstransportserver: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -613,6 +631,8 @@ pub trait IWdsTransportMulticastSessionPolicy_Impl: Sized + super::Com::IDispatc
     fn SlowClientFallback(&self) -> ::windows::core::Result<i16>;
     fn SetSlowClientFallback(&self, bclientfallback: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportMulticastSessionPolicy {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportMulticastSessionPolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportMulticastSessionPolicy_Impl, const OFFSET: isize>() -> IWdsTransportMulticastSessionPolicy_Vtbl {
@@ -720,6 +740,8 @@ pub trait IWdsTransportNamespace_Impl: Sized + super::Com::IDispatch_Impl {
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn RetrieveContents(&self) -> ::windows::core::Result<IWdsTransportCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportNamespace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportNamespace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespace_Impl, const OFFSET: isize>() -> IWdsTransportNamespace_Vtbl {
@@ -938,6 +960,8 @@ impl IWdsTransportNamespace_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceAutoCast_Impl: Sized + super::Com::IDispatch_Impl + IWdsTransportNamespace_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportNamespaceAutoCast {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportNamespaceAutoCast_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespaceAutoCast_Impl, const OFFSET: isize>() -> IWdsTransportNamespaceAutoCast_Vtbl {
         Self { base__: IWdsTransportNamespace_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -952,6 +976,8 @@ pub trait IWdsTransportNamespaceManager_Impl: Sized + super::Com::IDispatch_Impl
     fn RetrieveNamespace(&self, bsznamespacename: &super::super::Foundation::BSTR) -> ::windows::core::Result<IWdsTransportNamespace>;
     fn RetrieveNamespaces(&self, bszcontentprovider: &super::super::Foundation::BSTR, bsznamespacename: &super::super::Foundation::BSTR, bincludetombstones: i16) -> ::windows::core::Result<IWdsTransportCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportNamespaceManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportNamespaceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespaceManager_Impl, const OFFSET: isize>() -> IWdsTransportNamespaceManager_Vtbl {
@@ -1004,6 +1030,8 @@ pub trait IWdsTransportNamespaceScheduledCast_Impl: Sized + super::Com::IDispatc
     fn StartTransmission(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportNamespaceScheduledCast {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportNamespaceScheduledCast_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespaceScheduledCast_Impl, const OFFSET: isize>() -> IWdsTransportNamespaceScheduledCast_Vtbl {
         unsafe extern "system" fn StartTransmission<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespaceScheduledCast_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1024,6 +1052,8 @@ pub trait IWdsTransportNamespaceScheduledCastAutoStart_Impl: Sized + super::Com:
     fn StartTime(&self) -> ::windows::core::Result<f64>;
     fn SetStartTime(&self, starttime: f64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportNamespaceScheduledCastAutoStart {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportNamespaceScheduledCastAutoStart_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespaceScheduledCastAutoStart_Impl, const OFFSET: isize>() -> IWdsTransportNamespaceScheduledCastAutoStart_Vtbl {
@@ -1074,6 +1104,8 @@ impl IWdsTransportNamespaceScheduledCastAutoStart_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceScheduledCastManualStart_Impl: Sized + super::Com::IDispatch_Impl + IWdsTransportNamespace_Impl + IWdsTransportNamespaceScheduledCast_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportNamespaceScheduledCastManualStart {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportNamespaceScheduledCastManualStart_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportNamespaceScheduledCastManualStart_Impl, const OFFSET: isize>() -> IWdsTransportNamespaceScheduledCastManualStart_Vtbl {
         Self { base__: IWdsTransportNamespaceScheduledCast_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1090,6 +1122,8 @@ pub trait IWdsTransportServer_Impl: Sized + super::Com::IDispatch_Impl {
     fn NamespaceManager(&self) -> ::windows::core::Result<IWdsTransportNamespaceManager>;
     fn DisconnectClient(&self, ulclientid: u32, disconnectiontype: WDSTRANSPORT_DISCONNECT_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportServer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportServer_Impl, const OFFSET: isize>() -> IWdsTransportServer_Vtbl {
@@ -1160,6 +1194,8 @@ pub trait IWdsTransportServer2_Impl: Sized + super::Com::IDispatch_Impl + IWdsTr
     fn TftpManager(&self) -> ::windows::core::Result<IWdsTransportTftpManager>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportServer2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportServer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportServer2_Impl, const OFFSET: isize>() -> IWdsTransportServer2_Vtbl {
         unsafe extern "system" fn TftpManager<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportServer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwdstransporttftpmanager: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1194,6 +1230,8 @@ pub trait IWdsTransportServicePolicy_Impl: Sized + super::Com::IDispatch_Impl + 
     fn NetworkProfile(&self) -> ::windows::core::Result<WDSTRANSPORT_NETWORK_PROFILE_TYPE>;
     fn SetNetworkProfile(&self, profiletype: WDSTRANSPORT_NETWORK_PROFILE_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportServicePolicy {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportServicePolicy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportServicePolicy_Impl, const OFFSET: isize>() -> IWdsTransportServicePolicy_Vtbl {
@@ -1323,6 +1361,8 @@ pub trait IWdsTransportServicePolicy2_Impl: Sized + super::Com::IDispatch_Impl +
     fn SetEnableTftpVariableWindowExtension(&self, benabletftpvariablewindowextension: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportServicePolicy2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportServicePolicy2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportServicePolicy2_Impl, const OFFSET: isize>() -> IWdsTransportServicePolicy2_Vtbl {
         unsafe extern "system" fn UdpPortPolicy<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportServicePolicy2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pudpportpolicy: *mut WDSTRANSPORT_UDP_PORT_POLICY) -> ::windows::core::HRESULT {
@@ -1398,6 +1438,8 @@ pub trait IWdsTransportSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn RetrieveClients(&self) -> ::windows::core::Result<IWdsTransportCollection>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportSession_Impl, const OFFSET: isize>() -> IWdsTransportSession_Vtbl {
@@ -1508,6 +1550,8 @@ pub trait IWdsTransportSetupManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn DeregisterContentProvider(&self, bszname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportSetupManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportSetupManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportSetupManager_Impl, const OFFSET: isize>() -> IWdsTransportSetupManager_Vtbl {
         unsafe extern "system" fn Version<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportSetupManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pullversion: *mut u64) -> ::windows::core::HRESULT {
@@ -1572,6 +1616,8 @@ pub trait IWdsTransportSetupManager2_Impl: Sized + super::Com::IDispatch_Impl + 
     fn ContentProviders(&self) -> ::windows::core::Result<IWdsTransportCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportSetupManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportSetupManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportSetupManager2_Impl, const OFFSET: isize>() -> IWdsTransportSetupManager2_Vtbl {
         unsafe extern "system" fn TftpCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportSetupManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pultftpcapabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -1616,6 +1662,8 @@ pub trait IWdsTransportTftpClient_Impl: Sized + super::Com::IDispatch_Impl {
     fn BlockSize(&self) -> ::windows::core::Result<u32>;
     fn WindowSize(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportTftpClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportTftpClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportTftpClient_Impl, const OFFSET: isize>() -> IWdsTransportTftpClient_Vtbl {
@@ -1715,6 +1763,8 @@ impl IWdsTransportTftpClient_Vtbl {
 pub trait IWdsTransportTftpManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn RetrieveTftpClients(&self) -> ::windows::core::Result<IWdsTransportCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWdsTransportTftpManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWdsTransportTftpManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWdsTransportTftpManager_Impl, const OFFSET: isize>() -> IWdsTransportTftpManager_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
@@ -8,6 +8,8 @@ pub trait IRDPSRAPIApplication_Impl: Sized + super::Com::IDispatch_Impl {
     fn Flags(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIApplication {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIApplication_Impl, const OFFSET: isize>() -> IRDPSRAPIApplication_Vtbl {
         unsafe extern "system" fn Windows<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwindowlist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -92,6 +94,8 @@ pub trait IRDPSRAPIApplicationFilter_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetEnabled(&self, newval: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIApplicationFilter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIApplicationFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIApplicationFilter_Impl, const OFFSET: isize>() -> IRDPSRAPIApplicationFilter_Vtbl {
         unsafe extern "system" fn Applications<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIApplicationFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, papplications: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -150,6 +154,8 @@ pub trait IRDPSRAPIApplicationList_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, item: i32) -> ::windows::core::Result<IRDPSRAPIApplication>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIApplicationList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIApplicationList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIApplicationList_Impl, const OFFSET: isize>() -> IRDPSRAPIApplicationList_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIApplicationList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -195,6 +201,8 @@ pub trait IRDPSRAPIAttendee_Impl: Sized + super::Com::IDispatch_Impl {
     fn Flags(&self) -> ::windows::core::Result<i32>;
     fn ConnectivityInfo(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIAttendee {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIAttendee_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAttendee_Impl, const OFFSET: isize>() -> IRDPSRAPIAttendee_Vtbl {
@@ -297,6 +305,8 @@ pub trait IRDPSRAPIAttendeeDisconnectInfo_Impl: Sized + super::Com::IDispatch_Im
     fn Code(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIAttendeeDisconnectInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIAttendeeDisconnectInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAttendeeDisconnectInfo_Impl, const OFFSET: isize>() -> IRDPSRAPIAttendeeDisconnectInfo_Vtbl {
         unsafe extern "system" fn Attendee<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAttendeeDisconnectInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -349,6 +359,8 @@ pub trait IRDPSRAPIAttendeeManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, id: i32) -> ::windows::core::Result<IRDPSRAPIAttendee>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIAttendeeManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIAttendeeManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAttendeeManager_Impl, const OFFSET: isize>() -> IRDPSRAPIAttendeeManager_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAttendeeManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -390,6 +402,7 @@ pub trait IRDPSRAPIAudioStream_Impl: Sized {
     fn GetBuffer(&self, ppbdata: *mut *mut u8, pcbdata: *mut u32, ptimestamp: *mut u64) -> ::windows::core::Result<()>;
     fn FreeBuffer(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRDPSRAPIAudioStream {}
 impl IRDPSRAPIAudioStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAudioStream_Impl, const OFFSET: isize>() -> IRDPSRAPIAudioStream_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIAudioStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnperiodinhundrednsintervals: *mut i64) -> ::windows::core::HRESULT {
@@ -441,6 +454,8 @@ pub trait IRDPSRAPIClipboardUseEvents_Impl: Sized {
     fn OnPasteFromClipboard(&self, clipboardformat: u32, pattendee: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<i16>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRDPSRAPIClipboardUseEvents {}
+#[cfg(feature = "Win32_System_Com")]
 impl IRDPSRAPIClipboardUseEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIClipboardUseEvents_Impl, const OFFSET: isize>() -> IRDPSRAPIClipboardUseEvents_Vtbl {
         unsafe extern "system" fn OnPasteFromClipboard<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIClipboardUseEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clipboardformat: u32, pattendee: ::windows::core::RawPtr, pretval: *mut i16) -> ::windows::core::HRESULT {
@@ -465,6 +480,8 @@ pub trait IRDPSRAPIDebug_Impl: Sized {
     fn SetCLXCmdLine(&self, clxcmdline: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn CLXCmdLine(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRDPSRAPIDebug {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRDPSRAPIDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIDebug_Impl, const OFFSET: isize>() -> IRDPSRAPIDebug_Vtbl {
@@ -501,6 +518,8 @@ pub trait IRDPSRAPIFrameBuffer_Impl: Sized + super::Com::IDispatch_Impl {
     fn Bpp(&self) -> ::windows::core::Result<i32>;
     fn GetFrameBufferBits(&self, x: i32, y: i32, width: i32, heigth: i32) -> ::windows::core::Result<*mut super::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIFrameBuffer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIFrameBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIFrameBuffer_Impl, const OFFSET: isize>() -> IRDPSRAPIFrameBuffer_Vtbl {
@@ -570,6 +589,8 @@ pub trait IRDPSRAPIInvitation_Impl: Sized + super::Com::IDispatch_Impl {
     fn Revoked(&self) -> ::windows::core::Result<i16>;
     fn SetRevoked(&self, newval: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIInvitation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIInvitation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIInvitation_Impl, const OFFSET: isize>() -> IRDPSRAPIInvitation_Vtbl {
@@ -661,6 +682,8 @@ pub trait IRDPSRAPIInvitationManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateInvitation(&self, bstrauthstring: &super::super::Foundation::BSTR, bstrgroupname: &super::super::Foundation::BSTR, bstrpassword: &super::super::Foundation::BSTR, attendeelimit: i32) -> ::windows::core::Result<IRDPSRAPIInvitation>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIInvitationManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIInvitationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIInvitationManager_Impl, const OFFSET: isize>() -> IRDPSRAPIInvitationManager_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIInvitationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -722,6 +745,7 @@ impl IRDPSRAPIInvitationManager_Vtbl {
 pub trait IRDPSRAPIPerfCounterLogger_Impl: Sized {
     fn LogValue(&self, lvalue: i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRDPSRAPIPerfCounterLogger {}
 impl IRDPSRAPIPerfCounterLogger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIPerfCounterLogger_Impl, const OFFSET: isize>() -> IRDPSRAPIPerfCounterLogger_Vtbl {
         unsafe extern "system" fn LogValue<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIPerfCounterLogger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lvalue: i64) -> ::windows::core::HRESULT {
@@ -739,6 +763,8 @@ impl IRDPSRAPIPerfCounterLogger_Vtbl {
 pub trait IRDPSRAPIPerfCounterLoggingManager_Impl: Sized {
     fn CreateLogger(&self, bstrcountername: &super::super::Foundation::BSTR) -> ::windows::core::Result<IRDPSRAPIPerfCounterLogger>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRDPSRAPIPerfCounterLoggingManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRDPSRAPIPerfCounterLoggingManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIPerfCounterLoggingManager_Impl, const OFFSET: isize>() -> IRDPSRAPIPerfCounterLoggingManager_Vtbl {
@@ -764,6 +790,8 @@ pub trait IRDPSRAPISessionProperties_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Property(&self, propertyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
     fn put_Property(&self, propertyname: &super::super::Foundation::BSTR, newval: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPISessionProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPISessionProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPISessionProperties_Impl, const OFFSET: isize>() -> IRDPSRAPISessionProperties_Vtbl {
@@ -810,6 +838,8 @@ pub trait IRDPSRAPISharingSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetDesktopSharedRect(&self, left: i32, top: i32, right: i32, bottom: i32) -> ::windows::core::Result<()>;
     fn GetDesktopSharedRect(&self, pleft: *mut i32, ptop: *mut i32, pright: *mut i32, pbottom: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPISharingSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPISharingSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPISharingSession_Impl, const OFFSET: isize>() -> IRDPSRAPISharingSession_Vtbl {
@@ -948,6 +978,8 @@ pub trait IRDPSRAPISharingSession2_Impl: Sized + super::Com::IDispatch_Impl + IR
     fn SendControlLevelChangeResponse(&self, pattendee: &::core::option::Option<IRDPSRAPIAttendee>, requestedlevel: CTRL_LEVEL, reasoncode: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPISharingSession2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPISharingSession2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPISharingSession2_Impl, const OFFSET: isize>() -> IRDPSRAPISharingSession2_Vtbl {
         unsafe extern "system" fn ConnectUsingTransportStream<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPISharingSession2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstream: ::windows::core::RawPtr, bstrgroup: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrauthenticatedattendeename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -990,6 +1022,8 @@ pub trait IRDPSRAPITcpConnectionInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn PeerPort(&self) -> ::windows::core::Result<i32>;
     fn PeerIP(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPITcpConnectionInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPITcpConnectionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITcpConnectionInfo_Impl, const OFFSET: isize>() -> IRDPSRAPITcpConnectionInfo_Vtbl {
@@ -1069,6 +1103,7 @@ pub trait IRDPSRAPITransportStream_Impl: Sized {
     fn Open(&self, pcallbacks: &::core::option::Option<IRDPSRAPITransportStreamEvents>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRDPSRAPITransportStream {}
 impl IRDPSRAPITransportStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITransportStream_Impl, const OFFSET: isize>() -> IRDPSRAPITransportStream_Vtbl {
         unsafe extern "system" fn AllocBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITransportStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxpayload: i32, ppbuffer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1133,6 +1168,7 @@ pub trait IRDPSRAPITransportStreamBuffer_Impl: Sized {
     fn Context(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetContext(&self, pcontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRDPSRAPITransportStreamBuffer {}
 impl IRDPSRAPITransportStreamBuffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITransportStreamBuffer_Impl, const OFFSET: isize>() -> IRDPSRAPITransportStreamBuffer_Vtbl {
         unsafe extern "system" fn Storage<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITransportStreamBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbstorage: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -1244,6 +1280,7 @@ pub trait IRDPSRAPITransportStreamEvents_Impl: Sized {
     fn OnReadCompleted(&self, pbuffer: &::core::option::Option<IRDPSRAPITransportStreamBuffer>);
     fn OnStreamClosed(&self, hrreason: ::windows::core::HRESULT);
 }
+impl ::windows::core::RuntimeName for IRDPSRAPITransportStreamEvents {}
 impl IRDPSRAPITransportStreamEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITransportStreamEvents_Impl, const OFFSET: isize>() -> IRDPSRAPITransportStreamEvents_Vtbl {
         unsafe extern "system" fn OnWriteCompleted<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPITransportStreamEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffer: ::windows::core::RawPtr) {
@@ -1289,6 +1326,8 @@ pub trait IRDPSRAPIViewer_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<IRDPSRAPISessionProperties>;
     fn StartReverseConnectListener(&self, bstrconnectionstring: &super::super::Foundation::BSTR, bstrusername: &super::super::Foundation::BSTR, bstrpassword: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIViewer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIViewer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIViewer_Impl, const OFFSET: isize>() -> IRDPSRAPIViewer_Vtbl {
@@ -1441,6 +1480,8 @@ pub trait IRDPSRAPIVirtualChannel_Impl: Sized + super::Com::IDispatch_Impl {
     fn Priority(&self) -> ::windows::core::Result<CHANNEL_PRIORITY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIVirtualChannel {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIVirtualChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIVirtualChannel_Impl, const OFFSET: isize>() -> IRDPSRAPIVirtualChannel_Vtbl {
         unsafe extern "system" fn SendData<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIVirtualChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrdata: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lattendeeid: i32, channelsendflags: u32) -> ::windows::core::HRESULT {
@@ -1506,6 +1547,8 @@ pub trait IRDPSRAPIVirtualChannelManager_Impl: Sized + super::Com::IDispatch_Imp
     fn CreateVirtualChannel(&self, bstrchannelname: &super::super::Foundation::BSTR, priority: CHANNEL_PRIORITY, channelflags: u32) -> ::windows::core::Result<IRDPSRAPIVirtualChannel>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIVirtualChannelManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIVirtualChannelManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIVirtualChannelManager_Impl, const OFFSET: isize>() -> IRDPSRAPIVirtualChannelManager_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIVirtualChannelManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1562,6 +1605,8 @@ pub trait IRDPSRAPIWindow_Impl: Sized + super::Com::IDispatch_Impl {
     fn Show(&self) -> ::windows::core::Result<()>;
     fn Flags(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIWindow {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIWindow_Impl, const OFFSET: isize>() -> IRDPSRAPIWindow_Vtbl {
@@ -1651,6 +1696,8 @@ pub trait IRDPSRAPIWindowList_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, item: i32) -> ::windows::core::Result<IRDPSRAPIWindow>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRDPSRAPIWindowList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRDPSRAPIWindowList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIWindowList_Impl, const OFFSET: isize>() -> IRDPSRAPIWindowList_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IRDPSRAPIWindowList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1695,6 +1742,7 @@ pub trait IRDPViewerInputSink_Impl: Sized {
     fn AddTouchInput(&self, contactid: u32, event: u32, x: i32, y: i32) -> ::windows::core::Result<()>;
     fn EndTouchFrame(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRDPViewerInputSink {}
 impl IRDPViewerInputSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRDPViewerInputSink_Impl, const OFFSET: isize>() -> IRDPViewerInputSink_Vtbl {
         unsafe extern "system" fn SendMouseButtonEvent<Identity: ::windows::core::IUnknownImpl, Impl: IRDPViewerInputSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buttontype: RDPSRAPI_MOUSE_BUTTON_TYPE, vbbuttondown: i16, xpos: u32, ypos: u32) -> ::windows::core::HRESULT {
@@ -1755,6 +1803,8 @@ impl IRDPViewerInputSink_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IRDPSessionEvents_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IRDPSessionEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IRDPSessionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IRDPSessionEvents_Impl, const OFFSET: isize>() -> _IRDPSessionEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/WebApp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/WebApp/impl.rs
@@ -1,6 +1,7 @@
 pub trait IWebApplicationActivation_Impl: Sized {
     fn CancelPendingActivation(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWebApplicationActivation {}
 impl IWebApplicationActivation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationActivation_Impl, const OFFSET: isize>() -> IWebApplicationActivation_Vtbl {
         unsafe extern "system" fn CancelPendingActivation<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationActivation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -18,6 +19,8 @@ impl IWebApplicationActivation_Vtbl {
 pub trait IWebApplicationAuthoringMode_Impl: Sized + super::super::super::Com::IServiceProvider_Impl {
     fn AuthoringClientBinary(&self) -> ::windows::core::Result<super::super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWebApplicationAuthoringMode {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWebApplicationAuthoringMode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationAuthoringMode_Impl, const OFFSET: isize>() -> IWebApplicationAuthoringMode_Vtbl {
@@ -49,6 +52,8 @@ pub trait IWebApplicationHost_Impl: Sized {
     fn Advise(&self, interfaceid: *const ::windows::core::GUID, callback: &::core::option::Option<::windows::core::IUnknown>, cookie: *mut u32) -> ::windows::core::Result<()>;
     fn Unadvise(&self, cookie: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_Web_MsHtml"))]
+impl ::windows::core::RuntimeName for IWebApplicationHost {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_Web_MsHtml"))]
 impl IWebApplicationHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationHost_Impl, const OFFSET: isize>() -> IWebApplicationHost_Vtbl {
@@ -106,6 +111,8 @@ pub trait IWebApplicationNavigationEvents_Impl: Sized {
     fn DownloadComplete(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_Web_MsHtml"))]
+impl ::windows::core::RuntimeName for IWebApplicationNavigationEvents {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_Web_MsHtml"))]
 impl IWebApplicationNavigationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationNavigationEvents_Impl, const OFFSET: isize>() -> IWebApplicationNavigationEvents_Vtbl {
         unsafe extern "system" fn BeforeNavigate<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationNavigationEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, htmlwindow: ::windows::core::RawPtr, url: ::windows::core::PCWSTR, navigationflags: u32, targetframename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -158,6 +165,8 @@ pub trait IWebApplicationScriptEvents_Impl: Sized {
     fn ScriptError(&self, htmlwindow: &::core::option::Option<super::super::super::super::Web::MsHtml::IHTMLWindow2>, scripterror: &::core::option::Option<super::IActiveScriptError>, url: &::windows::core::PCWSTR, errorhandled: super::super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_Web_MsHtml"))]
+impl ::windows::core::RuntimeName for IWebApplicationScriptEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_Web_MsHtml"))]
 impl IWebApplicationScriptEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationScriptEvents_Impl, const OFFSET: isize>() -> IWebApplicationScriptEvents_Vtbl {
         unsafe extern "system" fn BeforeScriptExecute<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationScriptEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, htmlwindow: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -183,6 +192,7 @@ impl IWebApplicationScriptEvents_Vtbl {
 pub trait IWebApplicationUIEvents_Impl: Sized {
     fn SecurityProblem(&self, securityproblem: u32, result: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWebApplicationUIEvents {}
 impl IWebApplicationUIEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationUIEvents_Impl, const OFFSET: isize>() -> IWebApplicationUIEvents_Vtbl {
         unsafe extern "system" fn SecurityProblem<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationUIEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, securityproblem: u32, result: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -200,6 +210,7 @@ pub trait IWebApplicationUpdateEvents_Impl: Sized {
     fn OnPaint(&self) -> ::windows::core::Result<()>;
     fn OnCssChanged(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWebApplicationUpdateEvents {}
 impl IWebApplicationUpdateEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationUpdateEvents_Impl, const OFFSET: isize>() -> IWebApplicationUpdateEvents_Vtbl {
         unsafe extern "system" fn OnPaint<Identity: ::windows::core::IUnknownImpl, Impl: IWebApplicationUpdateEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
@@ -8,6 +8,7 @@ pub trait AsyncIDebugApplicationNodeEvents_Impl: Sized {
     fn Begin_onAttach(&self, prddpparent: &::core::option::Option<IDebugApplicationNode>) -> ::windows::core::Result<()>;
     fn Finish_onAttach(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIDebugApplicationNodeEvents {}
 impl AsyncIDebugApplicationNodeEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIDebugApplicationNodeEvents_Impl, const OFFSET: isize>() -> AsyncIDebugApplicationNodeEvents_Vtbl {
         unsafe extern "system" fn Begin_onAddChild<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIDebugApplicationNodeEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prddpchild: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -69,6 +70,8 @@ impl AsyncIDebugApplicationNodeEvents_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait DebugBaseEventCallbacks_Impl: Sized + IDebugEventCallbacks_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for DebugBaseEventCallbacks {}
+#[cfg(feature = "Win32_Foundation")]
 impl DebugBaseEventCallbacks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DebugBaseEventCallbacks_Impl, const OFFSET: isize>() -> DebugBaseEventCallbacks_Vtbl {
         Self { base__: IDebugEventCallbacks_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -79,6 +82,8 @@ impl DebugBaseEventCallbacks_Vtbl {
 }
 #[cfg(feature = "Win32_Foundation")]
 pub trait DebugBaseEventCallbacksWide_Impl: Sized + IDebugEventCallbacksWide_Impl {}
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for DebugBaseEventCallbacksWide {}
 #[cfg(feature = "Win32_Foundation")]
 impl DebugBaseEventCallbacksWide_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DebugBaseEventCallbacksWide_Impl, const OFFSET: isize>() -> DebugBaseEventCallbacksWide_Vtbl {
@@ -104,6 +109,8 @@ pub trait IActiveScript_Impl: Sized {
     fn InterruptScriptThread(&self, stidthread: u32, pexcepinfo: *const super::super::Com::EXCEPINFO, dwflags: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IActiveScript>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IActiveScript {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IActiveScript_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScript_Impl, const OFFSET: isize>() -> IActiveScript_Vtbl {
@@ -247,6 +254,8 @@ pub trait IActiveScriptAuthor_Impl: Sized {
     fn IsCommitChar(&self, ch: u16) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IActiveScriptAuthor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IActiveScriptAuthor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptAuthor_Impl, const OFFSET: isize>() -> IActiveScriptAuthor_Vtbl {
         unsafe extern "system" fn AddNamedItem<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptAuthor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, dwflags: u32, pdisp: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -378,6 +387,8 @@ pub trait IActiveScriptAuthorProcedure_Impl: Sized {
     fn ParseProcedureText(&self, pszcode: &::windows::core::PCWSTR, pszformalparams: &::windows::core::PCWSTR, pszprocedurename: &::windows::core::PCWSTR, pszitemname: &::windows::core::PCWSTR, pszdelimiter: &::windows::core::PCWSTR, dwcookie: u32, dwflags: u32, pdispfor: &::core::option::Option<super::super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptAuthorProcedure {}
+#[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptAuthorProcedure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptAuthorProcedure_Impl, const OFFSET: isize>() -> IActiveScriptAuthorProcedure_Vtbl {
         unsafe extern "system" fn ParseProcedureText<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptAuthorProcedure_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcode: ::windows::core::PCWSTR, pszformalparams: ::windows::core::PCWSTR, pszprocedurename: ::windows::core::PCWSTR, pszitemname: ::windows::core::PCWSTR, pszdelimiter: ::windows::core::PCWSTR, dwcookie: u32, dwflags: u32, pdispfor: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -396,6 +407,7 @@ pub trait IActiveScriptDebug32_Impl: Sized {
     fn GetScriptletTextAttributes(&self, pstrcode: &::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::Result<()>;
     fn EnumCodeContextsOfPosition(&self, dwsourcecontext: u32, ucharacteroffset: u32, unumchars: u32) -> ::windows::core::Result<IEnumDebugCodeContexts>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptDebug32 {}
 impl IActiveScriptDebug32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptDebug32_Impl, const OFFSET: isize>() -> IActiveScriptDebug32_Vtbl {
         unsafe extern "system" fn GetScriptTextAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptDebug32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT {
@@ -435,6 +447,7 @@ pub trait IActiveScriptDebug64_Impl: Sized {
     fn GetScriptletTextAttributes(&self, pstrcode: &::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::Result<()>;
     fn EnumCodeContextsOfPosition(&self, dwsourcecontext: u64, ucharacteroffset: u32, unumchars: u32) -> ::windows::core::Result<IEnumDebugCodeContexts>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptDebug64 {}
 impl IActiveScriptDebug64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptDebug64_Impl, const OFFSET: isize>() -> IActiveScriptDebug64_Vtbl {
         unsafe extern "system" fn GetScriptTextAttributes<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptDebug64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT {
@@ -476,6 +489,8 @@ pub trait IActiveScriptEncode_Impl: Sized {
     fn GetEncodeProgId(&self, pbstrout: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptEncode {}
+#[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptEncode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptEncode_Impl, const OFFSET: isize>() -> IActiveScriptEncode_Vtbl {
         unsafe extern "system" fn EncodeSection<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptEncode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pchin: ::windows::core::PCWSTR, cchin: u32, pchout: ::windows::core::PWSTR, cchout: u32, pcchret: *mut u32) -> ::windows::core::HRESULT {
@@ -510,6 +525,8 @@ pub trait IActiveScriptError_Impl: Sized {
     fn GetSourcePosition(&self, pdwsourcecontext: *mut u32, pullinenumber: *mut u32, plcharacterposition: *mut i32) -> ::windows::core::Result<()>;
     fn GetSourceLineText(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IActiveScriptError {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IActiveScriptError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptError_Impl, const OFFSET: isize>() -> IActiveScriptError_Vtbl {
@@ -556,6 +573,8 @@ pub trait IActiveScriptError64_Impl: Sized + IActiveScriptError_Impl {
     fn GetSourcePosition64(&self, pdwsourcecontext: *mut u64, pullinenumber: *mut u32, plcharacterposition: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IActiveScriptError64 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IActiveScriptError64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptError64_Impl, const OFFSET: isize>() -> IActiveScriptError64_Vtbl {
         unsafe extern "system" fn GetSourcePosition64<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptError64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwsourcecontext: *mut u64, pullinenumber: *mut u32, plcharacterposition: *mut i32) -> ::windows::core::HRESULT {
@@ -574,6 +593,8 @@ pub trait IActiveScriptErrorDebug_Impl: Sized + IActiveScriptError_Impl {
     fn GetDocumentContext(&self) -> ::windows::core::Result<IDebugDocumentContext>;
     fn GetStackFrame(&self) -> ::windows::core::Result<IDebugStackFrame>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IActiveScriptErrorDebug {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IActiveScriptErrorDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptErrorDebug_Impl, const OFFSET: isize>() -> IActiveScriptErrorDebug_Vtbl {
@@ -612,6 +633,7 @@ impl IActiveScriptErrorDebug_Vtbl {
 pub trait IActiveScriptErrorDebug110_Impl: Sized {
     fn GetExceptionThrownKind(&self) -> ::windows::core::Result<SCRIPT_ERROR_DEBUG_EXCEPTION_THROWN_KIND>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptErrorDebug110 {}
 impl IActiveScriptErrorDebug110_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptErrorDebug110_Impl, const OFFSET: isize>() -> IActiveScriptErrorDebug110_Vtbl {
         unsafe extern "system" fn GetExceptionThrownKind<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptErrorDebug110_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pexceptionkind: *mut SCRIPT_ERROR_DEBUG_EXCEPTION_THROWN_KIND) -> ::windows::core::HRESULT {
@@ -634,6 +656,7 @@ impl IActiveScriptErrorDebug110_Vtbl {
 pub trait IActiveScriptGarbageCollector_Impl: Sized {
     fn CollectGarbage(&self, scriptgctype: SCRIPTGCTYPE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptGarbageCollector {}
 impl IActiveScriptGarbageCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptGarbageCollector_Impl, const OFFSET: isize>() -> IActiveScriptGarbageCollector_Vtbl {
         unsafe extern "system" fn CollectGarbage<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptGarbageCollector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scriptgctype: SCRIPTGCTYPE) -> ::windows::core::HRESULT {
@@ -651,6 +674,8 @@ impl IActiveScriptGarbageCollector_Vtbl {
 pub trait IActiveScriptHostEncode_Impl: Sized {
     fn EncodeScriptHostFile(&self, bstrinfile: &super::super::super::Foundation::BSTR, pbstroutfile: *mut super::super::super::Foundation::BSTR, cflags: u32, bstrdefaultlang: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptHostEncode {}
 #[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptHostEncode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptHostEncode_Impl, const OFFSET: isize>() -> IActiveScriptHostEncode_Vtbl {
@@ -671,6 +696,8 @@ pub trait IActiveScriptParse32_Impl: Sized {
     fn AddScriptlet(&self, pstrdefaultname: &::windows::core::PCWSTR, pstrcode: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, pstrsubitemname: &::windows::core::PCWSTR, pstreventname: &::windows::core::PCWSTR, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32, pbstrname: *mut super::super::super::Foundation::BSTR, pexcepinfo: *mut super::super::Com::EXCEPINFO) -> ::windows::core::Result<()>;
     fn ParseScriptText(&self, pstrcode: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32, pvarresult: *mut super::super::Com::VARIANT, pexcepinfo: *mut super::super::Com::EXCEPINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IActiveScriptParse32 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IActiveScriptParse32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParse32_Impl, const OFFSET: isize>() -> IActiveScriptParse32_Vtbl {
@@ -709,6 +736,8 @@ pub trait IActiveScriptParse64_Impl: Sized {
     fn ParseScriptText(&self, pstrcode: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32, pvarresult: *mut super::super::Com::VARIANT, pexcepinfo: *mut super::super::Com::EXCEPINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IActiveScriptParse64 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IActiveScriptParse64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParse64_Impl, const OFFSET: isize>() -> IActiveScriptParse64_Vtbl {
         unsafe extern "system" fn InitNew<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParse64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -742,6 +771,8 @@ impl IActiveScriptParse64_Vtbl {
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedure2_32_Impl: Sized + IActiveScriptParseProcedure32_Impl {}
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptParseProcedure2_32 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptParseProcedure2_32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedure2_32_Impl, const OFFSET: isize>() -> IActiveScriptParseProcedure2_32_Vtbl {
         Self { base__: IActiveScriptParseProcedure32_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -752,6 +783,8 @@ impl IActiveScriptParseProcedure2_32_Vtbl {
 }
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedure2_64_Impl: Sized + IActiveScriptParseProcedure64_Impl {}
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptParseProcedure2_64 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptParseProcedure2_64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedure2_64_Impl, const OFFSET: isize>() -> IActiveScriptParseProcedure2_64_Vtbl {
@@ -765,6 +798,8 @@ impl IActiveScriptParseProcedure2_64_Vtbl {
 pub trait IActiveScriptParseProcedure32_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstrprocedurename: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptParseProcedure32 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptParseProcedure32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedure32_Impl, const OFFSET: isize>() -> IActiveScriptParseProcedure32_Vtbl {
@@ -790,6 +825,8 @@ pub trait IActiveScriptParseProcedure64_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstrprocedurename: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptParseProcedure64 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptParseProcedure64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedure64_Impl, const OFFSET: isize>() -> IActiveScriptParseProcedure64_Vtbl {
         unsafe extern "system" fn ParseProcedureText<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedure64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, pstrformalparams: ::windows::core::PCWSTR, pstrprocedurename: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, punkcontext: *mut ::core::ffi::c_void, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32, ppdisp: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -814,6 +851,8 @@ pub trait IActiveScriptParseProcedureOld32_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptParseProcedureOld32 {}
+#[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptParseProcedureOld32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedureOld32_Impl, const OFFSET: isize>() -> IActiveScriptParseProcedureOld32_Vtbl {
         unsafe extern "system" fn ParseProcedureText<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedureOld32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, pstrformalparams: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, punkcontext: *mut ::core::ffi::c_void, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32, ppdisp: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -837,6 +876,8 @@ impl IActiveScriptParseProcedureOld32_Vtbl {
 pub trait IActiveScriptParseProcedureOld64_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IActiveScriptParseProcedureOld64 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IActiveScriptParseProcedureOld64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptParseProcedureOld64_Impl, const OFFSET: isize>() -> IActiveScriptParseProcedureOld64_Vtbl {
@@ -865,6 +906,7 @@ pub trait IActiveScriptProfilerCallback_Impl: Sized {
     fn OnFunctionEnter(&self, scriptid: i32, functionid: i32) -> ::windows::core::Result<()>;
     fn OnFunctionExit(&self, scriptid: i32, functionid: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerCallback {}
 impl IActiveScriptProfilerCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerCallback_Impl, const OFFSET: isize>() -> IActiveScriptProfilerCallback_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcontext: u32) -> ::windows::core::HRESULT {
@@ -915,6 +957,7 @@ pub trait IActiveScriptProfilerCallback2_Impl: Sized + IActiveScriptProfilerCall
     fn OnFunctionEnterByName(&self, pwszfunctionname: &::windows::core::PCWSTR, r#type: PROFILER_SCRIPT_TYPE) -> ::windows::core::Result<()>;
     fn OnFunctionExitByName(&self, pwszfunctionname: &::windows::core::PCWSTR, r#type: PROFILER_SCRIPT_TYPE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerCallback2 {}
 impl IActiveScriptProfilerCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerCallback2_Impl, const OFFSET: isize>() -> IActiveScriptProfilerCallback2_Vtbl {
         unsafe extern "system" fn OnFunctionEnterByName<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszfunctionname: ::windows::core::PCWSTR, r#type: PROFILER_SCRIPT_TYPE) -> ::windows::core::HRESULT {
@@ -940,6 +983,7 @@ impl IActiveScriptProfilerCallback2_Vtbl {
 pub trait IActiveScriptProfilerCallback3_Impl: Sized + IActiveScriptProfilerCallback_Impl + IActiveScriptProfilerCallback2_Impl {
     fn SetWebWorkerId(&self, webworkerid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerCallback3 {}
 impl IActiveScriptProfilerCallback3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerCallback3_Impl, const OFFSET: isize>() -> IActiveScriptProfilerCallback3_Vtbl {
         unsafe extern "system" fn SetWebWorkerId<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerCallback3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, webworkerid: u32) -> ::windows::core::HRESULT {
@@ -958,6 +1002,7 @@ pub trait IActiveScriptProfilerControl_Impl: Sized {
     fn SetProfilerEventMask(&self, dweventmask: u32) -> ::windows::core::Result<()>;
     fn StopProfiling(&self, hrshutdownreason: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerControl {}
 impl IActiveScriptProfilerControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl_Impl, const OFFSET: isize>() -> IActiveScriptProfilerControl_Vtbl {
         unsafe extern "system" fn StartProfiling<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsidprofilerobject: *const ::windows::core::GUID, dweventmask: u32, dwcontext: u32) -> ::windows::core::HRESULT {
@@ -990,6 +1035,7 @@ pub trait IActiveScriptProfilerControl2_Impl: Sized + IActiveScriptProfilerContr
     fn CompleteProfilerStart(&self) -> ::windows::core::Result<()>;
     fn PrepareProfilerStop(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerControl2 {}
 impl IActiveScriptProfilerControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl2_Impl, const OFFSET: isize>() -> IActiveScriptProfilerControl2_Vtbl {
         unsafe extern "system" fn CompleteProfilerStart<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1015,6 +1061,7 @@ impl IActiveScriptProfilerControl2_Vtbl {
 pub trait IActiveScriptProfilerControl3_Impl: Sized + IActiveScriptProfilerControl_Impl + IActiveScriptProfilerControl2_Impl {
     fn EnumHeap(&self) -> ::windows::core::Result<IActiveScriptProfilerHeapEnum>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerControl3 {}
 impl IActiveScriptProfilerControl3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl3_Impl, const OFFSET: isize>() -> IActiveScriptProfilerControl3_Vtbl {
         unsafe extern "system" fn EnumHeap<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1037,6 +1084,7 @@ impl IActiveScriptProfilerControl3_Vtbl {
 pub trait IActiveScriptProfilerControl4_Impl: Sized + IActiveScriptProfilerControl_Impl + IActiveScriptProfilerControl2_Impl + IActiveScriptProfilerControl3_Impl {
     fn SummarizeHeap(&self, heapsummary: *mut PROFILER_HEAP_SUMMARY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerControl4 {}
 impl IActiveScriptProfilerControl4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl4_Impl, const OFFSET: isize>() -> IActiveScriptProfilerControl4_Vtbl {
         unsafe extern "system" fn SummarizeHeap<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, heapsummary: *mut PROFILER_HEAP_SUMMARY) -> ::windows::core::HRESULT {
@@ -1053,6 +1101,7 @@ impl IActiveScriptProfilerControl4_Vtbl {
 pub trait IActiveScriptProfilerControl5_Impl: Sized + IActiveScriptProfilerControl_Impl + IActiveScriptProfilerControl2_Impl + IActiveScriptProfilerControl3_Impl + IActiveScriptProfilerControl4_Impl {
     fn EnumHeap2(&self, enumflags: PROFILER_HEAP_ENUM_FLAGS) -> ::windows::core::Result<IActiveScriptProfilerHeapEnum>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptProfilerControl5 {}
 impl IActiveScriptProfilerControl5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl5_Impl, const OFFSET: isize>() -> IActiveScriptProfilerControl5_Vtbl {
         unsafe extern "system" fn EnumHeap2<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerControl5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumflags: PROFILER_HEAP_ENUM_FLAGS, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1079,6 +1128,8 @@ pub trait IActiveScriptProfilerHeapEnum_Impl: Sized {
     fn FreeObjectAndOptionalInfo(&self, celt: u32, heapobjects: *const *const PROFILER_HEAP_OBJECT) -> ::windows::core::Result<()>;
     fn GetNameIdMap(&self, pnamelist: *mut *mut *mut ::windows::core::PWSTR, pcelt: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptProfilerHeapEnum {}
 #[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptProfilerHeapEnum_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProfilerHeapEnum_Impl, const OFFSET: isize>() -> IActiveScriptProfilerHeapEnum_Vtbl {
@@ -1120,6 +1171,8 @@ pub trait IActiveScriptProperty_Impl: Sized {
     fn SetProperty(&self, dwproperty: u32, pvarindex: *const super::super::Com::VARIANT, pvarvalue: *const super::super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IActiveScriptProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IActiveScriptProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProperty_Impl, const OFFSET: isize>() -> IActiveScriptProperty_Vtbl {
         unsafe extern "system" fn GetProperty<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwproperty: u32, pvarindex: *const super::super::Com::VARIANT, pvarvalue: *mut super::super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -1151,6 +1204,7 @@ impl IActiveScriptProperty_Vtbl {
 pub trait IActiveScriptSIPInfo_Impl: Sized {
     fn GetSIPOID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptSIPInfo {}
 impl IActiveScriptSIPInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSIPInfo_Impl, const OFFSET: isize>() -> IActiveScriptSIPInfo_Vtbl {
         unsafe extern "system" fn GetSIPOID<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSIPInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poid_sip: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1181,6 +1235,8 @@ pub trait IActiveScriptSite_Impl: Sized {
     fn OnEnterScript(&self) -> ::windows::core::Result<()>;
     fn OnLeaveScript(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IActiveScriptSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IActiveScriptSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSite_Impl, const OFFSET: isize>() -> IActiveScriptSite_Vtbl {
@@ -1260,6 +1316,8 @@ pub trait IActiveScriptSiteDebug32_Impl: Sized {
     fn OnScriptErrorDebug(&self, perrordebug: &::core::option::Option<IActiveScriptErrorDebug>, pfenterdebugger: *mut super::super::super::Foundation::BOOL, pfcallonscripterrorwhencontinuing: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptSiteDebug32 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptSiteDebug32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteDebug32_Impl, const OFFSET: isize>() -> IActiveScriptSiteDebug32_Vtbl {
         unsafe extern "system" fn GetDocumentContextFromPosition<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteDebug32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsourcecontext: u32, ucharacteroffset: u32, unumchars: u32, ppsc: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1320,6 +1378,8 @@ pub trait IActiveScriptSiteDebug64_Impl: Sized {
     fn OnScriptErrorDebug(&self, perrordebug: &::core::option::Option<IActiveScriptErrorDebug>, pfenterdebugger: *mut super::super::super::Foundation::BOOL, pfcallonscripterrorwhencontinuing: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptSiteDebug64 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptSiteDebug64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteDebug64_Impl, const OFFSET: isize>() -> IActiveScriptSiteDebug64_Vtbl {
         unsafe extern "system" fn GetDocumentContextFromPosition<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteDebug64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsourcecontext: u64, ucharacteroffset: u32, unumchars: u32, ppsc: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1377,6 +1437,8 @@ pub trait IActiveScriptSiteDebugEx_Impl: Sized {
     fn OnCanNotJITScriptErrorDebug(&self, perrordebug: &::core::option::Option<IActiveScriptErrorDebug>) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptSiteDebugEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptSiteDebugEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteDebugEx_Impl, const OFFSET: isize>() -> IActiveScriptSiteDebugEx_Vtbl {
         unsafe extern "system" fn OnCanNotJITScriptErrorDebug<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteDebugEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, perrordebug: ::windows::core::RawPtr, pfcallonscripterrorwhencontinuing: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1402,6 +1464,7 @@ impl IActiveScriptSiteDebugEx_Vtbl {
 pub trait IActiveScriptSiteInterruptPoll_Impl: Sized {
     fn QueryContinue(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptSiteInterruptPoll {}
 impl IActiveScriptSiteInterruptPoll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteInterruptPoll_Impl, const OFFSET: isize>() -> IActiveScriptSiteInterruptPoll_Vtbl {
         unsafe extern "system" fn QueryContinue<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteInterruptPoll_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1418,6 +1481,7 @@ impl IActiveScriptSiteInterruptPoll_Vtbl {
 pub trait IActiveScriptSiteTraceInfo_Impl: Sized {
     fn SendScriptTraceInfo(&self, stieventtype: SCRIPTTRACEINFO, guidcontextid: &::windows::core::GUID, dwscriptcontextcookie: u32, lscriptstatementstart: i32, lscriptstatementend: i32, dwreserved: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptSiteTraceInfo {}
 impl IActiveScriptSiteTraceInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteTraceInfo_Impl, const OFFSET: isize>() -> IActiveScriptSiteTraceInfo_Vtbl {
         unsafe extern "system" fn SendScriptTraceInfo<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteTraceInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stieventtype: SCRIPTTRACEINFO, guidcontextid: ::windows::core::GUID, dwscriptcontextcookie: u32, lscriptstatementstart: i32, lscriptstatementend: i32, dwreserved: u64) -> ::windows::core::HRESULT {
@@ -1434,6 +1498,7 @@ impl IActiveScriptSiteTraceInfo_Vtbl {
 pub trait IActiveScriptSiteUIControl_Impl: Sized {
     fn GetUIBehavior(&self, uicitem: SCRIPTUICITEM) -> ::windows::core::Result<SCRIPTUICHANDLING>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptSiteUIControl {}
 impl IActiveScriptSiteUIControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteUIControl_Impl, const OFFSET: isize>() -> IActiveScriptSiteUIControl_Vtbl {
         unsafe extern "system" fn GetUIBehavior<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteUIControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uicitem: SCRIPTUICITEM, puichandling: *mut SCRIPTUICHANDLING) -> ::windows::core::HRESULT {
@@ -1458,6 +1523,8 @@ pub trait IActiveScriptSiteWindow_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
     fn EnableModeless(&self, fenable: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptSiteWindow {}
 #[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptSiteWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptSiteWindow_Impl, const OFFSET: isize>() -> IActiveScriptSiteWindow_Vtbl {
@@ -1492,6 +1559,7 @@ pub trait IActiveScriptStats_Impl: Sized {
     fn GetStatEx(&self, guid: *const ::windows::core::GUID, pluhi: *mut u32, plulo: *mut u32) -> ::windows::core::Result<()>;
     fn ResetStats(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptStats {}
 impl IActiveScriptStats_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptStats_Impl, const OFFSET: isize>() -> IActiveScriptStats_Vtbl {
         unsafe extern "system" fn GetStat<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptStats_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, stid: u32, pluhi: *mut u32, plulo: *mut u32) -> ::windows::core::HRESULT {
@@ -1525,6 +1593,8 @@ pub trait IActiveScriptStringCompare_Impl: Sized {
     fn StrComp(&self, bszstr1: &super::super::super::Foundation::BSTR, bszstr2: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<i32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActiveScriptStringCompare {}
+#[cfg(feature = "Win32_Foundation")]
 impl IActiveScriptStringCompare_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptStringCompare_Impl, const OFFSET: isize>() -> IActiveScriptStringCompare_Vtbl {
         unsafe extern "system" fn StrComp<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptStringCompare_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bszstr1: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, bszstr2: ::core::mem::ManuallyDrop<super::super::super::Foundation::BSTR>, iret: *mut i32) -> ::windows::core::HRESULT {
@@ -1548,6 +1618,7 @@ pub trait IActiveScriptTraceInfo_Impl: Sized {
     fn StartScriptTracing(&self, psitetraceinfo: &::core::option::Option<IActiveScriptSiteTraceInfo>, guidcontextid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn StopScriptTracing(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveScriptTraceInfo {}
 impl IActiveScriptTraceInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptTraceInfo_Impl, const OFFSET: isize>() -> IActiveScriptTraceInfo_Vtbl {
         unsafe extern "system" fn StartScriptTracing<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptTraceInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psitetraceinfo: ::windows::core::RawPtr, guidcontextid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1576,6 +1647,8 @@ pub trait IActiveScriptWinRTErrorDebug_Impl: Sized + IActiveScriptError_Impl {
     fn GetRestrictedErrorReference(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn GetCapabilitySid(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IActiveScriptWinRTErrorDebug {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IActiveScriptWinRTErrorDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveScriptWinRTErrorDebug_Impl, const OFFSET: isize>() -> IActiveScriptWinRTErrorDebug_Vtbl {
@@ -1631,6 +1704,7 @@ pub trait IApplicationDebugger_Impl: Sized {
     fn onClose(&self) -> ::windows::core::Result<()>;
     fn onDebuggerEvent(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IApplicationDebugger {}
 impl IApplicationDebugger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDebugger_Impl, const OFFSET: isize>() -> IApplicationDebugger_Vtbl {
         unsafe extern "system" fn QueryAlive<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDebugger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1687,6 +1761,7 @@ pub trait IApplicationDebuggerUI_Impl: Sized {
     fn BringDocumentToTop(&self, pddt: &::core::option::Option<IDebugDocumentText>) -> ::windows::core::Result<()>;
     fn BringDocumentContextToTop(&self, pddc: &::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IApplicationDebuggerUI {}
 impl IApplicationDebuggerUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDebuggerUI_Impl, const OFFSET: isize>() -> IApplicationDebuggerUI_Vtbl {
         unsafe extern "system" fn BringDocumentToTop<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDebuggerUI_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pddt: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1714,6 +1789,8 @@ pub trait IBindEventHandler_Impl: Sized {
     fn BindHandler(&self, pstrevent: &::windows::core::PCWSTR, pdisp: &::core::option::Option<super::super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBindEventHandler {}
+#[cfg(feature = "Win32_System_Com")]
 impl IBindEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindEventHandler_Impl, const OFFSET: isize>() -> IBindEventHandler_Vtbl {
         unsafe extern "system" fn BindHandler<Identity: ::windows::core::IUnknownImpl, Impl: IBindEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrevent: ::windows::core::PCWSTR, pdisp: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1730,6 +1807,7 @@ impl IBindEventHandler_Vtbl {
 pub trait ICodeAddressConcept_Impl: Sized {
     fn GetContainingSymbol(&self, pcontextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IDebugHostSymbol>;
 }
+impl ::windows::core::RuntimeName for ICodeAddressConcept {}
 impl ICodeAddressConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICodeAddressConcept_Impl, const OFFSET: isize>() -> ICodeAddressConcept_Vtbl {
         unsafe extern "system" fn GetContainingSymbol<Identity: ::windows::core::IUnknownImpl, Impl: ICodeAddressConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontextobject: ::windows::core::RawPtr, ppsymbol: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1752,6 +1830,7 @@ impl ICodeAddressConcept_Vtbl {
 pub trait IComparableConcept_Impl: Sized {
     fn CompareObjects(&self, contextobject: &::core::option::Option<IModelObject>, otherobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IComparableConcept {}
 impl IComparableConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComparableConcept_Impl, const OFFSET: isize>() -> IComparableConcept_Vtbl {
         unsafe extern "system" fn CompareObjects<Identity: ::windows::core::IUnknownImpl, Impl: IComparableConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, otherobject: ::windows::core::RawPtr, comparisonresult: *mut i32) -> ::windows::core::HRESULT {
@@ -1776,6 +1855,8 @@ pub trait IDataModelConcept_Impl: Sized {
     fn InitializeObject(&self, modelobject: &::core::option::Option<IModelObject>, matchingtypesignature: &::core::option::Option<IDebugHostTypeSignature>, wildcardmatches: &::core::option::Option<IDebugHostSymbolEnumerator>) -> ::windows::core::Result<()>;
     fn GetName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelConcept {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDataModelConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelConcept_Impl, const OFFSET: isize>() -> IDataModelConcept_Vtbl {
@@ -1828,6 +1909,8 @@ pub trait IDataModelManager_Impl: Sized {
     fn UnregisterNamedModel(&self, modelname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn AcquireNamedModel(&self, modelname: &::windows::core::PCWSTR) -> ::windows::core::Result<IModelObject>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataModelManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataModelManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelManager_Impl, const OFFSET: isize>() -> IDataModelManager_Vtbl {
@@ -2037,6 +2120,8 @@ pub trait IDataModelManager2_Impl: Sized + IDataModelManager_Impl {
     fn CreateTypedIntrinsicObjectEx(&self, context: &::core::option::Option<IDebugHostContext>, intrinsicdata: *const super::super::Com::VARIANT, r#type: &::core::option::Option<IDebugHostType>) -> ::windows::core::Result<IModelObject>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataModelManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataModelManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelManager2_Impl, const OFFSET: isize>() -> IDataModelManager2_Vtbl {
         unsafe extern "system" fn AcquireSubNamespace<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, modelname: ::windows::core::PCWSTR, subnamespacemodelname: ::windows::core::PCWSTR, accessname: ::windows::core::PCWSTR, metadata: ::windows::core::RawPtr, namespacemodelobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2077,6 +2162,7 @@ pub trait IDataModelNameBinder_Impl: Sized {
     fn EnumerateValues(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IKeyEnumerator>;
     fn EnumerateReferences(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IKeyEnumerator>;
 }
+impl ::windows::core::RuntimeName for IDataModelNameBinder {}
 impl IDataModelNameBinder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelNameBinder_Impl, const OFFSET: isize>() -> IDataModelNameBinder_Vtbl {
         unsafe extern "system" fn BindValue<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelNameBinder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, name: ::windows::core::PCWSTR, value: *mut ::windows::core::RawPtr, metadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2133,6 +2219,8 @@ pub trait IDataModelScript_Impl: Sized {
     fn IsInvocable(&self) -> ::windows::core::Result<bool>;
     fn InvokeMain(&self, client: &::core::option::Option<IDataModelScriptClient>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDataModelScript {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDataModelScript_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScript_Impl, const OFFSET: isize>() -> IDataModelScript_Vtbl {
@@ -2201,6 +2289,7 @@ impl IDataModelScript_Vtbl {
 pub trait IDataModelScriptClient_Impl: Sized {
     fn ReportError(&self, errclass: ErrorClass, hrfail: ::windows::core::HRESULT, message: &::windows::core::PCWSTR, line: u32, position: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptClient {}
 impl IDataModelScriptClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptClient_Impl, const OFFSET: isize>() -> IDataModelScriptClient_Vtbl {
         unsafe extern "system" fn ReportError<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, errclass: ErrorClass, hrfail: ::windows::core::HRESULT, message: ::windows::core::PCWSTR, line: u32, position: u32) -> ::windows::core::HRESULT {
@@ -2227,6 +2316,8 @@ pub trait IDataModelScriptDebug_Impl: Sized {
     fn StartDebugging(&self, debugclient: &::core::option::Option<IDataModelScriptDebugClient>) -> ::windows::core::Result<()>;
     fn StopDebugging(&self, debugclient: &::core::option::Option<IDataModelScriptDebugClient>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelScriptDebug {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDataModelScriptDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebug_Impl, const OFFSET: isize>() -> IDataModelScriptDebug_Vtbl {
@@ -2333,6 +2424,8 @@ pub trait IDataModelScriptDebug2_Impl: Sized + IDataModelScriptDebug_Impl {
     fn SetBreakpointAtFunction(&self, functionname: &::windows::core::PCWSTR) -> ::windows::core::Result<IDataModelScriptDebugBreakpoint>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelScriptDebug2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDataModelScriptDebug2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebug2_Impl, const OFFSET: isize>() -> IDataModelScriptDebug2_Vtbl {
         unsafe extern "system" fn SetBreakpointAtFunction<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebug2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, functionname: ::windows::core::PCWSTR, breakpoint: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2361,6 +2454,8 @@ pub trait IDataModelScriptDebugBreakpoint_Impl: Sized {
     fn Remove(&self);
     fn GetPosition(&self, position: *mut ScriptDebugPosition, positionspanend: *mut ScriptDebugPosition, linetext: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelScriptDebugBreakpoint {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDataModelScriptDebugBreakpoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugBreakpoint_Impl, const OFFSET: isize>() -> IDataModelScriptDebugBreakpoint_Vtbl {
@@ -2412,6 +2507,7 @@ pub trait IDataModelScriptDebugBreakpointEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDataModelScriptDebugBreakpoint>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptDebugBreakpointEnumerator {}
 impl IDataModelScriptDebugBreakpointEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugBreakpointEnumerator_Impl, const OFFSET: isize>() -> IDataModelScriptDebugBreakpointEnumerator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugBreakpointEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2443,6 +2539,7 @@ impl IDataModelScriptDebugBreakpointEnumerator_Vtbl {
 pub trait IDataModelScriptDebugClient_Impl: Sized {
     fn NotifyDebugEvent(&self, peventinfo: *const ScriptDebugEventInformation, pscript: &::core::option::Option<IDataModelScript>, peventdataobject: &::core::option::Option<IModelObject>, resumeeventkind: *mut ScriptExecutionKind) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptDebugClient {}
 impl IDataModelScriptDebugClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugClient_Impl, const OFFSET: isize>() -> IDataModelScriptDebugClient_Vtbl {
         unsafe extern "system" fn NotifyDebugEvent<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventinfo: *const ScriptDebugEventInformation, pscript: ::windows::core::RawPtr, peventdataobject: ::windows::core::RawPtr, resumeeventkind: *mut ScriptExecutionKind) -> ::windows::core::HRESULT {
@@ -2460,6 +2557,7 @@ pub trait IDataModelScriptDebugStack_Impl: Sized {
     fn GetFrameCount(&self) -> u64;
     fn GetStackFrame(&self, framenumber: u64) -> ::windows::core::Result<IDataModelScriptDebugStackFrame>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptDebugStack {}
 impl IDataModelScriptDebugStack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugStack_Impl, const OFFSET: isize>() -> IDataModelScriptDebugStack_Vtbl {
         unsafe extern "system" fn GetFrameCount<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugStack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u64 {
@@ -2498,6 +2596,8 @@ pub trait IDataModelScriptDebugStackFrame_Impl: Sized {
     fn EnumerateLocals(&self) -> ::windows::core::Result<IDataModelScriptDebugVariableSetEnumerator>;
     fn EnumerateArguments(&self) -> ::windows::core::Result<IDataModelScriptDebugVariableSetEnumerator>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelScriptDebugStackFrame {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDataModelScriptDebugStackFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugStackFrame_Impl, const OFFSET: isize>() -> IDataModelScriptDebugStackFrame_Vtbl {
@@ -2587,6 +2687,8 @@ pub trait IDataModelScriptDebugVariableSetEnumerator_Impl: Sized {
     fn GetNext(&self, variablename: *mut super::super::super::Foundation::BSTR, variablevalue: *mut ::core::option::Option<IModelObject>, variablemetadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelScriptDebugVariableSetEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDataModelScriptDebugVariableSetEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugVariableSetEnumerator_Impl, const OFFSET: isize>() -> IDataModelScriptDebugVariableSetEnumerator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptDebugVariableSetEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2613,6 +2715,7 @@ pub trait IDataModelScriptHostContext_Impl: Sized {
     fn NotifyScriptChange(&self, script: &::core::option::Option<IDataModelScript>, changekind: ScriptChangeKind) -> ::windows::core::Result<()>;
     fn GetNamespaceObject(&self) -> ::windows::core::Result<IModelObject>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptHostContext {}
 impl IDataModelScriptHostContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptHostContext_Impl, const OFFSET: isize>() -> IDataModelScriptHostContext_Vtbl {
         unsafe extern "system" fn NotifyScriptChange<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptHostContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, script: ::windows::core::RawPtr, changekind: ScriptChangeKind) -> ::windows::core::HRESULT {
@@ -2649,6 +2752,7 @@ pub trait IDataModelScriptManager_Impl: Sized {
     fn FindProviderForScriptExtension(&self, scriptextension: &::windows::core::PCWSTR) -> ::windows::core::Result<IDataModelScriptProvider>;
     fn EnumerateScriptProviders(&self) -> ::windows::core::Result<IDataModelScriptProviderEnumerator>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptManager {}
 impl IDataModelScriptManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptManager_Impl, const OFFSET: isize>() -> IDataModelScriptManager_Vtbl {
         unsafe extern "system" fn GetDefaultNameBinder<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppnamebinder: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2728,6 +2832,8 @@ pub trait IDataModelScriptProvider_Impl: Sized {
     fn EnumerateTemplates(&self) -> ::windows::core::Result<IDataModelScriptTemplateEnumerator>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataModelScriptProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDataModelScriptProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptProvider_Impl, const OFFSET: isize>() -> IDataModelScriptProvider_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2802,6 +2908,7 @@ pub trait IDataModelScriptProviderEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDataModelScriptProvider>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptProviderEnumerator {}
 impl IDataModelScriptProviderEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptProviderEnumerator_Impl, const OFFSET: isize>() -> IDataModelScriptProviderEnumerator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptProviderEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2836,6 +2943,8 @@ pub trait IDataModelScriptTemplate_Impl: Sized {
     fn GetDescription(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
     fn GetContent(&self) -> ::windows::core::Result<super::super::Com::IStream>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDataModelScriptTemplate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDataModelScriptTemplate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptTemplate_Impl, const OFFSET: isize>() -> IDataModelScriptTemplate_Vtbl {
@@ -2887,6 +2996,7 @@ pub trait IDataModelScriptTemplateEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDataModelScriptTemplate>;
 }
+impl ::windows::core::RuntimeName for IDataModelScriptTemplateEnumerator {}
 impl IDataModelScriptTemplateEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptTemplateEnumerator_Impl, const OFFSET: isize>() -> IDataModelScriptTemplateEnumerator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDataModelScriptTemplateEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2919,6 +3029,7 @@ pub trait IDebugAdvanced_Impl: Sized {
     fn GetThreadContext(&self, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn SetThreadContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugAdvanced {}
 impl IDebugAdvanced_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced_Impl, const OFFSET: isize>() -> IDebugAdvanced_Vtbl {
         unsafe extern "system" fn GetThreadContext<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT {
@@ -2950,6 +3061,7 @@ pub trait IDebugAdvanced2_Impl: Sized {
     fn GetSymbolInformation(&self, which: u32, arg64: u64, arg32: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, infosize: *mut u32, stringbuffer: ::windows::core::PSTR, stringbuffersize: u32, stringsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetSystemObjectInformation(&self, which: u32, arg64: u64, arg32: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, infosize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugAdvanced2 {}
 impl IDebugAdvanced2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced2_Impl, const OFFSET: isize>() -> IDebugAdvanced2_Vtbl {
         unsafe extern "system" fn GetThreadContext<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT {
@@ -3014,6 +3126,7 @@ pub trait IDebugAdvanced3_Impl: Sized {
     fn FindSourceFileAndTokenWide(&self, startelement: u32, modaddr: u64, file: &::windows::core::PCWSTR, flags: u32, filetoken: *const ::core::ffi::c_void, filetokensize: u32, foundelement: *mut u32, buffer: ::windows::core::PWSTR, buffersize: u32, foundsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetSymbolInformationWide(&self, which: u32, arg64: u64, arg32: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, infosize: *mut u32, stringbuffer: ::windows::core::PWSTR, stringbuffersize: u32, stringsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugAdvanced3 {}
 impl IDebugAdvanced3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced3_Impl, const OFFSET: isize>() -> IDebugAdvanced3_Vtbl {
         unsafe extern "system" fn GetThreadContext<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT {
@@ -3097,6 +3210,7 @@ pub trait IDebugAdvanced4_Impl: Sized {
     fn GetSymbolInformationWide(&self, which: u32, arg64: u64, arg32: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, infosize: *mut u32, stringbuffer: ::windows::core::PWSTR, stringbuffersize: u32, stringsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetSymbolInformationWideEx(&self, which: u32, arg64: u64, arg32: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, infosize: *mut u32, stringbuffer: ::windows::core::PWSTR, stringbuffersize: u32, stringsize: *mut u32, pinfoex: *mut SYMBOL_INFO_EX) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugAdvanced4 {}
 impl IDebugAdvanced4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced4_Impl, const OFFSET: isize>() -> IDebugAdvanced4_Vtbl {
         unsafe extern "system" fn GetThreadContext<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAdvanced4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT {
@@ -3180,6 +3294,8 @@ pub trait IDebugApplication11032_Impl: Sized + IRemoteDebugApplication110_Impl {
     fn CallableWaitForHandles(&self, handlecount: u32, phandles: *const super::super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplication11032 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugApplication11032_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplication11032_Impl, const OFFSET: isize>() -> IDebugApplication11032_Vtbl {
         unsafe extern "system" fn SynchronousCallInMainThread<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplication11032_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptc: ::windows::core::RawPtr, dwparam1: usize, dwparam2: usize, dwparam3: usize) -> ::windows::core::HRESULT {
@@ -3220,6 +3336,8 @@ pub trait IDebugApplication11064_Impl: Sized + IRemoteDebugApplication110_Impl {
     fn AsynchronousCallInMainThread(&self, pptc: &::core::option::Option<IDebugThreadCall64>, dwparam1: usize, dwparam2: usize, dwparam3: usize) -> ::windows::core::Result<()>;
     fn CallableWaitForHandles(&self, handlecount: u32, phandles: *const super::super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplication11064 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugApplication11064_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplication11064_Impl, const OFFSET: isize>() -> IDebugApplication11064_Vtbl {
@@ -3278,6 +3396,8 @@ pub trait IDebugApplication32_Impl: Sized + IRemoteDebugApplication_Impl {
     fn AddGlobalExpressionContextProvider(&self, pdsfs: &::core::option::Option<IProvideExpressionContexts>) -> ::windows::core::Result<u32>;
     fn RemoveGlobalExpressionContextProvider(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplication32 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugApplication32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplication32_Impl, const OFFSET: isize>() -> IDebugApplication32_Vtbl {
@@ -3469,6 +3589,8 @@ pub trait IDebugApplication64_Impl: Sized + IRemoteDebugApplication_Impl {
     fn RemoveGlobalExpressionContextProvider(&self, dwcookie: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplication64 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugApplication64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplication64_Impl, const OFFSET: isize>() -> IDebugApplication64_Vtbl {
         unsafe extern "system" fn SetName<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplication64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -3645,6 +3767,8 @@ pub trait IDebugApplicationNode_Impl: Sized + IDebugDocumentInfo_Impl + IDebugDo
     fn Detach(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplicationNode {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugApplicationNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationNode_Impl, const OFFSET: isize>() -> IDebugApplicationNode_Vtbl {
         unsafe extern "system" fn EnumChildren<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationNode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pperddp: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3708,6 +3832,7 @@ pub trait IDebugApplicationNode100_Impl: Sized {
     fn GetExcludedDocuments(&self, filter: APPLICATION_NODE_EVENT_FILTER) -> ::windows::core::Result<TEXT_DOCUMENT_ARRAY>;
     fn QueryIsChildNode(&self, psearchkey: &::core::option::Option<IDebugDocument>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugApplicationNode100 {}
 impl IDebugApplicationNode100_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationNode100_Impl, const OFFSET: isize>() -> IDebugApplicationNode100_Vtbl {
         unsafe extern "system" fn SetFilterForEventSink<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationNode100_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcookie: u32, filter: APPLICATION_NODE_EVENT_FILTER) -> ::windows::core::HRESULT {
@@ -3748,6 +3873,7 @@ pub trait IDebugApplicationNodeEvents_Impl: Sized {
     fn onDetach(&self) -> ::windows::core::Result<()>;
     fn onAttach(&self, prddpparent: &::core::option::Option<IDebugApplicationNode>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugApplicationNodeEvents {}
 impl IDebugApplicationNodeEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationNodeEvents_Impl, const OFFSET: isize>() -> IDebugApplicationNodeEvents_Vtbl {
         unsafe extern "system" fn onAddChild<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationNodeEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prddpchild: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3790,6 +3916,8 @@ pub trait IDebugApplicationThread_Impl: Sized + IRemoteDebugApplicationThread_Im
     fn SetDescription(&self, pstrdescription: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetStateString(&self, pstrstate: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplicationThread {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugApplicationThread_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThread_Impl, const OFFSET: isize>() -> IDebugApplicationThread_Vtbl {
@@ -3838,6 +3966,8 @@ pub trait IDebugApplicationThread11032_Impl: Sized {
     fn IsThreadCallable(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
     fn AsynchronousCallIntoThread(&self, pptc: &::core::option::Option<IDebugThreadCall32>, dwparam1: usize, dwparam2: usize, dwparam3: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplicationThread11032 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugApplicationThread11032_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThread11032_Impl, const OFFSET: isize>() -> IDebugApplicationThread11032_Vtbl {
@@ -3899,6 +4029,8 @@ pub trait IDebugApplicationThread11064_Impl: Sized {
     fn AsynchronousCallIntoThread(&self, pptc: &::core::option::Option<IDebugThreadCall64>, dwparam1: usize, dwparam2: usize, dwparam3: usize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplicationThread11064 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugApplicationThread11064_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThread11064_Impl, const OFFSET: isize>() -> IDebugApplicationThread11064_Vtbl {
         unsafe extern "system" fn GetActiveThreadRequestCount<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThread11064_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puithreadrequests: *mut u32) -> ::windows::core::HRESULT {
@@ -3956,6 +4088,8 @@ pub trait IDebugApplicationThread64_Impl: Sized + IRemoteDebugApplicationThread_
     fn SynchronousCallIntoThread64(&self, pstcb: &::core::option::Option<IDebugThreadCall64>, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugApplicationThread64 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugApplicationThread64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThread64_Impl, const OFFSET: isize>() -> IDebugApplicationThread64_Vtbl {
         unsafe extern "system" fn SynchronousCallIntoThread64<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThread64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstcb: ::windows::core::RawPtr, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::HRESULT {
@@ -3978,6 +4112,7 @@ pub trait IDebugApplicationThreadEvents110_Impl: Sized {
     fn OnThreadRequestComplete(&self) -> ::windows::core::Result<()>;
     fn OnBeginThreadRequest(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugApplicationThreadEvents110 {}
 impl IDebugApplicationThreadEvents110_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThreadEvents110_Impl, const OFFSET: isize>() -> IDebugApplicationThreadEvents110_Vtbl {
         unsafe extern "system" fn OnSuspendForBreakPoint<Identity: ::windows::core::IUnknownImpl, Impl: IDebugApplicationThreadEvents110_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4019,6 +4154,7 @@ pub trait IDebugAsyncOperation_Impl: Sized {
     fn QueryIsComplete(&self) -> ::windows::core::Result<()>;
     fn GetResult(&self, phrresult: *mut ::windows::core::HRESULT, ppunkresult: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugAsyncOperation {}
 impl IDebugAsyncOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAsyncOperation_Impl, const OFFSET: isize>() -> IDebugAsyncOperation_Vtbl {
         unsafe extern "system" fn GetSyncDebugOperation<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAsyncOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsdo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4068,6 +4204,7 @@ impl IDebugAsyncOperation_Vtbl {
 pub trait IDebugAsyncOperationCallBack_Impl: Sized {
     fn onComplete(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugAsyncOperationCallBack {}
 impl IDebugAsyncOperationCallBack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAsyncOperationCallBack_Impl, const OFFSET: isize>() -> IDebugAsyncOperationCallBack_Vtbl {
         unsafe extern "system" fn onComplete<Identity: ::windows::core::IUnknownImpl, Impl: IDebugAsyncOperationCallBack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4104,6 +4241,7 @@ pub trait IDebugBreakpoint_Impl: Sized {
     fn SetOffsetExpression(&self, expression: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetParameters(&self) -> ::windows::core::Result<DEBUG_BREAKPOINT_PARAMETERS>;
 }
+impl ::windows::core::RuntimeName for IDebugBreakpoint {}
 impl IDebugBreakpoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugBreakpoint_Impl, const OFFSET: isize>() -> IDebugBreakpoint_Vtbl {
         unsafe extern "system" fn GetId<Identity: ::windows::core::IUnknownImpl, Impl: IDebugBreakpoint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -4315,6 +4453,7 @@ pub trait IDebugBreakpoint2_Impl: Sized {
     fn GetOffsetExpressionWide(&self, buffer: ::windows::core::PWSTR, buffersize: u32, expressionsize: *mut u32) -> ::windows::core::Result<()>;
     fn SetOffsetExpressionWide(&self, expression: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugBreakpoint2 {}
 impl IDebugBreakpoint2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugBreakpoint2_Impl, const OFFSET: isize>() -> IDebugBreakpoint2_Vtbl {
         unsafe extern "system" fn GetId<Identity: ::windows::core::IUnknownImpl, Impl: IDebugBreakpoint2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -4551,6 +4690,7 @@ pub trait IDebugBreakpoint3_Impl: Sized {
     fn SetOffsetExpressionWide(&self, expression: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetGuid(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IDebugBreakpoint3 {}
 impl IDebugBreakpoint3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugBreakpoint3_Impl, const OFFSET: isize>() -> IDebugBreakpoint3_Vtbl {
         unsafe extern "system" fn GetId<Identity: ::windows::core::IUnknownImpl, Impl: IDebugBreakpoint3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -4818,6 +4958,7 @@ pub trait IDebugClient_Impl: Sized {
     fn SetEventCallbacks(&self, callbacks: &::core::option::Option<IDebugEventCallbacks>) -> ::windows::core::Result<()>;
     fn FlushCallbacks(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient {}
 impl IDebugClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient_Impl, const OFFSET: isize>() -> IDebugClient_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -5219,6 +5360,7 @@ pub trait IDebugClient2_Impl: Sized {
     fn DetachCurrentProcess(&self) -> ::windows::core::Result<()>;
     fn AbandonCurrentProcess(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient2 {}
 impl IDebugClient2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient2_Impl, const OFFSET: isize>() -> IDebugClient2_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -5672,6 +5814,7 @@ pub trait IDebugClient3_Impl: Sized {
     fn CreateProcessWide(&self, server: u64, commandline: &::windows::core::PCWSTR, createflags: u32) -> ::windows::core::Result<()>;
     fn CreateProcessAndAttachWide(&self, server: u64, commandline: &::windows::core::PCWSTR, createflags: u32, processid: u32, attachflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient3 {}
 impl IDebugClient3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient3_Impl, const OFFSET: isize>() -> IDebugClient3_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -6161,6 +6304,7 @@ pub trait IDebugClient4_Impl: Sized {
     fn GetDumpFile(&self, index: u32, buffer: ::windows::core::PSTR, buffersize: u32, namesize: *mut u32, handle: *mut u64, r#type: *mut u32) -> ::windows::core::Result<()>;
     fn GetDumpFileWide(&self, index: u32, buffer: ::windows::core::PWSTR, buffersize: u32, namesize: *mut u32, handle: *mut u64, r#type: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient4 {}
 impl IDebugClient4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient4_Impl, const OFFSET: isize>() -> IDebugClient4_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -6721,6 +6865,7 @@ pub trait IDebugClient5_Impl: Sized {
     fn GetQuitLockStringWide(&self, buffer: ::windows::core::PWSTR, buffersize: u32, stringsize: *mut u32) -> ::windows::core::Result<()>;
     fn SetQuitLockStringWide(&self, string: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient5 {}
 impl IDebugClient5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient5_Impl, const OFFSET: isize>() -> IDebugClient5_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -7504,6 +7649,7 @@ pub trait IDebugClient6_Impl: Sized {
     fn SetQuitLockStringWide(&self, string: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetEventContextCallbacks(&self, callbacks: &::core::option::Option<IDebugEventContextCallbacks>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient6 {}
 impl IDebugClient6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient6_Impl, const OFFSET: isize>() -> IDebugClient6_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -8294,6 +8440,7 @@ pub trait IDebugClient7_Impl: Sized {
     fn SetEventContextCallbacks(&self, callbacks: &::core::option::Option<IDebugEventContextCallbacks>) -> ::windows::core::Result<()>;
     fn SetClientContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient7 {}
 impl IDebugClient7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient7_Impl, const OFFSET: isize>() -> IDebugClient7_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -9091,6 +9238,7 @@ pub trait IDebugClient8_Impl: Sized {
     fn SetClientContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn OpenDumpFileWide2(&self, filename: &::windows::core::PCWSTR, filehandle: u64, alternatearch: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugClient8 {}
 impl IDebugClient8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient8_Impl, const OFFSET: isize>() -> IDebugClient8_Vtbl {
         unsafe extern "system" fn AttachKernel<Identity: ::windows::core::IUnknownImpl, Impl: IDebugClient8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -9801,6 +9949,7 @@ pub trait IDebugCodeContext_Impl: Sized {
     fn GetDocumentContext(&self) -> ::windows::core::Result<IDebugDocumentContext>;
     fn SetBreakPoint(&self, bps: BREAKPOINT_STATE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugCodeContext {}
 impl IDebugCodeContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugCodeContext_Impl, const OFFSET: isize>() -> IDebugCodeContext_Vtbl {
         unsafe extern "system" fn GetDocumentContext<Identity: ::windows::core::IUnknownImpl, Impl: IDebugCodeContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsc: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9924,6 +10073,8 @@ pub trait IDebugControl_Impl: Sized {
     fn WaitForEvent(&self, flags: u32, timeout: u32) -> ::windows::core::Result<()>;
     fn GetLastEventInformation(&self, r#type: *mut u32, processid: *mut u32, threadid: *mut u32, extrainformation: *mut ::core::ffi::c_void, extrainformationsize: u32, extrainformationused: *mut u32, description: ::windows::core::PSTR, descriptionsize: u32, descriptionused: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl_Impl, const OFFSET: isize>() -> IDebugControl_Vtbl {
@@ -10748,6 +10899,8 @@ pub trait IDebugControl2_Impl: Sized {
     fn RemoveTextReplacements(&self) -> ::windows::core::Result<()>;
     fn OutputTextReplacements(&self, outputcontrol: u32, flags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl2_Impl, const OFFSET: isize>() -> IDebugControl2_Vtbl {
@@ -11657,6 +11810,8 @@ pub trait IDebugControl3_Impl: Sized {
     fn GetCurrentEventIndex(&self) -> ::windows::core::Result<u32>;
     fn SetNextEventIndex(&self, relation: u32, value: u32) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl3_Impl, const OFFSET: isize>() -> IDebugControl3_Vtbl {
@@ -12739,6 +12894,8 @@ pub trait IDebugControl4_Impl: Sized {
     fn GetManagedStatusWide(&self, flags: *mut u32, whichstring: u32, string: ::windows::core::PWSTR, stringsize: u32, stringneeded: *mut u32) -> ::windows::core::Result<()>;
     fn ResetManagedStatus(&self, flags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl4_Impl, const OFFSET: isize>() -> IDebugControl4_Vtbl {
@@ -14186,6 +14343,8 @@ pub trait IDebugControl5_Impl: Sized {
     fn OutputContextStackTraceEx(&self, outputcontrol: u32, frames: *const DEBUG_STACK_FRAME_EX, framessize: u32, framecontexts: *const ::core::ffi::c_void, framecontextssize: u32, framecontextsentrysize: u32, flags: u32) -> ::windows::core::Result<()>;
     fn GetBreakpointByGuid(&self, guid: *const ::windows::core::GUID) -> ::windows::core::Result<IDebugBreakpoint3>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl5_Impl, const OFFSET: isize>() -> IDebugControl5_Vtbl {
@@ -15671,6 +15830,8 @@ pub trait IDebugControl6_Impl: Sized {
     fn GetExecutionStatusEx(&self) -> ::windows::core::Result<u32>;
     fn GetSynchronizationStatus(&self, sendsattempted: *mut u32, secondssincelastresponse: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl6 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl6_Impl, const OFFSET: isize>() -> IDebugControl6_Vtbl {
@@ -17176,6 +17337,8 @@ pub trait IDebugControl7_Impl: Sized {
     fn GetDebuggeeType2(&self, flags: u32, class: *mut u32, qualifier: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
+impl ::windows::core::RuntimeName for IDebugControl7 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 impl IDebugControl7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl7_Impl, const OFFSET: isize>() -> IDebugControl7_Vtbl {
         unsafe extern "system" fn GetInterrupt<Identity: ::windows::core::IUnknownImpl, Impl: IDebugControl7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -18511,6 +18674,7 @@ impl IDebugControl7_Vtbl {
 pub trait IDebugCookie_Impl: Sized {
     fn SetDebugCookie(&self, dwdebugappcookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugCookie {}
 impl IDebugCookie_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugCookie_Impl, const OFFSET: isize>() -> IDebugCookie_Vtbl {
         unsafe extern "system" fn SetDebugCookie<Identity: ::windows::core::IUnknownImpl, Impl: IDebugCookie_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwdebugappcookie: u32) -> ::windows::core::HRESULT {
@@ -18546,6 +18710,7 @@ pub trait IDebugDataSpaces_Impl: Sized {
     fn ReadDebuggerData(&self, index: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, datasize: *mut u32) -> ::windows::core::Result<()>;
     fn ReadProcessorSystemData(&self, processor: u32, index: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, datasize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugDataSpaces {}
 impl IDebugDataSpaces_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDataSpaces_Impl, const OFFSET: isize>() -> IDebugDataSpaces_Vtbl {
         unsafe extern "system" fn ReadVirtual<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDataSpaces_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::HRESULT {
@@ -18753,6 +18918,8 @@ pub trait IDebugDataSpaces2_Impl: Sized {
     fn FillPhysical(&self, start: u64, size: u32, pattern: *const ::core::ffi::c_void, patternsize: u32) -> ::windows::core::Result<u32>;
     fn QueryVirtual(&self, offset: u64) -> ::windows::core::Result<super::super::Memory::MEMORY_BASIC_INFORMATION64>;
 }
+#[cfg(feature = "Win32_System_Memory")]
+impl ::windows::core::RuntimeName for IDebugDataSpaces2 {}
 #[cfg(feature = "Win32_System_Memory")]
 impl IDebugDataSpaces2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDataSpaces2_Impl, const OFFSET: isize>() -> IDebugDataSpaces2_Vtbl {
@@ -19026,6 +19193,8 @@ pub trait IDebugDataSpaces3_Impl: Sized {
     fn GetNextTagged(&self, handle: u64, tag: *mut ::windows::core::GUID, size: *mut u32) -> ::windows::core::Result<()>;
     fn EndEnumTagged(&self, handle: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Memory")]
+impl ::windows::core::RuntimeName for IDebugDataSpaces3 {}
 #[cfg(feature = "Win32_System_Memory")]
 impl IDebugDataSpaces3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDataSpaces3_Impl, const OFFSET: isize>() -> IDebugDataSpaces3_Vtbl {
@@ -19351,6 +19520,8 @@ pub trait IDebugDataSpaces4_Impl: Sized {
     fn ReadPhysical2(&self, offset: u64, flags: u32, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::Result<()>;
     fn WritePhysical2(&self, offset: u64, flags: u32, buffer: *const ::core::ffi::c_void, buffersize: u32) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_System_Memory")]
+impl ::windows::core::RuntimeName for IDebugDataSpaces4 {}
 #[cfg(feature = "Win32_System_Memory")]
 impl IDebugDataSpaces4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDataSpaces4_Impl, const OFFSET: isize>() -> IDebugDataSpaces4_Vtbl {
@@ -19713,6 +19884,8 @@ impl IDebugDataSpaces4_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugDocument_Impl: Sized + IDebugDocumentInfo_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocument {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocument_Impl, const OFFSET: isize>() -> IDebugDocument_Vtbl {
         Self { base__: IDebugDocumentInfo_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -19725,6 +19898,7 @@ pub trait IDebugDocumentContext_Impl: Sized {
     fn GetDocument(&self) -> ::windows::core::Result<IDebugDocument>;
     fn EnumCodeContexts(&self) -> ::windows::core::Result<IEnumDebugCodeContexts>;
 }
+impl ::windows::core::RuntimeName for IDebugDocumentContext {}
 impl IDebugDocumentContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentContext_Impl, const OFFSET: isize>() -> IDebugDocumentContext_Vtbl {
         unsafe extern "system" fn GetDocument<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsd: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19780,6 +19954,8 @@ pub trait IDebugDocumentHelper32_Impl: Sized {
     fn BringDocumentToTop(&self) -> ::windows::core::Result<()>;
     fn BringDocumentContextToTop(&self, pddc: &::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentHelper32 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentHelper32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentHelper32_Impl, const OFFSET: isize>() -> IDebugDocumentHelper32_Vtbl {
@@ -19939,6 +20115,8 @@ pub trait IDebugDocumentHelper64_Impl: Sized {
     fn BringDocumentContextToTop(&self, pddc: &::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentHelper64 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentHelper64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentHelper64_Impl, const OFFSET: isize>() -> IDebugDocumentHelper64_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentHelper64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pda: ::windows::core::RawPtr, pszshortname: ::windows::core::PCWSTR, pszlongname: ::windows::core::PCWSTR, docattr: u32) -> ::windows::core::HRESULT {
@@ -20085,6 +20263,8 @@ pub trait IDebugDocumentHost_Impl: Sized {
     fn NotifyChanged(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentHost {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentHost_Impl, const OFFSET: isize>() -> IDebugDocumentHost_Vtbl {
         unsafe extern "system" fn GetDeferredText<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwtextstartcookie: u32, pchartext: ::windows::core::PWSTR, pstatextattr: *mut u16, pcnumchars: *mut u32, cmaxchars: u32) -> ::windows::core::HRESULT {
@@ -20149,6 +20329,8 @@ pub trait IDebugDocumentInfo_Impl: Sized {
     fn GetDocumentClassId(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentInfo_Impl, const OFFSET: isize>() -> IDebugDocumentInfo_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dnt: DOCUMENTNAMETYPE, pbstrname: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -20188,6 +20370,8 @@ pub trait IDebugDocumentProvider_Impl: Sized + IDebugDocumentInfo_Impl {
     fn GetDocument(&self) -> ::windows::core::Result<IDebugDocument>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentProvider_Impl, const OFFSET: isize>() -> IDebugDocumentProvider_Vtbl {
         unsafe extern "system" fn GetDocument<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppssd: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -20217,6 +20401,8 @@ pub trait IDebugDocumentText_Impl: Sized + IDebugDocumentInfo_Impl + IDebugDocum
     fn GetPositionOfContext(&self, psc: &::core::option::Option<IDebugDocumentContext>, pccharacterposition: *mut u32, cnumchars: *mut u32) -> ::windows::core::Result<()>;
     fn GetContextOfPosition(&self, ccharacterposition: u32, cnumchars: u32) -> ::windows::core::Result<IDebugDocumentContext>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentText {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentText_Impl, const OFFSET: isize>() -> IDebugDocumentText_Vtbl {
@@ -20295,6 +20481,8 @@ pub trait IDebugDocumentTextAuthor_Impl: Sized + IDebugDocumentInfo_Impl + IDebu
     fn ReplaceText(&self, ccharacterposition: u32, cnumtoreplace: u32, pchartext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentTextAuthor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentTextAuthor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentTextAuthor_Impl, const OFFSET: isize>() -> IDebugDocumentTextAuthor_Vtbl {
         unsafe extern "system" fn InsertText<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentTextAuthor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ccharacterposition: u32, cnumtoinsert: u32, pchartext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -20331,6 +20519,7 @@ pub trait IDebugDocumentTextEvents_Impl: Sized {
     fn onUpdateTextAttributes(&self, ccharacterposition: u32, cnumtoupdate: u32) -> ::windows::core::Result<()>;
     fn onUpdateDocumentAttributes(&self, textdocattr: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugDocumentTextEvents {}
 impl IDebugDocumentTextEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentTextEvents_Impl, const OFFSET: isize>() -> IDebugDocumentTextEvents_Vtbl {
         unsafe extern "system" fn onDestroy<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentTextEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -20384,6 +20573,8 @@ pub trait IDebugDocumentTextExternalAuthor_Impl: Sized {
     fn NotifyChanged(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugDocumentTextExternalAuthor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugDocumentTextExternalAuthor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentTextExternalAuthor_Impl, const OFFSET: isize>() -> IDebugDocumentTextExternalAuthor_Vtbl {
         unsafe extern "system" fn GetPathName<Identity: ::windows::core::IUnknownImpl, Impl: IDebugDocumentTextExternalAuthor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrlongname: *mut super::super::super::Foundation::BSTR, pfisoriginalfile: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -20435,6 +20626,8 @@ pub trait IDebugEventCallbacks_Impl: Sized {
     fn ChangeEngineState(&self, flags: u32, argument: u64) -> ::windows::core::Result<()>;
     fn ChangeSymbolState(&self, flags: u32, argument: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugEventCallbacks {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugEventCallbacks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugEventCallbacks_Impl, const OFFSET: isize>() -> IDebugEventCallbacks_Vtbl {
@@ -20556,6 +20749,8 @@ pub trait IDebugEventCallbacksWide_Impl: Sized {
     fn ChangeSymbolState(&self, flags: u32, argument: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugEventCallbacksWide {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugEventCallbacksWide_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugEventCallbacksWide_Impl, const OFFSET: isize>() -> IDebugEventCallbacksWide_Vtbl {
         unsafe extern "system" fn GetInterestMask<Identity: ::windows::core::IUnknownImpl, Impl: IDebugEventCallbacksWide_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mask: *mut u32) -> ::windows::core::HRESULT {
@@ -20675,6 +20870,8 @@ pub trait IDebugEventContextCallbacks_Impl: Sized {
     fn ChangeEngineState(&self, flags: u32, argument: u64, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn ChangeSymbolState(&self, flags: u32, argument: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugEventContextCallbacks {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugEventContextCallbacks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugEventContextCallbacks_Impl, const OFFSET: isize>() -> IDebugEventContextCallbacks_Vtbl {
@@ -20801,6 +20998,8 @@ pub trait IDebugExpression_Impl: Sized {
     fn GetResultAsDebugProperty(&self, phrresult: *mut ::windows::core::HRESULT, ppdp: *mut ::core::option::Option<IDebugProperty>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugExpression {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugExpression_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugExpression_Impl, const OFFSET: isize>() -> IDebugExpression_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IDebugExpression_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdecb: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -20844,6 +21043,7 @@ impl IDebugExpression_Vtbl {
 pub trait IDebugExpressionCallBack_Impl: Sized {
     fn onComplete(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugExpressionCallBack {}
 impl IDebugExpressionCallBack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugExpressionCallBack_Impl, const OFFSET: isize>() -> IDebugExpressionCallBack_Vtbl {
         unsafe extern "system" fn onComplete<Identity: ::windows::core::IUnknownImpl, Impl: IDebugExpressionCallBack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -20862,6 +21062,8 @@ pub trait IDebugExpressionContext_Impl: Sized {
     fn ParseLanguageText(&self, pstrcode: &::windows::core::PCWSTR, nradix: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<IDebugExpression>;
     fn GetLanguageInfo(&self, pbstrlanguagename: *mut super::super::super::Foundation::BSTR, planguageid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugExpressionContext {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugExpressionContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugExpressionContext_Impl, const OFFSET: isize>() -> IDebugExpressionContext_Vtbl {
@@ -20896,6 +21098,8 @@ pub trait IDebugExtendedProperty_Impl: Sized + IDebugProperty_Impl {
     fn GetExtendedPropertyInfo(&self, dwfieldspec: u32, nradix: u32) -> ::windows::core::Result<ExtendedDebugPropertyInfo>;
     fn EnumExtendedMembers(&self, dwfieldspec: u32, nradix: u32) -> ::windows::core::Result<IEnumDebugExtendedPropertyInfo>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugExtendedProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IDebugExtendedProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugExtendedProperty_Impl, const OFFSET: isize>() -> IDebugExtendedProperty_Vtbl {
@@ -20937,6 +21141,8 @@ pub trait IDebugFormatter_Impl: Sized {
     fn GetVariantForString(&self, pwstrvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Com::VARIANT>;
     fn GetStringForVarType(&self, vt: u16, ptdescarraytype: *const super::super::Com::TYPEDESC) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugFormatter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDebugFormatter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugFormatter_Impl, const OFFSET: isize>() -> IDebugFormatter_Vtbl {
@@ -20991,6 +21197,8 @@ pub trait IDebugHelper_Impl: Sized {
     fn CreateSimpleConnectionPoint(&self, pdisp: &::core::option::Option<super::super::Com::IDispatch>) -> ::windows::core::Result<ISimpleConnectionPoint>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugHelper {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDebugHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHelper_Impl, const OFFSET: isize>() -> IDebugHelper_Vtbl {
         unsafe extern "system" fn CreatePropertyBrowser<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvar: *const super::super::Com::VARIANT, bstrname: ::windows::core::PCWSTR, pdat: ::windows::core::RawPtr, ppdob: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21042,6 +21250,7 @@ pub trait IDebugHost_Impl: Sized {
     fn GetCurrentContext(&self) -> ::windows::core::Result<IDebugHostContext>;
     fn GetDefaultMetadata(&self) -> ::windows::core::Result<IKeyStore>;
 }
+impl ::windows::core::RuntimeName for IDebugHost {}
 impl IDebugHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHost_Impl, const OFFSET: isize>() -> IDebugHost_Vtbl {
         unsafe extern "system" fn GetHostDefinedInterface<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hostunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -21093,6 +21302,8 @@ pub trait IDebugHostBaseClass_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetOffset(&self) -> ::windows::core::Result<u64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostBaseClass {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugHostBaseClass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostBaseClass_Impl, const OFFSET: isize>() -> IDebugHostBaseClass_Vtbl {
         unsafe extern "system" fn GetOffset<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostBaseClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, offset: *mut u64) -> ::windows::core::HRESULT {
@@ -21117,6 +21328,8 @@ pub trait IDebugHostConstant_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetValue(&self) -> ::windows::core::Result<super::super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugHostConstant {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDebugHostConstant_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostConstant_Impl, const OFFSET: isize>() -> IDebugHostConstant_Vtbl {
         unsafe extern "system" fn GetValue<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostConstant_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut super::super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -21139,6 +21352,7 @@ impl IDebugHostConstant_Vtbl {
 pub trait IDebugHostContext_Impl: Sized {
     fn IsEqualTo(&self, pcontext: &::core::option::Option<IDebugHostContext>) -> ::windows::core::Result<bool>;
 }
+impl ::windows::core::RuntimeName for IDebugHostContext {}
 impl IDebugHostContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostContext_Impl, const OFFSET: isize>() -> IDebugHostContext_Vtbl {
         unsafe extern "system" fn IsEqualTo<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontext: ::windows::core::RawPtr, pisequal: *mut bool) -> ::windows::core::HRESULT {
@@ -21164,6 +21378,8 @@ pub trait IDebugHostData_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLocation(&self) -> ::windows::core::Result<Location>;
     fn GetValue(&self) -> ::windows::core::Result<super::super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugHostData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDebugHostData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostData_Impl, const OFFSET: isize>() -> IDebugHostData_Vtbl {
@@ -21214,6 +21430,7 @@ impl IDebugHostData_Vtbl {
 pub trait IDebugHostErrorSink_Impl: Sized {
     fn ReportError(&self, errclass: ErrorClass, hrerror: ::windows::core::HRESULT, message: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugHostErrorSink {}
 impl IDebugHostErrorSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostErrorSink_Impl, const OFFSET: isize>() -> IDebugHostErrorSink_Vtbl {
         unsafe extern "system" fn ReportError<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostErrorSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, errclass: ErrorClass, hrerror: ::windows::core::HRESULT, message: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -21231,6 +21448,7 @@ pub trait IDebugHostEvaluator_Impl: Sized {
     fn EvaluateExpression(&self, context: &::core::option::Option<IDebugHostContext>, expression: &::windows::core::PCWSTR, bindingcontext: &::core::option::Option<IModelObject>, result: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn EvaluateExtendedExpression(&self, context: &::core::option::Option<IDebugHostContext>, expression: &::windows::core::PCWSTR, bindingcontext: &::core::option::Option<IModelObject>, result: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugHostEvaluator {}
 impl IDebugHostEvaluator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostEvaluator_Impl, const OFFSET: isize>() -> IDebugHostEvaluator_Vtbl {
         unsafe extern "system" fn EvaluateExpression<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostEvaluator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr, expression: ::windows::core::PCWSTR, bindingcontext: ::windows::core::RawPtr, result: *mut ::windows::core::RawPtr, metadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21256,6 +21474,7 @@ impl IDebugHostEvaluator_Vtbl {
 pub trait IDebugHostEvaluator2_Impl: Sized + IDebugHostEvaluator_Impl {
     fn AssignTo(&self, assignmentreference: &::core::option::Option<IModelObject>, assignmentvalue: &::core::option::Option<IModelObject>, assignmentresult: *mut ::core::option::Option<IModelObject>, assignmentmetadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugHostEvaluator2 {}
 impl IDebugHostEvaluator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostEvaluator2_Impl, const OFFSET: isize>() -> IDebugHostEvaluator2_Vtbl {
         unsafe extern "system" fn AssignTo<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostEvaluator2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, assignmentreference: ::windows::core::RawPtr, assignmentvalue: ::windows::core::RawPtr, assignmentresult: *mut ::windows::core::RawPtr, assignmentmetadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21273,6 +21492,7 @@ pub trait IDebugHostExtensibility_Impl: Sized {
     fn CreateFunctionAlias(&self, aliasname: &::windows::core::PCWSTR, functionobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
     fn DestroyFunctionAlias(&self, aliasname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugHostExtensibility {}
 impl IDebugHostExtensibility_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostExtensibility_Impl, const OFFSET: isize>() -> IDebugHostExtensibility_Vtbl {
         unsafe extern "system" fn CreateFunctionAlias<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostExtensibility_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, aliasname: ::windows::core::PCWSTR, functionobject: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21302,6 +21522,8 @@ pub trait IDebugHostField_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLocation(&self) -> ::windows::core::Result<Location>;
     fn GetValue(&self) -> ::windows::core::Result<super::super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugHostField {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDebugHostField_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostField_Impl, const OFFSET: isize>() -> IDebugHostField_Vtbl {
@@ -21370,6 +21592,8 @@ pub trait IDebugHostMemory_Impl: Sized {
     fn GetDisplayStringForLocation(&self, context: &::core::option::Option<IDebugHostContext>, location: &Location, verbose: u8) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostMemory {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugHostMemory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostMemory_Impl, const OFFSET: isize>() -> IDebugHostMemory_Vtbl {
         unsafe extern "system" fn ReadBytes<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostMemory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr, location: Location, buffer: *mut ::core::ffi::c_void, buffersize: u64, bytesread: *mut u64) -> ::windows::core::HRESULT {
@@ -21427,6 +21651,8 @@ pub trait IDebugHostMemory2_Impl: Sized + IDebugHostMemory_Impl {
     fn LinearizeLocation(&self, context: &::core::option::Option<IDebugHostContext>, location: &Location) -> ::windows::core::Result<Location>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostMemory2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugHostMemory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostMemory2_Impl, const OFFSET: isize>() -> IDebugHostMemory2_Vtbl {
         unsafe extern "system" fn LinearizeLocation<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostMemory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr, location: Location, plinearizedlocation: *mut Location) -> ::windows::core::HRESULT {
@@ -21455,6 +21681,8 @@ pub trait IDebugHostModule_Impl: Sized + IDebugHostSymbol_Impl {
     fn FindSymbolByRVA(&self, rva: u64) -> ::windows::core::Result<IDebugHostSymbol>;
     fn FindSymbolByName(&self, symbolname: &::windows::core::PCWSTR) -> ::windows::core::Result<IDebugHostSymbol>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostModule {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugHostModule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostModule_Impl, const OFFSET: isize>() -> IDebugHostModule_Vtbl {
@@ -21537,6 +21765,8 @@ pub trait IDebugHostModule2_Impl: Sized + IDebugHostSymbol_Impl + IDebugHostModu
     fn FindContainingSymbolByRVA(&self, rva: u64, symbol: *mut ::core::option::Option<IDebugHostSymbol>, offset: *mut u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostModule2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugHostModule2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostModule2_Impl, const OFFSET: isize>() -> IDebugHostModule2_Vtbl {
         unsafe extern "system" fn FindContainingSymbolByRVA<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostModule2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rva: u64, symbol: *mut ::windows::core::RawPtr, offset: *mut u64) -> ::windows::core::HRESULT {
@@ -21553,6 +21783,7 @@ impl IDebugHostModule2_Vtbl {
 pub trait IDebugHostModuleSignature_Impl: Sized {
     fn IsMatch(&self, pmodule: &::core::option::Option<IDebugHostModule>) -> ::windows::core::Result<bool>;
 }
+impl ::windows::core::RuntimeName for IDebugHostModuleSignature {}
 impl IDebugHostModuleSignature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostModuleSignature_Impl, const OFFSET: isize>() -> IDebugHostModuleSignature_Vtbl {
         unsafe extern "system" fn IsMatch<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostModuleSignature_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmodule: ::windows::core::RawPtr, ismatch: *mut bool) -> ::windows::core::HRESULT {
@@ -21577,6 +21808,8 @@ pub trait IDebugHostPublic_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLocationKind(&self) -> ::windows::core::Result<LocationKind>;
     fn GetLocation(&self) -> ::windows::core::Result<Location>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostPublic {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugHostPublic_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostPublic_Impl, const OFFSET: isize>() -> IDebugHostPublic_Vtbl {
@@ -21615,6 +21848,7 @@ impl IDebugHostPublic_Vtbl {
 pub trait IDebugHostScriptHost_Impl: Sized {
     fn CreateContext(&self, script: &::core::option::Option<IDataModelScript>) -> ::windows::core::Result<IDataModelScriptHostContext>;
 }
+impl ::windows::core::RuntimeName for IDebugHostScriptHost {}
 impl IDebugHostScriptHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostScriptHost_Impl, const OFFSET: isize>() -> IDebugHostScriptHost_Vtbl {
         unsafe extern "system" fn CreateContext<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostScriptHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, script: ::windows::core::RawPtr, scriptcontext: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21637,6 +21871,7 @@ impl IDebugHostScriptHost_Vtbl {
 pub trait IDebugHostStatus_Impl: Sized {
     fn PollUserInterrupt(&self) -> ::windows::core::Result<bool>;
 }
+impl ::windows::core::RuntimeName for IDebugHostStatus {}
 impl IDebugHostStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostStatus_Impl, const OFFSET: isize>() -> IDebugHostStatus_Vtbl {
         unsafe extern "system" fn PollUserInterrupt<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interruptrequested: *mut bool) -> ::windows::core::HRESULT {
@@ -21666,6 +21901,8 @@ pub trait IDebugHostSymbol_Impl: Sized {
     fn GetContainingModule(&self) -> ::windows::core::Result<IDebugHostModule>;
     fn CompareAgainst(&self, pcomparisonsymbol: &::core::option::Option<IDebugHostSymbol>, comparisonflags: u32) -> ::windows::core::Result<bool>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostSymbol {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugHostSymbol_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbol_Impl, const OFFSET: isize>() -> IDebugHostSymbol_Vtbl {
@@ -21766,6 +22003,8 @@ pub trait IDebugHostSymbol2_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLanguage(&self) -> ::windows::core::Result<LanguageKind>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostSymbol2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugHostSymbol2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbol2_Impl, const OFFSET: isize>() -> IDebugHostSymbol2_Vtbl {
         unsafe extern "system" fn GetLanguage<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbol2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pkind: *mut LanguageKind) -> ::windows::core::HRESULT {
@@ -21789,6 +22028,7 @@ pub trait IDebugHostSymbolEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDebugHostSymbol>;
 }
+impl ::windows::core::RuntimeName for IDebugHostSymbolEnumerator {}
 impl IDebugHostSymbolEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbolEnumerator_Impl, const OFFSET: isize>() -> IDebugHostSymbolEnumerator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbolEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -21826,6 +22066,7 @@ pub trait IDebugHostSymbols_Impl: Sized {
     fn FindModuleByLocation(&self, context: &::core::option::Option<IDebugHostContext>, modulelocation: &Location) -> ::windows::core::Result<IDebugHostModule>;
     fn GetMostDerivedObject(&self, pcontext: &::core::option::Option<IDebugHostContext>, location: &Location, objecttype: &::core::option::Option<IDebugHostType>, derivedlocation: *mut Location, derivedtype: *mut ::core::option::Option<IDebugHostType>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugHostSymbols {}
 impl IDebugHostSymbols_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbols_Impl, const OFFSET: isize>() -> IDebugHostSymbols_Vtbl {
         unsafe extern "system" fn CreateModuleSignature<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostSymbols_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszmodulename: ::windows::core::PCWSTR, pwszminversion: ::windows::core::PCWSTR, pwszmaxversion: ::windows::core::PCWSTR, ppmodulesignature: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21936,6 +22177,8 @@ pub trait IDebugHostType_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetGenericArgumentCount(&self) -> ::windows::core::Result<u64>;
     fn GetGenericArgumentAt(&self, i: u64) -> ::windows::core::Result<IDebugHostSymbol>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostType {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugHostType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostType_Impl, const OFFSET: isize>() -> IDebugHostType_Vtbl {
@@ -22166,6 +22409,8 @@ pub trait IDebugHostType2_Impl: Sized + IDebugHostSymbol_Impl + IDebugHostType_I
     fn GetFunctionInstancePointerType(&self) -> ::windows::core::Result<IDebugHostType2>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugHostType2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugHostType2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostType2_Impl, const OFFSET: isize>() -> IDebugHostType2_Vtbl {
         unsafe extern "system" fn IsTypedef<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostType2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, istypedef: *mut bool) -> ::windows::core::HRESULT {
@@ -22241,6 +22486,7 @@ pub trait IDebugHostTypeSignature_Impl: Sized {
     fn IsMatch(&self, r#type: &::core::option::Option<IDebugHostType>, ismatch: *mut bool, wildcardmatches: *mut ::core::option::Option<IDebugHostSymbolEnumerator>) -> ::windows::core::Result<()>;
     fn CompareAgainst(&self, typesignature: &::core::option::Option<IDebugHostTypeSignature>) -> ::windows::core::Result<SignatureComparison>;
 }
+impl ::windows::core::RuntimeName for IDebugHostTypeSignature {}
 impl IDebugHostTypeSignature_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostTypeSignature_Impl, const OFFSET: isize>() -> IDebugHostTypeSignature_Vtbl {
         unsafe extern "system" fn GetHashCode<Identity: ::windows::core::IUnknownImpl, Impl: IDebugHostTypeSignature_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hashcode: *mut u32) -> ::windows::core::HRESULT {
@@ -22285,6 +22531,7 @@ pub trait IDebugInputCallbacks_Impl: Sized {
     fn StartInput(&self, buffersize: u32) -> ::windows::core::Result<()>;
     fn EndInput(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugInputCallbacks {}
 impl IDebugInputCallbacks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugInputCallbacks_Impl, const OFFSET: isize>() -> IDebugInputCallbacks_Vtbl {
         unsafe extern "system" fn StartInput<Identity: ::windows::core::IUnknownImpl, Impl: IDebugInputCallbacks_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffersize: u32) -> ::windows::core::HRESULT {
@@ -22310,6 +22557,7 @@ impl IDebugInputCallbacks_Vtbl {
 pub trait IDebugOutputCallbacks_Impl: Sized {
     fn Output(&self, mask: u32, text: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugOutputCallbacks {}
 impl IDebugOutputCallbacks_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputCallbacks_Impl, const OFFSET: isize>() -> IDebugOutputCallbacks_Vtbl {
         unsafe extern "system" fn Output<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputCallbacks_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mask: u32, text: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -22328,6 +22576,7 @@ pub trait IDebugOutputCallbacks2_Impl: Sized {
     fn GetInterestMask(&self) -> ::windows::core::Result<u32>;
     fn Output2(&self, which: u32, flags: u32, arg: u64, text: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugOutputCallbacks2 {}
 impl IDebugOutputCallbacks2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputCallbacks2_Impl, const OFFSET: isize>() -> IDebugOutputCallbacks2_Vtbl {
         unsafe extern "system" fn Output<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputCallbacks2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mask: u32, text: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
@@ -22365,6 +22614,7 @@ impl IDebugOutputCallbacks2_Vtbl {
 pub trait IDebugOutputCallbacksWide_Impl: Sized {
     fn Output(&self, mask: u32, text: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugOutputCallbacksWide {}
 impl IDebugOutputCallbacksWide_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputCallbacksWide_Impl, const OFFSET: isize>() -> IDebugOutputCallbacksWide_Vtbl {
         unsafe extern "system" fn Output<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputCallbacksWide_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mask: u32, text: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -22381,6 +22631,7 @@ impl IDebugOutputCallbacksWide_Vtbl {
 pub trait IDebugOutputStream_Impl: Sized {
     fn Write(&self, psz: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugOutputStream {}
 impl IDebugOutputStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputStream_Impl, const OFFSET: isize>() -> IDebugOutputStream_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows::core::IUnknownImpl, Impl: IDebugOutputStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psz: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -22397,6 +22648,7 @@ impl IDebugOutputStream_Vtbl {
 pub trait IDebugPlmClient_Impl: Sized {
     fn LaunchPlmPackageForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugPlmClient {}
 impl IDebugPlmClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPlmClient_Impl, const OFFSET: isize>() -> IDebugPlmClient_Vtbl {
         unsafe extern "system" fn LaunchPlmPackageForDebugWide<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPlmClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT {
@@ -22417,6 +22669,7 @@ pub trait IDebugPlmClient2_Impl: Sized {
     fn LaunchPlmPackageForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
     fn LaunchPlmBgTaskForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, backgroundtaskid: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugPlmClient2 {}
 impl IDebugPlmClient2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPlmClient2_Impl, const OFFSET: isize>() -> IDebugPlmClient2_Vtbl {
         unsafe extern "system" fn LaunchPlmPackageForDebugWide<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPlmClient2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT {
@@ -22452,6 +22705,7 @@ pub trait IDebugPlmClient3_Impl: Sized {
     fn LaunchAndDebugPlmAppWide(&self, server: u64, packagefullname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ActivateAndDebugPlmBgTaskWide(&self, server: u64, packagefullname: &::windows::core::PCWSTR, backgroundtaskid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugPlmClient3 {}
 impl IDebugPlmClient3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPlmClient3_Impl, const OFFSET: isize>() -> IDebugPlmClient3_Vtbl {
         unsafe extern "system" fn LaunchPlmPackageForDebugWide<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPlmClient3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT {
@@ -22537,6 +22791,8 @@ pub trait IDebugProperty_Impl: Sized {
     fn GetParent(&self) -> ::windows::core::Result<IDebugProperty>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDebugProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDebugProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugProperty_Impl, const OFFSET: isize>() -> IDebugProperty_Vtbl {
         unsafe extern "system" fn GetPropertyInfo<Identity: ::windows::core::IUnknownImpl, Impl: IDebugProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwfieldspec: u32, nradix: u32, ppropertyinfo: *mut DebugPropertyInfo) -> ::windows::core::HRESULT {
@@ -22600,6 +22856,8 @@ pub trait IDebugPropertyEnumType_All_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugPropertyEnumType_All {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugPropertyEnumType_All_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPropertyEnumType_All_Impl, const OFFSET: isize>() -> IDebugPropertyEnumType_All_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPropertyEnumType_All_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, __midl__idebugpropertyenumtype_all0000: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -22622,6 +22880,8 @@ impl IDebugPropertyEnumType_All_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugPropertyEnumType_Arguments_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugPropertyEnumType_Arguments {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugPropertyEnumType_Arguments_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPropertyEnumType_Arguments_Impl, const OFFSET: isize>() -> IDebugPropertyEnumType_Arguments_Vtbl {
         Self { base__: IDebugPropertyEnumType_All_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -22632,6 +22892,8 @@ impl IDebugPropertyEnumType_Arguments_Vtbl {
 }
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugPropertyEnumType_Locals_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugPropertyEnumType_Locals {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugPropertyEnumType_Locals_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPropertyEnumType_Locals_Impl, const OFFSET: isize>() -> IDebugPropertyEnumType_Locals_Vtbl {
@@ -22644,6 +22906,8 @@ impl IDebugPropertyEnumType_Locals_Vtbl {
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugPropertyEnumType_LocalsPlusArgs_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugPropertyEnumType_LocalsPlusArgs {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugPropertyEnumType_LocalsPlusArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPropertyEnumType_LocalsPlusArgs_Impl, const OFFSET: isize>() -> IDebugPropertyEnumType_LocalsPlusArgs_Vtbl {
         Self { base__: IDebugPropertyEnumType_All_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -22654,6 +22918,8 @@ impl IDebugPropertyEnumType_LocalsPlusArgs_Vtbl {
 }
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugPropertyEnumType_Registers_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugPropertyEnumType_Registers {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugPropertyEnumType_Registers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugPropertyEnumType_Registers_Impl, const OFFSET: isize>() -> IDebugPropertyEnumType_Registers_Vtbl {
@@ -22677,6 +22943,8 @@ pub trait IDebugRegisters_Impl: Sized {
     fn GetStackOffset(&self) -> ::windows::core::Result<u64>;
     fn GetFrameOffset(&self) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugRegisters {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugRegisters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugRegisters_Impl, const OFFSET: isize>() -> IDebugRegisters_Vtbl {
@@ -22819,6 +23087,8 @@ pub trait IDebugRegisters2_Impl: Sized {
     fn GetStackOffset2(&self, source: u32) -> ::windows::core::Result<u64>;
     fn GetFrameOffset2(&self, source: u32) -> ::windows::core::Result<u64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugRegisters2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugRegisters2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugRegisters2_Impl, const OFFSET: isize>() -> IDebugRegisters2_Vtbl {
@@ -23067,6 +23337,7 @@ impl IDebugRegisters2_Vtbl {
 pub trait IDebugSessionProvider_Impl: Sized {
     fn StartDebugSession(&self, pda: &::core::option::Option<IRemoteDebugApplication>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugSessionProvider {}
 impl IDebugSessionProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSessionProvider_Impl, const OFFSET: isize>() -> IDebugSessionProvider_Vtbl {
         unsafe extern "system" fn StartDebugSession<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSessionProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pda: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -23088,6 +23359,8 @@ pub trait IDebugStackFrame_Impl: Sized {
     fn GetThread(&self) -> ::windows::core::Result<IDebugApplicationThread>;
     fn GetDebugProperty(&self) -> ::windows::core::Result<IDebugProperty>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugStackFrame {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugStackFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrame_Impl, const OFFSET: isize>() -> IDebugStackFrame_Vtbl {
@@ -23165,6 +23438,8 @@ pub trait IDebugStackFrame110_Impl: Sized + IDebugStackFrame_Impl {
     fn GetScriptInvocationContext(&self) -> ::windows::core::Result<IScriptInvocationContext>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugStackFrame110 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugStackFrame110_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrame110_Impl, const OFFSET: isize>() -> IDebugStackFrame110_Vtbl {
         unsafe extern "system" fn GetStackFrameType<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrame110_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstackframekind: *mut DEBUG_STACKFRAME_TYPE) -> ::windows::core::HRESULT {
@@ -23202,6 +23477,7 @@ impl IDebugStackFrame110_Vtbl {
 pub trait IDebugStackFrameSniffer_Impl: Sized {
     fn EnumStackFrames(&self) -> ::windows::core::Result<IEnumDebugStackFrames>;
 }
+impl ::windows::core::RuntimeName for IDebugStackFrameSniffer {}
 impl IDebugStackFrameSniffer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrameSniffer_Impl, const OFFSET: isize>() -> IDebugStackFrameSniffer_Vtbl {
         unsafe extern "system" fn EnumStackFrames<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrameSniffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppedsf: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -23224,6 +23500,7 @@ impl IDebugStackFrameSniffer_Vtbl {
 pub trait IDebugStackFrameSnifferEx32_Impl: Sized + IDebugStackFrameSniffer_Impl {
     fn EnumStackFramesEx32(&self, dwspmin: u32) -> ::windows::core::Result<IEnumDebugStackFrames>;
 }
+impl ::windows::core::RuntimeName for IDebugStackFrameSnifferEx32 {}
 impl IDebugStackFrameSnifferEx32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrameSnifferEx32_Impl, const OFFSET: isize>() -> IDebugStackFrameSnifferEx32_Vtbl {
         unsafe extern "system" fn EnumStackFramesEx32<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrameSnifferEx32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwspmin: u32, ppedsf: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -23246,6 +23523,7 @@ impl IDebugStackFrameSnifferEx32_Vtbl {
 pub trait IDebugStackFrameSnifferEx64_Impl: Sized + IDebugStackFrameSniffer_Impl {
     fn EnumStackFramesEx64(&self, dwspmin: u64) -> ::windows::core::Result<IEnumDebugStackFrames64>;
 }
+impl ::windows::core::RuntimeName for IDebugStackFrameSnifferEx64 {}
 impl IDebugStackFrameSnifferEx64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrameSnifferEx64_Impl, const OFFSET: isize>() -> IDebugStackFrameSnifferEx64_Vtbl {
         unsafe extern "system" fn EnumStackFramesEx64<Identity: ::windows::core::IUnknownImpl, Impl: IDebugStackFrameSnifferEx64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwspmin: u64, ppedsf: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -23278,6 +23556,8 @@ pub trait IDebugSymbolGroup_Impl: Sized {
     fn WriteSymbol(&self, index: u32, value: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn OutputAsType(&self, index: u32, r#type: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbolGroup {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbolGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbolGroup_Impl, const OFFSET: isize>() -> IDebugSymbolGroup_Vtbl {
@@ -23381,6 +23661,8 @@ pub trait IDebugSymbolGroup2_Impl: Sized {
     fn GetSymbolValueTextWide(&self, index: u32, buffer: ::windows::core::PWSTR, buffersize: u32, namesize: *mut u32) -> ::windows::core::Result<()>;
     fn GetSymbolEntryInformation(&self, index: u32) -> ::windows::core::Result<DEBUG_SYMBOL_ENTRY>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbolGroup2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbolGroup2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbolGroup2_Impl, const OFFSET: isize>() -> IDebugSymbolGroup2_Vtbl {
@@ -23612,6 +23894,8 @@ pub trait IDebugSymbols_Impl: Sized {
     fn FindSourceFile(&self, startelement: u32, file: &::windows::core::PCSTR, flags: u32, foundelement: *mut u32, buffer: ::windows::core::PSTR, buffersize: u32, foundsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetSourceFileLineOffsets(&self, file: &::windows::core::PCSTR, buffer: *mut u64, bufferlines: u32, filelines: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbols {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbols_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbols_Impl, const OFFSET: isize>() -> IDebugSymbols_Vtbl {
@@ -24069,6 +24353,8 @@ pub trait IDebugSymbols2_Impl: Sized {
     fn RemoveTypeOptions(&self, options: u32) -> ::windows::core::Result<()>;
     fn SetTypeOptions(&self, options: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbols2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbols2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbols2_Impl, const OFFSET: isize>() -> IDebugSymbols2_Vtbl {
@@ -24646,6 +24932,8 @@ pub trait IDebugSymbols3_Impl: Sized {
     fn GetSourceEntryOffsetRegions(&self, entry: *const DEBUG_SYMBOL_SOURCE_ENTRY, flags: u32, regions: *mut DEBUG_OFFSET_REGION, regionscount: u32, regionsavail: *mut u32) -> ::windows::core::Result<()>;
     fn GetSourceEntryBySourceEntry(&self, fromentry: *const DEBUG_SYMBOL_SOURCE_ENTRY, flags: u32) -> ::windows::core::Result<DEBUG_SYMBOL_SOURCE_ENTRY>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbols3 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbols3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbols3_Impl, const OFFSET: isize>() -> IDebugSymbols3_Vtbl {
@@ -25716,6 +26004,8 @@ pub trait IDebugSymbols4_Impl: Sized {
     fn GetLineByInlineContextWide(&self, offset: u64, inlinecontext: u32, line: *mut u32, filebuffer: ::windows::core::PWSTR, filebuffersize: u32, filesize: *mut u32, displacement: *mut u64) -> ::windows::core::Result<()>;
     fn OutputSymbolByInlineContext(&self, outputcontrol: u32, flags: u32, offset: u64, inlinecontext: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbols4 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbols4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbols4_Impl, const OFFSET: isize>() -> IDebugSymbols4_Vtbl {
@@ -26831,6 +27121,8 @@ pub trait IDebugSymbols5_Impl: Sized {
     fn SetScopeFrameByIndexEx(&self, flags: u32, index: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDebugSymbols5 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDebugSymbols5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbols5_Impl, const OFFSET: isize>() -> IDebugSymbols5_Vtbl {
         unsafe extern "system" fn GetSymbolOptions<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSymbols5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: *mut u32) -> ::windows::core::HRESULT {
@@ -27832,6 +28124,7 @@ pub trait IDebugSyncOperation_Impl: Sized {
     fn Execute(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn InProgressAbort(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugSyncOperation {}
 impl IDebugSyncOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSyncOperation_Impl, const OFFSET: isize>() -> IDebugSyncOperation_Vtbl {
         unsafe extern "system" fn GetTargetThread<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSyncOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppattarget: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -27903,6 +28196,7 @@ pub trait IDebugSystemObjects_Impl: Sized {
     fn GetProcessIdByHandle(&self, handle: u64) -> ::windows::core::Result<u32>;
     fn GetCurrentProcessExecutableName(&self, buffer: ::windows::core::PSTR, buffersize: u32, exesize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugSystemObjects {}
 impl IDebugSystemObjects_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects_Impl, const OFFSET: isize>() -> IDebugSystemObjects_Vtbl {
         unsafe extern "system" fn GetEventThread<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -28261,6 +28555,7 @@ pub trait IDebugSystemObjects2_Impl: Sized {
     fn GetImplicitProcessDataOffset(&self) -> ::windows::core::Result<u64>;
     fn SetImplicitProcessDataOffset(&self, offset: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugSystemObjects2 {}
 impl IDebugSystemObjects2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects2_Impl, const OFFSET: isize>() -> IDebugSystemObjects2_Vtbl {
         unsafe extern "system" fn GetEventThread<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -28676,6 +28971,7 @@ pub trait IDebugSystemObjects3_Impl: Sized {
     fn GetSystemByServer(&self, server: u64) -> ::windows::core::Result<u32>;
     fn GetCurrentSystemServerName(&self, buffer: ::windows::core::PSTR, buffersize: u32, namesize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugSystemObjects3 {}
 impl IDebugSystemObjects3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects3_Impl, const OFFSET: isize>() -> IDebugSystemObjects3_Vtbl {
         unsafe extern "system" fn GetEventThread<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -29177,6 +29473,7 @@ pub trait IDebugSystemObjects4_Impl: Sized {
     fn GetCurrentProcessExecutableNameWide(&self, buffer: ::windows::core::PWSTR, buffersize: u32, exesize: *mut u32) -> ::windows::core::Result<()>;
     fn GetCurrentSystemServerNameWide(&self, buffer: ::windows::core::PWSTR, buffersize: u32, namesize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugSystemObjects4 {}
 impl IDebugSystemObjects4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects4_Impl, const OFFSET: isize>() -> IDebugSystemObjects4_Vtbl {
         unsafe extern "system" fn GetEventThread<Identity: ::windows::core::IUnknownImpl, Impl: IDebugSystemObjects4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT {
@@ -29646,6 +29943,7 @@ impl IDebugSystemObjects4_Vtbl {
 pub trait IDebugThreadCall32_Impl: Sized {
     fn ThreadCallHandler(&self, dwparam1: u32, dwparam2: u32, dwparam3: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugThreadCall32 {}
 impl IDebugThreadCall32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugThreadCall32_Impl, const OFFSET: isize>() -> IDebugThreadCall32_Vtbl {
         unsafe extern "system" fn ThreadCallHandler<Identity: ::windows::core::IUnknownImpl, Impl: IDebugThreadCall32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwparam1: u32, dwparam2: u32, dwparam3: u32) -> ::windows::core::HRESULT {
@@ -29662,6 +29960,7 @@ impl IDebugThreadCall32_Vtbl {
 pub trait IDebugThreadCall64_Impl: Sized {
     fn ThreadCallHandler(&self, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDebugThreadCall64 {}
 impl IDebugThreadCall64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDebugThreadCall64_Impl, const OFFSET: isize>() -> IDebugThreadCall64_Vtbl {
         unsafe extern "system" fn ThreadCallHandler<Identity: ::windows::core::IUnknownImpl, Impl: IDebugThreadCall64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::HRESULT {
@@ -29682,6 +29981,7 @@ pub trait IDynamicConceptProviderConcept_Impl: Sized {
     fn NotifyParentChange(&self, parentmodel: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
     fn NotifyDestruct(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDynamicConceptProviderConcept {}
 impl IDynamicConceptProviderConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicConceptProviderConcept_Impl, const OFFSET: isize>() -> IDynamicConceptProviderConcept_Vtbl {
         unsafe extern "system" fn GetConcept<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicConceptProviderConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, conceptid: *const ::windows::core::GUID, conceptinterface: *mut *mut ::core::ffi::c_void, conceptmetadata: *mut ::windows::core::RawPtr, hasconcept: *mut bool) -> ::windows::core::HRESULT {
@@ -29727,6 +30027,7 @@ pub trait IDynamicKeyProviderConcept_Impl: Sized {
     fn SetKey(&self, contextobject: &::core::option::Option<IModelObject>, key: &::windows::core::PCWSTR, keyvalue: &::core::option::Option<IModelObject>, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn EnumerateKeys(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IKeyEnumerator>;
 }
+impl ::windows::core::RuntimeName for IDynamicKeyProviderConcept {}
 impl IDynamicKeyProviderConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicKeyProviderConcept_Impl, const OFFSET: isize>() -> IDynamicKeyProviderConcept_Vtbl {
         unsafe extern "system" fn GetKey<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicKeyProviderConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, key: ::windows::core::PCWSTR, keyvalue: *mut ::windows::core::RawPtr, metadata: *mut ::windows::core::RawPtr, haskey: *mut bool) -> ::windows::core::HRESULT {
@@ -29767,6 +30068,7 @@ pub trait IEnumDebugApplicationNodes_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDebugApplicationNodes>;
 }
+impl ::windows::core::RuntimeName for IEnumDebugApplicationNodes {}
 impl IEnumDebugApplicationNodes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugApplicationNodes_Impl, const OFFSET: isize>() -> IEnumDebugApplicationNodes_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugApplicationNodes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pprddp: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -29813,6 +30115,7 @@ pub trait IEnumDebugCodeContexts_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDebugCodeContexts>;
 }
+impl ::windows::core::RuntimeName for IEnumDebugCodeContexts {}
 impl IEnumDebugCodeContexts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugCodeContexts_Impl, const OFFSET: isize>() -> IEnumDebugCodeContexts_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugCodeContexts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pscc: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -29859,6 +30162,7 @@ pub trait IEnumDebugExpressionContexts_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumDebugExpressionContexts>;
 }
+impl ::windows::core::RuntimeName for IEnumDebugExpressionContexts {}
 impl IEnumDebugExpressionContexts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugExpressionContexts_Impl, const OFFSET: isize>() -> IEnumDebugExpressionContexts_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugExpressionContexts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppdec: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -29907,6 +30211,8 @@ pub trait IEnumDebugExtendedPropertyInfo_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumDebugExtendedPropertyInfo>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumDebugExtendedPropertyInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IEnumDebugExtendedPropertyInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugExtendedPropertyInfo_Impl, const OFFSET: isize>() -> IEnumDebugExtendedPropertyInfo_Vtbl {
@@ -29969,6 +30275,8 @@ pub trait IEnumDebugPropertyInfo_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumDebugPropertyInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumDebugPropertyInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugPropertyInfo_Impl, const OFFSET: isize>() -> IEnumDebugPropertyInfo_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugPropertyInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pi: *mut DebugPropertyInfo, pceltsfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -30029,6 +30337,8 @@ pub trait IEnumDebugStackFrames_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumDebugStackFrames>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumDebugStackFrames {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumDebugStackFrames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugStackFrames_Impl, const OFFSET: isize>() -> IEnumDebugStackFrames_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugStackFrames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, prgdsfd: *mut DebugStackFrameDescriptor, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -30074,6 +30384,8 @@ pub trait IEnumDebugStackFrames64_Impl: Sized + IEnumDebugStackFrames_Impl {
     fn Next64(&self, celt: u32, prgdsfd: *mut DebugStackFrameDescriptor64, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumDebugStackFrames64 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumDebugStackFrames64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugStackFrames64_Impl, const OFFSET: isize>() -> IEnumDebugStackFrames64_Vtbl {
         unsafe extern "system" fn Next64<Identity: ::windows::core::IUnknownImpl, Impl: IEnumDebugStackFrames64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, prgdsfd: *mut DebugStackFrameDescriptor64, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -30091,6 +30403,7 @@ pub trait IEnumJsStackFrames_Impl: Sized {
     fn Next(&self, cframecount: u32, pframes: *mut __MIDL___MIDL_itf_jscript9diag_0000_0007_0001, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumJsStackFrames {}
 impl IEnumJsStackFrames_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumJsStackFrames_Impl, const OFFSET: isize>() -> IEnumJsStackFrames_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumJsStackFrames_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cframecount: u32, pframes: *mut __MIDL___MIDL_itf_jscript9diag_0000_0007_0001, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -30115,6 +30428,7 @@ pub trait IEnumRemoteDebugApplicationThreads_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumRemoteDebugApplicationThreads>;
 }
+impl ::windows::core::RuntimeName for IEnumRemoteDebugApplicationThreads {}
 impl IEnumRemoteDebugApplicationThreads_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRemoteDebugApplicationThreads_Impl, const OFFSET: isize>() -> IEnumRemoteDebugApplicationThreads_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRemoteDebugApplicationThreads_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pprdat: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -30161,6 +30475,7 @@ pub trait IEnumRemoteDebugApplications_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumRemoteDebugApplications>;
 }
+impl ::windows::core::RuntimeName for IEnumRemoteDebugApplications {}
 impl IEnumRemoteDebugApplications_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRemoteDebugApplications_Impl, const OFFSET: isize>() -> IEnumRemoteDebugApplications_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRemoteDebugApplications_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppda: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -30204,6 +30519,7 @@ impl IEnumRemoteDebugApplications_Vtbl {
 pub trait IEquatableConcept_Impl: Sized {
     fn AreObjectsEqual(&self, contextobject: &::core::option::Option<IModelObject>, otherobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<bool>;
 }
+impl ::windows::core::RuntimeName for IEquatableConcept {}
 impl IEquatableConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEquatableConcept_Impl, const OFFSET: isize>() -> IEquatableConcept_Vtbl {
         unsafe extern "system" fn AreObjectsEqual<Identity: ::windows::core::IUnknownImpl, Impl: IEquatableConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, otherobject: ::windows::core::RawPtr, isequal: *mut bool) -> ::windows::core::HRESULT {
@@ -30226,6 +30542,7 @@ impl IEquatableConcept_Vtbl {
 pub trait IHostDataModelAccess_Impl: Sized {
     fn GetDataModel(&self, manager: *mut ::core::option::Option<IDataModelManager>, host: *mut ::core::option::Option<IDebugHost>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IHostDataModelAccess {}
 impl IHostDataModelAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHostDataModelAccess_Impl, const OFFSET: isize>() -> IHostDataModelAccess_Vtbl {
         unsafe extern "system" fn GetDataModel<Identity: ::windows::core::IUnknownImpl, Impl: IHostDataModelAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, manager: *mut ::windows::core::RawPtr, host: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -30244,6 +30561,7 @@ pub trait IIndexableConcept_Impl: Sized {
     fn GetAt(&self, contextobject: &::core::option::Option<IModelObject>, indexercount: u64, indexers: *const ::core::option::Option<IModelObject>, object: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn SetAt(&self, contextobject: &::core::option::Option<IModelObject>, indexercount: u64, indexers: *const ::core::option::Option<IModelObject>, value: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIndexableConcept {}
 impl IIndexableConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIndexableConcept_Impl, const OFFSET: isize>() -> IIndexableConcept_Vtbl {
         unsafe extern "system" fn GetDimensionality<Identity: ::windows::core::IUnknownImpl, Impl: IIndexableConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, dimensionality: *mut u64) -> ::windows::core::HRESULT {
@@ -30282,6 +30600,7 @@ pub trait IIterableConcept_Impl: Sized {
     fn GetDefaultIndexDimensionality(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<u64>;
     fn GetIterator(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelIterator>;
 }
+impl ::windows::core::RuntimeName for IIterableConcept {}
 impl IIterableConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIterableConcept_Impl, const OFFSET: isize>() -> IIterableConcept_Vtbl {
         unsafe extern "system" fn GetDefaultIndexDimensionality<Identity: ::windows::core::IUnknownImpl, Impl: IIterableConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, dimensionality: *mut u64) -> ::windows::core::HRESULT {
@@ -30319,6 +30638,7 @@ impl IIterableConcept_Vtbl {
 pub trait IJsDebug_Impl: Sized {
     fn OpenVirtualProcess(&self, processid: u32, runtimejsbaseaddress: u64, pdatatarget: &::core::option::Option<IJsDebugDataTarget>) -> ::windows::core::Result<IJsDebugProcess>;
 }
+impl ::windows::core::RuntimeName for IJsDebug {}
 impl IJsDebug_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebug_Impl, const OFFSET: isize>() -> IJsDebug_Vtbl {
         unsafe extern "system" fn OpenVirtualProcess<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebug_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, processid: u32, runtimejsbaseaddress: u64, pdatatarget: ::windows::core::RawPtr, ppprocess: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -30346,6 +30666,8 @@ pub trait IJsDebugBreakPoint_Impl: Sized {
     fn Delete(&self) -> ::windows::core::Result<()>;
     fn GetDocumentPosition(&self, pdocumentid: *mut u64, pcharacteroffset: *mut u32, pstatementcharcount: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IJsDebugBreakPoint {}
 #[cfg(feature = "Win32_Foundation")]
 impl IJsDebugBreakPoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugBreakPoint_Impl, const OFFSET: isize>() -> IJsDebugBreakPoint_Vtbl {
@@ -30405,6 +30727,8 @@ pub trait IJsDebugDataTarget_Impl: Sized {
     fn CreateStackFrameEnumerator(&self, threadid: u32) -> ::windows::core::Result<IEnumJsStackFrames>;
     fn GetThreadContext(&self, threadid: u32, contextflags: u32, contextsize: u32, pcontext: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IJsDebugDataTarget {}
 #[cfg(feature = "Win32_Foundation")]
 impl IJsDebugDataTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugDataTarget_Impl, const OFFSET: isize>() -> IJsDebugDataTarget_Vtbl {
@@ -30511,6 +30835,8 @@ pub trait IJsDebugFrame_Impl: Sized {
     fn Evaluate(&self, pexpressiontext: &::windows::core::PCWSTR, ppdebugproperty: *mut ::core::option::Option<IJsDebugProperty>, perror: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IJsDebugFrame {}
+#[cfg(feature = "Win32_Foundation")]
 impl IJsDebugFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugFrame_Impl, const OFFSET: isize>() -> IJsDebugFrame_Vtbl {
         unsafe extern "system" fn GetStackRange<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugFrame_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstart: *mut u64, pend: *mut u64) -> ::windows::core::HRESULT {
@@ -30589,6 +30915,8 @@ pub trait IJsDebugProcess_Impl: Sized {
     fn GetExternalStepAddress(&self) -> ::windows::core::Result<u64>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IJsDebugProcess {}
+#[cfg(feature = "Win32_Foundation")]
 impl IJsDebugProcess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugProcess_Impl, const OFFSET: isize>() -> IJsDebugProcess_Vtbl {
         unsafe extern "system" fn CreateStackWalker<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugProcess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, threadid: u32, ppstackwalker: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -30647,6 +30975,8 @@ pub trait IJsDebugProperty_Impl: Sized {
     fn GetMembers(&self, members: JS_PROPERTY_MEMBERS) -> ::windows::core::Result<IJsEnumDebugProperty>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IJsDebugProperty {}
+#[cfg(feature = "Win32_Foundation")]
 impl IJsDebugProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugProperty_Impl, const OFFSET: isize>() -> IJsDebugProperty_Vtbl {
         unsafe extern "system" fn GetPropertyInfo<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nradix: u32, ppropertyinfo: *mut JsDebugPropertyInfo) -> ::windows::core::HRESULT {
@@ -30684,6 +31014,7 @@ impl IJsDebugProperty_Vtbl {
 pub trait IJsDebugStackWalker_Impl: Sized {
     fn GetNext(&self) -> ::windows::core::Result<IJsDebugFrame>;
 }
+impl ::windows::core::RuntimeName for IJsDebugStackWalker {}
 impl IJsDebugStackWalker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugStackWalker_Impl, const OFFSET: isize>() -> IJsDebugStackWalker_Vtbl {
         unsafe extern "system" fn GetNext<Identity: ::windows::core::IUnknownImpl, Impl: IJsDebugStackWalker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppframe: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -30707,6 +31038,7 @@ pub trait IJsEnumDebugProperty_Impl: Sized {
     fn Next(&self, count: u32, ppdebugproperty: *mut ::core::option::Option<IJsDebugProperty>, pactualcount: *mut u32) -> ::windows::core::Result<()>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IJsEnumDebugProperty {}
 impl IJsEnumDebugProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IJsEnumDebugProperty_Impl, const OFFSET: isize>() -> IJsEnumDebugProperty_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IJsEnumDebugProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: u32, ppdebugproperty: *mut ::windows::core::RawPtr, pactualcount: *mut u32) -> ::windows::core::HRESULT {
@@ -30741,6 +31073,8 @@ pub trait IKeyEnumerator_Impl: Sized {
     fn GetNext(&self, key: *mut super::super::super::Foundation::BSTR, value: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IKeyEnumerator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IKeyEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKeyEnumerator_Impl, const OFFSET: isize>() -> IKeyEnumerator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IKeyEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -30770,6 +31104,7 @@ pub trait IKeyStore_Impl: Sized {
     fn SetKeyValue(&self, key: &::windows::core::PCWSTR, object: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
     fn ClearKeys(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IKeyStore {}
 impl IKeyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKeyStore_Impl, const OFFSET: isize>() -> IKeyStore_Vtbl {
         unsafe extern "system" fn GetKey<Identity: ::windows::core::IUnknownImpl, Impl: IKeyStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, object: *mut ::windows::core::RawPtr, metadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -30815,6 +31150,7 @@ pub trait IMachineDebugManager_Impl: Sized {
     fn RemoveApplication(&self, dwappcookie: u32) -> ::windows::core::Result<()>;
     fn EnumApplications(&self) -> ::windows::core::Result<IEnumRemoteDebugApplications>;
 }
+impl ::windows::core::RuntimeName for IMachineDebugManager {}
 impl IMachineDebugManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMachineDebugManager_Impl, const OFFSET: isize>() -> IMachineDebugManager_Vtbl {
         unsafe extern "system" fn AddApplication<Identity: ::windows::core::IUnknownImpl, Impl: IMachineDebugManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pda: ::windows::core::RawPtr, pdwappcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -30860,6 +31196,7 @@ pub trait IMachineDebugManagerCookie_Impl: Sized {
     fn RemoveApplication(&self, dwdebugappcookie: u32, dwappcookie: u32) -> ::windows::core::Result<()>;
     fn EnumApplications(&self) -> ::windows::core::Result<IEnumRemoteDebugApplications>;
 }
+impl ::windows::core::RuntimeName for IMachineDebugManagerCookie {}
 impl IMachineDebugManagerCookie_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMachineDebugManagerCookie_Impl, const OFFSET: isize>() -> IMachineDebugManagerCookie_Vtbl {
         unsafe extern "system" fn AddApplication<Identity: ::windows::core::IUnknownImpl, Impl: IMachineDebugManagerCookie_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pda: ::windows::core::RawPtr, dwdebugappcookie: u32, pdwappcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -30904,6 +31241,7 @@ pub trait IMachineDebugManagerEvents_Impl: Sized {
     fn onAddApplication(&self, pda: &::core::option::Option<IRemoteDebugApplication>, dwappcookie: u32) -> ::windows::core::Result<()>;
     fn onRemoveApplication(&self, pda: &::core::option::Option<IRemoteDebugApplication>, dwappcookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMachineDebugManagerEvents {}
 impl IMachineDebugManagerEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMachineDebugManagerEvents_Impl, const OFFSET: isize>() -> IMachineDebugManagerEvents_Vtbl {
         unsafe extern "system" fn onAddApplication<Identity: ::windows::core::IUnknownImpl, Impl: IMachineDebugManagerEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pda: ::windows::core::RawPtr, dwappcookie: u32) -> ::windows::core::HRESULT {
@@ -30930,6 +31268,7 @@ pub trait IModelIterator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self, object: *mut ::core::option::Option<IModelObject>, dimensions: u64, indexers: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IModelIterator {}
 impl IModelIterator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModelIterator_Impl, const OFFSET: isize>() -> IModelIterator_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IModelIterator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -30962,6 +31301,8 @@ pub trait IModelKeyReference_Impl: Sized {
     fn SetKey(&self, object: &::core::option::Option<IModelObject>, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn SetKeyValue(&self, object: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IModelKeyReference {}
 #[cfg(feature = "Win32_Foundation")]
 impl IModelKeyReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModelKeyReference_Impl, const OFFSET: isize>() -> IModelKeyReference_Vtbl {
@@ -31038,6 +31379,8 @@ pub trait IModelKeyReference2_Impl: Sized + IModelKeyReference_Impl {
     fn OverrideContextObject(&self, newcontextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IModelKeyReference2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IModelKeyReference2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModelKeyReference2_Impl, const OFFSET: isize>() -> IModelKeyReference2_Vtbl {
         unsafe extern "system" fn OverrideContextObject<Identity: ::windows::core::IUnknownImpl, Impl: IModelKeyReference2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newcontextobject: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31054,6 +31397,7 @@ impl IModelKeyReference2_Vtbl {
 pub trait IModelMethod_Impl: Sized {
     fn Call(&self, pcontextobject: &::core::option::Option<IModelObject>, argcount: u64, pparguments: *const ::core::option::Option<IModelObject>, ppresult: *mut ::core::option::Option<IModelObject>, ppmetadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IModelMethod {}
 impl IModelMethod_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModelMethod_Impl, const OFFSET: isize>() -> IModelMethod_Vtbl {
         unsafe extern "system" fn Call<Identity: ::windows::core::IUnknownImpl, Impl: IModelMethod_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontextobject: ::windows::core::RawPtr, argcount: u64, pparguments: *const ::windows::core::RawPtr, ppresult: *mut ::windows::core::RawPtr, ppmetadata: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31103,6 +31447,8 @@ pub trait IModelObject_Impl: Sized {
     fn Compare(&self, other: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelObject>;
     fn IsEqualTo(&self, other: &::core::option::Option<IModelObject>) -> ::windows::core::Result<bool>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IModelObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IModelObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModelObject_Impl, const OFFSET: isize>() -> IModelObject_Vtbl {
@@ -31430,6 +31776,7 @@ pub trait IModelPropertyAccessor_Impl: Sized {
     fn GetValue(&self, key: &::windows::core::PCWSTR, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelObject>;
     fn SetValue(&self, key: &::windows::core::PCWSTR, contextobject: &::core::option::Option<IModelObject>, value: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IModelPropertyAccessor {}
 impl IModelPropertyAccessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModelPropertyAccessor_Impl, const OFFSET: isize>() -> IModelPropertyAccessor_Vtbl {
         unsafe extern "system" fn GetValue<Identity: ::windows::core::IUnknownImpl, Impl: IModelPropertyAccessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, contextobject: ::windows::core::RawPtr, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31462,6 +31809,7 @@ pub trait IObjectSafety_Impl: Sized {
     fn GetInterfaceSafetyOptions(&self, riid: *const ::windows::core::GUID, pdwsupportedoptions: *mut u32, pdwenabledoptions: *mut u32) -> ::windows::core::Result<()>;
     fn SetInterfaceSafetyOptions(&self, riid: *const ::windows::core::GUID, dwoptionsetmask: u32, dwenabledoptions: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectSafety {}
 impl IObjectSafety_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectSafety_Impl, const OFFSET: isize>() -> IObjectSafety_Vtbl {
         unsafe extern "system" fn GetInterfaceSafetyOptions<Identity: ::windows::core::IUnknownImpl, Impl: IObjectSafety_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pdwsupportedoptions: *mut u32, pdwenabledoptions: *mut u32) -> ::windows::core::HRESULT {
@@ -31491,6 +31839,8 @@ pub trait IPerPropertyBrowsing2_Impl: Sized {
     fn GetPredefinedStrings(&self, dispid: i32, pcastrings: *mut super::super::Ole::CALPOLESTR, pcacookies: *mut super::super::Ole::CADWORD) -> ::windows::core::Result<()>;
     fn SetPredefinedValue(&self, dispid: i32, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPerPropertyBrowsing2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IPerPropertyBrowsing2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPerPropertyBrowsing2_Impl, const OFFSET: isize>() -> IPerPropertyBrowsing2_Vtbl {
@@ -31541,6 +31891,7 @@ impl IPerPropertyBrowsing2_Vtbl {
 pub trait IPreferredRuntimeTypeConcept_Impl: Sized {
     fn CastToPreferredRuntimeType(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelObject>;
 }
+impl ::windows::core::RuntimeName for IPreferredRuntimeTypeConcept {}
 impl IPreferredRuntimeTypeConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPreferredRuntimeTypeConcept_Impl, const OFFSET: isize>() -> IPreferredRuntimeTypeConcept_Vtbl {
         unsafe extern "system" fn CastToPreferredRuntimeType<Identity: ::windows::core::IUnknownImpl, Impl: IPreferredRuntimeTypeConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, object: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31570,6 +31921,7 @@ pub trait IProcessDebugManager32_Impl: Sized {
     fn RemoveApplication(&self, dwappcookie: u32) -> ::windows::core::Result<()>;
     fn CreateDebugDocumentHelper(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDebugDocumentHelper32>;
 }
+impl ::windows::core::RuntimeName for IProcessDebugManager32 {}
 impl IProcessDebugManager32_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProcessDebugManager32_Impl, const OFFSET: isize>() -> IProcessDebugManager32_Vtbl {
         unsafe extern "system" fn CreateApplication<Identity: ::windows::core::IUnknownImpl, Impl: IProcessDebugManager32_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppda: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31641,6 +31993,7 @@ pub trait IProcessDebugManager64_Impl: Sized {
     fn RemoveApplication(&self, dwappcookie: u32) -> ::windows::core::Result<()>;
     fn CreateDebugDocumentHelper(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDebugDocumentHelper64>;
 }
+impl ::windows::core::RuntimeName for IProcessDebugManager64 {}
 impl IProcessDebugManager64_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProcessDebugManager64_Impl, const OFFSET: isize>() -> IProcessDebugManager64_Vtbl {
         unsafe extern "system" fn CreateApplication<Identity: ::windows::core::IUnknownImpl, Impl: IProcessDebugManager64_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppda: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31708,6 +32061,7 @@ impl IProcessDebugManager64_Vtbl {
 pub trait IProvideExpressionContexts_Impl: Sized {
     fn EnumExpressionContexts(&self) -> ::windows::core::Result<IEnumDebugExpressionContexts>;
 }
+impl ::windows::core::RuntimeName for IProvideExpressionContexts {}
 impl IProvideExpressionContexts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideExpressionContexts_Impl, const OFFSET: isize>() -> IProvideExpressionContexts_Vtbl {
         unsafe extern "system" fn EnumExpressionContexts<Identity: ::windows::core::IUnknownImpl, Impl: IProvideExpressionContexts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppedec: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -31732,6 +32086,8 @@ pub trait IRawEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self, name: *mut super::super::super::Foundation::BSTR, kind: *mut SymbolKind, value: *mut ::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRawEnumerator {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRawEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawEnumerator_Impl, const OFFSET: isize>() -> IRawEnumerator_Vtbl {
@@ -31769,6 +32125,8 @@ pub trait IRemoteDebugApplication_Impl: Sized {
     fn GetRootNode(&self) -> ::windows::core::Result<IDebugApplicationNode>;
     fn EnumGlobalExpressionContexts(&self) -> ::windows::core::Result<IEnumDebugExpressionContexts>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRemoteDebugApplication {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRemoteDebugApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugApplication_Impl, const OFFSET: isize>() -> IRemoteDebugApplication_Vtbl {
@@ -31887,6 +32245,7 @@ pub trait IRemoteDebugApplication110_Impl: Sized {
     fn GetCurrentDebuggerOptions(&self) -> ::windows::core::Result<SCRIPT_DEBUGGER_OPTIONS>;
     fn GetMainThread(&self) -> ::windows::core::Result<IRemoteDebugApplicationThread>;
 }
+impl ::windows::core::RuntimeName for IRemoteDebugApplication110 {}
 impl IRemoteDebugApplication110_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugApplication110_Impl, const OFFSET: isize>() -> IRemoteDebugApplication110_Vtbl {
         unsafe extern "system" fn SetDebuggerOptions<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugApplication110_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mask: SCRIPT_DEBUGGER_OPTIONS, value: SCRIPT_DEBUGGER_OPTIONS) -> ::windows::core::HRESULT {
@@ -31939,6 +32298,7 @@ pub trait IRemoteDebugApplicationEvents_Impl: Sized {
     fn OnDestroyThread(&self, prdat: &::core::option::Option<IRemoteDebugApplicationThread>) -> ::windows::core::Result<()>;
     fn OnBreakFlagChange(&self, abf: u32, prdatsteppingthread: &::core::option::Option<IRemoteDebugApplicationThread>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRemoteDebugApplicationEvents {}
 impl IRemoteDebugApplicationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugApplicationEvents_Impl, const OFFSET: isize>() -> IRemoteDebugApplicationEvents_Vtbl {
         unsafe extern "system" fn OnConnectDebugger<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugApplicationEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pad: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -32021,6 +32381,8 @@ pub trait IRemoteDebugApplicationThread_Impl: Sized {
     fn Resume(&self) -> ::windows::core::Result<u32>;
     fn GetSuspendCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRemoteDebugApplicationThread {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRemoteDebugApplicationThread_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugApplicationThread_Impl, const OFFSET: isize>() -> IRemoteDebugApplicationThread_Vtbl {
@@ -32133,6 +32495,8 @@ pub trait IRemoteDebugCriticalErrorEvent110_Impl: Sized {
     fn GetErrorInfo(&self, pbstrsource: *mut super::super::super::Foundation::BSTR, pmessageid: *mut i32, pbstrmessage: *mut super::super::super::Foundation::BSTR, pplocation: *mut ::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRemoteDebugCriticalErrorEvent110 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRemoteDebugCriticalErrorEvent110_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugCriticalErrorEvent110_Impl, const OFFSET: isize>() -> IRemoteDebugCriticalErrorEvent110_Vtbl {
         unsafe extern "system" fn GetErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugCriticalErrorEvent110_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrsource: *mut super::super::super::Foundation::BSTR, pmessageid: *mut i32, pbstrmessage: *mut super::super::super::Foundation::BSTR, pplocation: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -32150,6 +32514,8 @@ impl IRemoteDebugCriticalErrorEvent110_Vtbl {
 pub trait IRemoteDebugInfoEvent110_Impl: Sized {
     fn GetEventInfo(&self, pmessagetype: *mut DEBUG_EVENT_INFO_TYPE, pbstrmessage: *mut super::super::super::Foundation::BSTR, pbstrurl: *mut super::super::super::Foundation::BSTR, pplocation: *mut ::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRemoteDebugInfoEvent110 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRemoteDebugInfoEvent110_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDebugInfoEvent110_Impl, const OFFSET: isize>() -> IRemoteDebugInfoEvent110_Vtbl {
@@ -32178,6 +32544,8 @@ pub trait IScriptEntry_Impl: Sized + IScriptNode_Impl {
     fn SetSignature(&self, pti: &::core::option::Option<super::super::Com::ITypeInfo>, imethod: u32) -> ::windows::core::Result<()>;
     fn GetRange(&self, pichmin: *mut u32, pcch: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IScriptEntry {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IScriptEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScriptEntry_Impl, const OFFSET: isize>() -> IScriptEntry_Vtbl {
@@ -32286,6 +32654,8 @@ pub trait IScriptInvocationContext_Impl: Sized {
     fn GetContextObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IScriptInvocationContext {}
+#[cfg(feature = "Win32_Foundation")]
 impl IScriptInvocationContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScriptInvocationContext_Impl, const OFFSET: isize>() -> IScriptInvocationContext_Vtbl {
         unsafe extern "system" fn GetContextType<Identity: ::windows::core::IUnknownImpl, Impl: IScriptInvocationContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinvocationcontexttype: *mut SCRIPT_INVOCATION_CONTEXT_TYPE) -> ::windows::core::HRESULT {
@@ -32345,6 +32715,8 @@ pub trait IScriptNode_Impl: Sized {
     fn CreateChildEntry(&self, isn: u32, dwcookie: u32, pszdelimiter: &::windows::core::PCWSTR) -> ::windows::core::Result<IScriptEntry>;
     fn CreateChildHandler(&self, pszdefaultname: &::windows::core::PCWSTR, prgpsznames: *const ::windows::core::PWSTR, cpsznames: u32, pszevent: &::windows::core::PCWSTR, pszdelimiter: &::windows::core::PCWSTR, ptisignature: &::core::option::Option<super::super::Com::ITypeInfo>, imethodsignature: u32, isn: u32, dwcookie: u32) -> ::windows::core::Result<IScriptEntry>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IScriptNode {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IScriptNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScriptNode_Impl, const OFFSET: isize>() -> IScriptNode_Vtbl {
@@ -32474,6 +32846,8 @@ pub trait IScriptScriptlet_Impl: Sized + IScriptNode_Impl + IScriptEntry_Impl {
     fn SetSimpleEventName(&self, psz: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IScriptScriptlet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IScriptScriptlet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScriptScriptlet_Impl, const OFFSET: isize>() -> IScriptScriptlet_Vtbl {
         unsafe extern "system" fn GetSubItemName<Identity: ::windows::core::IUnknownImpl, Impl: IScriptScriptlet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstr: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -32546,6 +32920,8 @@ pub trait ISimpleConnectionPoint_Impl: Sized {
     fn Unadvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISimpleConnectionPoint {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISimpleConnectionPoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleConnectionPoint_Impl, const OFFSET: isize>() -> ISimpleConnectionPoint_Vtbl {
         unsafe extern "system" fn GetEventCount<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleConnectionPoint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulcount: *mut u32) -> ::windows::core::HRESULT {
@@ -32597,6 +32973,8 @@ pub trait IStringDisplayableConcept_Impl: Sized {
     fn ToDisplayString(&self, contextobject: &::core::option::Option<IModelObject>, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStringDisplayableConcept {}
+#[cfg(feature = "Win32_Foundation")]
 impl IStringDisplayableConcept_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStringDisplayableConcept_Impl, const OFFSET: isize>() -> IStringDisplayableConcept_Vtbl {
         unsafe extern "system" fn ToDisplayString<Identity: ::windows::core::IUnknownImpl, Impl: IStringDisplayableConcept_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, contextobject: ::windows::core::RawPtr, metadata: ::windows::core::RawPtr, displaystring: *mut super::super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -32621,6 +32999,8 @@ pub trait ITridentEventSink_Impl: Sized {
     fn FireEvent(&self, pstrevent: &::windows::core::PCWSTR, pdp: *const super::super::Com::DISPPARAMS, pvarres: *mut super::super::Com::VARIANT, pei: *mut super::super::Com::EXCEPINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITridentEventSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITridentEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITridentEventSink_Impl, const OFFSET: isize>() -> ITridentEventSink_Vtbl {
         unsafe extern "system" fn FireEvent<Identity: ::windows::core::IUnknownImpl, Impl: ITridentEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrevent: ::windows::core::PCWSTR, pdp: *const super::super::Com::DISPPARAMS, pvarres: *mut super::super::Com::VARIANT, pei: *mut super::super::Com::EXCEPINFO) -> ::windows::core::HRESULT {
@@ -32639,6 +33019,8 @@ pub trait IWebAppDiagnosticsObjectInitialization_Impl: Sized {
     fn Initialize(&self, hpassedhandle: super::super::super::Foundation::HANDLE_PTR, pdebugapplication: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWebAppDiagnosticsObjectInitialization {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWebAppDiagnosticsObjectInitialization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebAppDiagnosticsObjectInitialization_Impl, const OFFSET: isize>() -> IWebAppDiagnosticsObjectInitialization_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWebAppDiagnosticsObjectInitialization_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hpassedhandle: super::super::super::Foundation::HANDLE_PTR, pdebugapplication: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -32656,6 +33038,7 @@ pub trait IWebAppDiagnosticsSetup_Impl: Sized {
     fn DiagnosticsSupported(&self) -> ::windows::core::Result<i16>;
     fn CreateObjectWithSiteAtWebApp(&self, rclsid: *const ::windows::core::GUID, dwclscontext: u32, riid: *const ::windows::core::GUID, hpasstoobject: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWebAppDiagnosticsSetup {}
 impl IWebAppDiagnosticsSetup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebAppDiagnosticsSetup_Impl, const OFFSET: isize>() -> IWebAppDiagnosticsSetup_Vtbl {
         unsafe extern "system" fn DiagnosticsSupported<Identity: ::windows::core::IUnknownImpl, Impl: IWebAppDiagnosticsSetup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut i16) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
@@ -12,6 +12,7 @@ pub trait ITraceEvent_Impl: Sized {
     fn SetTimeStamp(&self, timestamp: *const i64) -> ::windows::core::Result<()>;
     fn SetProviderId(&self, providerid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITraceEvent {}
 impl ITraceEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITraceEvent_Impl, const OFFSET: isize>() -> ITraceEvent_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: ITraceEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newevent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -117,6 +118,7 @@ pub trait ITraceEventCallback_Impl: Sized {
     fn OnFinalizeProcessTrace(&self, relogger: &::core::option::Option<ITraceRelogger>) -> ::windows::core::Result<()>;
     fn OnEvent(&self, event: &::core::option::Option<ITraceEvent>, relogger: &::core::option::Option<ITraceRelogger>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITraceEventCallback {}
 impl ITraceEventCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITraceEventCallback_Impl, const OFFSET: isize>() -> ITraceEventCallback_Vtbl {
         unsafe extern "system" fn OnBeginProcessTrace<Identity: ::windows::core::IUnknownImpl, Impl: ITraceEventCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, headerevent: ::windows::core::RawPtr, relogger: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -157,6 +159,8 @@ pub trait ITraceRelogger_Impl: Sized {
     fn SetCompressionMode(&self, compressionmode: super::super::super::Foundation::BOOLEAN) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITraceRelogger {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITraceRelogger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITraceRelogger_Impl, const OFFSET: isize>() -> ITraceRelogger_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
@@ -2,6 +2,7 @@ pub trait IDtcLuConfigure_Impl: Sized {
     fn Add(&self, puclupair: *const u8, cblupair: u32) -> ::windows::core::Result<()>;
     fn Delete(&self, puclupair: *const u8, cblupair: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuConfigure {}
 impl IDtcLuConfigure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuConfigure_Impl, const OFFSET: isize>() -> IDtcLuConfigure_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuConfigure_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puclupair: *const u8, cblupair: u32) -> ::windows::core::HRESULT {
@@ -21,6 +22,7 @@ impl IDtcLuConfigure_Vtbl {
     }
 }
 pub trait IDtcLuRecovery_Impl: Sized {}
+impl ::windows::core::RuntimeName for IDtcLuRecovery {}
 impl IDtcLuRecovery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecovery_Impl, const OFFSET: isize>() -> IDtcLuRecovery_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -32,6 +34,7 @@ impl IDtcLuRecovery_Vtbl {
 pub trait IDtcLuRecoveryFactory_Impl: Sized {
     fn Create(&self, puclupair: *const u8, cblupair: u32) -> ::windows::core::Result<IDtcLuRecovery>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRecoveryFactory {}
 impl IDtcLuRecoveryFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryFactory_Impl, const OFFSET: isize>() -> IDtcLuRecoveryFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puclupair: *const u8, cblupair: u32, pprecovery: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -54,6 +57,7 @@ impl IDtcLuRecoveryFactory_Vtbl {
 pub trait IDtcLuRecoveryInitiatedByDtc_Impl: Sized {
     fn GetWork(&self, pwork: *mut _DtcLu_LocalRecovery_Work, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRecoveryInitiatedByDtc {}
 impl IDtcLuRecoveryInitiatedByDtc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByDtc_Impl, const OFFSET: isize>() -> IDtcLuRecoveryInitiatedByDtc_Vtbl {
         unsafe extern "system" fn GetWork<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByDtc_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwork: *mut _DtcLu_LocalRecovery_Work, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -70,6 +74,7 @@ impl IDtcLuRecoveryInitiatedByDtc_Vtbl {
 pub trait IDtcLuRecoveryInitiatedByDtcStatusWork_Impl: Sized {
     fn HandleCheckLuStatus(&self, lrecoveryseqnum: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRecoveryInitiatedByDtcStatusWork {}
 impl IDtcLuRecoveryInitiatedByDtcStatusWork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByDtcStatusWork_Impl, const OFFSET: isize>() -> IDtcLuRecoveryInitiatedByDtcStatusWork_Vtbl {
         unsafe extern "system" fn HandleCheckLuStatus<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByDtcStatusWork_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lrecoveryseqnum: i32) -> ::windows::core::HRESULT {
@@ -99,6 +104,8 @@ pub trait IDtcLuRecoveryInitiatedByDtcTransWork_Impl: Sized {
     fn GetRecoverySeqNum(&self, plrecoveryseqnum: *mut i32) -> ::windows::core::Result<()>;
     fn ObsoleteRecoverySeqNum(&self, lnewrecoveryseqnum: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcLuRecoveryInitiatedByDtcTransWork {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDtcLuRecoveryInitiatedByDtcTransWork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByDtcTransWork_Impl, const OFFSET: isize>() -> IDtcLuRecoveryInitiatedByDtcTransWork_Vtbl {
@@ -191,6 +198,7 @@ impl IDtcLuRecoveryInitiatedByDtcTransWork_Vtbl {
 pub trait IDtcLuRecoveryInitiatedByLu_Impl: Sized {
     fn GetObjectToHandleWorkFromLu(&self) -> ::windows::core::Result<IDtcLuRecoveryInitiatedByLuWork>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRecoveryInitiatedByLu {}
 impl IDtcLuRecoveryInitiatedByLu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByLu_Impl, const OFFSET: isize>() -> IDtcLuRecoveryInitiatedByLu_Vtbl {
         unsafe extern "system" fn GetObjectToHandleWorkFromLu<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByLu_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwork: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -223,6 +231,7 @@ pub trait IDtcLuRecoveryInitiatedByLuWork_Impl: Sized {
     fn HandleErrorFromOurCompareStates(&self, error: _DtcLu_CompareStates_Error) -> ::windows::core::Result<()>;
     fn ConversationLost(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRecoveryInitiatedByLuWork {}
 impl IDtcLuRecoveryInitiatedByLuWork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByLuWork_Impl, const OFFSET: isize>() -> IDtcLuRecoveryInitiatedByLuWork_Vtbl {
         unsafe extern "system" fn HandleTheirXln<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRecoveryInitiatedByLuWork_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lrecoveryseqnum: i32, xln: _DtcLu_Xln, premotelogname: *mut u8, cbremotelogname: u32, pourlogname: *mut u8, cbourlogname: u32, dwprotocol: u32, presponse: *mut _DtcLu_Xln_Response) -> ::windows::core::HRESULT {
@@ -291,6 +300,8 @@ pub trait IDtcLuRmEnlistment_Impl: Sized {
     fn RequestCommit(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcLuRmEnlistment {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDtcLuRmEnlistment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRmEnlistment_Impl, const OFFSET: isize>() -> IDtcLuRmEnlistment_Vtbl {
         unsafe extern "system" fn Unplug<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRmEnlistment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fconversationlost: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -340,6 +351,7 @@ impl IDtcLuRmEnlistment_Vtbl {
 pub trait IDtcLuRmEnlistmentFactory_Impl: Sized {
     fn Create(&self, puclupair: *mut u8, cblupair: u32, pitransaction: &::core::option::Option<ITransaction>, ptransid: *mut u8, cbtransid: u32, prmenlistmentsink: &::core::option::Option<IDtcLuRmEnlistmentSink>, pprmenlistment: *mut ::core::option::Option<IDtcLuRmEnlistment>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRmEnlistmentFactory {}
 impl IDtcLuRmEnlistmentFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRmEnlistmentFactory_Impl, const OFFSET: isize>() -> IDtcLuRmEnlistmentFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRmEnlistmentFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puclupair: *mut u8, cblupair: u32, pitransaction: ::windows::core::RawPtr, ptransid: *mut u8, cbtransid: u32, prmenlistmentsink: ::windows::core::RawPtr, pprmenlistment: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -364,6 +376,7 @@ pub trait IDtcLuRmEnlistmentSink_Impl: Sized {
     fn Prepare(&self) -> ::windows::core::Result<()>;
     fn RequestCommit(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuRmEnlistmentSink {}
 impl IDtcLuRmEnlistmentSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRmEnlistmentSink_Impl, const OFFSET: isize>() -> IDtcLuRmEnlistmentSink_Vtbl {
         unsafe extern "system" fn AckUnplug<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuRmEnlistmentSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -439,6 +452,8 @@ pub trait IDtcLuSubordinateDtc_Impl: Sized {
     fn RequestCommit(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcLuSubordinateDtc {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDtcLuSubordinateDtc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuSubordinateDtc_Impl, const OFFSET: isize>() -> IDtcLuSubordinateDtc_Vtbl {
         unsafe extern "system" fn Unplug<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuSubordinateDtc_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fconversationlost: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -494,6 +509,7 @@ impl IDtcLuSubordinateDtc_Vtbl {
 pub trait IDtcLuSubordinateDtcFactory_Impl: Sized {
     fn Create(&self, puclupair: *mut u8, cblupair: u32, punktransactionouter: &::core::option::Option<::windows::core::IUnknown>, isolevel: i32, isoflags: u32, poptions: &::core::option::Option<ITransactionOptions>, pptransaction: *mut ::core::option::Option<ITransaction>, ptransid: *mut u8, cbtransid: u32, psubordinatedtcsink: &::core::option::Option<IDtcLuSubordinateDtcSink>, ppsubordinatedtc: *mut ::core::option::Option<IDtcLuSubordinateDtc>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuSubordinateDtcFactory {}
 impl IDtcLuSubordinateDtcFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuSubordinateDtcFactory_Impl, const OFFSET: isize>() -> IDtcLuSubordinateDtcFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuSubordinateDtcFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puclupair: *mut u8, cblupair: u32, punktransactionouter: *mut ::core::ffi::c_void, isolevel: i32, isoflags: u32, poptions: ::windows::core::RawPtr, pptransaction: *mut ::windows::core::RawPtr, ptransid: *mut u8, cbtransid: u32, psubordinatedtcsink: ::windows::core::RawPtr, ppsubordinatedtc: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -519,6 +535,7 @@ pub trait IDtcLuSubordinateDtcSink_Impl: Sized {
     fn Forget(&self) -> ::windows::core::Result<()>;
     fn RequestCommit(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcLuSubordinateDtcSink {}
 impl IDtcLuSubordinateDtcSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuSubordinateDtcSink_Impl, const OFFSET: isize>() -> IDtcLuSubordinateDtcSink_Vtbl {
         unsafe extern "system" fn AckUnplug<Identity: ::windows::core::IUnknownImpl, Impl: IDtcLuSubordinateDtcSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -593,6 +610,8 @@ pub trait IDtcNetworkAccessConfig_Impl: Sized {
     fn SetXAAccess(&self, bxaaccess: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn RestartDtcService(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcNetworkAccessConfig {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDtcNetworkAccessConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcNetworkAccessConfig_Impl, const OFFSET: isize>() -> IDtcNetworkAccessConfig_Vtbl {
@@ -728,6 +747,8 @@ pub trait IDtcNetworkAccessConfig2_Impl: Sized + IDtcNetworkAccessConfig_Impl {
     fn SetAuthenticationLevel(&self, authlevel: AUTHENTICATION_LEVEL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcNetworkAccessConfig2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDtcNetworkAccessConfig2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcNetworkAccessConfig2_Impl, const OFFSET: isize>() -> IDtcNetworkAccessConfig2_Vtbl {
         unsafe extern "system" fn GetNetworkInboundAccess<Identity: ::windows::core::IUnknownImpl, Impl: IDtcNetworkAccessConfig2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbinbound: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -798,6 +819,8 @@ pub trait IDtcNetworkAccessConfig3_Impl: Sized + IDtcNetworkAccessConfig_Impl + 
     fn SetLUAccess(&self, bluaccess: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcNetworkAccessConfig3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDtcNetworkAccessConfig3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcNetworkAccessConfig3_Impl, const OFFSET: isize>() -> IDtcNetworkAccessConfig3_Vtbl {
         unsafe extern "system" fn GetLUAccess<Identity: ::windows::core::IUnknownImpl, Impl: IDtcNetworkAccessConfig3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbluaccess: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -832,6 +855,8 @@ pub trait IDtcToXaHelper_Impl: Sized {
     fn TranslateTridToXid(&self, pitransaction: &::core::option::Option<ITransaction>, pguidbqual: *const ::windows::core::GUID) -> ::windows::core::Result<xid_t>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcToXaHelper {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDtcToXaHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaHelper_Impl, const OFFSET: isize>() -> IDtcToXaHelper_Vtbl {
         unsafe extern "system" fn Close<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, i_fdorecovery: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -863,6 +888,7 @@ impl IDtcToXaHelper_Vtbl {
 pub trait IDtcToXaHelperFactory_Impl: Sized {
     fn Create(&self, pszdsn: &::windows::core::PCSTR, pszclientdllname: &::windows::core::PCSTR, pguidrm: *mut ::windows::core::GUID, ppxahelper: *mut ::core::option::Option<IDtcToXaHelper>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDtcToXaHelperFactory {}
 impl IDtcToXaHelperFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaHelperFactory_Impl, const OFFSET: isize>() -> IDtcToXaHelperFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaHelperFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdsn: ::windows::core::PCSTR, pszclientdllname: ::windows::core::PCSTR, pguidrm: *mut ::windows::core::GUID, ppxahelper: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -883,6 +909,8 @@ pub trait IDtcToXaHelperSinglePipe_Impl: Sized {
     fn EnlistWithRM(&self, dwrmcookie: u32, i_pitransaction: &::core::option::Option<ITransaction>, i_pitransres: &::core::option::Option<ITransactionResourceAsync>) -> ::windows::core::Result<ITransactionEnlistmentAsync>;
     fn ReleaseRMCookie(&self, i_dwrmcookie: u32, i_fnormal: super::super::Foundation::BOOL);
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcToXaHelperSinglePipe {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDtcToXaHelperSinglePipe_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaHelperSinglePipe_Impl, const OFFSET: isize>() -> IDtcToXaHelperSinglePipe_Vtbl {
@@ -932,6 +960,8 @@ pub trait IDtcToXaMapper_Impl: Sized {
     fn ReleaseResourceManager(&self, dwrmcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDtcToXaMapper {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDtcToXaMapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaMapper_Impl, const OFFSET: isize>() -> IDtcToXaMapper_Vtbl {
         unsafe extern "system" fn RequestNewResourceManager<Identity: ::windows::core::IUnknownImpl, Impl: IDtcToXaMapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdsn: ::windows::core::PCSTR, pszclientdllname: ::windows::core::PCSTR, pdwrmcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -969,6 +999,7 @@ impl IDtcToXaMapper_Vtbl {
 pub trait IGetDispenser_Impl: Sized {
     fn GetDispenser(&self, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGetDispenser {}
 impl IGetDispenser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetDispenser_Impl, const OFFSET: isize>() -> IGetDispenser_Vtbl {
         unsafe extern "system" fn GetDispenser<Identity: ::windows::core::IUnknownImpl, Impl: IGetDispenser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -986,6 +1017,8 @@ impl IGetDispenser_Vtbl {
 pub trait IKernelTransaction_Impl: Sized {
     fn GetHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IKernelTransaction {}
 #[cfg(feature = "Win32_Foundation")]
 impl IKernelTransaction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKernelTransaction_Impl, const OFFSET: isize>() -> IKernelTransaction_Vtbl {
@@ -1010,6 +1043,7 @@ pub trait ILastResourceManager_Impl: Sized {
     fn TransactionCommitted(&self, pprepinfo: *const u8, cbprepinfo: u32) -> ::windows::core::Result<()>;
     fn RecoveryDone(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILastResourceManager {}
 impl ILastResourceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILastResourceManager_Impl, const OFFSET: isize>() -> ILastResourceManager_Vtbl {
         unsafe extern "system" fn TransactionCommitted<Identity: ::windows::core::IUnknownImpl, Impl: ILastResourceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprepinfo: *const u8, cbprepinfo: u32) -> ::windows::core::HRESULT {
@@ -1036,6 +1070,7 @@ pub trait IPrepareInfo_Impl: Sized {
     fn GetPrepareInfoSize(&self, pcbprepinfo: *mut u32) -> ::windows::core::Result<()>;
     fn GetPrepareInfo(&self, pprepinfo: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrepareInfo {}
 impl IPrepareInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrepareInfo_Impl, const OFFSET: isize>() -> IPrepareInfo_Vtbl {
         unsafe extern "system" fn GetPrepareInfoSize<Identity: ::windows::core::IUnknownImpl, Impl: IPrepareInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcbprepinfo: *mut u32) -> ::windows::core::HRESULT {
@@ -1062,6 +1097,7 @@ pub trait IPrepareInfo2_Impl: Sized {
     fn GetPrepareInfoSize(&self) -> ::windows::core::Result<u32>;
     fn GetPrepareInfo(&self, cbprepareinfo: u32, pprepinfo: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPrepareInfo2 {}
 impl IPrepareInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrepareInfo2_Impl, const OFFSET: isize>() -> IPrepareInfo2_Vtbl {
         unsafe extern "system" fn GetPrepareInfoSize<Identity: ::windows::core::IUnknownImpl, Impl: IPrepareInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcbprepinfo: *mut u32) -> ::windows::core::HRESULT {
@@ -1096,6 +1132,8 @@ pub trait IRMHelper_Impl: Sized {
     fn RMInfo(&self, pxa_switch: *mut xa_switch_t, fcdeclcallingconv: super::super::Foundation::BOOL, pszopenstring: &::windows::core::PCSTR, pszclosestring: &::windows::core::PCSTR, guidrmrecovery: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRMHelper {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRMHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRMHelper_Impl, const OFFSET: isize>() -> IRMHelper_Vtbl {
         unsafe extern "system" fn RMCount<Identity: ::windows::core::IUnknownImpl, Impl: IRMHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwctotalnumberofrms: u32) -> ::windows::core::HRESULT {
@@ -1124,6 +1162,7 @@ pub trait IResourceManager_Impl: Sized {
     fn ReenlistmentComplete(&self) -> ::windows::core::Result<()>;
     fn GetDistributedTransactionManager(&self, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IResourceManager {}
 impl IResourceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManager_Impl, const OFFSET: isize>() -> IResourceManager_Vtbl {
         unsafe extern "system" fn Enlist<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: ::windows::core::RawPtr, pres: ::windows::core::RawPtr, puow: *mut BOID, pisolevel: *mut i32, ppenlist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1170,6 +1209,8 @@ pub trait IResourceManager2_Impl: Sized + IResourceManager_Impl {
     fn Reenlist2(&self, pxid: *const xid_t, dwtimeout: u32) -> ::windows::core::Result<XACTSTAT>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResourceManager2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IResourceManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManager2_Impl, const OFFSET: isize>() -> IResourceManager2_Vtbl {
         unsafe extern "system" fn Enlist2<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: ::windows::core::RawPtr, presasync: ::windows::core::RawPtr, puow: *mut BOID, pisolevel: *mut i32, pxid: *mut xid_t, ppenlist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1201,6 +1242,7 @@ impl IResourceManager2_Vtbl {
 pub trait IResourceManagerFactory_Impl: Sized {
     fn Create(&self, pguidrm: *const ::windows::core::GUID, pszrmname: &::windows::core::PCSTR, piresmgrsink: &::core::option::Option<IResourceManagerSink>) -> ::windows::core::Result<IResourceManager>;
 }
+impl ::windows::core::RuntimeName for IResourceManagerFactory {}
 impl IResourceManagerFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerFactory_Impl, const OFFSET: isize>() -> IResourceManagerFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidrm: *const ::windows::core::GUID, pszrmname: ::windows::core::PCSTR, piresmgrsink: ::windows::core::RawPtr, ppresmgr: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1223,6 +1265,7 @@ impl IResourceManagerFactory_Vtbl {
 pub trait IResourceManagerFactory2_Impl: Sized + IResourceManagerFactory_Impl {
     fn CreateEx(&self, pguidrm: *const ::windows::core::GUID, pszrmname: &::windows::core::PCSTR, piresmgrsink: &::core::option::Option<IResourceManagerSink>, riidrequested: *const ::windows::core::GUID, ppvresmgr: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IResourceManagerFactory2 {}
 impl IResourceManagerFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerFactory2_Impl, const OFFSET: isize>() -> IResourceManagerFactory2_Vtbl {
         unsafe extern "system" fn CreateEx<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidrm: *const ::windows::core::GUID, pszrmname: ::windows::core::PCSTR, piresmgrsink: ::windows::core::RawPtr, riidrequested: *const ::windows::core::GUID, ppvresmgr: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1240,6 +1283,8 @@ impl IResourceManagerFactory2_Vtbl {
 pub trait IResourceManagerRejoinable_Impl: Sized + IResourceManager_Impl + IResourceManager2_Impl {
     fn Rejoin(&self, pprepinfo: *const u8, cbprepinfo: u32, ltimeout: u32) -> ::windows::core::Result<XACTSTAT>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResourceManagerRejoinable {}
 #[cfg(feature = "Win32_Foundation")]
 impl IResourceManagerRejoinable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerRejoinable_Impl, const OFFSET: isize>() -> IResourceManagerRejoinable_Vtbl {
@@ -1263,6 +1308,7 @@ impl IResourceManagerRejoinable_Vtbl {
 pub trait IResourceManagerSink_Impl: Sized {
     fn TMDown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IResourceManagerSink {}
 impl IResourceManagerSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerSink_Impl, const OFFSET: isize>() -> IResourceManagerSink_Vtbl {
         unsafe extern "system" fn TMDown<Identity: ::windows::core::IUnknownImpl, Impl: IResourceManagerSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1281,6 +1327,7 @@ pub trait ITipHelper_Impl: Sized {
     fn PullAsync(&self, i_psztxurl: *const u8, i_ptippullsink: &::core::option::Option<ITipPullSink>) -> ::windows::core::Result<ITransaction>;
     fn GetLocalTmUrl(&self) -> ::windows::core::Result<*mut u8>;
 }
+impl ::windows::core::RuntimeName for ITipHelper {}
 impl ITipHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITipHelper_Impl, const OFFSET: isize>() -> ITipHelper_Vtbl {
         unsafe extern "system" fn Pull<Identity: ::windows::core::IUnknownImpl, Impl: ITipHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, i_psztxurl: *const u8, o_ppitransaction: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1330,6 +1377,7 @@ impl ITipHelper_Vtbl {
 pub trait ITipPullSink_Impl: Sized {
     fn PullComplete(&self, i_hrpull: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITipPullSink {}
 impl ITipPullSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITipPullSink_Impl, const OFFSET: isize>() -> ITipPullSink_Vtbl {
         unsafe extern "system" fn PullComplete<Identity: ::windows::core::IUnknownImpl, Impl: ITipPullSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, i_hrpull: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1347,6 +1395,7 @@ pub trait ITipTransaction_Impl: Sized {
     fn Push(&self, i_pszremotetmurl: *const u8) -> ::windows::core::Result<::windows::core::PSTR>;
     fn GetTransactionUrl(&self) -> ::windows::core::Result<::windows::core::PSTR>;
 }
+impl ::windows::core::RuntimeName for ITipTransaction {}
 impl ITipTransaction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITipTransaction_Impl, const OFFSET: isize>() -> ITipTransaction_Vtbl {
         unsafe extern "system" fn Push<Identity: ::windows::core::IUnknownImpl, Impl: ITipTransaction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, i_pszremotetmurl: *const u8, o_ppszremotetxurl: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT {
@@ -1385,6 +1434,7 @@ pub trait ITmNodeName_Impl: Sized {
     fn GetNodeNameSize(&self) -> ::windows::core::Result<u32>;
     fn GetNodeName(&self, cbnodenamebuffersize: u32, pnodenamebuffer: &::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITmNodeName {}
 impl ITmNodeName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITmNodeName_Impl, const OFFSET: isize>() -> ITmNodeName_Vtbl {
         unsafe extern "system" fn GetNodeNameSize<Identity: ::windows::core::IUnknownImpl, Impl: ITmNodeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcbnodenamesize: *mut u32) -> ::windows::core::HRESULT {
@@ -1419,6 +1469,8 @@ pub trait ITransaction_Impl: Sized {
     fn Abort(&self, pboidreason: *const BOID, fretaining: super::super::Foundation::BOOL, fasync: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetTransactionInfo(&self) -> ::windows::core::Result<XACTTRANSINFO>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransaction {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITransaction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransaction_Impl, const OFFSET: isize>() -> ITransaction_Vtbl {
@@ -1459,6 +1511,8 @@ pub trait ITransaction2_Impl: Sized + ITransaction_Impl + ITransactionCloner_Imp
     fn GetTransactionInfo2(&self) -> ::windows::core::Result<XACTTRANSINFO>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransaction2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITransaction2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransaction2_Impl, const OFFSET: isize>() -> ITransaction2_Vtbl {
         unsafe extern "system" fn GetTransactionInfo2<Identity: ::windows::core::IUnknownImpl, Impl: ITransaction2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *mut XACTTRANSINFO) -> ::windows::core::HRESULT {
@@ -1483,6 +1537,8 @@ pub trait ITransactionCloner_Impl: Sized + ITransaction_Impl {
     fn CloneWithCommitDisabled(&self) -> ::windows::core::Result<ITransaction>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransactionCloner {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITransactionCloner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionCloner_Impl, const OFFSET: isize>() -> ITransactionCloner_Vtbl {
         unsafe extern "system" fn CloneWithCommitDisabled<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionCloner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppitransaction: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1506,6 +1562,7 @@ pub trait ITransactionDispenser_Impl: Sized {
     fn GetOptionsObject(&self) -> ::windows::core::Result<ITransactionOptions>;
     fn BeginTransaction(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, isolevel: i32, isoflags: u32, poptions: &::core::option::Option<ITransactionOptions>) -> ::windows::core::Result<ITransaction>;
 }
+impl ::windows::core::RuntimeName for ITransactionDispenser {}
 impl ITransactionDispenser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionDispenser_Impl, const OFFSET: isize>() -> ITransactionDispenser_Vtbl {
         unsafe extern "system" fn GetOptionsObject<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionDispenser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppoptions: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1547,6 +1604,8 @@ pub trait ITransactionEnlistmentAsync_Impl: Sized {
     fn AbortRequestDone(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITransactionEnlistmentAsync {}
+#[cfg(feature = "Win32_System_Com")]
 impl ITransactionEnlistmentAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionEnlistmentAsync_Impl, const OFFSET: isize>() -> ITransactionEnlistmentAsync_Vtbl {
         unsafe extern "system" fn PrepareRequestDone<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionEnlistmentAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, pmk: ::windows::core::RawPtr, pboidreason: *const BOID) -> ::windows::core::HRESULT {
@@ -1579,6 +1638,7 @@ pub trait ITransactionExport_Impl: Sized {
     fn Export(&self, punktransaction: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
     fn GetTransactionCookie(&self, punktransaction: &::core::option::Option<::windows::core::IUnknown>, cbtransactioncookie: u32, rgbtransactioncookie: *mut u8, pcbused: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionExport {}
 impl ITransactionExport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionExport_Impl, const OFFSET: isize>() -> ITransactionExport_Vtbl {
         unsafe extern "system" fn Export<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionExport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punktransaction: *mut ::core::ffi::c_void, pcbtransactioncookie: *mut u32) -> ::windows::core::HRESULT {
@@ -1611,6 +1671,7 @@ pub trait ITransactionExportFactory_Impl: Sized {
     fn GetRemoteClassId(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn Create(&self, cbwhereabouts: u32, rgbwhereabouts: *const u8) -> ::windows::core::Result<ITransactionExport>;
 }
+impl ::windows::core::RuntimeName for ITransactionExportFactory {}
 impl ITransactionExportFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionExportFactory_Impl, const OFFSET: isize>() -> ITransactionExportFactory_Vtbl {
         unsafe extern "system" fn GetRemoteClassId<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionExportFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -1648,6 +1709,7 @@ impl ITransactionExportFactory_Vtbl {
 pub trait ITransactionImport_Impl: Sized {
     fn Import(&self, cbtransactioncookie: u32, rgbtransactioncookie: *const u8, piid: *const ::windows::core::GUID, ppvtransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionImport {}
 impl ITransactionImport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionImport_Impl, const OFFSET: isize>() -> ITransactionImport_Vtbl {
         unsafe extern "system" fn Import<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionImport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbtransactioncookie: u32, rgbtransactioncookie: *const u8, piid: *const ::windows::core::GUID, ppvtransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1665,6 +1727,7 @@ pub trait ITransactionImportWhereabouts_Impl: Sized {
     fn GetWhereaboutsSize(&self) -> ::windows::core::Result<u32>;
     fn GetWhereabouts(&self, cbwhereabouts: u32, rgbwhereabouts: *mut u8, pcbused: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionImportWhereabouts {}
 impl ITransactionImportWhereabouts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionImportWhereabouts_Impl, const OFFSET: isize>() -> ITransactionImportWhereabouts_Vtbl {
         unsafe extern "system" fn GetWhereaboutsSize<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionImportWhereabouts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcbwhereabouts: *mut u32) -> ::windows::core::HRESULT {
@@ -1696,6 +1759,7 @@ impl ITransactionImportWhereabouts_Vtbl {
 pub trait ITransactionLastEnlistmentAsync_Impl: Sized {
     fn TransactionOutcome(&self, xactstat: XACTSTAT, pboidreason: *const BOID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionLastEnlistmentAsync {}
 impl ITransactionLastEnlistmentAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionLastEnlistmentAsync_Impl, const OFFSET: isize>() -> ITransactionLastEnlistmentAsync_Vtbl {
         unsafe extern "system" fn TransactionOutcome<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionLastEnlistmentAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xactstat: XACTSTAT, pboidreason: *const BOID) -> ::windows::core::HRESULT {
@@ -1713,6 +1777,7 @@ pub trait ITransactionLastResourceAsync_Impl: Sized {
     fn DelegateCommit(&self, grfrm: u32) -> ::windows::core::Result<()>;
     fn ForgetRequest(&self, pnewuow: *const BOID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionLastResourceAsync {}
 impl ITransactionLastResourceAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionLastResourceAsync_Impl, const OFFSET: isize>() -> ITransactionLastResourceAsync_Vtbl {
         unsafe extern "system" fn DelegateCommit<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionLastResourceAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, grfrm: u32) -> ::windows::core::HRESULT {
@@ -1739,6 +1804,7 @@ pub trait ITransactionOptions_Impl: Sized {
     fn SetOptions(&self, poptions: *const XACTOPT) -> ::windows::core::Result<()>;
     fn GetOptions(&self, poptions: *mut XACTOPT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionOptions {}
 impl ITransactionOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionOptions_Impl, const OFFSET: isize>() -> ITransactionOptions_Vtbl {
         unsafe extern "system" fn SetOptions<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poptions: *const XACTOPT) -> ::windows::core::HRESULT {
@@ -1768,6 +1834,8 @@ pub trait ITransactionOutcomeEvents_Impl: Sized {
     fn HeuristicDecision(&self, dwdecision: u32, pboidreason: *const BOID, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn Indoubt(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransactionOutcomeEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITransactionOutcomeEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionOutcomeEvents_Impl, const OFFSET: isize>() -> ITransactionOutcomeEvents_Vtbl {
@@ -1810,6 +1878,7 @@ pub trait ITransactionPhase0EnlistmentAsync_Impl: Sized {
     fn Unenlist(&self) -> ::windows::core::Result<()>;
     fn GetTransaction(&self) -> ::windows::core::Result<ITransaction>;
 }
+impl ::windows::core::RuntimeName for ITransactionPhase0EnlistmentAsync {}
 impl ITransactionPhase0EnlistmentAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionPhase0EnlistmentAsync_Impl, const OFFSET: isize>() -> ITransactionPhase0EnlistmentAsync_Vtbl {
         unsafe extern "system" fn Enable<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionPhase0EnlistmentAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1859,6 +1928,7 @@ impl ITransactionPhase0EnlistmentAsync_Vtbl {
 pub trait ITransactionPhase0Factory_Impl: Sized {
     fn Create(&self, pphase0notify: &::core::option::Option<ITransactionPhase0NotifyAsync>) -> ::windows::core::Result<ITransactionPhase0EnlistmentAsync>;
 }
+impl ::windows::core::RuntimeName for ITransactionPhase0Factory {}
 impl ITransactionPhase0Factory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionPhase0Factory_Impl, const OFFSET: isize>() -> ITransactionPhase0Factory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionPhase0Factory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pphase0notify: ::windows::core::RawPtr, ppphase0enlistment: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1883,6 +1953,8 @@ pub trait ITransactionPhase0NotifyAsync_Impl: Sized {
     fn Phase0Request(&self, fabortinghint: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn EnlistCompleted(&self, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransactionPhase0NotifyAsync {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITransactionPhase0NotifyAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionPhase0NotifyAsync_Impl, const OFFSET: isize>() -> ITransactionPhase0NotifyAsync_Vtbl {
@@ -1912,6 +1984,7 @@ pub trait ITransactionReceiver_Impl: Sized {
     fn MarshalReturnToken(&self, cbreturntoken: u32, rgbreturntoken: *mut u8, pcbused: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionReceiver {}
 impl ITransactionReceiver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionReceiver_Impl, const OFFSET: isize>() -> ITransactionReceiver_Vtbl {
         unsafe extern "system" fn UnmarshalPropagationToken<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionReceiver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbtoken: u32, rgbtoken: *const u8, pptransaction: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1961,6 +2034,7 @@ impl ITransactionReceiver_Vtbl {
 pub trait ITransactionReceiverFactory_Impl: Sized {
     fn Create(&self) -> ::windows::core::Result<ITransactionReceiver>;
 }
+impl ::windows::core::RuntimeName for ITransactionReceiverFactory {}
 impl ITransactionReceiverFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionReceiverFactory_Impl, const OFFSET: isize>() -> ITransactionReceiverFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionReceiverFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppreceiver: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1987,6 +2061,8 @@ pub trait ITransactionResource_Impl: Sized {
     fn AbortRequest(&self, pboidreason: *const BOID, fretaining: super::super::Foundation::BOOL, pnewuow: *const BOID) -> ::windows::core::Result<()>;
     fn TMDown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransactionResource {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITransactionResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionResource_Impl, const OFFSET: isize>() -> ITransactionResource_Vtbl {
@@ -2030,6 +2106,8 @@ pub trait ITransactionResourceAsync_Impl: Sized {
     fn TMDown(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransactionResourceAsync {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITransactionResourceAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionResourceAsync_Impl, const OFFSET: isize>() -> ITransactionResourceAsync_Vtbl {
         unsafe extern "system" fn PrepareRequest<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionResourceAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fretaining: super::super::Foundation::BOOL, grfrm: u32, fwantmoniker: super::super::Foundation::BOOL, fsinglephase: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2071,6 +2149,7 @@ pub trait ITransactionTransmitter_Impl: Sized {
     fn UnmarshalReturnToken(&self, cbreturntoken: u32, rgbreturntoken: *const u8) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionTransmitter {}
 impl ITransactionTransmitter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionTransmitter_Impl, const OFFSET: isize>() -> ITransactionTransmitter_Vtbl {
         unsafe extern "system" fn Set<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionTransmitter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2120,6 +2199,7 @@ impl ITransactionTransmitter_Vtbl {
 pub trait ITransactionTransmitterFactory_Impl: Sized {
     fn Create(&self) -> ::windows::core::Result<ITransactionTransmitter>;
 }
+impl ::windows::core::RuntimeName for ITransactionTransmitterFactory {}
 impl ITransactionTransmitterFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionTransmitterFactory_Impl, const OFFSET: isize>() -> ITransactionTransmitterFactory_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionTransmitterFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptransmitter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2142,6 +2222,7 @@ impl ITransactionTransmitterFactory_Vtbl {
 pub trait ITransactionVoterBallotAsync2_Impl: Sized {
     fn VoteRequestDone(&self, hr: ::windows::core::HRESULT, pboidreason: *const BOID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransactionVoterBallotAsync2 {}
 impl ITransactionVoterBallotAsync2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionVoterBallotAsync2_Impl, const OFFSET: isize>() -> ITransactionVoterBallotAsync2_Vtbl {
         unsafe extern "system" fn VoteRequestDone<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionVoterBallotAsync2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, pboidreason: *const BOID) -> ::windows::core::HRESULT {
@@ -2158,6 +2239,7 @@ impl ITransactionVoterBallotAsync2_Vtbl {
 pub trait ITransactionVoterFactory2_Impl: Sized {
     fn Create(&self, ptransaction: &::core::option::Option<ITransaction>, pvoternotify: &::core::option::Option<ITransactionVoterNotifyAsync2>) -> ::windows::core::Result<ITransactionVoterBallotAsync2>;
 }
+impl ::windows::core::RuntimeName for ITransactionVoterFactory2 {}
 impl ITransactionVoterFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionVoterFactory2_Impl, const OFFSET: isize>() -> ITransactionVoterFactory2_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionVoterFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: ::windows::core::RawPtr, pvoternotify: ::windows::core::RawPtr, ppvoterballot: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2182,6 +2264,8 @@ pub trait ITransactionVoterNotifyAsync2_Impl: Sized + ITransactionOutcomeEvents_
     fn VoteRequest(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransactionVoterNotifyAsync2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITransactionVoterNotifyAsync2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionVoterNotifyAsync2_Impl, const OFFSET: isize>() -> ITransactionVoterNotifyAsync2_Vtbl {
         unsafe extern "system" fn VoteRequest<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionVoterNotifyAsync2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2199,6 +2283,7 @@ pub trait IXAConfig_Impl: Sized {
     fn Initialize(&self, clsidhelperdll: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXAConfig {}
 impl IXAConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAConfig_Impl, const OFFSET: isize>() -> IXAConfig_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IXAConfig_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsidhelperdll: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2224,6 +2309,7 @@ impl IXAConfig_Vtbl {
 pub trait IXAObtainRMInfo_Impl: Sized {
     fn ObtainRMInfo(&self, pirmhelper: &::core::option::Option<IRMHelper>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IXAObtainRMInfo {}
 impl IXAObtainRMInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXAObtainRMInfo_Impl, const OFFSET: isize>() -> IXAObtainRMInfo_Vtbl {
         unsafe extern "system" fn ObtainRMInfo<Identity: ::windows::core::IUnknownImpl, Impl: IXAObtainRMInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pirmhelper: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2240,6 +2326,7 @@ impl IXAObtainRMInfo_Vtbl {
 pub trait IXATransLookup_Impl: Sized {
     fn Lookup(&self) -> ::windows::core::Result<ITransaction>;
 }
+impl ::windows::core::RuntimeName for IXATransLookup {}
 impl IXATransLookup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXATransLookup_Impl, const OFFSET: isize>() -> IXATransLookup_Vtbl {
         unsafe extern "system" fn Lookup<Identity: ::windows::core::IUnknownImpl, Impl: IXATransLookup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptransaction: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2263,6 +2350,8 @@ impl IXATransLookup_Vtbl {
 pub trait IXATransLookup2_Impl: Sized {
     fn Lookup(&self, pxid: *const xid_t) -> ::windows::core::Result<ITransaction>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXATransLookup2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXATransLookup2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXATransLookup2_Impl, const OFFSET: isize>() -> IXATransLookup2_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/impl.rs
@@ -9,6 +9,8 @@ pub trait ISensLogon_Impl: Sized + super::Com::IDispatch_Impl {
     fn StopScreenSaver(&self, bstrusername: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISensLogon {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISensLogon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensLogon_Impl, const OFFSET: isize>() -> ISensLogon_Vtbl {
         unsafe extern "system" fn Logon<Identity: ::windows::core::IUnknownImpl, Impl: ISensLogon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrusername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -70,6 +72,8 @@ pub trait ISensLogon2_Impl: Sized + super::Com::IDispatch_Impl {
     fn PostShell(&self, bstrusername: &super::super::Foundation::BSTR, dwsessionid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISensLogon2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISensLogon2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensLogon2_Impl, const OFFSET: isize>() -> ISensLogon2_Vtbl {
         unsafe extern "system" fn Logon<Identity: ::windows::core::IUnknownImpl, Impl: ISensLogon2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrusername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, dwsessionid: u32) -> ::windows::core::HRESULT {
@@ -119,6 +123,8 @@ pub trait ISensNetwork_Impl: Sized + super::Com::IDispatch_Impl {
     fn DestinationReachableNoQOCInfo(&self, bstrdestination: &super::super::Foundation::BSTR, bstrconnection: &super::super::Foundation::BSTR, ultype: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISensNetwork {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISensNetwork_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensNetwork_Impl, const OFFSET: isize>() -> ISensNetwork_Vtbl {
         unsafe extern "system" fn ConnectionMade<Identity: ::windows::core::IUnknownImpl, Impl: ISensNetwork_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrconnection: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ultype: u32, lpqocinfo: *const SENS_QOCINFO) -> ::windows::core::HRESULT {
@@ -165,6 +171,8 @@ pub trait ISensOnNow_Impl: Sized + super::Com::IDispatch_Impl {
     fn OnBatteryPower(&self, dwbatterylifepercent: u32) -> ::windows::core::Result<()>;
     fn BatteryLow(&self, dwbatterylifepercent: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISensOnNow {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISensOnNow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISensOnNow_Impl, const OFFSET: isize>() -> ISensOnNow_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
@@ -11,6 +11,8 @@ pub trait IGPEInformation_Impl: Sized {
     fn PolicyChanged(&self, bmachine: super::super::Foundation::BOOL, badd: super::super::Foundation::BOOL, pguidextension: *mut ::windows::core::GUID, pguidsnapin: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IGPEInformation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IGPEInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPEInformation_Impl, const OFFSET: isize>() -> IGPEInformation_Vtbl {
         unsafe extern "system" fn GetName<Identity: ::windows::core::IUnknownImpl, Impl: IGPEInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::HRESULT {
@@ -90,6 +92,8 @@ pub trait IGPM_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateMigrationTable(&self) -> ::windows::core::Result<IGPMMigrationTable>;
     fn InitializeReporting(&self, bstradmpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPM {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPM_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPM_Impl, const OFFSET: isize>() -> IGPM_Vtbl {
@@ -245,6 +249,8 @@ pub trait IGPM2_Impl: Sized + super::Com::IDispatch_Impl + IGPM_Impl {
     fn InitializeReportingEx(&self, bstradmpath: &super::super::Foundation::BSTR, reportingoptions: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPM2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPM2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPM2_Impl, const OFFSET: isize>() -> IGPM2_Vtbl {
         unsafe extern "system" fn GetBackupDirEx<Identity: ::windows::core::IUnknownImpl, Impl: IGPM2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrbackupdir: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, backupdirtype: GPMBackupType, ppigpmbackupdirex: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -278,6 +284,8 @@ pub trait IGPMAsyncCancel_Impl: Sized + super::Com::IDispatch_Impl {
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMAsyncCancel {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMAsyncCancel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMAsyncCancel_Impl, const OFFSET: isize>() -> IGPMAsyncCancel_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: IGPMAsyncCancel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -295,6 +303,8 @@ impl IGPMAsyncCancel_Vtbl {
 pub trait IGPMAsyncProgress_Impl: Sized + super::Com::IDispatch_Impl {
     fn Status(&self, lprogressnumerator: i32, lprogressdenominator: i32, hrstatus: ::windows::core::HRESULT, presult: *const super::Com::VARIANT, ppigpmstatusmsgcollection: &::core::option::Option<IGPMStatusMsgCollection>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMAsyncProgress {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMAsyncProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMAsyncProgress_Impl, const OFFSET: isize>() -> IGPMAsyncProgress_Vtbl {
@@ -322,6 +332,8 @@ pub trait IGPMBackup_Impl: Sized + super::Com::IDispatch_Impl {
     fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const super::Com::VARIANT, pvargpmcancel: *mut super::Com::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows::core::Result<()>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &super::super::Foundation::BSTR) -> ::windows::core::Result<IGPMResult>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMBackup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMBackup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMBackup_Impl, const OFFSET: isize>() -> IGPMBackup_Vtbl {
@@ -448,6 +460,8 @@ pub trait IGPMBackupCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMBackupCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMBackupCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMBackupCollection_Impl, const OFFSET: isize>() -> IGPMBackupCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMBackupCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -500,6 +514,8 @@ pub trait IGPMBackupDir_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetBackup(&self, bstrid: &super::super::Foundation::BSTR) -> ::windows::core::Result<IGPMBackup>;
     fn SearchBackups(&self, pigpmsearchcriteria: &::core::option::Option<IGPMSearchCriteria>) -> ::windows::core::Result<IGPMBackupCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMBackupDir {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMBackupDir_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMBackupDir_Impl, const OFFSET: isize>() -> IGPMBackupDir_Vtbl {
@@ -554,6 +570,8 @@ pub trait IGPMBackupDirEx_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetBackup(&self, bstrid: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
     fn SearchBackups(&self, pigpmsearchcriteria: &::core::option::Option<IGPMSearchCriteria>) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMBackupDirEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMBackupDirEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMBackupDirEx_Impl, const OFFSET: isize>() -> IGPMBackupDirEx_Vtbl {
@@ -620,6 +638,8 @@ pub trait IGPMCSECollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMCSECollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMCSECollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMCSECollection_Impl, const OFFSET: isize>() -> IGPMCSECollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMCSECollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -673,6 +693,8 @@ pub trait IGPMClientSideExtension_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsUserEnabled(&self) -> ::windows::core::Result<i16>;
     fn IsComputerEnabled(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMClientSideExtension {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMClientSideExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMClientSideExtension_Impl, const OFFSET: isize>() -> IGPMClientSideExtension_Vtbl {
@@ -795,6 +817,8 @@ pub trait IGPMConstants_Impl: Sized + super::Com::IDispatch_Impl {
     fn RsopPlanningAssumeUserWQLFilterTrue(&self) -> ::windows::core::Result<i32>;
     fn RsopPlanningAssumeCompWQLFilterTrue(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMConstants {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMConstants_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMConstants_Impl, const OFFSET: isize>() -> IGPMConstants_Vtbl {
@@ -1545,6 +1569,8 @@ pub trait IGPMConstants2_Impl: Sized + super::Com::IDispatch_Impl + IGPMConstant
     fn ReportComments(&self) -> ::windows::core::Result<GPMReportingOptions>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMConstants2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMConstants2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMConstants2_Impl, const OFFSET: isize>() -> IGPMConstants2_Vtbl {
         unsafe extern "system" fn BackupTypeGPO<Identity: ::windows::core::IUnknownImpl, Impl: IGPMConstants2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut GPMBackupType) -> ::windows::core::HRESULT {
@@ -1749,6 +1775,8 @@ pub trait IGPMDomain_Impl: Sized + super::Com::IDispatch_Impl {
     fn SearchWMIFilters(&self, pigpmsearchcriteria: &::core::option::Option<IGPMSearchCriteria>) -> ::windows::core::Result<IGPMWMIFilterCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMDomain {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMDomain_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMDomain_Impl, const OFFSET: isize>() -> IGPMDomain_Vtbl {
         unsafe extern "system" fn DomainController<Identity: ::windows::core::IUnknownImpl, Impl: IGPMDomain_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1883,6 +1911,8 @@ pub trait IGPMDomain2_Impl: Sized + super::Com::IDispatch_Impl + IGPMDomain_Impl
     fn RestoreStarterGPO(&self, pigpmtmplbackup: &::core::option::Option<IGPMStarterGPOBackup>, pvargpmprogress: *const super::Com::VARIANT, pvargpmcancel: *mut super::Com::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMDomain2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMDomain2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMDomain2_Impl, const OFFSET: isize>() -> IGPMDomain2_Vtbl {
         unsafe extern "system" fn CreateStarterGPO<Identity: ::windows::core::IUnknownImpl, Impl: IGPMDomain2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppnewtemplate: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1961,6 +1991,8 @@ pub trait IGPMDomain3_Impl: Sized + super::Com::IDispatch_Impl + IGPMDomain_Impl
     fn SetInfrastructureFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMDomain3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMDomain3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMDomain3_Impl, const OFFSET: isize>() -> IGPMDomain3_Vtbl {
         unsafe extern "system" fn GenerateReport<Identity: ::windows::core::IUnknownImpl, Impl: IGPMDomain3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, pvargpmprogress: *const super::Com::VARIANT, pvargpmcancel: *mut super::Com::VARIANT, ppigpmresult: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2033,6 +2065,8 @@ pub trait IGPMGPO_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsACLConsistent(&self) -> ::windows::core::Result<i16>;
     fn MakeACLConsistent(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMGPO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMGPO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPO_Impl, const OFFSET: isize>() -> IGPMGPO_Vtbl {
@@ -2326,6 +2360,8 @@ pub trait IGPMGPO2_Impl: Sized + super::Com::IDispatch_Impl + IGPMGPO_Impl {
     fn SetDescription(&self, newval: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMGPO2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMGPO2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPO2_Impl, const OFFSET: isize>() -> IGPMGPO2_Vtbl {
         unsafe extern "system" fn Description<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPO2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2360,6 +2396,8 @@ pub trait IGPMGPO3_Impl: Sized + super::Com::IDispatch_Impl + IGPMGPO_Impl + IGP
     fn SetInfrastructureDC(&self, newval: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetInfrastructureFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMGPO3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMGPO3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPO3_Impl, const OFFSET: isize>() -> IGPMGPO3_Vtbl {
@@ -2401,6 +2439,8 @@ pub trait IGPMGPOCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, lindex: i32) -> ::windows::core::Result<super::Com::VARIANT>;
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMGPOCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMGPOCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPOCollection_Impl, const OFFSET: isize>() -> IGPMGPOCollection_Vtbl {
@@ -2460,6 +2500,8 @@ pub trait IGPMGPOLink_Impl: Sized + super::Com::IDispatch_Impl {
     fn SOM(&self) -> ::windows::core::Result<IGPMSOM>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMGPOLink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMGPOLink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPOLink_Impl, const OFFSET: isize>() -> IGPMGPOLink_Vtbl {
@@ -2568,6 +2610,8 @@ pub trait IGPMGPOLinksCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMGPOLinksCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMGPOLinksCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPOLinksCollection_Impl, const OFFSET: isize>() -> IGPMGPOLinksCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMGPOLinksCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -2621,6 +2665,8 @@ pub trait IGPMMapEntry_Impl: Sized + super::Com::IDispatch_Impl {
     fn DestinationOption(&self) -> ::windows::core::Result<GPMDestinationOption>;
     fn EntryType(&self) -> ::windows::core::Result<GPMEntryType>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMMapEntry {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMMapEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMMapEntry_Impl, const OFFSET: isize>() -> IGPMMapEntry_Vtbl {
@@ -2687,6 +2733,8 @@ pub trait IGPMMapEntryCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMMapEntryCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMMapEntryCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMMapEntryCollection_Impl, const OFFSET: isize>() -> IGPMMapEntryCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMMapEntryCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -2744,6 +2792,8 @@ pub trait IGPMMigrationTable_Impl: Sized + super::Com::IDispatch_Impl {
     fn Validate(&self) -> ::windows::core::Result<IGPMResult>;
     fn GetEntries(&self) -> ::windows::core::Result<IGPMMapEntryCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMMigrationTable {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMMigrationTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMMigrationTable_Impl, const OFFSET: isize>() -> IGPMMigrationTable_Vtbl {
@@ -2841,6 +2891,8 @@ pub trait IGPMPermission_Impl: Sized + super::Com::IDispatch_Impl {
     fn Permission(&self) -> ::windows::core::Result<GPMPermissionType>;
     fn Trustee(&self) -> ::windows::core::Result<IGPMTrustee>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMPermission {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMPermission_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMPermission_Impl, const OFFSET: isize>() -> IGPMPermission_Vtbl {
@@ -2950,6 +3002,8 @@ pub trait IGPMRSOP_Impl: Sized + super::Com::IDispatch_Impl {
     fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const super::Com::VARIANT, pvargpmcancel: *mut super::Com::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows::core::Result<()>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &super::super::Foundation::BSTR) -> ::windows::core::Result<IGPMResult>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMRSOP {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMRSOP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMRSOP_Impl, const OFFSET: isize>() -> IGPMRSOP_Vtbl {
@@ -3286,6 +3340,8 @@ pub trait IGPMResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn OverallStatus(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMResult {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMResult_Impl, const OFFSET: isize>() -> IGPMResult_Vtbl {
         unsafe extern "system" fn Status<Identity: ::windows::core::IUnknownImpl, Impl: IGPMResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppigpmstatusmsgcollection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3339,6 +3395,8 @@ pub trait IGPMSOM_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityInfo(&self) -> ::windows::core::Result<IGPMSecurityInfo>;
     fn SetSecurityInfo(&self, psecurityinfo: &::core::option::Option<IGPMSecurityInfo>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMSOM {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMSOM_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSOM_Impl, const OFFSET: isize>() -> IGPMSOM_Vtbl {
@@ -3465,6 +3523,8 @@ pub trait IGPMSOMCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMSOMCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMSOMCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSOMCollection_Impl, const OFFSET: isize>() -> IGPMSOMCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSOMCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -3516,6 +3576,8 @@ pub trait IGPMSearchCriteria_Impl: Sized + super::Com::IDispatch_Impl {
     fn Add(&self, searchproperty: GPMSearchProperty, searchoperation: GPMSearchOperation, varvalue: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMSearchCriteria {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMSearchCriteria_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSearchCriteria_Impl, const OFFSET: isize>() -> IGPMSearchCriteria_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSearchCriteria_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, searchproperty: GPMSearchProperty, searchoperation: GPMSearchOperation, varvalue: ::core::mem::ManuallyDrop<super::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -3538,6 +3600,8 @@ pub trait IGPMSecurityInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Remove(&self, pperm: &::core::option::Option<IGPMPermission>) -> ::windows::core::Result<()>;
     fn RemoveTrustee(&self, bstrtrustee: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMSecurityInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMSecurityInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSecurityInfo_Impl, const OFFSET: isize>() -> IGPMSecurityInfo_Vtbl {
@@ -3611,6 +3675,8 @@ pub trait IGPMSitesContainer_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSite(&self, bstrsitename: &super::super::Foundation::BSTR) -> ::windows::core::Result<IGPMSOM>;
     fn SearchSites(&self, pigpmsearchcriteria: &::core::option::Option<IGPMSearchCriteria>) -> ::windows::core::Result<IGPMSOMCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMSitesContainer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMSitesContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMSitesContainer_Impl, const OFFSET: isize>() -> IGPMSitesContainer_Vtbl {
@@ -3706,6 +3772,8 @@ pub trait IGPMStarterGPO_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityInfo(&self) -> ::windows::core::Result<IGPMSecurityInfo>;
     fn SetSecurityInfo(&self, psecurityinfo: &::core::option::Option<IGPMSecurityInfo>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMStarterGPO {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMStarterGPO_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStarterGPO_Impl, const OFFSET: isize>() -> IGPMStarterGPO_Vtbl {
@@ -3950,6 +4018,8 @@ pub trait IGPMStarterGPOBackup_Impl: Sized + super::Com::IDispatch_Impl {
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &super::super::Foundation::BSTR) -> ::windows::core::Result<IGPMResult>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMStarterGPOBackup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMStarterGPOBackup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStarterGPOBackup_Impl, const OFFSET: isize>() -> IGPMStarterGPOBackup_Vtbl {
         unsafe extern "system" fn BackupDir<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStarterGPOBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrbackupdir: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4087,6 +4157,8 @@ pub trait IGPMStarterGPOBackupCollection_Impl: Sized + super::Com::IDispatch_Imp
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMStarterGPOBackupCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMStarterGPOBackupCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStarterGPOBackupCollection_Impl, const OFFSET: isize>() -> IGPMStarterGPOBackupCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStarterGPOBackupCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -4139,6 +4211,8 @@ pub trait IGPMStarterGPOCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, lindex: i32) -> ::windows::core::Result<super::Com::VARIANT>;
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMStarterGPOCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMStarterGPOCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStarterGPOCollection_Impl, const OFFSET: isize>() -> IGPMStarterGPOCollection_Vtbl {
@@ -4195,6 +4269,8 @@ pub trait IGPMStatusMessage_Impl: Sized + super::Com::IDispatch_Impl {
     fn OperationCode(&self) -> ::windows::core::Result<()>;
     fn Message(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMStatusMessage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMStatusMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStatusMessage_Impl, const OFFSET: isize>() -> IGPMStatusMessage_Vtbl {
@@ -4273,6 +4349,8 @@ pub trait IGPMStatusMsgCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMStatusMsgCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMStatusMsgCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStatusMsgCollection_Impl, const OFFSET: isize>() -> IGPMStatusMsgCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMStatusMsgCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -4327,6 +4405,8 @@ pub trait IGPMTrustee_Impl: Sized + super::Com::IDispatch_Impl {
     fn TrusteeDSPath(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn TrusteeType(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMTrustee {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMTrustee_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMTrustee_Impl, const OFFSET: isize>() -> IGPMTrustee_Vtbl {
@@ -4409,6 +4489,8 @@ pub trait IGPMWMIFilter_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityInfo(&self) -> ::windows::core::Result<IGPMSecurityInfo>;
     fn SetSecurityInfo(&self, psecurityinfo: &::core::option::Option<IGPMSecurityInfo>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMWMIFilter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMWMIFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMWMIFilter_Impl, const OFFSET: isize>() -> IGPMWMIFilter_Vtbl {
@@ -4505,6 +4587,8 @@ pub trait IGPMWMIFilterCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::Ole::IEnumVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IGPMWMIFilterCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IGPMWMIFilterCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGPMWMIFilterCollection_Impl, const OFFSET: isize>() -> IGPMWMIFilterCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IGPMWMIFilterCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT {
@@ -4572,6 +4656,8 @@ pub trait IGroupPolicyObject_Impl: Sized {
     fn GetMachineName(&self, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::Result<()>;
     fn GetPropertySheetPages(&self, hpages: *mut *mut super::super::UI::Controls::HPROPSHEETPAGE, upagecount: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Controls"))]
+impl ::windows::core::RuntimeName for IGroupPolicyObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Controls"))]
 impl IGroupPolicyObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGroupPolicyObject_Impl, const OFFSET: isize>() -> IGroupPolicyObject_Vtbl {
@@ -4696,6 +4782,7 @@ pub trait IRSOPInformation_Impl: Sized {
     fn GetFlags(&self, pdwflags: *mut u32) -> ::windows::core::Result<()>;
     fn GetEventLogEntryText(&self, pszeventsource: &::windows::core::PCWSTR, pszeventlogname: &::windows::core::PCWSTR, pszeventtime: &::windows::core::PCWSTR, dweventid: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IRSOPInformation {}
 impl IRSOPInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRSOPInformation_Impl, const OFFSET: isize>() -> IRSOPInformation_Vtbl {
         unsafe extern "system" fn GetNamespace<Identity: ::windows::core::IUnknownImpl, Impl: IRSOPInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsection: u32, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
@@ -4,6 +4,8 @@ pub trait AsyncIFtpAuthenticationProvider_Impl: Sized {
     fn Finish_AuthenticateUser(&self, ppszcanonicalusername: *mut ::windows::core::PWSTR, pfauthenticated: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for AsyncIFtpAuthenticationProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl AsyncIFtpAuthenticationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpAuthenticationProvider_Impl, const OFFSET: isize>() -> AsyncIFtpAuthenticationProvider_Vtbl {
         unsafe extern "system" fn Begin_AuthenticateUser<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpAuthenticationProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszpassword: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -30,6 +32,7 @@ pub trait AsyncIFtpAuthorizationProvider_Impl: Sized {
     fn Begin_GetUserAccessPermission(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszvirtualpath: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_GetUserAccessPermission(&self) -> ::windows::core::Result<FTP_ACCESS>;
 }
+impl ::windows::core::RuntimeName for AsyncIFtpAuthorizationProvider {}
 impl AsyncIFtpAuthorizationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpAuthorizationProvider_Impl, const OFFSET: isize>() -> AsyncIFtpAuthorizationProvider_Vtbl {
         unsafe extern "system" fn Begin_GetUserAccessPermission<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpAuthorizationProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszvirtualpath: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -62,6 +65,7 @@ pub trait AsyncIFtpHomeDirectoryProvider_Impl: Sized {
     fn Begin_GetUserHomeDirectoryData(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_GetUserHomeDirectoryData(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for AsyncIFtpHomeDirectoryProvider {}
 impl AsyncIFtpHomeDirectoryProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpHomeDirectoryProvider_Impl, const OFFSET: isize>() -> AsyncIFtpHomeDirectoryProvider_Vtbl {
         unsafe extern "system" fn Begin_GetUserHomeDirectoryData<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpHomeDirectoryProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -94,6 +98,7 @@ pub trait AsyncIFtpLogProvider_Impl: Sized {
     fn Begin_Log(&self, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::Result<()>;
     fn Finish_Log(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIFtpLogProvider {}
 impl AsyncIFtpLogProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpLogProvider_Impl, const OFFSET: isize>() -> AsyncIFtpLogProvider_Vtbl {
         unsafe extern "system" fn Begin_Log<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpLogProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::HRESULT {
@@ -121,6 +126,8 @@ pub trait AsyncIFtpPostprocessProvider_Impl: Sized {
     fn Begin_HandlePostprocess(&self, ppostprocessparameters: *const POST_PROCESS_PARAMETERS) -> ::windows::core::Result<()>;
     fn Finish_HandlePostprocess(&self) -> ::windows::core::Result<FTP_PROCESS_STATUS>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for AsyncIFtpPostprocessProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl AsyncIFtpPostprocessProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpPostprocessProvider_Impl, const OFFSET: isize>() -> AsyncIFtpPostprocessProvider_Vtbl {
@@ -156,6 +163,8 @@ pub trait AsyncIFtpPreprocessProvider_Impl: Sized {
     fn Finish_HandlePreprocess(&self) -> ::windows::core::Result<FTP_PROCESS_STATUS>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for AsyncIFtpPreprocessProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl AsyncIFtpPreprocessProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpPreprocessProvider_Impl, const OFFSET: isize>() -> AsyncIFtpPreprocessProvider_Vtbl {
         unsafe extern "system" fn Begin_HandlePreprocess<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpPreprocessProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS) -> ::windows::core::HRESULT {
@@ -189,6 +198,8 @@ pub trait AsyncIFtpRoleProvider_Impl: Sized {
     fn Begin_IsUserInRole(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszrole: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_IsUserInRole(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for AsyncIFtpRoleProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl AsyncIFtpRoleProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIFtpRoleProvider_Impl, const OFFSET: isize>() -> AsyncIFtpRoleProvider_Vtbl {
@@ -224,6 +235,7 @@ pub trait AsyncIMSAdminBaseSinkW_Impl: Sized {
     fn Begin_ShutdownNotify(&self) -> ::windows::core::Result<()>;
     fn Finish_ShutdownNotify(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for AsyncIMSAdminBaseSinkW {}
 impl AsyncIMSAdminBaseSinkW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIMSAdminBaseSinkW_Impl, const OFFSET: isize>() -> AsyncIMSAdminBaseSinkW_Vtbl {
         unsafe extern "system" fn Begin_SinkNotify<Identity: ::windows::core::IUnknownImpl, Impl: AsyncIMSAdminBaseSinkW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::HRESULT {
@@ -263,6 +275,7 @@ pub trait IADMEXT_Impl: Sized {
     fn EnumDcomCLSIDs(&self, pclsiddcom: *mut ::windows::core::GUID, dwenumindex: u32) -> ::windows::core::Result<()>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IADMEXT {}
 impl IADMEXT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADMEXT_Impl, const OFFSET: isize>() -> IADMEXT_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IADMEXT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -296,6 +309,8 @@ pub trait IFtpAuthenticationProvider_Impl: Sized {
     fn AuthenticateUser(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszpassword: &::windows::core::PCWSTR, ppszcanonicalusername: *mut ::windows::core::PWSTR, pfauthenticated: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFtpAuthenticationProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFtpAuthenticationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpAuthenticationProvider_Impl, const OFFSET: isize>() -> IFtpAuthenticationProvider_Vtbl {
         unsafe extern "system" fn AuthenticateUser<Identity: ::windows::core::IUnknownImpl, Impl: IFtpAuthenticationProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszpassword: ::windows::core::PCWSTR, ppszcanonicalusername: *mut ::windows::core::PWSTR, pfauthenticated: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -312,6 +327,7 @@ impl IFtpAuthenticationProvider_Vtbl {
 pub trait IFtpAuthorizationProvider_Impl: Sized {
     fn GetUserAccessPermission(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszvirtualpath: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<FTP_ACCESS>;
 }
+impl ::windows::core::RuntimeName for IFtpAuthorizationProvider {}
 impl IFtpAuthorizationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpAuthorizationProvider_Impl, const OFFSET: isize>() -> IFtpAuthorizationProvider_Vtbl {
         unsafe extern "system" fn GetUserAccessPermission<Identity: ::windows::core::IUnknownImpl, Impl: IFtpAuthorizationProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszvirtualpath: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pftpaccess: *mut FTP_ACCESS) -> ::windows::core::HRESULT {
@@ -334,6 +350,7 @@ impl IFtpAuthorizationProvider_Vtbl {
 pub trait IFtpHomeDirectoryProvider_Impl: Sized {
     fn GetUserHomeDirectoryData(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IFtpHomeDirectoryProvider {}
 impl IFtpHomeDirectoryProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpHomeDirectoryProvider_Impl, const OFFSET: isize>() -> IFtpHomeDirectoryProvider_Vtbl {
         unsafe extern "system" fn GetUserHomeDirectoryData<Identity: ::windows::core::IUnknownImpl, Impl: IFtpHomeDirectoryProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, ppszhomedirectorydata: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -356,6 +373,7 @@ impl IFtpHomeDirectoryProvider_Vtbl {
 pub trait IFtpLogProvider_Impl: Sized {
     fn Log(&self, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFtpLogProvider {}
 impl IFtpLogProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpLogProvider_Impl, const OFFSET: isize>() -> IFtpLogProvider_Vtbl {
         unsafe extern "system" fn Log<Identity: ::windows::core::IUnknownImpl, Impl: IFtpLogProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::HRESULT {
@@ -373,6 +391,8 @@ impl IFtpLogProvider_Vtbl {
 pub trait IFtpPostprocessProvider_Impl: Sized {
     fn HandlePostprocess(&self, ppostprocessparameters: *const POST_PROCESS_PARAMETERS) -> ::windows::core::Result<FTP_PROCESS_STATUS>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFtpPostprocessProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFtpPostprocessProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpPostprocessProvider_Impl, const OFFSET: isize>() -> IFtpPostprocessProvider_Vtbl {
@@ -398,6 +418,8 @@ pub trait IFtpPreprocessProvider_Impl: Sized {
     fn HandlePreprocess(&self, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS) -> ::windows::core::Result<FTP_PROCESS_STATUS>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFtpPreprocessProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFtpPreprocessProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpPreprocessProvider_Impl, const OFFSET: isize>() -> IFtpPreprocessProvider_Vtbl {
         unsafe extern "system" fn HandlePreprocess<Identity: ::windows::core::IUnknownImpl, Impl: IFtpPreprocessProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS, pftpprocessstatus: *mut FTP_PROCESS_STATUS) -> ::windows::core::HRESULT {
@@ -422,6 +444,8 @@ pub trait IFtpProviderConstruct_Impl: Sized {
     fn Construct(&self, configurationentries: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IFtpProviderConstruct {}
+#[cfg(feature = "Win32_System_Com")]
 impl IFtpProviderConstruct_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpProviderConstruct_Impl, const OFFSET: isize>() -> IFtpProviderConstruct_Vtbl {
         unsafe extern "system" fn Construct<Identity: ::windows::core::IUnknownImpl, Impl: IFtpProviderConstruct_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, configurationentries: *const super::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -439,6 +463,8 @@ impl IFtpProviderConstruct_Vtbl {
 pub trait IFtpRoleProvider_Impl: Sized {
     fn IsUserInRole(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszrole: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFtpRoleProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFtpRoleProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFtpRoleProvider_Impl, const OFFSET: isize>() -> IFtpRoleProvider_Vtbl {
@@ -468,6 +494,8 @@ pub trait IMSAdminBase2W_Impl: Sized + IMSAdminBaseW_Impl {
     fn RestoreHistory(&self, pszmdhistorylocation: &::windows::core::PCWSTR, dwmdmajorversion: u32, dwmdminorversion: u32, dwmdflags: u32) -> ::windows::core::Result<()>;
     fn EnumHistory(&self, pszmdhistorylocation: &::windows::core::PWSTR, pdwmdmajorversion: *mut u32, pdwmdminorversion: *mut u32, pftmdhistorytime: *mut super::super::Foundation::FILETIME, dwmdenumindex: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMSAdminBase2W {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMSAdminBase2W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSAdminBase2W_Impl, const OFFSET: isize>() -> IMSAdminBase2W_Vtbl {
@@ -520,6 +548,8 @@ pub trait IMSAdminBase3W_Impl: Sized + IMSAdminBaseW_Impl + IMSAdminBase2W_Impl 
     fn GetChildPaths(&self, hmdhandle: u32, pszmdpath: &::windows::core::PCWSTR, cchmdbuffersize: u32, pszbuffer: &::windows::core::PWSTR, pcchmdrequiredbuffersize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMSAdminBase3W {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMSAdminBase3W_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSAdminBase3W_Impl, const OFFSET: isize>() -> IMSAdminBase3W_Vtbl {
         unsafe extern "system" fn GetChildPaths<Identity: ::windows::core::IUnknownImpl, Impl: IMSAdminBase3W_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hmdhandle: u32, pszmdpath: ::windows::core::PCWSTR, cchmdbuffersize: u32, pszbuffer: ::windows::core::PWSTR, pcchmdrequiredbuffersize: *mut u32) -> ::windows::core::HRESULT {
@@ -537,6 +567,7 @@ pub trait IMSAdminBaseSinkW_Impl: Sized {
     fn SinkNotify(&self, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::Result<()>;
     fn ShutdownNotify(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMSAdminBaseSinkW {}
 impl IMSAdminBaseSinkW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSAdminBaseSinkW_Impl, const OFFSET: isize>() -> IMSAdminBaseSinkW_Vtbl {
         unsafe extern "system" fn SinkNotify<Identity: ::windows::core::IUnknownImpl, Impl: IMSAdminBaseSinkW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::HRESULT {
@@ -593,6 +624,8 @@ pub trait IMSAdminBaseW_Impl: Sized {
     fn UnmarshalInterface(&self) -> ::windows::core::Result<IMSAdminBaseW>;
     fn GetServerGuid(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMSAdminBaseW {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMSAdminBaseW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSAdminBaseW_Impl, const OFFSET: isize>() -> IMSAdminBaseW_Vtbl {
@@ -823,6 +856,7 @@ impl IMSAdminBaseW_Vtbl {
 pub trait IMSImpExpHelpW_Impl: Sized {
     fn EnumeratePathsInFile(&self, pszfilename: &::windows::core::PCWSTR, pszkeytype: &::windows::core::PCWSTR, dwmdbuffersize: u32, pszbuffer: &::windows::core::PWSTR, pdwmdrequiredbuffersize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMSImpExpHelpW {}
 impl IMSImpExpHelpW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSImpExpHelpW_Impl, const OFFSET: isize>() -> IMSImpExpHelpW_Vtbl {
         unsafe extern "system" fn EnumeratePathsInFile<Identity: ::windows::core::IUnknownImpl, Impl: IMSImpExpHelpW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfilename: ::windows::core::PCWSTR, pszkeytype: ::windows::core::PCWSTR, dwmdbuffersize: u32, pszbuffer: ::windows::core::PWSTR, pdwmdrequiredbuffersize: *mut u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/impl.rs
@@ -3,6 +3,8 @@ pub trait IMSMQApplication_Impl: Sized + super::Com::IDispatch_Impl {
     fn MachineIdOfMachineName(&self, machinename: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQApplication {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQApplication_Impl, const OFFSET: isize>() -> IMSMQApplication_Vtbl {
         unsafe extern "system" fn MachineIdOfMachineName<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, machinename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbstrguid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -32,6 +34,8 @@ pub trait IMSMQApplication2_Impl: Sized + super::Com::IDispatch_Impl + IMSMQAppl
     fn IsDsEnabled(&self) -> ::windows::core::Result<i16>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQApplication2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQApplication2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQApplication2_Impl, const OFFSET: isize>() -> IMSMQApplication2_Vtbl {
@@ -134,6 +138,8 @@ pub trait IMSMQApplication3_Impl: Sized + super::Com::IDispatch_Impl + IMSMQAppl
     fn Disconnect(&self) -> ::windows::core::Result<()>;
     fn Tidy(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQApplication3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQApplication3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQApplication3_Impl, const OFFSET: isize>() -> IMSMQApplication3_Vtbl {
@@ -248,6 +254,8 @@ pub trait IMSMQCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQCollection_Impl, const OFFSET: isize>() -> IMSMQCollection_Vtbl {
         unsafe extern "system" fn Item<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: *const super::Com::VARIANT, pvarret: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -299,6 +307,8 @@ pub trait IMSMQCoordinatedTransactionDispenser_Impl: Sized + super::Com::IDispat
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQCoordinatedTransactionDispenser {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQCoordinatedTransactionDispenser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQCoordinatedTransactionDispenser_Impl, const OFFSET: isize>() -> IMSMQCoordinatedTransactionDispenser_Vtbl {
         unsafe extern "system" fn BeginTransaction<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQCoordinatedTransactionDispenser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -323,6 +333,8 @@ pub trait IMSMQCoordinatedTransactionDispenser2_Impl: Sized + super::Com::IDispa
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction2>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQCoordinatedTransactionDispenser2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQCoordinatedTransactionDispenser2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQCoordinatedTransactionDispenser2_Impl, const OFFSET: isize>() -> IMSMQCoordinatedTransactionDispenser2_Vtbl {
@@ -363,6 +375,8 @@ pub trait IMSMQCoordinatedTransactionDispenser3_Impl: Sized + super::Com::IDispa
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction3>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQCoordinatedTransactionDispenser3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQCoordinatedTransactionDispenser3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQCoordinatedTransactionDispenser3_Impl, const OFFSET: isize>() -> IMSMQCoordinatedTransactionDispenser3_Vtbl {
@@ -415,6 +429,8 @@ pub trait IMSMQDestination_Impl: Sized + super::Com::IDispatch_Impl {
     fn putref_Destinations(&self, pdestinations: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQDestination {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQDestination_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQDestination_Impl, const OFFSET: isize>() -> IMSMQDestination_Vtbl {
@@ -555,6 +571,8 @@ impl IMSMQDestination_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQEvent_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQEvent_Impl, const OFFSET: isize>() -> IMSMQEvent_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -567,6 +585,8 @@ impl IMSMQEvent_Vtbl {
 pub trait IMSMQEvent2_Impl: Sized + super::Com::IDispatch_Impl + IMSMQEvent_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQEvent2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQEvent2_Impl, const OFFSET: isize>() -> IMSMQEvent2_Vtbl {
@@ -590,6 +610,8 @@ impl IMSMQEvent2_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQEvent3_Impl: Sized + super::Com::IDispatch_Impl + IMSMQEvent_Impl + IMSMQEvent2_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQEvent3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQEvent3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQEvent3_Impl, const OFFSET: isize>() -> IMSMQEvent3_Vtbl {
         Self { base__: IMSMQEvent2_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -610,6 +632,8 @@ pub trait IMSMQManagement_Impl: Sized + super::Com::IDispatch_Impl {
     fn TransactionalStatus(&self) -> ::windows::core::Result<i32>;
     fn BytesInQueue(&self) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQManagement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQManagement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQManagement_Impl, const OFFSET: isize>() -> IMSMQManagement_Vtbl {
@@ -775,6 +799,8 @@ pub trait IMSMQMessage_Impl: Sized + super::Com::IDispatch_Impl {
     fn Send(&self, destinationqueue: &::core::option::Option<IMSMQQueue>, transaction: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
     fn AttachCurrentSecurityContext(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQMessage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQMessage_Impl, const OFFSET: isize>() -> IMSMQMessage_Vtbl {
@@ -1326,6 +1352,8 @@ pub trait IMSMQMessage2_Impl: Sized + super::Com::IDispatch_Impl {
     fn putref_AdminQueueInfo(&self, pqinfoadmin: &::core::option::Option<IMSMQQueueInfo2>) -> ::windows::core::Result<()>;
     fn ReceivedAuthenticationLevel(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQMessage2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQMessage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQMessage2_Impl, const OFFSET: isize>() -> IMSMQMessage2_Vtbl {
@@ -2145,6 +2173,8 @@ pub trait IMSMQMessage3_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetSoapHeader(&self, bstrsoapheader: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetSoapBody(&self, bstrsoapbody: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQMessage3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQMessage3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQMessage3_Impl, const OFFSET: isize>() -> IMSMQMessage3_Vtbl {
@@ -3121,6 +3151,8 @@ pub trait IMSMQMessage4_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetSoapBody(&self, bstrsoapbody: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQMessage4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQMessage4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQMessage4_Impl, const OFFSET: isize>() -> IMSMQMessage4_Vtbl {
         unsafe extern "system" fn Class<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQMessage4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plclass: *mut i32) -> ::windows::core::HRESULT {
@@ -4011,6 +4043,8 @@ pub trait IMSMQOutgoingQueueManagement_Impl: Sized + super::Com::IDispatch_Impl 
     fn EodResend(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQOutgoingQueueManagement {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQOutgoingQueueManagement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQOutgoingQueueManagement_Impl, const OFFSET: isize>() -> IMSMQOutgoingQueueManagement_Vtbl {
         unsafe extern "system" fn State<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQOutgoingQueueManagement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plstate: *mut i32) -> ::windows::core::HRESULT {
@@ -4081,6 +4115,8 @@ pub trait IMSMQPrivateDestination_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetHandle(&self, varhandle: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQPrivateDestination {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQPrivateDestination_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQPrivateDestination_Impl, const OFFSET: isize>() -> IMSMQPrivateDestination_Vtbl {
         unsafe extern "system" fn Handle<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQPrivateDestination_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvarhandle: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4115,6 +4151,8 @@ pub trait IMSMQPrivateEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn FireArrivedEvent(&self, pq: &::core::option::Option<IMSMQQueue>, msgcursor: i32) -> ::windows::core::Result<()>;
     fn FireArrivedErrorEvent(&self, pq: &::core::option::Option<IMSMQQueue>, hrstatus: ::windows::core::HRESULT, msgcursor: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQPrivateEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQPrivateEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQPrivateEvent_Impl, const OFFSET: isize>() -> IMSMQPrivateEvent_Vtbl {
@@ -4155,6 +4193,8 @@ pub trait IMSMQQuery_Impl: Sized + super::Com::IDispatch_Impl {
     fn LookupQueue(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQuery {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQuery_Impl, const OFFSET: isize>() -> IMSMQQuery_Vtbl {
         unsafe extern "system" fn LookupQueue<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT, ppqinfos: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4179,6 +4219,8 @@ pub trait IMSMQQuery2_Impl: Sized + super::Com::IDispatch_Impl {
     fn LookupQueue(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos2>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQuery2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQuery2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQuery2_Impl, const OFFSET: isize>() -> IMSMQQuery2_Vtbl {
@@ -4220,6 +4262,8 @@ pub trait IMSMQQuery3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
     fn LookupQueue(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT, multicastaddress: *const super::Com::VARIANT, relmulticastaddress: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos3>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQuery3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQuery3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQuery3_Impl, const OFFSET: isize>() -> IMSMQQuery3_Vtbl {
@@ -4285,6 +4329,8 @@ pub trait IMSMQQuery4_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
     fn LookupQueue(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT, multicastaddress: *const super::Com::VARIANT, relmulticastaddress: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos4>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQuery4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQuery4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQuery4_Impl, const OFFSET: isize>() -> IMSMQQuery4_Vtbl {
@@ -4360,6 +4406,8 @@ pub trait IMSMQQueue_Impl: Sized + super::Com::IDispatch_Impl {
     fn PeekNext(&self, wantdestinationqueue: *const super::Com::VARIANT, wantbody: *const super::Com::VARIANT, receivetimeout: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQMessage>;
     fn PeekCurrent(&self, wantdestinationqueue: *const super::Com::VARIANT, wantbody: *const super::Com::VARIANT, receivetimeout: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQMessage>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueue {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueue_Impl, const OFFSET: isize>() -> IMSMQQueue_Vtbl {
@@ -4531,6 +4579,8 @@ pub trait IMSMQQueue2_Impl: Sized + super::Com::IDispatch_Impl {
     fn PeekCurrent(&self, wantdestinationqueue: *const super::Com::VARIANT, wantbody: *const super::Com::VARIANT, receivetimeout: *const super::Com::VARIANT, wantconnectortype: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQMessage2>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueue2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueue2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueue2_Impl, const OFFSET: isize>() -> IMSMQQueue2_Vtbl {
@@ -4787,6 +4837,8 @@ pub trait IMSMQQueue3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Purge(&self) -> ::windows::core::Result<()>;
     fn IsOpen2(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueue3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueue3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueue3_Impl, const OFFSET: isize>() -> IMSMQQueue3_Vtbl {
@@ -5194,6 +5246,8 @@ pub trait IMSMQQueue4_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsOpen2(&self) -> ::windows::core::Result<i16>;
     fn ReceiveByLookupIdAllowPeek(&self, lookupid: &super::Com::VARIANT, transaction: *const super::Com::VARIANT, wantdestinationqueue: *const super::Com::VARIANT, wantbody: *const super::Com::VARIANT, wantconnectortype: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQMessage4>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueue4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueue4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueue4_Impl, const OFFSET: isize>() -> IMSMQQueue4_Vtbl {
@@ -5611,6 +5665,8 @@ pub trait IMSMQQueueInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Update(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfo_Impl, const OFFSET: isize>() -> IMSMQQueueInfo_Vtbl {
         unsafe extern "system" fn QueueGuid<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrguidqueue: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5934,6 +5990,8 @@ pub trait IMSMQQueueInfo2_Impl: Sized + super::Com::IDispatch_Impl {
     fn Security(&self) -> ::windows::core::Result<super::Com::VARIANT>;
     fn SetSecurity(&self, varsecurity: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfo2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfo2_Impl, const OFFSET: isize>() -> IMSMQQueueInfo2_Vtbl {
@@ -6305,6 +6363,8 @@ pub trait IMSMQQueueInfo3_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetMulticastAddress(&self, bstrmulticastaddress: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn ADsPath(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfo3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfo3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfo3_Impl, const OFFSET: isize>() -> IMSMQQueueInfo3_Vtbl {
@@ -6731,6 +6791,8 @@ pub trait IMSMQQueueInfo4_Impl: Sized + super::Com::IDispatch_Impl {
     fn ADsPath(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfo4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfo4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfo4_Impl, const OFFSET: isize>() -> IMSMQQueueInfo4_Vtbl {
         unsafe extern "system" fn QueueGuid<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfo4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrguidqueue: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -7119,6 +7181,8 @@ pub trait IMSMQQueueInfos_Impl: Sized + super::Com::IDispatch_Impl {
     fn Next(&self) -> ::windows::core::Result<IMSMQQueueInfo>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfos {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfos_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos_Impl, const OFFSET: isize>() -> IMSMQQueueInfos_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7153,6 +7217,8 @@ pub trait IMSMQQueueInfos2_Impl: Sized + super::Com::IDispatch_Impl {
     fn Next(&self) -> ::windows::core::Result<IMSMQQueueInfo2>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfos2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfos2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos2_Impl, const OFFSET: isize>() -> IMSMQQueueInfos2_Vtbl {
@@ -7201,6 +7267,8 @@ pub trait IMSMQQueueInfos3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfos3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfos3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos3_Impl, const OFFSET: isize>() -> IMSMQQueueInfos3_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7248,6 +7316,8 @@ pub trait IMSMQQueueInfos4_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueInfos4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueInfos4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos4_Impl, const OFFSET: isize>() -> IMSMQQueueInfos4_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueInfos4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7294,6 +7364,8 @@ pub trait IMSMQQueueManagement_Impl: Sized + super::Com::IDispatch_Impl + IMSMQM
     fn BytesInJournal(&self) -> ::windows::core::Result<super::Com::VARIANT>;
     fn EodGetReceiveInfo(&self) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQQueueManagement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQQueueManagement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQQueueManagement_Impl, const OFFSET: isize>() -> IMSMQQueueManagement_Vtbl {
@@ -7348,6 +7420,8 @@ pub trait IMSMQTransaction_Impl: Sized + super::Com::IDispatch_Impl {
     fn Abort(&self, fretaining: *const super::Com::VARIANT, fasync: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQTransaction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQTransaction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransaction_Impl, const OFFSET: isize>() -> IMSMQTransaction_Vtbl {
         unsafe extern "system" fn Transaction<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransaction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pltransaction: *mut i32) -> ::windows::core::HRESULT {
@@ -7388,6 +7462,8 @@ pub trait IMSMQTransaction2_Impl: Sized + super::Com::IDispatch_Impl + IMSMQTran
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQTransaction2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQTransaction2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransaction2_Impl, const OFFSET: isize>() -> IMSMQTransaction2_Vtbl {
         unsafe extern "system" fn InitNew<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransaction2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, vartransaction: ::core::mem::ManuallyDrop<super::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -7421,6 +7497,8 @@ pub trait IMSMQTransaction3_Impl: Sized + super::Com::IDispatch_Impl + IMSMQTran
     fn ITransaction(&self) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQTransaction3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQTransaction3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransaction3_Impl, const OFFSET: isize>() -> IMSMQTransaction3_Vtbl {
         unsafe extern "system" fn ITransaction<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransaction3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvaritransaction: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -7444,6 +7522,8 @@ impl IMSMQTransaction3_Vtbl {
 pub trait IMSMQTransactionDispenser_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQTransactionDispenser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQTransactionDispenser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransactionDispenser_Impl, const OFFSET: isize>() -> IMSMQTransactionDispenser_Vtbl {
@@ -7469,6 +7549,8 @@ pub trait IMSMQTransactionDispenser2_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction2>;
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQTransactionDispenser2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQTransactionDispenser2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransactionDispenser2_Impl, const OFFSET: isize>() -> IMSMQTransactionDispenser2_Vtbl {
@@ -7510,6 +7592,8 @@ pub trait IMSMQTransactionDispenser3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMSMQTransactionDispenser3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMSMQTransactionDispenser3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransactionDispenser3_Impl, const OFFSET: isize>() -> IMSMQTransactionDispenser3_Vtbl {
         unsafe extern "system" fn BeginTransaction<Identity: ::windows::core::IUnknownImpl, Impl: IMSMQTransactionDispenser3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptransaction: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7546,6 +7630,8 @@ impl IMSMQTransactionDispenser3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _DMSMQEventEvents_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _DMSMQEventEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _DMSMQEventEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _DMSMQEventEvents_Impl, const OFFSET: isize>() -> _DMSMQEventEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
@@ -1,6 +1,8 @@
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait AppEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for AppEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl AppEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: AppEvents_Impl, const OFFSET: isize>() -> AppEvents_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -21,6 +23,8 @@ pub trait Column_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetAsSortColumn(&self, sortorder: _ColumnSortOrder) -> ::windows::core::Result<()>;
     fn IsSortColumn(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Column {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Column_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Column_Impl, const OFFSET: isize>() -> Column_Vtbl {
@@ -123,6 +127,8 @@ pub trait Columns_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Columns {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Columns_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Columns_Impl, const OFFSET: isize>() -> Columns_Vtbl {
         unsafe extern "system" fn Item<Identity: ::windows::core::IUnknownImpl, Impl: Columns_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, column: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -175,6 +181,8 @@ pub trait ContextMenu_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, indexorpath: &super::Com::VARIANT) -> ::windows::core::Result<MenuItem>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ContextMenu {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ContextMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ContextMenu_Impl, const OFFSET: isize>() -> ContextMenu_Vtbl {
@@ -241,6 +249,8 @@ pub trait Document_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateProperties(&self) -> ::windows::core::Result<Properties>;
     fn Application(&self) -> ::windows::core::Result<_Application>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Document {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Document_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Document_Impl, const OFFSET: isize>() -> Document_Vtbl {
@@ -425,6 +435,8 @@ pub trait Extension_Impl: Sized + super::Com::IDispatch_Impl {
     fn Enable(&self, enable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Extension {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Extension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Extension_Impl, const OFFSET: isize>() -> Extension_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: Extension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -514,6 +526,8 @@ pub trait Extensions_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Extensions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Extensions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Extensions_Impl, const OFFSET: isize>() -> Extensions_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: Extensions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -574,6 +588,8 @@ pub trait Frame_Impl: Sized + super::Com::IDispatch_Impl {
     fn Right(&self) -> ::windows::core::Result<i32>;
     fn SetRight(&self, right: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Frame {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Frame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Frame_Impl, const OFFSET: isize>() -> Frame_Vtbl {
@@ -681,6 +697,7 @@ pub trait IColumnData_Impl: Sized {
     fn SetColumnSortData(&self, pcolid: *const SColumnSetID, pcolsortdata: *const MMC_SORT_SET_DATA) -> ::windows::core::Result<()>;
     fn GetColumnSortData(&self, pcolid: *const SColumnSetID) -> ::windows::core::Result<*mut MMC_SORT_SET_DATA>;
 }
+impl ::windows::core::RuntimeName for IColumnData {}
 impl IColumnData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnData_Impl, const OFFSET: isize>() -> IColumnData_Vtbl {
         unsafe extern "system" fn SetColumnConfigData<Identity: ::windows::core::IUnknownImpl, Impl: IColumnData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcolid: *const SColumnSetID, pcolsetdata: *const MMC_COLUMN_SET_DATA) -> ::windows::core::HRESULT {
@@ -737,6 +754,8 @@ pub trait IComponent_Impl: Sized {
     fn GetDisplayInfo(&self, presultdataitem: *mut RESULTDATAITEM) -> ::windows::core::Result<()>;
     fn CompareObjects(&self, lpdataobjecta: &::core::option::Option<super::Com::IDataObject>, lpdataobjectb: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IComponent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IComponent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponent_Impl, const OFFSET: isize>() -> IComponent_Vtbl {
@@ -803,6 +822,8 @@ pub trait IComponent2_Impl: Sized + IComponent_Impl {
     fn RestoreResultView(&self, cookie: isize, presultviewtype: *const RESULT_VIEW_TYPE_INFO) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IComponent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IComponent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponent2_Impl, const OFFSET: isize>() -> IComponent2_Vtbl {
         unsafe extern "system" fn QueryDispatch<Identity: ::windows::core::IUnknownImpl, Impl: IComponent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cookie: isize, r#type: DATA_OBJECT_TYPES, ppdispatch: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -847,6 +868,8 @@ pub trait IComponentData_Impl: Sized {
     fn GetDisplayInfo(&self, pscopedataitem: *mut SCOPEDATAITEM) -> ::windows::core::Result<()>;
     fn CompareObjects(&self, lpdataobjecta: &::core::option::Option<super::Com::IDataObject>, lpdataobjectb: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IComponentData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IComponentData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentData_Impl, const OFFSET: isize>() -> IComponentData_Vtbl {
@@ -917,6 +940,8 @@ pub trait IComponentData2_Impl: Sized + IComponentData_Impl {
     fn QueryDispatch(&self, cookie: isize, r#type: DATA_OBJECT_TYPES) -> ::windows::core::Result<super::Com::IDispatch>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IComponentData2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IComponentData2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentData2_Impl, const OFFSET: isize>() -> IComponentData2_Vtbl {
         unsafe extern "system" fn QueryDispatch<Identity: ::windows::core::IUnknownImpl, Impl: IComponentData2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cookie: isize, r#type: DATA_OBJECT_TYPES, ppdispatch: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -950,6 +975,8 @@ pub trait IConsole_Impl: Sized {
     fn GetMainWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
     fn NewWindow(&self, hscopeitem: isize, loptions: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IConsole {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IConsole_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsole_Impl, const OFFSET: isize>() -> IConsole_Vtbl {
@@ -1070,6 +1097,8 @@ pub trait IConsole2_Impl: Sized + IConsole_Impl {
     fn SetStatusText(&self, pszstatustext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IConsole2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IConsole2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsole2_Impl, const OFFSET: isize>() -> IConsole2_Vtbl {
         unsafe extern "system" fn Expand<Identity: ::windows::core::IUnknownImpl, Impl: IConsole2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hitem: isize, bexpand: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1103,6 +1132,8 @@ pub trait IConsole3_Impl: Sized + IConsole_Impl + IConsole2_Impl {
     fn RenameScopeItem(&self, hscopeitem: isize) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IConsole3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IConsole3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsole3_Impl, const OFFSET: isize>() -> IConsole3_Vtbl {
         unsafe extern "system" fn RenameScopeItem<Identity: ::windows::core::IUnknownImpl, Impl: IConsole3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hscopeitem: isize) -> ::windows::core::HRESULT {
@@ -1126,6 +1157,8 @@ pub trait IConsoleNameSpace_Impl: Sized {
     fn GetNextItem(&self, item: isize, pitemnext: *mut isize, pcookie: *mut isize) -> ::windows::core::Result<()>;
     fn GetParentItem(&self, item: isize, pitemparent: *mut isize, pcookie: *mut isize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IConsoleNameSpace {}
 #[cfg(feature = "Win32_Foundation")]
 impl IConsoleNameSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsoleNameSpace_Impl, const OFFSET: isize>() -> IConsoleNameSpace_Vtbl {
@@ -1185,6 +1218,8 @@ pub trait IConsoleNameSpace2_Impl: Sized + IConsoleNameSpace_Impl {
     fn AddExtension(&self, hitem: isize, lpclsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IConsoleNameSpace2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IConsoleNameSpace2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsoleNameSpace2_Impl, const OFFSET: isize>() -> IConsoleNameSpace2_Vtbl {
         unsafe extern "system" fn Expand<Identity: ::windows::core::IUnknownImpl, Impl: IConsoleNameSpace2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hitem: isize) -> ::windows::core::HRESULT {
@@ -1211,6 +1246,7 @@ pub trait IConsolePower_Impl: Sized {
     fn SetExecutionState(&self, dwadd: u32, dwremove: u32) -> ::windows::core::Result<()>;
     fn ResetIdleTimer(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IConsolePower {}
 impl IConsolePower_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsolePower_Impl, const OFFSET: isize>() -> IConsolePower_Vtbl {
         unsafe extern "system" fn SetExecutionState<Identity: ::windows::core::IUnknownImpl, Impl: IConsolePower_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwadd: u32, dwremove: u32) -> ::windows::core::HRESULT {
@@ -1238,6 +1274,8 @@ pub trait IConsolePowerSink_Impl: Sized {
     fn OnPowerBroadcast(&self, nevent: u32, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IConsolePowerSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl IConsolePowerSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsolePowerSink_Impl, const OFFSET: isize>() -> IConsolePowerSink_Vtbl {
         unsafe extern "system" fn OnPowerBroadcast<Identity: ::windows::core::IUnknownImpl, Impl: IConsolePowerSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nevent: u32, lparam: super::super::Foundation::LPARAM, plreturn: *mut super::super::Foundation::LRESULT) -> ::windows::core::HRESULT {
@@ -1264,6 +1302,8 @@ pub trait IConsoleVerb_Impl: Sized {
     fn SetDefaultVerb(&self, ecmdid: MMC_CONSOLE_VERB) -> ::windows::core::Result<()>;
     fn GetDefaultVerb(&self) -> ::windows::core::Result<MMC_CONSOLE_VERB>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IConsoleVerb {}
 #[cfg(feature = "Win32_Foundation")]
 impl IConsoleVerb_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConsoleVerb_Impl, const OFFSET: isize>() -> IConsoleVerb_Vtbl {
@@ -1314,6 +1354,7 @@ impl IConsoleVerb_Vtbl {
 pub trait IContextMenuCallback_Impl: Sized {
     fn AddItem(&self, pitem: *const CONTEXTMENUITEM) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContextMenuCallback {}
 impl IContextMenuCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuCallback_Impl, const OFFSET: isize>() -> IContextMenuCallback_Vtbl {
         unsafe extern "system" fn AddItem<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pitem: *const CONTEXTMENUITEM) -> ::windows::core::HRESULT {
@@ -1330,6 +1371,7 @@ impl IContextMenuCallback_Vtbl {
 pub trait IContextMenuCallback2_Impl: Sized {
     fn AddItem(&self, pitem: *const CONTEXTMENUITEM2) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContextMenuCallback2 {}
 impl IContextMenuCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuCallback2_Impl, const OFFSET: isize>() -> IContextMenuCallback2_Vtbl {
         unsafe extern "system" fn AddItem<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pitem: *const CONTEXTMENUITEM2) -> ::windows::core::HRESULT {
@@ -1350,6 +1392,8 @@ pub trait IContextMenuProvider_Impl: Sized + IContextMenuCallback_Impl {
     fn AddThirdPartyExtensionItems(&self, pidataobject: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
     fn ShowContextMenu(&self, hwndparent: super::super::Foundation::HWND, xpos: i32, ypos: i32) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IContextMenuProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IContextMenuProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuProvider_Impl, const OFFSET: isize>() -> IContextMenuProvider_Vtbl {
@@ -1396,6 +1440,7 @@ pub trait IControlbar_Impl: Sized {
     fn Attach(&self, ntype: MMC_CONTROL_TYPE, lpunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Detach(&self, lpunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IControlbar {}
 impl IControlbar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IControlbar_Impl, const OFFSET: isize>() -> IControlbar_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IControlbar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ntype: MMC_CONTROL_TYPE, pextendcontrolbar: ::windows::core::RawPtr, ppunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1433,6 +1478,7 @@ impl IControlbar_Vtbl {
 pub trait IDisplayHelp_Impl: Sized {
     fn ShowTopic(&self, pszhelptopic: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDisplayHelp {}
 impl IDisplayHelp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayHelp_Impl, const OFFSET: isize>() -> IDisplayHelp_Vtbl {
         unsafe extern "system" fn ShowTopic<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayHelp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszhelptopic: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1452,6 +1498,7 @@ pub trait IEnumTASK_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumTASK>;
 }
+impl ::windows::core::RuntimeName for IEnumTASK {}
 impl IEnumTASK_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTASK_Impl, const OFFSET: isize>() -> IEnumTASK_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTASK_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut MMC_TASK, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1498,6 +1545,8 @@ pub trait IExtendContextMenu_Impl: Sized {
     fn Command(&self, lcommandid: i32, pidataobject: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IExtendContextMenu {}
+#[cfg(feature = "Win32_System_Com")]
 impl IExtendContextMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtendContextMenu_Impl, const OFFSET: isize>() -> IExtendContextMenu_Vtbl {
         unsafe extern "system" fn AddMenuItems<Identity: ::windows::core::IUnknownImpl, Impl: IExtendContextMenu_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidataobject: ::windows::core::RawPtr, picallback: ::windows::core::RawPtr, pinsertionallowed: *mut i32) -> ::windows::core::HRESULT {
@@ -1525,6 +1574,8 @@ pub trait IExtendControlbar_Impl: Sized {
     fn SetControlbar(&self, pcontrolbar: &::core::option::Option<IControlbar>) -> ::windows::core::Result<()>;
     fn ControlbarNotify(&self, event: MMC_NOTIFY_TYPE, arg: super::super::Foundation::LPARAM, param2: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IExtendControlbar {}
 #[cfg(feature = "Win32_Foundation")]
 impl IExtendControlbar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtendControlbar_Impl, const OFFSET: isize>() -> IExtendControlbar_Vtbl {
@@ -1554,6 +1605,8 @@ pub trait IExtendPropertySheet_Impl: Sized {
     fn QueryPagesFor(&self, lpdataobject: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IExtendPropertySheet {}
+#[cfg(feature = "Win32_System_Com")]
 impl IExtendPropertySheet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtendPropertySheet_Impl, const OFFSET: isize>() -> IExtendPropertySheet_Vtbl {
         unsafe extern "system" fn CreatePropertyPages<Identity: ::windows::core::IUnknownImpl, Impl: IExtendPropertySheet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpprovider: ::windows::core::RawPtr, handle: isize, lpidataobject: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1581,6 +1634,8 @@ pub trait IExtendPropertySheet2_Impl: Sized + IExtendPropertySheet_Impl {
     fn GetWatermarks(&self, lpidataobject: &::core::option::Option<super::Com::IDataObject>, lphwatermark: *mut super::super::Graphics::Gdi::HBITMAP, lphheader: *mut super::super::Graphics::Gdi::HBITMAP, lphpalette: *mut super::super::Graphics::Gdi::HPALETTE, bstretch: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IExtendPropertySheet2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IExtendPropertySheet2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtendPropertySheet2_Impl, const OFFSET: isize>() -> IExtendPropertySheet2_Vtbl {
         unsafe extern "system" fn GetWatermarks<Identity: ::windows::core::IUnknownImpl, Impl: IExtendPropertySheet2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpidataobject: ::windows::core::RawPtr, lphwatermark: *mut super::super::Graphics::Gdi::HBITMAP, lphheader: *mut super::super::Graphics::Gdi::HBITMAP, lphpalette: *mut super::super::Graphics::Gdi::HPALETTE, bstretch: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -1603,6 +1658,8 @@ pub trait IExtendTaskPad_Impl: Sized {
     fn GetBackground(&self, pszgroup: &::windows::core::PCWSTR) -> ::windows::core::Result<MMC_TASK_DISPLAY_OBJECT>;
     fn GetListPadInfo(&self, pszgroup: &::windows::core::PCWSTR) -> ::windows::core::Result<MMC_LISTPAD_INFO>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IExtendTaskPad {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IExtendTaskPad_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtendTaskPad_Impl, const OFFSET: isize>() -> IExtendTaskPad_Vtbl {
@@ -1685,6 +1742,8 @@ pub trait IExtendView_Impl: Sized {
     fn GetViews(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>, pviewextensioncallback: &::core::option::Option<IViewExtensionCallback>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IExtendView {}
+#[cfg(feature = "Win32_System_Com")]
 impl IExtendView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtendView_Impl, const OFFSET: isize>() -> IExtendView_Vtbl {
         unsafe extern "system" fn GetViews<Identity: ::windows::core::IUnknownImpl, Impl: IExtendView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdataobject: ::windows::core::RawPtr, pviewextensioncallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1706,6 +1765,7 @@ pub trait IHeaderCtrl_Impl: Sized {
     fn SetColumnWidth(&self, ncol: i32, nwidth: i32) -> ::windows::core::Result<()>;
     fn GetColumnWidth(&self, ncol: i32) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IHeaderCtrl {}
 impl IHeaderCtrl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHeaderCtrl_Impl, const OFFSET: isize>() -> IHeaderCtrl_Vtbl {
         unsafe extern "system" fn InsertColumn<Identity: ::windows::core::IUnknownImpl, Impl: IHeaderCtrl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ncol: i32, title: ::windows::core::PCWSTR, nformat: i32, nwidth: i32) -> ::windows::core::HRESULT {
@@ -1769,6 +1829,7 @@ pub trait IHeaderCtrl2_Impl: Sized + IHeaderCtrl_Impl {
     fn SetColumnFilter(&self, ncolumn: u32, dwtype: u32, pfilterdata: *const MMC_FILTERDATA) -> ::windows::core::Result<()>;
     fn GetColumnFilter(&self, ncolumn: u32, pdwtype: *mut u32, pfilterdata: *mut MMC_FILTERDATA) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IHeaderCtrl2 {}
 impl IHeaderCtrl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHeaderCtrl2_Impl, const OFFSET: isize>() -> IHeaderCtrl2_Vtbl {
         unsafe extern "system" fn SetChangeTimeOut<Identity: ::windows::core::IUnknownImpl, Impl: IHeaderCtrl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, utimeout: u32) -> ::windows::core::HRESULT {
@@ -1801,6 +1862,7 @@ pub trait IImageList_Impl: Sized {
     fn ImageListSetIcon(&self, picon: *const isize, nloc: i32) -> ::windows::core::Result<()>;
     fn ImageListSetStrip(&self, pbmapsm: *const isize, pbmaplg: *const isize, nstartloc: i32, cmask: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IImageList {}
 impl IImageList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImageList_Impl, const OFFSET: isize>() -> IImageList_Vtbl {
         unsafe extern "system" fn ImageListSetIcon<Identity: ::windows::core::IUnknownImpl, Impl: IImageList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, picon: *const isize, nloc: i32) -> ::windows::core::HRESULT {
@@ -1826,6 +1888,7 @@ impl IImageList_Vtbl {
 pub trait IMMCVersionInfo_Impl: Sized {
     fn GetMMCVersion(&self, pversionmajor: *mut i32, pversionminor: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMMCVersionInfo {}
 impl IMMCVersionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMMCVersionInfo_Impl, const OFFSET: isize>() -> IMMCVersionInfo_Vtbl {
         unsafe extern "system" fn GetMMCVersion<Identity: ::windows::core::IUnknownImpl, Impl: IMMCVersionInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pversionmajor: *mut i32, pversionminor: *mut i32) -> ::windows::core::HRESULT {
@@ -1845,6 +1908,8 @@ pub trait IMenuButton_Impl: Sized {
     fn SetButton(&self, idcommand: i32, lpbuttontext: &::windows::core::PCWSTR, lptooltiptext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetButtonState(&self, idcommand: i32, nstate: MMC_BUTTON_STATE, bstate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMenuButton {}
 #[cfg(feature = "Win32_Foundation")]
 impl IMenuButton_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMenuButton_Impl, const OFFSET: isize>() -> IMenuButton_Vtbl {
@@ -1880,6 +1945,7 @@ pub trait IMessageView_Impl: Sized {
     fn SetIcon(&self, id: IconIdentifier) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMessageView {}
 impl IMessageView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMessageView_Impl, const OFFSET: isize>() -> IMessageView_Vtbl {
         unsafe extern "system" fn SetTitleText<Identity: ::windows::core::IUnknownImpl, Impl: IMessageView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psztitletext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1919,6 +1985,8 @@ pub trait INodeProperties_Impl: Sized {
     fn GetProperty(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>, szpropertyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<*mut u16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for INodeProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl INodeProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INodeProperties_Impl, const OFFSET: isize>() -> INodeProperties_Vtbl {
         unsafe extern "system" fn GetProperty<Identity: ::windows::core::IUnknownImpl, Impl: INodeProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdataobject: ::windows::core::RawPtr, szpropertyname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbstrproperty: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -1943,6 +2011,8 @@ pub trait IPropertySheetCallback_Impl: Sized {
     fn AddPage(&self, hpage: super::super::UI::Controls::HPROPSHEETPAGE) -> ::windows::core::Result<()>;
     fn RemovePage(&self, hpage: super::super::UI::Controls::HPROPSHEETPAGE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Controls")]
+impl ::windows::core::RuntimeName for IPropertySheetCallback {}
 #[cfg(feature = "Win32_UI_Controls")]
 impl IPropertySheetCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySheetCallback_Impl, const OFFSET: isize>() -> IPropertySheetCallback_Vtbl {
@@ -1974,6 +2044,8 @@ pub trait IPropertySheetProvider_Impl: Sized {
     fn AddExtensionPages(&self) -> ::windows::core::Result<()>;
     fn Show(&self, window: isize, page: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPropertySheetProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPropertySheetProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySheetProvider_Impl, const OFFSET: isize>() -> IPropertySheetProvider_Vtbl {
@@ -2020,6 +2092,7 @@ pub trait IRequiredExtensions_Impl: Sized {
     fn GetFirstExtension(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetNextExtension(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IRequiredExtensions {}
 impl IRequiredExtensions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRequiredExtensions_Impl, const OFFSET: isize>() -> IRequiredExtensions_Vtbl {
         unsafe extern "system" fn EnableAllExtensions<Identity: ::windows::core::IUnknownImpl, Impl: IRequiredExtensions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2078,6 +2151,8 @@ pub trait IResultData_Impl: Sized {
     fn SetDescBarText(&self, desctext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetItemCount(&self, nitemcount: i32, dwoptions: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResultData {}
 #[cfg(feature = "Win32_Foundation")]
 impl IResultData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResultData_Impl, const OFFSET: isize>() -> IResultData_Vtbl {
@@ -2196,6 +2271,8 @@ pub trait IResultData2_Impl: Sized + IResultData_Impl {
     fn RenameResultItem(&self, itemid: isize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResultData2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IResultData2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResultData2_Impl, const OFFSET: isize>() -> IResultData2_Vtbl {
         unsafe extern "system" fn RenameResultItem<Identity: ::windows::core::IUnknownImpl, Impl: IResultData2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, itemid: isize) -> ::windows::core::HRESULT {
@@ -2214,6 +2291,8 @@ pub trait IResultDataCompare_Impl: Sized {
     fn Compare(&self, luserparam: super::super::Foundation::LPARAM, cookiea: isize, cookieb: isize, pnresult: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResultDataCompare {}
+#[cfg(feature = "Win32_Foundation")]
 impl IResultDataCompare_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResultDataCompare_Impl, const OFFSET: isize>() -> IResultDataCompare_Vtbl {
         unsafe extern "system" fn Compare<Identity: ::windows::core::IUnknownImpl, Impl: IResultDataCompare_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, luserparam: super::super::Foundation::LPARAM, cookiea: isize, cookieb: isize, pnresult: *mut i32) -> ::windows::core::HRESULT {
@@ -2231,6 +2310,8 @@ impl IResultDataCompare_Vtbl {
 pub trait IResultDataCompareEx_Impl: Sized {
     fn Compare(&self, prdc: *const RDCOMPARE) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResultDataCompareEx {}
 #[cfg(feature = "Win32_Foundation")]
 impl IResultDataCompareEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResultDataCompareEx_Impl, const OFFSET: isize>() -> IResultDataCompareEx_Vtbl {
@@ -2257,6 +2338,8 @@ pub trait IResultOwnerData_Impl: Sized {
     fn CacheHint(&self, nstartindex: i32, nendindex: i32) -> ::windows::core::Result<()>;
     fn SortItems(&self, ncolumn: i32, dwsortoptions: u32, luserparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResultOwnerData {}
 #[cfg(feature = "Win32_Foundation")]
 impl IResultOwnerData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResultOwnerData_Impl, const OFFSET: isize>() -> IResultOwnerData_Vtbl {
@@ -2300,6 +2383,8 @@ pub trait ISnapinAbout_Impl: Sized {
     fn GetSnapinImage(&self) -> ::windows::core::Result<super::super::UI::WindowsAndMessaging::HICON>;
     fn GetStaticFolderImage(&self, hsmallimage: *mut super::super::Graphics::Gdi::HBITMAP, hsmallimageopen: *mut super::super::Graphics::Gdi::HBITMAP, hlargeimage: *mut super::super::Graphics::Gdi::HBITMAP, cmask: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ISnapinAbout {}
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ISnapinAbout_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinAbout_Impl, const OFFSET: isize>() -> ISnapinAbout_Vtbl {
@@ -2368,6 +2453,7 @@ impl ISnapinAbout_Vtbl {
 pub trait ISnapinHelp_Impl: Sized {
     fn GetHelpTopic(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISnapinHelp {}
 impl ISnapinHelp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinHelp_Impl, const OFFSET: isize>() -> ISnapinHelp_Vtbl {
         unsafe extern "system" fn GetHelpTopic<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinHelp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpcompiledhelpfile: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2390,6 +2476,7 @@ impl ISnapinHelp_Vtbl {
 pub trait ISnapinHelp2_Impl: Sized + ISnapinHelp_Impl {
     fn GetLinkedTopics(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISnapinHelp2 {}
 impl ISnapinHelp2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinHelp2_Impl, const OFFSET: isize>() -> ISnapinHelp2_Vtbl {
         unsafe extern "system" fn GetLinkedTopics<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinHelp2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpcompiledhelpfiles: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2415,6 +2502,8 @@ pub trait ISnapinProperties_Impl: Sized {
     fn QueryPropertyNames(&self, pcallback: &::core::option::Option<ISnapinPropertiesCallback>) -> ::windows::core::Result<()>;
     fn PropertiesChanged(&self, cproperties: i32, pproperties: *const MMC_SNAPIN_PROPERTY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISnapinProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISnapinProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinProperties_Impl, const OFFSET: isize>() -> ISnapinProperties_Vtbl {
@@ -2447,6 +2536,7 @@ impl ISnapinProperties_Vtbl {
 pub trait ISnapinPropertiesCallback_Impl: Sized {
     fn AddPropertyName(&self, pszpropname: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISnapinPropertiesCallback {}
 impl ISnapinPropertiesCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinPropertiesCallback_Impl, const OFFSET: isize>() -> ISnapinPropertiesCallback_Vtbl {
         unsafe extern "system" fn AddPropertyName<Identity: ::windows::core::IUnknownImpl, Impl: ISnapinPropertiesCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpropname: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT {
@@ -2470,6 +2560,8 @@ pub trait IStringTable_Impl: Sized {
     fn FindString(&self, pszfind: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
     fn Enumerate(&self) -> ::windows::core::Result<super::Com::IEnumString>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IStringTable {}
 #[cfg(feature = "Win32_System_Com")]
 impl IStringTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStringTable_Impl, const OFFSET: isize>() -> IStringTable_Vtbl {
@@ -2557,6 +2649,8 @@ pub trait IToolbar_Impl: Sized {
     fn SetButtonState(&self, idcommand: i32, nstate: MMC_BUTTON_STATE, bstate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IToolbar {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IToolbar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IToolbar_Impl, const OFFSET: isize>() -> IToolbar_Vtbl {
         unsafe extern "system" fn AddBitmap<Identity: ::windows::core::IUnknownImpl, Impl: IToolbar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nimages: i32, hbmp: super::super::Graphics::Gdi::HBITMAP, cxsize: i32, cysize: i32, crmask: u32) -> ::windows::core::HRESULT {
@@ -2614,6 +2708,8 @@ pub trait IViewExtensionCallback_Impl: Sized {
     fn AddView(&self, pextviewdata: *const MMC_EXT_VIEW_DATA) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IViewExtensionCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IViewExtensionCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewExtensionCallback_Impl, const OFFSET: isize>() -> IViewExtensionCallback_Vtbl {
         unsafe extern "system" fn AddView<Identity: ::windows::core::IUnknownImpl, Impl: IViewExtensionCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pextviewdata: *const MMC_EXT_VIEW_DATA) -> ::windows::core::HRESULT {
@@ -2636,6 +2732,8 @@ pub trait MenuItem_Impl: Sized + super::Com::IDispatch_Impl {
     fn Execute(&self) -> ::windows::core::Result<()>;
     fn Enabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for MenuItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl MenuItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: MenuItem_Impl, const OFFSET: isize>() -> MenuItem_Vtbl {
@@ -2722,6 +2820,8 @@ pub trait Node_Impl: Sized + super::Com::IDispatch_Impl {
     fn Nodetype(&self) -> ::windows::core::Result<*mut u16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Node {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Node_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Node_Impl, const OFFSET: isize>() -> Node_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: Node_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -2799,6 +2899,8 @@ pub trait Nodes_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Nodes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Nodes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Nodes_Impl, const OFFSET: isize>() -> Nodes_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: Nodes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2852,6 +2954,8 @@ pub trait Properties_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn Remove(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Properties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Properties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Properties_Impl, const OFFSET: isize>() -> Properties_Vtbl {
@@ -2912,6 +3016,8 @@ pub trait Property_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<*mut u16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Property {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Property_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Property_Impl, const OFFSET: isize>() -> Property_Vtbl {
         unsafe extern "system" fn Value<Identity: ::windows::core::IUnknownImpl, Impl: Property_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2960,6 +3066,8 @@ pub trait ScopeNamespace_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetRoot(&self) -> ::windows::core::Result<Node>;
     fn Expand(&self, node: &::core::option::Option<Node>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ScopeNamespace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ScopeNamespace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ScopeNamespace_Impl, const OFFSET: isize>() -> ScopeNamespace_Vtbl {
@@ -3035,6 +3143,8 @@ pub trait SnapIn_Impl: Sized + super::Com::IDispatch_Impl {
     fn Properties(&self) -> ::windows::core::Result<Properties>;
     fn EnableAllExtensions(&self, enable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for SnapIn {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl SnapIn_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: SnapIn_Impl, const OFFSET: isize>() -> SnapIn_Vtbl {
@@ -3132,6 +3242,8 @@ pub trait SnapIns_Impl: Sized + super::Com::IDispatch_Impl {
     fn Add(&self, snapinnameorclsid: &super::super::Foundation::BSTR, parentsnapin: &super::Com::VARIANT, properties: &super::Com::VARIANT) -> ::windows::core::Result<SnapIn>;
     fn Remove(&self, snapin: &::core::option::Option<SnapIn>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for SnapIns {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl SnapIns_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: SnapIns_Impl, const OFFSET: isize>() -> SnapIns_Vtbl {
@@ -3242,6 +3354,8 @@ pub trait View_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetListViewMode(&self, mode: _ListViewMode) -> ::windows::core::Result<()>;
     fn ControlObject(&self) -> ::windows::core::Result<super::Com::IDispatch>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for View {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl View_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: View_Impl, const OFFSET: isize>() -> View_Vtbl {
@@ -3615,6 +3729,8 @@ pub trait Views_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Views {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Views_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Views_Impl, const OFFSET: isize>() -> Views_Vtbl {
         unsafe extern "system" fn Item<Identity: ::windows::core::IUnknownImpl, Impl: Views_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, view: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3682,6 +3798,8 @@ pub trait _AppEvents_Impl: Sized + super::Com::IDispatch_Impl {
     fn OnToolbarButtonClicked(&self) -> ::windows::core::Result<()>;
     fn OnListUpdated(&self, view: &::core::option::Option<View>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _AppEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _AppEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _AppEvents_Impl, const OFFSET: isize>() -> _AppEvents_Vtbl {
@@ -3780,6 +3898,8 @@ pub trait _Application_Impl: Sized + super::Com::IDispatch_Impl {
     fn VersionMajor(&self) -> ::windows::core::Result<i32>;
     fn VersionMinor(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _Application {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _Application_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _Application_Impl, const OFFSET: isize>() -> _Application_Vtbl {
@@ -3904,6 +4024,8 @@ pub trait _EventConnector_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectTo(&self, application: &::core::option::Option<_Application>) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _EventConnector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _EventConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _EventConnector_Impl, const OFFSET: isize>() -> _EventConnector_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
@@ -3,6 +3,8 @@ pub trait IAdviseSinkEx_Impl: Sized + super::Com::IAdviseSink_Impl {
     fn OnViewStatusChange(&self, dwviewstatus: u32);
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IAdviseSinkEx {}
+#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IAdviseSinkEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAdviseSinkEx_Impl, const OFFSET: isize>() -> IAdviseSinkEx_Vtbl {
         unsafe extern "system" fn OnViewStatusChange<Identity: ::windows::core::IUnknownImpl, Impl: IAdviseSinkEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwviewstatus: u32) {
@@ -20,6 +22,8 @@ impl IAdviseSinkEx_Vtbl {
 pub trait ICanHandleException_Impl: Sized {
     fn CanHandleException(&self, pexcepinfo: *const super::Com::EXCEPINFO, pvar: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICanHandleException {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICanHandleException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICanHandleException_Impl, const OFFSET: isize>() -> ICanHandleException_Vtbl {
@@ -40,6 +44,8 @@ pub trait IClassFactory2_Impl: Sized + super::Com::IClassFactory_Impl {
     fn RequestLicKey(&self, dwreserved: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn CreateInstanceLic(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, punkreserved: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, bstrkey: &super::super::Foundation::BSTR, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IClassFactory2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IClassFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClassFactory2_Impl, const OFFSET: isize>() -> IClassFactory2_Vtbl {
@@ -78,6 +84,7 @@ impl IClassFactory2_Vtbl {
 pub trait IContinue_Impl: Sized {
     fn FContinue(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContinue {}
 impl IContinue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContinue_Impl, const OFFSET: isize>() -> IContinue_Vtbl {
         unsafe extern "system" fn FContinue<Identity: ::windows::core::IUnknownImpl, Impl: IContinue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -95,6 +102,7 @@ pub trait IContinueCallback_Impl: Sized {
     fn FContinue(&self) -> ::windows::core::Result<()>;
     fn FContinuePrinting(&self, ncntprinted: i32, ncurpage: i32, pwszprintstatus: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IContinueCallback {}
 impl IContinueCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContinueCallback_Impl, const OFFSET: isize>() -> IContinueCallback_Vtbl {
         unsafe extern "system" fn FContinue<Identity: ::windows::core::IUnknownImpl, Impl: IContinueCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -124,6 +132,7 @@ pub trait ICreateErrorInfo_Impl: Sized {
     fn SetHelpFile(&self, szhelpfile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetHelpContext(&self, dwhelpcontext: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICreateErrorInfo {}
 impl ICreateErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateErrorInfo_Impl, const OFFSET: isize>() -> ICreateErrorInfo_Vtbl {
         unsafe extern "system" fn SetGUID<Identity: ::windows::core::IUnknownImpl, Impl: ICreateErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -190,6 +199,8 @@ pub trait ICreateTypeInfo_Impl: Sized {
     fn SetTypeIdldesc(&self, pidldesc: *const super::Com::IDLDESC) -> ::windows::core::Result<()>;
     fn LayOut(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICreateTypeInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICreateTypeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeInfo_Impl, const OFFSET: isize>() -> ICreateTypeInfo_Vtbl {
@@ -358,6 +369,8 @@ pub trait ICreateTypeInfo2_Impl: Sized + ICreateTypeInfo_Impl {
     fn SetName(&self, szname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICreateTypeInfo2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICreateTypeInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeInfo2_Impl, const OFFSET: isize>() -> ICreateTypeInfo2_Vtbl {
         unsafe extern "system" fn DeleteFuncDesc<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::HRESULT {
@@ -472,6 +485,8 @@ pub trait ICreateTypeLib_Impl: Sized {
     fn SaveAllChanges(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ICreateTypeLib {}
+#[cfg(feature = "Win32_System_Com")]
 impl ICreateTypeLib_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeLib_Impl, const OFFSET: isize>() -> ICreateTypeLib_Vtbl {
         unsafe extern "system" fn CreateTypeInfo<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeLib_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCWSTR, tkind: super::Com::TYPEKIND, ppctinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -556,6 +571,8 @@ pub trait ICreateTypeLib2_Impl: Sized + ICreateTypeLib_Impl {
     fn SetHelpStringDll(&self, szfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICreateTypeLib2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICreateTypeLib2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeLib2_Impl, const OFFSET: isize>() -> ICreateTypeLib2_Vtbl {
         unsafe extern "system" fn DeleteTypeInfo<Identity: ::windows::core::IUnknownImpl, Impl: ICreateTypeLib2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -599,6 +616,8 @@ pub trait IDispError_Impl: Sized {
     fn GetHelpInfo(&self, pbstrfilename: *mut super::super::Foundation::BSTR, pdwcontext: *mut u32) -> ::windows::core::Result<()>;
     fn GetDescription(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDispError {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDispError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispError_Impl, const OFFSET: isize>() -> IDispError_Vtbl {
@@ -687,6 +706,8 @@ pub trait IDispatchEx_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetNextDispID(&self, grfdex: u32, id: i32) -> ::windows::core::Result<i32>;
     fn GetNameSpaceParent(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDispatchEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDispatchEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDispatchEx_Impl, const OFFSET: isize>() -> IDispatchEx_Vtbl {
@@ -782,6 +803,8 @@ pub trait IDropSource_Impl: Sized {
     fn GiveFeedback(&self, dweffect: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDropSource {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDropSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDropSource_Impl, const OFFSET: isize>() -> IDropSource_Vtbl {
         unsafe extern "system" fn QueryContinueDrag<Identity: ::windows::core::IUnknownImpl, Impl: IDropSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fescapepressed: super::super::Foundation::BOOL, grfkeystate: u32) -> ::windows::core::HRESULT {
@@ -809,6 +832,8 @@ pub trait IDropSourceNotify_Impl: Sized {
     fn DragEnterTarget(&self, hwndtarget: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn DragLeaveTarget(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDropSourceNotify {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDropSourceNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDropSourceNotify_Impl, const OFFSET: isize>() -> IDropSourceNotify_Vtbl {
@@ -839,6 +864,8 @@ pub trait IDropTarget_Impl: Sized {
     fn DragLeave(&self) -> ::windows::core::Result<()>;
     fn Drop(&self, pdataobj: &::core::option::Option<super::Com::IDataObject>, grfkeystate: u32, pt: &super::super::Foundation::POINTL, pdweffect: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDropTarget {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDropTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDropTarget_Impl, const OFFSET: isize>() -> IDropTarget_Vtbl {
@@ -880,6 +907,8 @@ pub trait IEnterpriseDropTarget_Impl: Sized {
     fn IsEvaluatingEdpPolicy(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnterpriseDropTarget {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnterpriseDropTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnterpriseDropTarget_Impl, const OFFSET: isize>() -> IEnterpriseDropTarget_Vtbl {
         unsafe extern "system" fn SetDropSourceEnterpriseId<Identity: ::windows::core::IUnknownImpl, Impl: IEnterpriseDropTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, identity: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -914,6 +943,7 @@ pub trait IEnumOLEVERB_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumOLEVERB>;
 }
+impl ::windows::core::RuntimeName for IEnumOLEVERB {}
 impl IEnumOLEVERB_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOLEVERB_Impl, const OFFSET: isize>() -> IEnumOLEVERB_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOLEVERB_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut OLEVERB, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -960,6 +990,7 @@ pub trait IEnumOleDocumentViews_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumOleDocumentViews>;
 }
+impl ::windows::core::RuntimeName for IEnumOleDocumentViews {}
 impl IEnumOleDocumentViews_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOleDocumentViews_Impl, const OFFSET: isize>() -> IEnumOleDocumentViews_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOleDocumentViews_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cviews: u32, rgpview: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1006,6 +1037,7 @@ pub trait IEnumOleUndoUnits_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumOleUndoUnits>;
 }
+impl ::windows::core::RuntimeName for IEnumOleUndoUnits {}
 impl IEnumOleUndoUnits_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOleUndoUnits_Impl, const OFFSET: isize>() -> IEnumOleUndoUnits_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumOleUndoUnits_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1053,6 +1085,8 @@ pub trait IEnumVARIANT_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IEnumVARIANT {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IEnumVARIANT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumVARIANT_Impl, const OFFSET: isize>() -> IEnumVARIANT_Vtbl {
@@ -1121,6 +1155,8 @@ pub trait IFont_Impl: Sized {
     fn ReleaseHfont(&self, hfont: super::super::Graphics::Gdi::HFONT) -> ::windows::core::Result<()>;
     fn SetHdc(&self, hdc: super::super::Graphics::Gdi::HDC) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFont {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IFont_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFont_Impl, const OFFSET: isize>() -> IFont_Vtbl {
@@ -1345,6 +1381,8 @@ impl IFont_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFontDisp_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFontDisp {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFontDisp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFontDisp_Impl, const OFFSET: isize>() -> IFontDisp_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1355,6 +1393,8 @@ impl IFontDisp_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFontEventsDisp_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFontEventsDisp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFontEventsDisp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFontEventsDisp_Impl, const OFFSET: isize>() -> IFontEventsDisp_Vtbl {
@@ -1367,6 +1407,7 @@ impl IFontEventsDisp_Vtbl {
 pub trait IGetOleObject_Impl: Sized {
     fn GetOleObject(&self, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGetOleObject {}
 impl IGetOleObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetOleObject_Impl, const OFFSET: isize>() -> IGetOleObject_Vtbl {
         unsafe extern "system" fn GetOleObject<Identity: ::windows::core::IUnknownImpl, Impl: IGetOleObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1383,6 +1424,7 @@ impl IGetOleObject_Vtbl {
 pub trait IGetVBAObject_Impl: Sized {
     fn GetObject(&self, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void, dwreserved: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGetVBAObject {}
 impl IGetVBAObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetVBAObject_Impl, const OFFSET: isize>() -> IGetVBAObject_Vtbl {
         unsafe extern "system" fn GetObject<Identity: ::windows::core::IUnknownImpl, Impl: IGetVBAObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void, dwreserved: u32) -> ::windows::core::HRESULT {
@@ -1399,6 +1441,7 @@ impl IGetVBAObject_Vtbl {
 pub trait IObjectIdentity_Impl: Sized {
     fn IsEqualObject(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectIdentity {}
 impl IObjectIdentity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectIdentity_Impl, const OFFSET: isize>() -> IObjectIdentity_Vtbl {
         unsafe extern "system" fn IsEqualObject<Identity: ::windows::core::IUnknownImpl, Impl: IObjectIdentity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1416,6 +1459,7 @@ pub trait IObjectWithSite_Impl: Sized {
     fn SetSite(&self, punksite: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetSite(&self, riid: *const ::windows::core::GUID, ppvsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectWithSite {}
 impl IObjectWithSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithSite_Impl, const OFFSET: isize>() -> IObjectWithSite_Vtbl {
         unsafe extern "system" fn SetSite<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punksite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1447,6 +1491,8 @@ pub trait IOleAdviseHolder_Impl: Sized {
     fn SendOnSave(&self) -> ::windows::core::Result<()>;
     fn SendOnClose(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOleAdviseHolder {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOleAdviseHolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleAdviseHolder_Impl, const OFFSET: isize>() -> IOleAdviseHolder_Vtbl {
@@ -1515,6 +1561,8 @@ pub trait IOleCache_Impl: Sized {
     fn SetData(&self, pformatetc: *const super::Com::FORMATETC, pmedium: *const super::Com::STGMEDIUM, frelease: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IOleCache {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IOleCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleCache_Impl, const OFFSET: isize>() -> IOleCache_Vtbl {
         unsafe extern "system" fn Cache<Identity: ::windows::core::IUnknownImpl, Impl: IOleCache_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pformatetc: *const super::Com::FORMATETC, advf: u32, pdwconnection: *mut u32) -> ::windows::core::HRESULT {
@@ -1573,6 +1621,8 @@ pub trait IOleCache2_Impl: Sized + IOleCache_Impl {
     fn DiscardCache(&self, dwdiscardoptions: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IOleCache2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IOleCache2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleCache2_Impl, const OFFSET: isize>() -> IOleCache2_Vtbl {
         unsafe extern "system" fn UpdateCache<Identity: ::windows::core::IUnknownImpl, Impl: IOleCache2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdataobject: ::windows::core::RawPtr, grfupdf: UPDFCACHE_FLAGS, preserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1600,6 +1650,8 @@ pub trait IOleCacheControl_Impl: Sized {
     fn OnRun(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
     fn OnStop(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOleCacheControl {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOleCacheControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleCacheControl_Impl, const OFFSET: isize>() -> IOleCacheControl_Vtbl {
@@ -1632,6 +1684,8 @@ pub trait IOleClientSite_Impl: Sized {
     fn OnShowWindow(&self, fshow: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn RequestNewObjectLayout(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOleClientSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOleClientSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleClientSite_Impl, const OFFSET: isize>() -> IOleClientSite_Vtbl {
@@ -1697,6 +1751,8 @@ pub trait IOleCommandTarget_Impl: Sized {
     fn Exec(&self, pguidcmdgroup: *const ::windows::core::GUID, ncmdid: u32, ncmdexecopt: u32, pvain: *const super::Com::VARIANT, pvaout: *mut super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOleCommandTarget {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOleCommandTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleCommandTarget_Impl, const OFFSET: isize>() -> IOleCommandTarget_Vtbl {
         unsafe extern "system" fn QueryStatus<Identity: ::windows::core::IUnknownImpl, Impl: IOleCommandTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidcmdgroup: *const ::windows::core::GUID, ccmds: u32, prgcmds: *mut OLECMD, pcmdtext: *mut OLECMDTEXT) -> ::windows::core::HRESULT {
@@ -1724,6 +1780,8 @@ pub trait IOleContainer_Impl: Sized + IParseDisplayName_Impl {
     fn EnumObjects(&self, grfflags: u32) -> ::windows::core::Result<super::Com::IEnumUnknown>;
     fn LockContainer(&self, flock: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOleContainer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOleContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleContainer_Impl, const OFFSET: isize>() -> IOleContainer_Vtbl {
@@ -1760,6 +1818,8 @@ pub trait IOleControl_Impl: Sized {
     fn OnAmbientPropertyChange(&self, dispid: i32) -> ::windows::core::Result<()>;
     fn FreezeEvents(&self, bfreeze: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleControl_Impl, const OFFSET: isize>() -> IOleControl_Vtbl {
@@ -1805,6 +1865,8 @@ pub trait IOleControlSite_Impl: Sized {
     fn OnFocus(&self, fgotfocus: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn ShowPropertyFrame(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleControlSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleControlSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleControlSite_Impl, const OFFSET: isize>() -> IOleControlSite_Vtbl {
@@ -1871,6 +1933,8 @@ pub trait IOleDocument_Impl: Sized {
     fn EnumViews(&self, ppenum: *mut ::core::option::Option<IEnumOleDocumentViews>, ppview: *mut ::core::option::Option<IOleDocumentView>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOleDocument {}
+#[cfg(feature = "Win32_System_Com")]
 impl IOleDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleDocument_Impl, const OFFSET: isize>() -> IOleDocument_Vtbl {
         unsafe extern "system" fn CreateView<Identity: ::windows::core::IUnknownImpl, Impl: IOleDocument_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pipsite: ::windows::core::RawPtr, pstm: ::windows::core::RawPtr, dwreserved: u32, ppview: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1914,6 +1978,7 @@ impl IOleDocument_Vtbl {
 pub trait IOleDocumentSite_Impl: Sized {
     fn ActivateMe(&self, pviewtoactivate: &::core::option::Option<IOleDocumentView>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOleDocumentSite {}
 impl IOleDocumentSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleDocumentSite_Impl, const OFFSET: isize>() -> IOleDocumentSite_Vtbl {
         unsafe extern "system" fn ActivateMe<Identity: ::windows::core::IUnknownImpl, Impl: IOleDocumentSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pviewtoactivate: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1943,6 +2008,8 @@ pub trait IOleDocumentView_Impl: Sized {
     fn ApplyViewState(&self, pstm: &::core::option::Option<super::Com::IStream>) -> ::windows::core::Result<()>;
     fn Clone(&self, pipsitenew: &::core::option::Option<IOleInPlaceSite>) -> ::windows::core::Result<IOleDocumentView>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOleDocumentView {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOleDocumentView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleDocumentView_Impl, const OFFSET: isize>() -> IOleDocumentView_Vtbl {
@@ -2065,6 +2132,8 @@ pub trait IOleInPlaceActiveObject_Impl: Sized + IOleWindow_Impl {
     fn EnableModeless(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleInPlaceActiveObject {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleInPlaceActiveObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceActiveObject_Impl, const OFFSET: isize>() -> IOleInPlaceActiveObject_Vtbl {
         unsafe extern "system" fn TranslateAccelerator<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceActiveObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpmsg: *const super::super::UI::WindowsAndMessaging::MSG) -> ::windows::core::HRESULT {
@@ -2114,6 +2183,8 @@ pub trait IOleInPlaceFrame_Impl: Sized + IOleWindow_Impl + IOleInPlaceUIWindow_I
     fn EnableModeless(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn TranslateAccelerator(&self, lpmsg: *const super::super::UI::WindowsAndMessaging::MSG, wid: u16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleInPlaceFrame {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleInPlaceFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceFrame_Impl, const OFFSET: isize>() -> IOleInPlaceFrame_Vtbl {
@@ -2169,6 +2240,8 @@ pub trait IOleInPlaceObject_Impl: Sized + IOleWindow_Impl {
     fn ReactivateAndUndo(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleInPlaceObject {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleInPlaceObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceObject_Impl, const OFFSET: isize>() -> IOleInPlaceObject_Vtbl {
         unsafe extern "system" fn InPlaceDeactivate<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2208,6 +2281,8 @@ pub trait IOleInPlaceObjectWindowless_Impl: Sized + IOleWindow_Impl + IOleInPlac
     fn OnWindowMessage(&self, msg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
     fn GetDropTarget(&self) -> ::windows::core::Result<IDropTarget>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleInPlaceObjectWindowless {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOleInPlaceObjectWindowless_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceObjectWindowless_Impl, const OFFSET: isize>() -> IOleInPlaceObjectWindowless_Vtbl {
@@ -2256,6 +2331,8 @@ pub trait IOleInPlaceSite_Impl: Sized + IOleWindow_Impl {
     fn DeactivateAndUndo(&self) -> ::windows::core::Result<()>;
     fn OnPosRectChange(&self, lprcposrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleInPlaceSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleInPlaceSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceSite_Impl, const OFFSET: isize>() -> IOleInPlaceSite_Vtbl {
@@ -2334,6 +2411,8 @@ pub trait IOleInPlaceSiteEx_Impl: Sized + IOleWindow_Impl + IOleInPlaceSite_Impl
     fn RequestUIActivate(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleInPlaceSiteEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleInPlaceSiteEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceSiteEx_Impl, const OFFSET: isize>() -> IOleInPlaceSiteEx_Vtbl {
         unsafe extern "system" fn OnInPlaceActivateEx<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceSiteEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfnoredraw: *mut super::super::Foundation::BOOL, dwflags: u32) -> ::windows::core::HRESULT {
@@ -2377,6 +2456,8 @@ pub trait IOleInPlaceSiteWindowless_Impl: Sized + IOleWindow_Impl + IOleInPlaceS
     fn AdjustRect(&self, prc: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
     fn OnDefWindowMessage(&self, msg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleInPlaceSiteWindowless {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleInPlaceSiteWindowless_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceSiteWindowless_Impl, const OFFSET: isize>() -> IOleInPlaceSiteWindowless_Vtbl {
@@ -2480,6 +2561,8 @@ pub trait IOleInPlaceUIWindow_Impl: Sized + IOleWindow_Impl {
     fn SetActiveObject(&self, pactiveobject: &::core::option::Option<IOleInPlaceActiveObject>, pszobjname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleInPlaceUIWindow {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleInPlaceUIWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceUIWindow_Impl, const OFFSET: isize>() -> IOleInPlaceUIWindow_Vtbl {
         unsafe extern "system" fn GetBorder<Identity: ::windows::core::IUnknownImpl, Impl: IOleInPlaceUIWindow_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lprectborder: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -2527,6 +2610,8 @@ pub trait IOleItemContainer_Impl: Sized + IParseDisplayName_Impl + IOleContainer
     fn IsRunning(&self, pszitem: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IOleItemContainer {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IOleItemContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleItemContainer_Impl, const OFFSET: isize>() -> IOleItemContainer_Vtbl {
         unsafe extern "system" fn GetObject<Identity: ::windows::core::IUnknownImpl, Impl: IOleItemContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszitem: ::windows::core::PCWSTR, dwspeedneeded: u32, pbc: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2569,6 +2654,8 @@ pub trait IOleLink_Impl: Sized {
     fn UnbindSource(&self) -> ::windows::core::Result<()>;
     fn Update(&self, pbc: &::core::option::Option<super::Com::IBindCtx>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IOleLink {}
 #[cfg(feature = "Win32_System_Com")]
 impl IOleLink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleLink_Impl, const OFFSET: isize>() -> IOleLink_Vtbl {
@@ -2694,6 +2781,8 @@ pub trait IOleObject_Impl: Sized {
     fn GetMiscStatus(&self, dwaspect: u32) -> ::windows::core::Result<u32>;
     fn SetColorScheme(&self, plogpal: *const super::super::Graphics::Gdi::LOGPALETTE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IOleObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IOleObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleObject_Impl, const OFFSET: isize>() -> IOleObject_Vtbl {
@@ -2900,6 +2989,8 @@ pub trait IOleParentUndoUnit_Impl: Sized + IOleUndoUnit_Impl {
     fn GetParentState(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleParentUndoUnit {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleParentUndoUnit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleParentUndoUnit_Impl, const OFFSET: isize>() -> IOleParentUndoUnit_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IOleParentUndoUnit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppuu: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2957,6 +3048,8 @@ pub trait IOleUILinkContainerA_Impl: Sized {
     fn UpdateLink(&self, dwlink: u32, ferrormessage: super::super::Foundation::BOOL, freserved: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn CancelLink(&self, dwlink: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUILinkContainerA {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOleUILinkContainerA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUILinkContainerA_Impl, const OFFSET: isize>() -> IOleUILinkContainerA_Vtbl {
@@ -3034,6 +3127,8 @@ pub trait IOleUILinkContainerW_Impl: Sized {
     fn CancelLink(&self, dwlink: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUILinkContainerW {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleUILinkContainerW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUILinkContainerW_Impl, const OFFSET: isize>() -> IOleUILinkContainerW_Vtbl {
         unsafe extern "system" fn GetNextLink<Identity: ::windows::core::IUnknownImpl, Impl: IOleUILinkContainerW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwlink: u32) -> u32 {
@@ -3103,6 +3198,8 @@ pub trait IOleUILinkInfoA_Impl: Sized + IOleUILinkContainerA_Impl {
     fn GetLastUpdate(&self, dwlink: u32) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUILinkInfoA {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleUILinkInfoA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUILinkInfoA_Impl, const OFFSET: isize>() -> IOleUILinkInfoA_Vtbl {
         unsafe extern "system" fn GetLastUpdate<Identity: ::windows::core::IUnknownImpl, Impl: IOleUILinkInfoA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwlink: u32, lplastupdate: *mut super::super::Foundation::FILETIME) -> ::windows::core::HRESULT {
@@ -3126,6 +3223,8 @@ impl IOleUILinkInfoA_Vtbl {
 pub trait IOleUILinkInfoW_Impl: Sized + IOleUILinkContainerW_Impl {
     fn GetLastUpdate(&self, dwlink: u32) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUILinkInfoW {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOleUILinkInfoW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUILinkInfoW_Impl, const OFFSET: isize>() -> IOleUILinkInfoW_Vtbl {
@@ -3154,6 +3253,8 @@ pub trait IOleUIObjInfoA_Impl: Sized {
     fn GetViewInfo(&self, dwobject: u32, phmetapict: *const isize, pdvaspect: *const u32, pncurrentscale: *const i32) -> ::windows::core::Result<()>;
     fn SetViewInfo(&self, dwobject: u32, hmetapict: isize, dvaspect: u32, ncurrentscale: i32, brelativetoorig: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUIObjInfoA {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOleUIObjInfoA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUIObjInfoA_Impl, const OFFSET: isize>() -> IOleUIObjInfoA_Vtbl {
@@ -3203,6 +3304,8 @@ pub trait IOleUIObjInfoW_Impl: Sized {
     fn GetViewInfo(&self, dwobject: u32, phmetapict: *const isize, pdvaspect: *const u32, pncurrentscale: *const i32) -> ::windows::core::Result<()>;
     fn SetViewInfo(&self, dwobject: u32, hmetapict: isize, dvaspect: u32, ncurrentscale: i32, brelativetoorig: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUIObjInfoW {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOleUIObjInfoW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUIObjInfoW_Impl, const OFFSET: isize>() -> IOleUIObjInfoW_Vtbl {
@@ -3259,6 +3362,8 @@ pub trait IOleUndoManager_Impl: Sized {
     fn GetLastRedoDescription(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Enable(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUndoManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOleUndoManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUndoManager_Impl, const OFFSET: isize>() -> IOleUndoManager_Vtbl {
@@ -3380,6 +3485,8 @@ pub trait IOleUndoUnit_Impl: Sized {
     fn OnNextAdd(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleUndoUnit {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleUndoUnit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleUndoUnit_Impl, const OFFSET: isize>() -> IOleUndoUnit_Vtbl {
         unsafe extern "system" fn Do<Identity: ::windows::core::IUnknownImpl, Impl: IOleUndoUnit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pundomanager: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3426,6 +3533,8 @@ pub trait IOleWindow_Impl: Sized {
     fn ContextSensitiveHelp(&self, fentermode: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOleWindow {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOleWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOleWindow_Impl, const OFFSET: isize>() -> IOleWindow_Vtbl {
         unsafe extern "system" fn GetWindow<Identity: ::windows::core::IUnknownImpl, Impl: IOleWindow_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -3459,6 +3568,8 @@ pub trait IParseDisplayName_Impl: Sized {
     fn ParseDisplayName(&self, pbc: &::core::option::Option<super::Com::IBindCtx>, pszdisplayname: &::windows::core::PCWSTR, pcheaten: *mut u32, ppmkout: *mut ::core::option::Option<super::Com::IMoniker>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IParseDisplayName {}
+#[cfg(feature = "Win32_System_Com")]
 impl IParseDisplayName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IParseDisplayName_Impl, const OFFSET: isize>() -> IParseDisplayName_Vtbl {
         unsafe extern "system" fn ParseDisplayName<Identity: ::windows::core::IUnknownImpl, Impl: IParseDisplayName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbc: ::windows::core::RawPtr, pszdisplayname: ::windows::core::PCWSTR, pcheaten: *mut u32, ppmkout: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3479,6 +3590,8 @@ pub trait IPerPropertyBrowsing_Impl: Sized {
     fn GetPredefinedStrings(&self, dispid: i32, pcastringsout: *mut CALPOLESTR, pcacookiesout: *mut CADWORD) -> ::windows::core::Result<()>;
     fn GetPredefinedValue(&self, dispid: i32, dwcookie: u32) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPerPropertyBrowsing {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPerPropertyBrowsing_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPerPropertyBrowsing_Impl, const OFFSET: isize>() -> IPerPropertyBrowsing_Vtbl {
@@ -3539,6 +3652,8 @@ pub trait IPersistPropertyBag_Impl: Sized + super::Com::IPersist_Impl {
     fn Save(&self, ppropbag: &::core::option::Option<super::Com::StructuredStorage::IPropertyBag>, fcleardirty: super::super::Foundation::BOOL, fsaveallproperties: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPersistPropertyBag {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPersistPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistPropertyBag_Impl, const OFFSET: isize>() -> IPersistPropertyBag_Vtbl {
         unsafe extern "system" fn InitNew<Identity: ::windows::core::IUnknownImpl, Impl: IPersistPropertyBag_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3574,6 +3689,8 @@ pub trait IPersistPropertyBag2_Impl: Sized + super::Com::IPersist_Impl {
     fn Save(&self, ppropbag: &::core::option::Option<super::Com::StructuredStorage::IPropertyBag2>, fcleardirty: super::super::Foundation::BOOL, fsaveallproperties: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn IsDirty(&self) -> ::windows::core::HRESULT;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPersistPropertyBag2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPersistPropertyBag2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistPropertyBag2_Impl, const OFFSET: isize>() -> IPersistPropertyBag2_Vtbl {
@@ -3626,6 +3743,8 @@ pub trait IPicture_Impl: Sized {
     fn SaveAsFile(&self, pstream: &::core::option::Option<super::Com::IStream>, fsavememcopy: super::super::Foundation::BOOL) -> ::windows::core::Result<i32>;
     fn Attributes(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPicture {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IPicture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPicture_Impl, const OFFSET: isize>() -> IPicture_Vtbl {
@@ -3793,6 +3912,8 @@ pub trait IPicture2_Impl: Sized {
     fn Attributes(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPicture2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IPicture2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPicture2_Impl, const OFFSET: isize>() -> IPicture2_Vtbl {
         unsafe extern "system" fn Handle<Identity: ::windows::core::IUnknownImpl, Impl: IPicture2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phandle: *mut usize) -> ::windows::core::HRESULT {
@@ -3944,6 +4065,8 @@ impl IPicture2_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPictureDisp_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPictureDisp {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IPictureDisp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPictureDisp_Impl, const OFFSET: isize>() -> IPictureDisp_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -3958,6 +4081,8 @@ pub trait IPointerInactive_Impl: Sized {
     fn OnInactiveMouseMove(&self, prectbounds: *const super::super::Foundation::RECT, x: i32, y: i32, grfkeystate: u32) -> ::windows::core::Result<()>;
     fn OnInactiveSetCursor(&self, prectbounds: *const super::super::Foundation::RECT, x: i32, y: i32, dwmousemsg: u32, fsetalways: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPointerInactive {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPointerInactive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPointerInactive_Impl, const OFFSET: isize>() -> IPointerInactive_Vtbl {
@@ -4000,6 +4125,8 @@ pub trait IPrint_Impl: Sized {
     fn Print(&self, grfflags: u32, pptd: *mut *mut super::Com::DVTARGETDEVICE, pppageset: *mut *mut PAGESET, pstgmoptions: *mut super::Com::STGMEDIUM, pcallback: &::core::option::Option<IContinueCallback>, nfirstpage: i32, pcpagesprinted: *mut i32, pnlastpage: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPrint {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPrint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrint_Impl, const OFFSET: isize>() -> IPrint_Vtbl {
         unsafe extern "system" fn SetInitialPageNum<Identity: ::windows::core::IUnknownImpl, Impl: IPrint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nfirstpage: i32) -> ::windows::core::HRESULT {
@@ -4032,6 +4159,7 @@ pub trait IPropertyNotifySink_Impl: Sized {
     fn OnChanged(&self, dispid: i32) -> ::windows::core::Result<()>;
     fn OnRequestEdit(&self, dispid: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPropertyNotifySink {}
 impl IPropertyNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyNotifySink_Impl, const OFFSET: isize>() -> IPropertyNotifySink_Vtbl {
         unsafe extern "system" fn OnChanged<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dispid: i32) -> ::windows::core::HRESULT {
@@ -4068,6 +4196,8 @@ pub trait IPropertyPage_Impl: Sized {
     fn Help(&self, pszhelpdir: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn TranslateAccelerator(&self, pmsg: *const super::super::UI::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPropertyPage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPropertyPage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyPage_Impl, const OFFSET: isize>() -> IPropertyPage_Vtbl {
@@ -4156,6 +4286,8 @@ pub trait IPropertyPage2_Impl: Sized + IPropertyPage_Impl {
     fn EditProperty(&self, dispid: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPropertyPage2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPropertyPage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyPage2_Impl, const OFFSET: isize>() -> IPropertyPage2_Vtbl {
         unsafe extern "system" fn EditProperty<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyPage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dispid: i32) -> ::windows::core::HRESULT {
@@ -4176,6 +4308,8 @@ pub trait IPropertyPageSite_Impl: Sized {
     fn GetPageContainer(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn TranslateAccelerator(&self, pmsg: *const super::super::UI::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPropertyPageSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPropertyPageSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyPageSite_Impl, const OFFSET: isize>() -> IPropertyPageSite_Vtbl {
@@ -4228,6 +4362,8 @@ pub trait IProtectFocus_Impl: Sized {
     fn AllowFocusChange(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IProtectFocus {}
+#[cfg(feature = "Win32_Foundation")]
 impl IProtectFocus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProtectFocus_Impl, const OFFSET: isize>() -> IProtectFocus_Vtbl {
         unsafe extern "system" fn AllowFocusChange<Identity: ::windows::core::IUnknownImpl, Impl: IProtectFocus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfallow: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -4253,6 +4389,8 @@ pub trait IProtectedModeMenuServices_Impl: Sized {
     fn LoadMenu(&self, pszmodulename: &::windows::core::PCWSTR, pszmenuname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::UI::WindowsAndMessaging::HMENU>;
     fn LoadMenuID(&self, pszmodulename: &::windows::core::PCWSTR, wresourceid: u16) -> ::windows::core::Result<super::super::UI::WindowsAndMessaging::HMENU>;
 }
+#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
+impl ::windows::core::RuntimeName for IProtectedModeMenuServices {}
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl IProtectedModeMenuServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProtectedModeMenuServices_Impl, const OFFSET: isize>() -> IProtectedModeMenuServices_Vtbl {
@@ -4305,6 +4443,8 @@ pub trait IProvideClassInfo_Impl: Sized {
     fn GetClassInfo(&self) -> ::windows::core::Result<super::Com::ITypeInfo>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IProvideClassInfo {}
+#[cfg(feature = "Win32_System_Com")]
 impl IProvideClassInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideClassInfo_Impl, const OFFSET: isize>() -> IProvideClassInfo_Vtbl {
         unsafe extern "system" fn GetClassInfo<Identity: ::windows::core::IUnknownImpl, Impl: IProvideClassInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppti: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4328,6 +4468,8 @@ impl IProvideClassInfo_Vtbl {
 pub trait IProvideClassInfo2_Impl: Sized + IProvideClassInfo_Impl {
     fn GetGUID(&self, dwguidkind: u32) -> ::windows::core::Result<::windows::core::GUID>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IProvideClassInfo2 {}
 #[cfg(feature = "Win32_System_Com")]
 impl IProvideClassInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideClassInfo2_Impl, const OFFSET: isize>() -> IProvideClassInfo2_Vtbl {
@@ -4353,6 +4495,8 @@ pub trait IProvideMultipleClassInfo_Impl: Sized + IProvideClassInfo_Impl + IProv
     fn GetMultiTypeInfoCount(&self) -> ::windows::core::Result<u32>;
     fn GetInfoOfIndex(&self, iti: u32, dwflags: MULTICLASSINFO_FLAGS, ppticoclass: *mut ::core::option::Option<super::Com::ITypeInfo>, pdwtiflags: *mut u32, pcdispidreserved: *mut u32, piidprimary: *mut ::windows::core::GUID, piidsource: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IProvideMultipleClassInfo {}
 #[cfg(feature = "Win32_System_Com")]
 impl IProvideMultipleClassInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideMultipleClassInfo_Impl, const OFFSET: isize>() -> IProvideMultipleClassInfo_Vtbl {
@@ -4385,6 +4529,7 @@ impl IProvideMultipleClassInfo_Vtbl {
 pub trait IProvideRuntimeContext_Impl: Sized {
     fn GetCurrentSourceContext(&self, pdwcontext: *mut usize, pfexecutingglobalcode: *mut i16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProvideRuntimeContext {}
 impl IProvideRuntimeContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideRuntimeContext_Impl, const OFFSET: isize>() -> IProvideRuntimeContext_Vtbl {
         unsafe extern "system" fn GetCurrentSourceContext<Identity: ::windows::core::IUnknownImpl, Impl: IProvideRuntimeContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcontext: *mut usize, pfexecutingglobalcode: *mut i16) -> ::windows::core::HRESULT {
@@ -4404,6 +4549,8 @@ pub trait IQuickActivate_Impl: Sized {
     fn SetContentExtent(&self, psizel: *const super::super::Foundation::SIZE) -> ::windows::core::Result<()>;
     fn GetContentExtent(&self) -> ::windows::core::Result<super::super::Foundation::SIZE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IQuickActivate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IQuickActivate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQuickActivate_Impl, const OFFSET: isize>() -> IQuickActivate_Vtbl {
@@ -4458,6 +4605,8 @@ pub trait IRecordInfo_Impl: Sized {
     fn RecordCreateCopy(&self, pvsource: *const ::core::ffi::c_void, ppvdest: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn RecordDestroy(&self, pvrecord: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRecordInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRecordInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRecordInfo_Impl, const OFFSET: isize>() -> IRecordInfo_Vtbl {
@@ -4601,6 +4750,8 @@ pub trait ISimpleFrameSite_Impl: Sized {
     fn PostMessageFilter(&self, hwnd: super::super::Foundation::HWND, msg: u32, wp: super::super::Foundation::WPARAM, lp: super::super::Foundation::LPARAM, plresult: *mut super::super::Foundation::LRESULT, dwcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISimpleFrameSite {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISimpleFrameSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleFrameSite_Impl, const OFFSET: isize>() -> ISimpleFrameSite_Vtbl {
         unsafe extern "system" fn PreMessageFilter<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleFrameSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, msg: u32, wp: super::super::Foundation::WPARAM, lp: super::super::Foundation::LPARAM, plresult: *mut super::super::Foundation::LRESULT, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -4626,6 +4777,7 @@ impl ISimpleFrameSite_Vtbl {
 pub trait ISpecifyPropertyPages_Impl: Sized {
     fn GetPages(&self) -> ::windows::core::Result<CAUUID>;
 }
+impl ::windows::core::RuntimeName for ISpecifyPropertyPages {}
 impl ISpecifyPropertyPages_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpecifyPropertyPages_Impl, const OFFSET: isize>() -> ISpecifyPropertyPages_Vtbl {
         unsafe extern "system" fn GetPages<Identity: ::windows::core::IUnknownImpl, Impl: ISpecifyPropertyPages_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppages: *mut CAUUID) -> ::windows::core::HRESULT {
@@ -4650,6 +4802,8 @@ pub trait ITypeChangeEvents_Impl: Sized {
     fn RequestTypeChange(&self, changekind: CHANGEKIND, ptinfobefore: &::core::option::Option<super::Com::ITypeInfo>, pstrname: &::windows::core::PCWSTR) -> ::windows::core::Result<i32>;
     fn AfterTypeChange(&self, changekind: CHANGEKIND, ptinfoafter: &::core::option::Option<super::Com::ITypeInfo>, pstrname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITypeChangeEvents {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITypeChangeEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeChangeEvents_Impl, const OFFSET: isize>() -> ITypeChangeEvents_Vtbl {
@@ -4684,6 +4838,8 @@ pub trait ITypeFactory_Impl: Sized {
     fn CreateFromTypeInfo(&self, ptypeinfo: &::core::option::Option<super::Com::ITypeInfo>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITypeFactory {}
+#[cfg(feature = "Win32_System_Com")]
 impl ITypeFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeFactory_Impl, const OFFSET: isize>() -> ITypeFactory_Vtbl {
         unsafe extern "system" fn CreateFromTypeInfo<Identity: ::windows::core::IUnknownImpl, Impl: ITypeFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptypeinfo: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4709,6 +4865,7 @@ pub trait ITypeMarshal_Impl: Sized {
     fn Unmarshal(&self, pvtype: *mut ::core::ffi::c_void, dwflags: u32, cbbufferlength: u32, pbuffer: *const u8, pcbread: *mut u32) -> ::windows::core::Result<()>;
     fn Free(&self, pvtype: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITypeMarshal {}
 impl ITypeMarshal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITypeMarshal_Impl, const OFFSET: isize>() -> ITypeMarshal_Vtbl {
         unsafe extern "system" fn Size<Identity: ::windows::core::IUnknownImpl, Impl: ITypeMarshal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvtype: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *const ::core::ffi::c_void, psize: *mut u32) -> ::windows::core::HRESULT {
@@ -4754,6 +4911,8 @@ pub trait IVBFormat_Impl: Sized {
     fn Format(&self, vdata: *mut super::Com::VARIANT, bstrformat: &super::super::Foundation::BSTR, lpbuffer: *mut ::core::ffi::c_void, cb: u16, lcid: i32, sfirstdayofweek: i16, sfirstweekofyear: u16, rcb: *mut u16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IVBFormat {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IVBFormat_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBFormat_Impl, const OFFSET: isize>() -> IVBFormat_Vtbl {
         unsafe extern "system" fn Format<Identity: ::windows::core::IUnknownImpl, Impl: IVBFormat_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, vdata: *mut super::Com::VARIANT, bstrformat: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lpbuffer: *mut ::core::ffi::c_void, cb: u16, lcid: i32, sfirstdayofweek: i16, sfirstweekofyear: u16, rcb: *mut u16) -> ::windows::core::HRESULT {
@@ -4771,6 +4930,8 @@ impl IVBFormat_Vtbl {
 pub trait IVBGetControl_Impl: Sized {
     fn EnumControls(&self, dwolecontf: OLECONTF, dwwhich: ENUM_CONTROLS_WHICH_FLAGS) -> ::windows::core::Result<super::Com::IEnumUnknown>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IVBGetControl {}
 #[cfg(feature = "Win32_System_Com")]
 impl IVBGetControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVBGetControl_Impl, const OFFSET: isize>() -> IVBGetControl_Vtbl {
@@ -4796,6 +4957,8 @@ pub trait IVariantChangeType_Impl: Sized {
     fn ChangeType(&self, pvardst: *mut super::Com::VARIANT, pvarsrc: *const super::Com::VARIANT, lcid: u32, vtnew: u16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IVariantChangeType {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IVariantChangeType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVariantChangeType_Impl, const OFFSET: isize>() -> IVariantChangeType_Vtbl {
         unsafe extern "system" fn ChangeType<Identity: ::windows::core::IUnknownImpl, Impl: IVariantChangeType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvardst: *mut super::Com::VARIANT, pvarsrc: *const super::Com::VARIANT, lcid: u32, vtnew: u16) -> ::windows::core::HRESULT {
@@ -4818,6 +4981,8 @@ pub trait IViewObject_Impl: Sized {
     fn SetAdvise(&self, aspects: u32, advf: u32, padvsink: &::core::option::Option<super::Com::IAdviseSink>) -> ::windows::core::Result<()>;
     fn GetAdvise(&self, paspects: *mut u32, padvf: *mut u32, ppadvsink: *mut ::core::option::Option<super::Com::IAdviseSink>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IViewObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IViewObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewObject_Impl, const OFFSET: isize>() -> IViewObject_Vtbl {
@@ -4870,6 +5035,8 @@ pub trait IViewObject2_Impl: Sized + IViewObject_Impl {
     fn GetExtent(&self, dwdrawaspect: u32, lindex: i32, ptd: *const super::Com::DVTARGETDEVICE) -> ::windows::core::Result<super::super::Foundation::SIZE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IViewObject2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IViewObject2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewObject2_Impl, const OFFSET: isize>() -> IViewObject2_Vtbl {
         unsafe extern "system" fn GetExtent<Identity: ::windows::core::IUnknownImpl, Impl: IViewObject2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwdrawaspect: u32, lindex: i32, ptd: *const super::Com::DVTARGETDEVICE, lpsizel: *mut super::super::Foundation::SIZE) -> ::windows::core::HRESULT {
@@ -4897,6 +5064,8 @@ pub trait IViewObjectEx_Impl: Sized + IViewObject_Impl + IViewObject2_Impl {
     fn QueryHitRect(&self, dwaspect: u32, prectbounds: *const super::super::Foundation::RECT, prectloc: *const super::super::Foundation::RECT, lclosehint: i32) -> ::windows::core::Result<u32>;
     fn GetNaturalExtent(&self, dwaspect: super::Com::DVASPECT, lindex: i32, ptd: *const super::Com::DVTARGETDEVICE, hictargetdev: super::super::Graphics::Gdi::HDC, pextentinfo: *const ExtentInfo) -> ::windows::core::Result<super::super::Foundation::SIZE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IViewObjectEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IViewObjectEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewObjectEx_Impl, const OFFSET: isize>() -> IViewObjectEx_Vtbl {
@@ -4971,6 +5140,7 @@ impl IViewObjectEx_Vtbl {
 pub trait IZoomEvents_Impl: Sized {
     fn OnZoomPercentChanged(&self, ulzoompercent: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IZoomEvents {}
 impl IZoomEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IZoomEvents_Impl, const OFFSET: isize>() -> IZoomEvents_Vtbl {
         unsafe extern "system" fn OnZoomPercentChanged<Identity: ::windows::core::IUnknownImpl, Impl: IZoomEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulzoompercent: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
@@ -3,6 +3,8 @@ pub trait IWPCGamesSettings_Impl: Sized + IWPCSettings_Impl {
     fn IsBlocked(&self, guidappid: &::windows::core::GUID) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWPCGamesSettings {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWPCGamesSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWPCGamesSettings_Impl, const OFFSET: isize>() -> IWPCGamesSettings_Vtbl {
         unsafe extern "system" fn IsBlocked<Identity: ::windows::core::IUnknownImpl, Impl: IWPCGamesSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidappid: ::windows::core::GUID, pdwreasons: *mut u32) -> ::windows::core::HRESULT {
@@ -28,6 +30,8 @@ pub trait IWPCProviderConfig_Impl: Sized {
     fn Configure(&self, hwnd: super::super::Foundation::HWND, bstrsid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn RequestOverride(&self, hwnd: super::super::Foundation::HWND, bstrpath: &super::super::Foundation::BSTR, dwflags: WPCFLAG_RESTRICTION) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWPCProviderConfig {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWPCProviderConfig_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWPCProviderConfig_Impl, const OFFSET: isize>() -> IWPCProviderConfig_Vtbl {
@@ -67,6 +71,7 @@ pub trait IWPCProviderState_Impl: Sized {
     fn Enable(&self) -> ::windows::core::Result<()>;
     fn Disable(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWPCProviderState {}
 impl IWPCProviderState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWPCProviderState_Impl, const OFFSET: isize>() -> IWPCProviderState_Vtbl {
         unsafe extern "system" fn Enable<Identity: ::windows::core::IUnknownImpl, Impl: IWPCProviderState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -92,6 +97,7 @@ impl IWPCProviderState_Vtbl {
 pub trait IWPCProviderSupport_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IWPCProviderSupport {}
 impl IWPCProviderSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWPCProviderSupport_Impl, const OFFSET: isize>() -> IWPCProviderSupport_Vtbl {
         unsafe extern "system" fn GetCurrent<Identity: ::windows::core::IUnknownImpl, Impl: IWPCProviderSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidprovider: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -117,6 +123,8 @@ pub trait IWPCSettings_Impl: Sized {
     fn GetLastSettingsChangeTime(&self) -> ::windows::core::Result<super::super::Foundation::SYSTEMTIME>;
     fn GetRestrictions(&self) -> ::windows::core::Result<WPCFLAG_RESTRICTION>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWPCSettings {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWPCSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWPCSettings_Impl, const OFFSET: isize>() -> IWPCSettings_Vtbl {
@@ -170,6 +178,8 @@ pub trait IWPCWebSettings_Impl: Sized + IWPCSettings_Impl {
     fn RequestURLOverride(&self, hwnd: super::super::Foundation::HWND, pcszurl: &::windows::core::PCWSTR, curls: u32, ppcszsuburls: *const ::windows::core::PWSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWPCWebSettings {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWPCWebSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWPCWebSettings_Impl, const OFFSET: isize>() -> IWPCWebSettings_Vtbl {
         unsafe extern "system" fn GetSettings<Identity: ::windows::core::IUnknownImpl, Impl: IWPCWebSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwsettings: *mut WPCFLAG_WEB_SETTING) -> ::windows::core::HRESULT {
@@ -207,6 +217,7 @@ impl IWPCWebSettings_Vtbl {
 pub trait IWindowsParentalControls_Impl: Sized + IWindowsParentalControlsCore_Impl {
     fn GetGamesSettings(&self, pcszsid: &::windows::core::PCWSTR) -> ::windows::core::Result<IWPCGamesSettings>;
 }
+impl ::windows::core::RuntimeName for IWindowsParentalControls {}
 impl IWindowsParentalControls_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsParentalControls_Impl, const OFFSET: isize>() -> IWindowsParentalControls_Vtbl {
         unsafe extern "system" fn GetGamesSettings<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsParentalControls_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcszsid: ::windows::core::PCWSTR, ppsettings: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -232,6 +243,7 @@ pub trait IWindowsParentalControlsCore_Impl: Sized {
     fn GetWebSettings(&self, pcszsid: &::windows::core::PCWSTR) -> ::windows::core::Result<IWPCWebSettings>;
     fn GetWebFilterInfo(&self, pguidid: *mut ::windows::core::GUID, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWindowsParentalControlsCore {}
 impl IWindowsParentalControlsCore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsParentalControlsCore_Impl, const OFFSET: isize>() -> IWindowsParentalControlsCore_Vtbl {
         unsafe extern "system" fn GetVisibility<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsParentalControlsCore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pevisibility: *mut WPCFLAG_VISIBILITY) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
@@ -1,6 +1,8 @@
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DICounterItem_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DICounterItem {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DICounterItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DICounterItem_Impl, const OFFSET: isize>() -> DICounterItem_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -11,6 +13,8 @@ impl DICounterItem_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DILogFileItem_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DILogFileItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DILogFileItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DILogFileItem_Impl, const OFFSET: isize>() -> DILogFileItem_Vtbl {
@@ -23,6 +27,8 @@ impl DILogFileItem_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DISystemMonitor_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DISystemMonitor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DISystemMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DISystemMonitor_Impl, const OFFSET: isize>() -> DISystemMonitor_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -34,6 +40,8 @@ impl DISystemMonitor_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DISystemMonitorEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DISystemMonitorEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DISystemMonitorEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DISystemMonitorEvents_Impl, const OFFSET: isize>() -> DISystemMonitorEvents_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -44,6 +52,8 @@ impl DISystemMonitorEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DISystemMonitorInternal_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DISystemMonitorInternal {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DISystemMonitorInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DISystemMonitorInternal_Impl, const OFFSET: isize>() -> DISystemMonitorInternal_Vtbl {
@@ -72,6 +82,8 @@ pub trait IAlertDataCollector_Impl: Sized + super::Com::IDispatch_Impl + IDataCo
     fn TriggerDataCollectorSet(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetTriggerDataCollectorSet(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAlertDataCollector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAlertDataCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAlertDataCollector_Impl, const OFFSET: isize>() -> IAlertDataCollector_Vtbl {
@@ -245,6 +257,8 @@ pub trait IApiTracingDataCollector_Impl: Sized + super::Com::IDispatch_Impl + ID
     fn SetExcludeApis(&self, excludeapis: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IApiTracingDataCollector {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IApiTracingDataCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApiTracingDataCollector_Impl, const OFFSET: isize>() -> IApiTracingDataCollector_Vtbl {
         unsafe extern "system" fn LogApiNamesOnly<Identity: ::windows::core::IUnknownImpl, Impl: IApiTracingDataCollector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, logapinames: *mut i16) -> ::windows::core::HRESULT {
@@ -402,6 +416,8 @@ pub trait IConfigurationDataCollector_Impl: Sized + super::Com::IDispatch_Impl +
     fn SystemStateFile(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetSystemStateFile(&self, filename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IConfigurationDataCollector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IConfigurationDataCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConfigurationDataCollector_Impl, const OFFSET: isize>() -> IConfigurationDataCollector_Vtbl {
@@ -591,6 +607,8 @@ pub trait ICounterItem_Impl: Sized {
     fn GetStatistics(&self, max: *mut f64, min: *mut f64, avg: *mut f64, status: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICounterItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICounterItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICounterItem_Impl, const OFFSET: isize>() -> ICounterItem_Vtbl {
         unsafe extern "system" fn Value<Identity: ::windows::core::IUnknownImpl, Impl: ICounterItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdblvalue: *mut f64) -> ::windows::core::HRESULT {
@@ -718,6 +736,8 @@ pub trait ICounterItem2_Impl: Sized + ICounterItem_Impl {
     fn GetDataAt(&self, iindex: i32, iwhich: SysmonDataType) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICounterItem2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICounterItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICounterItem2_Impl, const OFFSET: isize>() -> ICounterItem2_Vtbl {
         unsafe extern "system" fn SetSelected<Identity: ::windows::core::IUnknownImpl, Impl: ICounterItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstate: i16) -> ::windows::core::HRESULT {
@@ -784,6 +804,8 @@ pub trait ICounters_Impl: Sized + super::Com::IDispatch_Impl {
     fn Add(&self, pathname: &super::super::Foundation::BSTR) -> ::windows::core::Result<DICounterItem>;
     fn Remove(&self, index: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICounters {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICounters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICounters_Impl, const OFFSET: isize>() -> ICounters_Vtbl {
@@ -877,6 +899,8 @@ pub trait IDataCollector_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetXml(&self, xml: &super::super::Foundation::BSTR) -> ::windows::core::Result<IValueMap>;
     fn CreateOutputLocation(&self, latest: i16) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataCollector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataCollector_Impl, const OFFSET: isize>() -> IDataCollector_Vtbl {
@@ -1141,6 +1165,8 @@ pub trait IDataCollectorCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateDataCollector(&self, r#type: DataCollectorType) -> ::windows::core::Result<IDataCollector>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataCollectorCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataCollectorCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataCollectorCollection_Impl, const OFFSET: isize>() -> IDataCollectorCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IDataCollectorCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -1292,6 +1318,8 @@ pub trait IDataCollectorSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetValue(&self, key: &super::super::Foundation::BSTR, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetValue(&self, key: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataCollectorSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataCollectorSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataCollectorSet_Impl, const OFFSET: isize>() -> IDataCollectorSet_Vtbl {
@@ -1879,6 +1907,8 @@ pub trait IDataCollectorSetCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetDataCollectorSets(&self, server: &super::super::Foundation::BSTR, filter: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataCollectorSetCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataCollectorSetCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataCollectorSetCollection_Impl, const OFFSET: isize>() -> IDataCollectorSetCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IDataCollectorSetCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -1983,6 +2013,8 @@ pub trait IDataManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn Run(&self, steps: DataManagerSteps, bstrfolder: &super::super::Foundation::BSTR) -> ::windows::core::Result<IValueMap>;
     fn Extract(&self, cabfilename: &super::super::Foundation::BSTR, destinationpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataManager_Impl, const OFFSET: isize>() -> IDataManager_Vtbl {
@@ -2234,6 +2266,8 @@ pub trait IFolderAction_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetSendCabTo(&self, bstrdestination: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFolderAction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFolderAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderAction_Impl, const OFFSET: isize>() -> IFolderAction_Vtbl {
         unsafe extern "system" fn Age<Identity: ::windows::core::IUnknownImpl, Impl: IFolderAction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pulage: *mut u32) -> ::windows::core::HRESULT {
@@ -2328,6 +2362,8 @@ pub trait IFolderActionCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateFolderAction(&self) -> ::windows::core::Result<IFolderAction>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFolderActionCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFolderActionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderActionCollection_Impl, const OFFSET: isize>() -> IFolderActionCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IFolderActionCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -2415,6 +2451,8 @@ pub trait ILogFileItem_Impl: Sized {
     fn Path(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ILogFileItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl ILogFileItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILogFileItem_Impl, const OFFSET: isize>() -> ILogFileItem_Vtbl {
         unsafe extern "system" fn Path<Identity: ::windows::core::IUnknownImpl, Impl: ILogFileItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstrvalue: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2442,6 +2480,8 @@ pub trait ILogFiles_Impl: Sized + super::Com::IDispatch_Impl {
     fn Add(&self, pathname: &super::super::Foundation::BSTR) -> ::windows::core::Result<DILogFileItem>;
     fn Remove(&self, index: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILogFiles {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILogFiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILogFiles_Impl, const OFFSET: isize>() -> ILogFiles_Vtbl {
@@ -2520,6 +2560,8 @@ pub trait IPerformanceCounterDataCollector_Impl: Sized + super::Com::IDispatch_I
     fn SegmentMaxRecords(&self) -> ::windows::core::Result<u32>;
     fn SetSegmentMaxRecords(&self, records: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPerformanceCounterDataCollector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPerformanceCounterDataCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPerformanceCounterDataCollector_Impl, const OFFSET: isize>() -> IPerformanceCounterDataCollector_Vtbl {
@@ -2633,6 +2675,8 @@ pub trait ISchedule_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetDays(&self, days: WeekDays) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISchedule {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISchedule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchedule_Impl, const OFFSET: isize>() -> ISchedule_Vtbl {
         unsafe extern "system" fn StartDate<Identity: ::windows::core::IUnknownImpl, Impl: ISchedule_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, start: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -2726,6 +2770,8 @@ pub trait IScheduleCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn AddRange(&self, pschedules: &::core::option::Option<IScheduleCollection>) -> ::windows::core::Result<()>;
     fn CreateSchedule(&self) -> ::windows::core::Result<ISchedule>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IScheduleCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IScheduleCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScheduleCollection_Impl, const OFFSET: isize>() -> IScheduleCollection_Vtbl {
@@ -2888,6 +2934,8 @@ pub trait ISystemMonitor_Impl: Sized {
     fn SetSqlLogSetName(&self, bssqllogsetname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SqlLogSetName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISystemMonitor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISystemMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISystemMonitor_Impl, const OFFSET: isize>() -> ISystemMonitor_Vtbl {
@@ -3595,6 +3643,8 @@ pub trait ISystemMonitor2_Impl: Sized + ISystemMonitor_Impl {
     fn LoadSettings(&self, bstrsettingfilename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISystemMonitor2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISystemMonitor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISystemMonitor2_Impl, const OFFSET: isize>() -> ISystemMonitor2_Vtbl {
         unsafe extern "system" fn SetEnableDigitGrouping<Identity: ::windows::core::IUnknownImpl, Impl: ISystemMonitor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstate: i16) -> ::windows::core::HRESULT {
@@ -3774,6 +3824,7 @@ pub trait ISystemMonitorEvents_Impl: Sized {
     fn OnSampleCollected(&self);
     fn OnDblClick(&self, index: i32);
 }
+impl ::windows::core::RuntimeName for ISystemMonitorEvents {}
 impl ISystemMonitorEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISystemMonitorEvents_Impl, const OFFSET: isize>() -> ISystemMonitorEvents_Vtbl {
         unsafe extern "system" fn OnCounterSelected<Identity: ::windows::core::IUnknownImpl, Impl: ISystemMonitorEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32) {
@@ -3857,6 +3908,8 @@ pub trait ITraceDataCollector_Impl: Sized + super::Com::IDispatch_Impl + IDataCo
     fn SetStreamMode(&self, mode: StreamMode) -> ::windows::core::Result<()>;
     fn TraceDataProviders(&self) -> ::windows::core::Result<ITraceDataProviderCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITraceDataCollector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITraceDataCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITraceDataCollector_Impl, const OFFSET: isize>() -> ITraceDataCollector_Vtbl {
@@ -4257,6 +4310,8 @@ pub trait ITraceDataProvider_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetRegisteredProcesses(&self) -> ::windows::core::Result<IValueMap>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITraceDataProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITraceDataProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITraceDataProvider_Impl, const OFFSET: isize>() -> ITraceDataProvider_Vtbl {
         unsafe extern "system" fn DisplayName<Identity: ::windows::core::IUnknownImpl, Impl: ITraceDataProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4461,6 +4516,8 @@ pub trait ITraceDataProviderCollection_Impl: Sized + super::Com::IDispatch_Impl 
     fn GetTraceDataProvidersByProcess(&self, server: &super::super::Foundation::BSTR, pid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITraceDataProviderCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITraceDataProviderCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITraceDataProviderCollection_Impl, const OFFSET: isize>() -> ITraceDataProviderCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ITraceDataProviderCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -4572,6 +4629,8 @@ pub trait IValueMap_Impl: Sized + super::Com::IDispatch_Impl {
     fn AddRange(&self, map: &::core::option::Option<IValueMap>) -> ::windows::core::Result<()>;
     fn CreateValueMapItem(&self) -> ::windows::core::Result<IValueMapItem>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IValueMap {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IValueMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IValueMap_Impl, const OFFSET: isize>() -> IValueMap_Vtbl {
@@ -4723,6 +4782,8 @@ pub trait IValueMapItem_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetValueMapType(&self, r#type: ValueMapType) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IValueMapItem {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IValueMapItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IValueMapItem_Impl, const OFFSET: isize>() -> IValueMapItem_Vtbl {
         unsafe extern "system" fn Description<Identity: ::windows::core::IUnknownImpl, Impl: IValueMapItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, description: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4843,6 +4904,8 @@ pub trait _ICounterItemUnion_Impl: Sized {
     fn Visible(&self) -> ::windows::core::Result<i16>;
     fn GetDataAt(&self, iindex: i32, iwhich: SysmonDataType) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ICounterItemUnion {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ICounterItemUnion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ICounterItemUnion_Impl, const OFFSET: isize>() -> _ICounterItemUnion_Vtbl {
@@ -5109,6 +5172,8 @@ pub trait _ISystemMonitorUnion_Impl: Sized {
     fn BatchingLock(&self, flock: i16, ebatchreason: SysmonBatchReason) -> ::windows::core::Result<()>;
     fn LoadSettings(&self, bstrsettingfilename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ISystemMonitorUnion {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ISystemMonitorUnion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ISystemMonitorUnion_Impl, const OFFSET: isize>() -> _ISystemMonitorUnion_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
@@ -4,6 +4,8 @@ pub trait INetworkTransportSettings_Impl: Sized {
     fn QuerySetting(&self, settingid: *const super::super::Networking::WinSock::TRANSPORT_SETTING_ID, lengthin: u32, valuein: *const u8, lengthout: *mut u32, valueout: *mut *mut u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Networking_WinSock")]
+impl ::windows::core::RuntimeName for INetworkTransportSettings {}
+#[cfg(feature = "Win32_Networking_WinSock")]
 impl INetworkTransportSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkTransportSettings_Impl, const OFFSET: isize>() -> INetworkTransportSettings_Vtbl {
         unsafe extern "system" fn ApplySetting<Identity: ::windows::core::IUnknownImpl, Impl: INetworkTransportSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, settingid: *const super::super::Networking::WinSock::TRANSPORT_SETTING_ID, lengthin: u32, valuein: *const u8, lengthout: *mut u32, valueout: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -30,6 +32,7 @@ pub trait INotificationTransportSync_Impl: Sized {
     fn CompleteDelivery(&self) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INotificationTransportSync {}
 impl INotificationTransportSync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INotificationTransportSync_Impl, const OFFSET: isize>() -> INotificationTransportSync_Vtbl {
         unsafe extern "system" fn CompleteDelivery<Identity: ::windows::core::IUnknownImpl, Impl: INotificationTransportSync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -57,6 +60,8 @@ pub trait IRTCBuddy_Impl: Sized + IRTCPresenceContact_Impl {
     fn Status(&self) -> ::windows::core::Result<RTC_PRESENCE_STATUS>;
     fn Notes(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCBuddy {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCBuddy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddy_Impl, const OFFSET: isize>() -> IRTCBuddy_Vtbl {
@@ -103,6 +108,8 @@ pub trait IRTCBuddy2_Impl: Sized + IRTCPresenceContact_Impl + IRTCBuddy_Impl {
     fn PresenceDevices(&self) -> ::windows::core::Result<IRTCCollection>;
     fn SubscriptionType(&self) -> ::windows::core::Result<RTC_BUDDY_SUBSCRIPTION_TYPE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRTCBuddy2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRTCBuddy2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddy2_Impl, const OFFSET: isize>() -> IRTCBuddy2_Vtbl {
@@ -209,6 +216,8 @@ pub trait IRTCBuddyEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Buddy(&self) -> ::windows::core::Result<IRTCBuddy>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCBuddyEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCBuddyEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddyEvent_Impl, const OFFSET: isize>() -> IRTCBuddyEvent_Vtbl {
         unsafe extern "system" fn Buddy<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddyEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbuddy: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -234,6 +243,8 @@ pub trait IRTCBuddyEvent2_Impl: Sized + super::Com::IDispatch_Impl + IRTCBuddyEv
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
     fn StatusText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCBuddyEvent2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCBuddyEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddyEvent2_Impl, const OFFSET: isize>() -> IRTCBuddyEvent2_Vtbl {
@@ -293,6 +304,8 @@ pub trait IRTCBuddyGroup_Impl: Sized {
     fn SetData(&self, bstrdata: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Profile(&self) -> ::windows::core::Result<IRTCProfile2>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRTCBuddyGroup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRTCBuddyGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddyGroup_Impl, const OFFSET: isize>() -> IRTCBuddyGroup_Vtbl {
@@ -395,6 +408,8 @@ pub trait IRTCBuddyGroupEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Buddy(&self) -> ::windows::core::Result<IRTCBuddy2>;
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCBuddyGroupEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCBuddyGroupEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCBuddyGroupEvent_Impl, const OFFSET: isize>() -> IRTCBuddyGroupEvent_Vtbl {
@@ -499,6 +514,8 @@ pub trait IRTCClient_Impl: Sized {
     fn InvokeTuningWizard(&self, hwndparent: isize) -> ::windows::core::Result<()>;
     fn IsTuned(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClient_Impl, const OFFSET: isize>() -> IRTCClient_Vtbl {
@@ -905,6 +922,8 @@ pub trait IRTCClient2_Impl: Sized + IRTCClient_Impl {
     fn get_AllowedPorts(&self, ltransport: i32) -> ::windows::core::Result<RTC_LISTEN_MODE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCClient2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCClient2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClient2_Impl, const OFFSET: isize>() -> IRTCClient2_Vtbl {
         unsafe extern "system" fn put_AnswerMode<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClient2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, entype: RTC_SESSION_TYPE, enmode: RTC_ANSWER_MODE) -> ::windows::core::HRESULT {
@@ -1029,6 +1048,8 @@ pub trait IRTCClientEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Client(&self) -> ::windows::core::Result<IRTCClient>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCClientEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCClientEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientEvent_Impl, const OFFSET: isize>() -> IRTCClientEvent_Vtbl {
         unsafe extern "system" fn EventType<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peneventtype: *mut RTC_CLIENT_EVENT_TYPE) -> ::windows::core::HRESULT {
@@ -1069,6 +1090,8 @@ pub trait IRTCClientPortManagement_Impl: Sized {
     fn StopListenAddressAndPort(&self, bstrinternallocaladdress: &super::super::Foundation::BSTR, linternallocalport: i32) -> ::windows::core::Result<()>;
     fn GetPortRange(&self, enporttype: RTC_PORT_TYPE, plminvalue: *mut i32, plmaxvalue: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCClientPortManagement {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCClientPortManagement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientPortManagement_Impl, const OFFSET: isize>() -> IRTCClientPortManagement_Vtbl {
@@ -1119,6 +1142,8 @@ pub trait IRTCClientPresence_Impl: Sized {
     fn PrivacyMode(&self) -> ::windows::core::Result<RTC_PRIVACY_MODE>;
     fn SetPrivacyMode(&self, enmode: RTC_PRIVACY_MODE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCClientPresence {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCClientPresence_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientPresence_Impl, const OFFSET: isize>() -> IRTCClientPresence_Vtbl {
@@ -1317,6 +1342,8 @@ pub trait IRTCClientPresence2_Impl: Sized + IRTCClientPresence_Impl {
     fn AddBuddyEx(&self, bstrpresentityuri: &super::super::Foundation::BSTR, bstrusername: &super::super::Foundation::BSTR, bstrdata: &super::super::Foundation::BSTR, fpersistent: i16, ensubscriptiontype: RTC_BUDDY_SUBSCRIPTION_TYPE, pprofile: &::core::option::Option<IRTCProfile>, lflags: i32) -> ::windows::core::Result<IRTCBuddy2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCClientPresence2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCClientPresence2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientPresence2_Impl, const OFFSET: isize>() -> IRTCClientPresence2_Vtbl {
         unsafe extern "system" fn EnablePresenceEx<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientPresence2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprofile: ::windows::core::RawPtr, varstorage: ::core::mem::ManuallyDrop<super::Com::VARIANT>, lflags: i32) -> ::windows::core::HRESULT {
@@ -1476,6 +1503,8 @@ pub trait IRTCClientProvisioning_Impl: Sized {
     fn SessionCapabilities(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRTCClientProvisioning {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRTCClientProvisioning_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientProvisioning_Impl, const OFFSET: isize>() -> IRTCClientProvisioning_Vtbl {
         unsafe extern "system" fn CreateProfile<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientProvisioning_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrprofilexml: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppprofile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1557,6 +1586,8 @@ pub trait IRTCClientProvisioning2_Impl: Sized + IRTCClientProvisioning_Impl {
     fn EnableProfileEx(&self, pprofile: &::core::option::Option<IRTCProfile>, lregisterflags: i32, lroamingflags: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRTCClientProvisioning2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRTCClientProvisioning2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientProvisioning2_Impl, const OFFSET: isize>() -> IRTCClientProvisioning2_Vtbl {
         unsafe extern "system" fn EnableProfileEx<Identity: ::windows::core::IUnknownImpl, Impl: IRTCClientProvisioning2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprofile: ::windows::core::RawPtr, lregisterflags: i32, lroamingflags: i32) -> ::windows::core::HRESULT {
@@ -1576,6 +1607,8 @@ pub trait IRTCCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::Com::VARIANT>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCCollection_Impl, const OFFSET: isize>() -> IRTCCollection_Vtbl {
@@ -1626,6 +1659,8 @@ impl IRTCCollection_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCDispatchEventNotification_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCDispatchEventNotification {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCDispatchEventNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCDispatchEventNotification_Impl, const OFFSET: isize>() -> IRTCDispatchEventNotification_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1640,6 +1675,7 @@ pub trait IRTCEnumBuddies_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumBuddies>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumBuddies {}
 impl IRTCEnumBuddies_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumBuddies_Impl, const OFFSET: isize>() -> IRTCEnumBuddies_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumBuddies_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1686,6 +1722,7 @@ pub trait IRTCEnumGroups_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumGroups>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumGroups {}
 impl IRTCEnumGroups_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumGroups_Impl, const OFFSET: isize>() -> IRTCEnumGroups_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumGroups_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1732,6 +1769,7 @@ pub trait IRTCEnumParticipants_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumParticipants>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumParticipants {}
 impl IRTCEnumParticipants_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumParticipants_Impl, const OFFSET: isize>() -> IRTCEnumParticipants_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumParticipants_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1778,6 +1816,7 @@ pub trait IRTCEnumPresenceDevices_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumPresenceDevices>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumPresenceDevices {}
 impl IRTCEnumPresenceDevices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumPresenceDevices_Impl, const OFFSET: isize>() -> IRTCEnumPresenceDevices_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumPresenceDevices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1824,6 +1863,7 @@ pub trait IRTCEnumProfiles_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumProfiles>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumProfiles {}
 impl IRTCEnumProfiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumProfiles_Impl, const OFFSET: isize>() -> IRTCEnumProfiles_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumProfiles_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1870,6 +1910,7 @@ pub trait IRTCEnumUserSearchResults_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumUserSearchResults>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumUserSearchResults {}
 impl IRTCEnumUserSearchResults_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumUserSearchResults_Impl, const OFFSET: isize>() -> IRTCEnumUserSearchResults_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumUserSearchResults_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1916,6 +1957,7 @@ pub trait IRTCEnumWatchers_Impl: Sized {
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IRTCEnumWatchers>;
 }
+impl ::windows::core::RuntimeName for IRTCEnumWatchers {}
 impl IRTCEnumWatchers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumWatchers_Impl, const OFFSET: isize>() -> IRTCEnumWatchers_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEnumWatchers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1961,6 +2003,8 @@ pub trait IRTCEventNotification_Impl: Sized {
     fn Event(&self, rtcevent: RTC_EVENT, pevent: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRTCEventNotification {}
+#[cfg(feature = "Win32_System_Com")]
 impl IRTCEventNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEventNotification_Impl, const OFFSET: isize>() -> IRTCEventNotification_Vtbl {
         unsafe extern "system" fn Event<Identity: ::windows::core::IUnknownImpl, Impl: IRTCEventNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rtcevent: RTC_EVENT, pevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1981,6 +2025,8 @@ pub trait IRTCInfoEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Info(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn InfoHeader(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCInfoEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCInfoEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCInfoEvent_Impl, const OFFSET: isize>() -> IRTCInfoEvent_Vtbl {
@@ -2048,6 +2094,8 @@ pub trait IRTCIntensityEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Direction(&self) -> ::windows::core::Result<RTC_AUDIO_DEVICE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCIntensityEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCIntensityEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCIntensityEvent_Impl, const OFFSET: isize>() -> IRTCIntensityEvent_Vtbl {
         unsafe extern "system" fn Level<Identity: ::windows::core::IUnknownImpl, Impl: IRTCIntensityEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pllevel: *mut i32) -> ::windows::core::HRESULT {
@@ -2113,6 +2161,8 @@ pub trait IRTCMediaEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn EventReason(&self) -> ::windows::core::Result<RTC_MEDIA_EVENT_REASON>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCMediaEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCMediaEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCMediaEvent_Impl, const OFFSET: isize>() -> IRTCMediaEvent_Vtbl {
         unsafe extern "system" fn MediaType<Identity: ::windows::core::IUnknownImpl, Impl: IRTCMediaEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmediatype: *mut i32) -> ::windows::core::HRESULT {
@@ -2169,6 +2219,8 @@ pub trait IRTCMediaRequestEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Reject(&self) -> ::windows::core::Result<()>;
     fn State(&self) -> ::windows::core::Result<RTC_REINVITE_STATE>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCMediaRequestEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCMediaRequestEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCMediaRequestEvent_Impl, const OFFSET: isize>() -> IRTCMediaRequestEvent_Vtbl {
@@ -2262,6 +2314,8 @@ pub trait IRTCMessagingEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn UserStatus(&self) -> ::windows::core::Result<RTC_MESSAGING_USER_STATUS>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCMessagingEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCMessagingEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCMessagingEvent_Impl, const OFFSET: isize>() -> IRTCMessagingEvent_Vtbl {
         unsafe extern "system" fn Session<Identity: ::windows::core::IUnknownImpl, Impl: IRTCMessagingEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsession: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2353,6 +2407,8 @@ pub trait IRTCParticipant_Impl: Sized {
     fn Session(&self) -> ::windows::core::Result<IRTCSession>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCParticipant {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRTCParticipant_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCParticipant_Impl, const OFFSET: isize>() -> IRTCParticipant_Vtbl {
         unsafe extern "system" fn UserURI<Identity: ::windows::core::IUnknownImpl, Impl: IRTCParticipant_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstruseruri: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2430,6 +2486,8 @@ pub trait IRTCParticipantStateChangeEvent_Impl: Sized + super::Com::IDispatch_Im
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCParticipantStateChangeEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCParticipantStateChangeEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCParticipantStateChangeEvent_Impl, const OFFSET: isize>() -> IRTCParticipantStateChangeEvent_Vtbl {
         unsafe extern "system" fn Participant<Identity: ::windows::core::IUnknownImpl, Impl: IRTCParticipantStateChangeEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppparticipant: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2483,6 +2541,8 @@ pub trait IRTCPortManager_Impl: Sized {
     fn ReleaseMapping(&self, bstrinternallocaladdress: &super::super::Foundation::BSTR, linternallocalport: i32, bstrexternallocaladdress: &super::super::Foundation::BSTR, lexternallocaladdress: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCPortManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRTCPortManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPortManager_Impl, const OFFSET: isize>() -> IRTCPortManager_Vtbl {
         unsafe extern "system" fn GetMapping<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPortManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrremoteaddress: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, enporttype: RTC_PORT_TYPE, pbstrinternallocaladdress: *mut super::super::Foundation::BSTR, plinternallocalport: *mut i32, pbstrexternallocaladdress: *mut super::super::Foundation::BSTR, plexternallocalport: *mut i32) -> ::windows::core::HRESULT {
@@ -2522,6 +2582,8 @@ pub trait IRTCPresenceContact_Impl: Sized {
     fn Persistent(&self) -> ::windows::core::Result<i16>;
     fn SetPersistent(&self, fpersistent: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCPresenceContact {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCPresenceContact_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresenceContact_Impl, const OFFSET: isize>() -> IRTCPresenceContact_Vtbl {
@@ -2612,6 +2674,8 @@ pub trait IRTCPresenceDataEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetPresenceData(&self, pbstrnamespace: *mut super::super::Foundation::BSTR, pbstrdata: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCPresenceDataEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCPresenceDataEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresenceDataEvent_Impl, const OFFSET: isize>() -> IRTCPresenceDataEvent_Vtbl {
         unsafe extern "system" fn StatusCode<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresenceDataEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plstatuscode: *mut i32) -> ::windows::core::HRESULT {
@@ -2659,6 +2723,8 @@ pub trait IRTCPresenceDevice_Impl: Sized {
     fn get_PresenceProperty(&self, enproperty: RTC_PRESENCE_PROPERTY) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetPresenceData(&self, pbstrnamespace: *mut super::super::Foundation::BSTR, pbstrdata: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCPresenceDevice {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCPresenceDevice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresenceDevice_Impl, const OFFSET: isize>() -> IRTCPresenceDevice_Vtbl {
@@ -2719,6 +2785,8 @@ pub trait IRTCPresencePropertyEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn PresenceProperty(&self) -> ::windows::core::Result<RTC_PRESENCE_PROPERTY>;
     fn Value(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCPresencePropertyEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCPresencePropertyEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresencePropertyEvent_Impl, const OFFSET: isize>() -> IRTCPresencePropertyEvent_Vtbl {
@@ -2785,6 +2853,8 @@ pub trait IRTCPresenceStatusEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetLocalPresenceInfo(&self, penstatus: *mut RTC_PRESENCE_STATUS, pbstrnotes: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCPresenceStatusEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCPresenceStatusEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresenceStatusEvent_Impl, const OFFSET: isize>() -> IRTCPresenceStatusEvent_Vtbl {
         unsafe extern "system" fn StatusCode<Identity: ::windows::core::IUnknownImpl, Impl: IRTCPresenceStatusEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plstatuscode: *mut i32) -> ::windows::core::HRESULT {
@@ -2846,6 +2916,8 @@ pub trait IRTCProfile_Impl: Sized {
     fn SessionCapabilities(&self) -> ::windows::core::Result<i32>;
     fn State(&self) -> ::windows::core::Result<RTC_REGISTRATION_STATE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCProfile {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCProfile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfile_Impl, const OFFSET: isize>() -> IRTCProfile_Vtbl {
@@ -3075,6 +3147,8 @@ pub trait IRTCProfile2_Impl: Sized + IRTCProfile_Impl {
     fn SetAllowedAuth(&self, lallowedauth: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCProfile2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRTCProfile2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfile2_Impl, const OFFSET: isize>() -> IRTCProfile2_Vtbl {
         unsafe extern "system" fn Realm<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfile2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrrealm: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3128,6 +3202,8 @@ pub trait IRTCProfileEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCProfileEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCProfileEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfileEvent_Impl, const OFFSET: isize>() -> IRTCProfileEvent_Vtbl {
         unsafe extern "system" fn Profile<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfileEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppprofile: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3179,6 +3255,8 @@ pub trait IRTCProfileEvent2_Impl: Sized + super::Com::IDispatch_Impl + IRTCProfi
     fn EventType(&self) -> ::windows::core::Result<RTC_PROFILE_EVENT_TYPE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCProfileEvent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCProfileEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfileEvent2_Impl, const OFFSET: isize>() -> IRTCProfileEvent2_Vtbl {
         unsafe extern "system" fn EventType<Identity: ::windows::core::IUnknownImpl, Impl: IRTCProfileEvent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventtype: *mut RTC_PROFILE_EVENT_TYPE) -> ::windows::core::HRESULT {
@@ -3206,6 +3284,8 @@ pub trait IRTCReInviteEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn State(&self) -> ::windows::core::Result<RTC_REINVITE_STATE>;
     fn GetRemoteSessionDescription(&self, pbstrcontenttype: *mut super::super::Foundation::BSTR, pbstrsessiondescription: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCReInviteEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCReInviteEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCReInviteEvent_Impl, const OFFSET: isize>() -> IRTCReInviteEvent_Vtbl {
@@ -3266,6 +3346,8 @@ pub trait IRTCRegistrationStateChangeEvent_Impl: Sized + super::Com::IDispatch_I
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
     fn StatusText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCRegistrationStateChangeEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCRegistrationStateChangeEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCRegistrationStateChangeEvent_Impl, const OFFSET: isize>() -> IRTCRegistrationStateChangeEvent_Vtbl {
@@ -3332,6 +3414,8 @@ pub trait IRTCRoamingEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
     fn StatusText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCRoamingEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCRoamingEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCRoamingEvent_Impl, const OFFSET: isize>() -> IRTCRoamingEvent_Vtbl {
@@ -3414,6 +3498,8 @@ pub trait IRTCSession_Impl: Sized {
     fn RemoveStream(&self, lmediatype: i32, lcookie: isize) -> ::windows::core::Result<()>;
     fn put_EncryptionKey(&self, lmediatype: i32, encryptionkey: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRTCSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRTCSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSession_Impl, const OFFSET: isize>() -> IRTCSession_Vtbl {
@@ -3615,6 +3701,8 @@ pub trait IRTCSession2_Impl: Sized + IRTCSession_Impl {
     fn ReInviteWithSessionDescription(&self, bstrcontenttype: &super::super::Foundation::BSTR, bstrsessiondescription: &super::super::Foundation::BSTR, lcookie: isize) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRTCSession2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRTCSession2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSession2_Impl, const OFFSET: isize>() -> IRTCSession2_Vtbl {
         unsafe extern "system" fn SendInfo<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSession2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrinfoheader: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrinfo: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lcookie: isize) -> ::windows::core::HRESULT {
@@ -3685,6 +3773,8 @@ pub trait IRTCSessionCallControl_Impl: Sized {
     fn ReferCookie(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn IsReferred(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCSessionCallControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCSessionCallControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionCallControl_Impl, const OFFSET: isize>() -> IRTCSessionCallControl_Vtbl {
@@ -3773,6 +3863,8 @@ pub trait IRTCSessionDescriptionManager_Impl: Sized {
     fn EvaluateSessionDescription(&self, bstrcontenttype: &super::super::Foundation::BSTR, bstrsessiondescription: &super::super::Foundation::BSTR, pfapplicationsession: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCSessionDescriptionManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRTCSessionDescriptionManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionDescriptionManager_Impl, const OFFSET: isize>() -> IRTCSessionDescriptionManager_Vtbl {
         unsafe extern "system" fn EvaluateSessionDescription<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionDescriptionManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrcontenttype: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrsessiondescription: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pfapplicationsession: *mut i16) -> ::windows::core::HRESULT {
@@ -3796,6 +3888,8 @@ pub trait IRTCSessionOperationCompleteEvent_Impl: Sized + super::Com::IDispatch_
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
     fn StatusText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCSessionOperationCompleteEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCSessionOperationCompleteEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionOperationCompleteEvent_Impl, const OFFSET: isize>() -> IRTCSessionOperationCompleteEvent_Vtbl {
@@ -3861,6 +3955,8 @@ pub trait IRTCSessionOperationCompleteEvent2_Impl: Sized + super::Com::IDispatch
     fn GetRemoteSessionDescription(&self, pbstrcontenttype: *mut super::super::Foundation::BSTR, pbstrsessiondescription: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCSessionOperationCompleteEvent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCSessionOperationCompleteEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionOperationCompleteEvent2_Impl, const OFFSET: isize>() -> IRTCSessionOperationCompleteEvent2_Vtbl {
         unsafe extern "system" fn Participant<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionOperationCompleteEvent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppparticipant: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3892,6 +3988,7 @@ impl IRTCSessionOperationCompleteEvent2_Vtbl {
 pub trait IRTCSessionPortManagement_Impl: Sized {
     fn SetPortManager(&self, pportmanager: &::core::option::Option<IRTCPortManager>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRTCSessionPortManagement {}
 impl IRTCSessionPortManagement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionPortManagement_Impl, const OFFSET: isize>() -> IRTCSessionPortManagement_Vtbl {
         unsafe extern "system" fn SetPortManager<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionPortManagement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pportmanager: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3912,6 +4009,8 @@ pub trait IRTCSessionReferStatusEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
     fn StatusText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCSessionReferStatusEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCSessionReferStatusEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionReferStatusEvent_Impl, const OFFSET: isize>() -> IRTCSessionReferStatusEvent_Vtbl {
@@ -3981,6 +4080,8 @@ pub trait IRTCSessionReferredEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Reject(&self) -> ::windows::core::Result<()>;
     fn SetReferredSessionState(&self, enstate: RTC_SESSION_STATE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCSessionReferredEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCSessionReferredEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionReferredEvent_Impl, const OFFSET: isize>() -> IRTCSessionReferredEvent_Vtbl {
@@ -4066,6 +4167,8 @@ pub trait IRTCSessionStateChangeEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCSessionStateChangeEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCSessionStateChangeEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionStateChangeEvent_Impl, const OFFSET: isize>() -> IRTCSessionStateChangeEvent_Vtbl {
         unsafe extern "system" fn Session<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionStateChangeEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsession: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4132,6 +4235,8 @@ pub trait IRTCSessionStateChangeEvent2_Impl: Sized + super::Com::IDispatch_Impl 
     fn GetRemoteSessionDescription(&self, pbstrcontenttype: *mut super::super::Foundation::BSTR, pbstrsessiondescription: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCSessionStateChangeEvent2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCSessionStateChangeEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionStateChangeEvent2_Impl, const OFFSET: isize>() -> IRTCSessionStateChangeEvent2_Vtbl {
         unsafe extern "system" fn MediaTypes<Identity: ::windows::core::IUnknownImpl, Impl: IRTCSessionStateChangeEvent2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmediatypes: *mut i32) -> ::windows::core::HRESULT {
@@ -4188,6 +4293,7 @@ pub trait IRTCUserSearch_Impl: Sized {
     fn CreateQuery(&self) -> ::windows::core::Result<IRTCUserSearchQuery>;
     fn ExecuteSearch(&self, pquery: &::core::option::Option<IRTCUserSearchQuery>, pprofile: &::core::option::Option<IRTCProfile>, lcookie: isize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRTCUserSearch {}
 impl IRTCUserSearch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCUserSearch_Impl, const OFFSET: isize>() -> IRTCUserSearch_Vtbl {
         unsafe extern "system" fn CreateQuery<Identity: ::windows::core::IUnknownImpl, Impl: IRTCUserSearch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppquery: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4226,6 +4332,8 @@ pub trait IRTCUserSearchQuery_Impl: Sized {
     fn SetSearchDomain(&self, bstrdomain: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SearchDomain(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCUserSearchQuery {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCUserSearchQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCUserSearchQuery_Impl, const OFFSET: isize>() -> IRTCUserSearchQuery_Vtbl {
@@ -4308,6 +4416,8 @@ pub trait IRTCUserSearchResult_Impl: Sized {
     fn get_Value(&self, encolumn: RTC_USER_SEARCH_COLUMN) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCUserSearchResult {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRTCUserSearchResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCUserSearchResult_Impl, const OFFSET: isize>() -> IRTCUserSearchResult_Vtbl {
         unsafe extern "system" fn get_Value<Identity: ::windows::core::IUnknownImpl, Impl: IRTCUserSearchResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, encolumn: RTC_USER_SEARCH_COLUMN, pbstrvalue: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4337,6 +4447,8 @@ pub trait IRTCUserSearchResultsEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
     fn MoreAvailable(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCUserSearchResultsEvent {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCUserSearchResultsEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCUserSearchResultsEvent_Impl, const OFFSET: isize>() -> IRTCUserSearchResultsEvent_Vtbl {
@@ -4438,6 +4550,8 @@ pub trait IRTCWatcher_Impl: Sized + IRTCPresenceContact_Impl {
     fn SetState(&self, enstate: RTC_WATCHER_STATE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCWatcher {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRTCWatcher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCWatcher_Impl, const OFFSET: isize>() -> IRTCWatcher_Vtbl {
         unsafe extern "system" fn State<Identity: ::windows::core::IUnknownImpl, Impl: IRTCWatcher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, penstate: *mut RTC_WATCHER_STATE) -> ::windows::core::HRESULT {
@@ -4471,6 +4585,8 @@ pub trait IRTCWatcher2_Impl: Sized + IRTCPresenceContact_Impl + IRTCWatcher_Impl
     fn Profile(&self) -> ::windows::core::Result<IRTCProfile2>;
     fn Scope(&self) -> ::windows::core::Result<RTC_ACE_SCOPE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRTCWatcher2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRTCWatcher2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCWatcher2_Impl, const OFFSET: isize>() -> IRTCWatcher2_Vtbl {
@@ -4507,6 +4623,8 @@ pub trait IRTCWatcherEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Watcher(&self) -> ::windows::core::Result<IRTCWatcher>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCWatcherEvent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCWatcherEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCWatcherEvent_Impl, const OFFSET: isize>() -> IRTCWatcherEvent_Vtbl {
         unsafe extern "system" fn Watcher<Identity: ::windows::core::IUnknownImpl, Impl: IRTCWatcherEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwatcher: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4531,6 +4649,8 @@ pub trait IRTCWatcherEvent2_Impl: Sized + super::Com::IDispatch_Impl + IRTCWatch
     fn EventType(&self) -> ::windows::core::Result<RTC_WATCHER_EVENT_TYPE>;
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRTCWatcherEvent2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRTCWatcherEvent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRTCWatcherEvent2_Impl, const OFFSET: isize>() -> IRTCWatcherEvent2_Vtbl {
@@ -4571,6 +4691,8 @@ pub trait ITransportSettingsInternal_Impl: Sized {
     fn ApplySetting(&self, setting: *mut TRANSPORT_SETTING) -> ::windows::core::Result<()>;
     fn QuerySetting(&self, setting: *mut TRANSPORT_SETTING) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Networking_WinSock")]
+impl ::windows::core::RuntimeName for ITransportSettingsInternal {}
 #[cfg(feature = "Win32_Networking_WinSock")]
 impl ITransportSettingsInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransportSettingsInternal_Impl, const OFFSET: isize>() -> ITransportSettingsInternal_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
@@ -1,6 +1,8 @@
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DRendezvousSessionEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DRendezvousSessionEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DRendezvousSessionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DRendezvousSessionEvents_Impl, const OFFSET: isize>() -> DRendezvousSessionEvents_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -12,6 +14,7 @@ impl DRendezvousSessionEvents_Vtbl {
 pub trait IRendezvousApplication_Impl: Sized {
     fn SetRendezvousSession(&self, prendezvoussession: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRendezvousApplication {}
 impl IRendezvousApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRendezvousApplication_Impl, const OFFSET: isize>() -> IRendezvousApplication_Vtbl {
         unsafe extern "system" fn SetRendezvousSession<Identity: ::windows::core::IUnknownImpl, Impl: IRendezvousApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prendezvoussession: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -33,6 +36,8 @@ pub trait IRendezvousSession_Impl: Sized {
     fn SendContextData(&self, bstrdata: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Terminate(&self, hr: ::windows::core::HRESULT, bstrappdata: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRendezvousSession {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRendezvousSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRendezvousSession_Impl, const OFFSET: isize>() -> IRendezvousSession_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
@@ -32,6 +32,8 @@ pub trait IADsTSUserEx_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetTerminalServicesInitialProgram(&self, pnewval: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IADsTSUserEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IADsTSUserEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADsTSUserEx_Impl, const OFFSET: isize>() -> IADsTSUserEx_Vtbl {
         unsafe extern "system" fn TerminalServicesProfilePath<Identity: ::windows::core::IUnknownImpl, Impl: IADsTSUserEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -320,6 +322,8 @@ pub trait IAudioDeviceEndpoint_Impl: Sized {
     fn WriteExclusiveModeParametersToSharedMemory(&self, htargetprocess: usize, hnsperiod: i64, hnsbufferduration: i64, u32latencycoefficient: u32, pu32sharedmemorysize: *mut u32, phsharedmemory: *mut usize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAudioDeviceEndpoint {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAudioDeviceEndpoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioDeviceEndpoint_Impl, const OFFSET: isize>() -> IAudioDeviceEndpoint_Vtbl {
         unsafe extern "system" fn SetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IAudioDeviceEndpoint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxperiod: i64, u32latencycoefficient: u32) -> ::windows::core::HRESULT {
@@ -374,6 +378,8 @@ pub trait IAudioEndpoint_Impl: Sized {
     fn SetStreamFlags(&self, streamflags: u32) -> ::windows::core::Result<()>;
     fn SetEventHandle(&self, eventhandle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio"))]
+impl ::windows::core::RuntimeName for IAudioEndpoint {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio"))]
 impl IAudioEndpoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpoint_Impl, const OFFSET: isize>() -> IAudioEndpoint_Vtbl {
@@ -438,6 +444,7 @@ pub trait IAudioEndpointControl_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioEndpointControl {}
 impl IAudioEndpointControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointControl_Impl, const OFFSET: isize>() -> IAudioEndpointControl_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -472,6 +479,7 @@ pub trait IAudioEndpointRT_Impl: Sized {
     fn SetPinInactive(&self) -> ::windows::core::Result<()>;
     fn SetPinActive(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAudioEndpointRT {}
 impl IAudioEndpointRT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointRT_Impl, const OFFSET: isize>() -> IAudioEndpointRT_Vtbl {
         unsafe extern "system" fn GetCurrentPadding<Identity: ::windows::core::IUnknownImpl, Impl: IAudioEndpointRT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppadding: *mut i64, paecurrentposition: *mut AE_CURRENT_POSITION) {
@@ -513,6 +521,8 @@ pub trait IAudioInputEndpointRT_Impl: Sized {
     fn PulseEndpoint(&self);
 }
 #[cfg(feature = "Win32_Media_Audio_Apo")]
+impl ::windows::core::RuntimeName for IAudioInputEndpointRT {}
+#[cfg(feature = "Win32_Media_Audio_Apo")]
 impl IAudioInputEndpointRT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioInputEndpointRT_Impl, const OFFSET: isize>() -> IAudioInputEndpointRT_Vtbl {
         unsafe extern "system" fn GetInputDataPointer<Identity: ::windows::core::IUnknownImpl, Impl: IAudioInputEndpointRT_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnectionproperty: *mut super::super::Media::Audio::Apo::APO_CONNECTION_PROPERTY, paetimestamp: *mut AE_CURRENT_POSITION) {
@@ -547,6 +557,8 @@ pub trait IAudioOutputEndpointRT_Impl: Sized {
     fn ReleaseOutputDataPointer(&self, pconnectionproperty: *const super::super::Media::Audio::Apo::APO_CONNECTION_PROPERTY);
     fn PulseEndpoint(&self);
 }
+#[cfg(feature = "Win32_Media_Audio_Apo")]
+impl ::windows::core::RuntimeName for IAudioOutputEndpointRT {}
 #[cfg(feature = "Win32_Media_Audio_Apo")]
 impl IAudioOutputEndpointRT_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioOutputEndpointRT_Impl, const OFFSET: isize>() -> IAudioOutputEndpointRT_Vtbl {
@@ -589,6 +601,8 @@ pub trait IRemoteDesktopClient_Impl: Sized + super::Com::IDispatch_Impl {
     fn attachEvent(&self, eventname: &super::super::Foundation::BSTR, callback: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
     fn detachEvent(&self, eventname: &super::super::Foundation::BSTR, callback: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRemoteDesktopClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRemoteDesktopClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDesktopClient_Impl, const OFFSET: isize>() -> IRemoteDesktopClient_Vtbl {
@@ -686,6 +700,8 @@ pub trait IRemoteDesktopClientActions_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSnapshot(&self, snapshotencoding: SnapshotEncodingType, snapshotformat: SnapshotFormatType, snapshotwidth: u32, snapshotheight: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRemoteDesktopClientActions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRemoteDesktopClientActions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDesktopClientActions_Impl, const OFFSET: isize>() -> IRemoteDesktopClientActions_Vtbl {
         unsafe extern "system" fn SuspendScreenUpdates<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDesktopClientActions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -733,6 +749,8 @@ pub trait IRemoteDesktopClientSettings_Impl: Sized + super::Com::IDispatch_Impl 
     fn GetRdpProperty(&self, propertyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
     fn SetRdpProperty(&self, propertyname: &super::super::Foundation::BSTR, value: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRemoteDesktopClientSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRemoteDesktopClientSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDesktopClientSettings_Impl, const OFFSET: isize>() -> IRemoteDesktopClientSettings_Vtbl {
@@ -789,6 +807,8 @@ pub trait IRemoteDesktopClientTouchPointer_Impl: Sized + super::Com::IDispatch_I
     fn SetPointerSpeed(&self, pointerspeed: u32) -> ::windows::core::Result<()>;
     fn PointerSpeed(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRemoteDesktopClientTouchPointer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRemoteDesktopClientTouchPointer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteDesktopClientTouchPointer_Impl, const OFFSET: isize>() -> IRemoteDesktopClientTouchPointer_Vtbl {
@@ -857,6 +877,7 @@ impl IRemoteDesktopClientTouchPointer_Vtbl {
 pub trait IRemoteSystemAdditionalInfoProvider_Impl: Sized {
     fn GetAdditionalInfo(&self, deduplicationid: *mut ::windows::core::HSTRING, riid: *const ::windows::core::GUID, mapview: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRemoteSystemAdditionalInfoProvider {}
 impl IRemoteSystemAdditionalInfoProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteSystemAdditionalInfoProvider_Impl, const OFFSET: isize>() -> IRemoteSystemAdditionalInfoProvider_Vtbl {
         unsafe extern "system" fn GetAdditionalInfo<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteSystemAdditionalInfoProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, deduplicationid: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>, riid: *const ::windows::core::GUID, mapview: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -874,6 +895,8 @@ impl IRemoteSystemAdditionalInfoProvider_Vtbl {
 pub trait ITSGAccountingEngine_Impl: Sized {
     fn DoAccounting(&self, accountingdatatype: AAAccountingDataType, accountingdata: &AAAccountingData) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITSGAccountingEngine {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITSGAccountingEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAccountingEngine_Impl, const OFFSET: isize>() -> ITSGAccountingEngine_Vtbl {
@@ -895,6 +918,8 @@ pub trait ITSGAuthenticateUserSink_Impl: Sized {
     fn ReauthenticateUser(&self, context: usize) -> ::windows::core::Result<()>;
     fn DisconnectUser(&self, context: usize) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITSGAuthenticateUserSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITSGAuthenticateUserSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAuthenticateUserSink_Impl, const OFFSET: isize>() -> ITSGAuthenticateUserSink_Vtbl {
@@ -934,6 +959,7 @@ pub trait ITSGAuthenticationEngine_Impl: Sized {
     fn AuthenticateUser(&self, mainsessionid: &::windows::core::GUID, cookiedata: *const u8, numcookiebytes: u32, context: usize, psink: &::core::option::Option<ITSGAuthenticateUserSink>) -> ::windows::core::Result<()>;
     fn CancelAuthentication(&self, mainsessionid: &::windows::core::GUID, context: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITSGAuthenticationEngine {}
 impl ITSGAuthenticationEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAuthenticationEngine_Impl, const OFFSET: isize>() -> ITSGAuthenticationEngine_Vtbl {
         unsafe extern "system" fn AuthenticateUser<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAuthenticationEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mainsessionid: ::windows::core::GUID, cookiedata: *const u8, numcookiebytes: u32, context: usize, psink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -959,6 +985,7 @@ impl ITSGAuthenticationEngine_Vtbl {
 pub trait ITSGAuthorizeConnectionSink_Impl: Sized {
     fn OnConnectionAuthorized(&self, hrin: ::windows::core::HRESULT, mainsessionid: &::windows::core::GUID, cbsohresponse: u32, pbsohresponse: *const u8, idletimeout: u32, sessiontimeout: u32, sessiontimeoutaction: SESSION_TIMEOUT_ACTION_TYPE, trustclass: AATrustClassID, policyattributes: *const u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITSGAuthorizeConnectionSink {}
 impl ITSGAuthorizeConnectionSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAuthorizeConnectionSink_Impl, const OFFSET: isize>() -> ITSGAuthorizeConnectionSink_Vtbl {
         unsafe extern "system" fn OnConnectionAuthorized<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAuthorizeConnectionSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrin: ::windows::core::HRESULT, mainsessionid: ::windows::core::GUID, cbsohresponse: u32, pbsohresponse: *const u8, idletimeout: u32, sessiontimeout: u32, sessiontimeoutaction: SESSION_TIMEOUT_ACTION_TYPE, trustclass: AATrustClassID, policyattributes: *const u32) -> ::windows::core::HRESULT {
@@ -976,6 +1003,8 @@ impl ITSGAuthorizeConnectionSink_Vtbl {
 pub trait ITSGAuthorizeResourceSink_Impl: Sized {
     fn OnChannelAuthorized(&self, hrin: ::windows::core::HRESULT, mainsessionid: &::windows::core::GUID, subsessionid: i32, allowedresourcenames: *const super::super::Foundation::BSTR, numallowedresourcenames: u32, failedresourcenames: *const super::super::Foundation::BSTR, numfailedresourcenames: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITSGAuthorizeResourceSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITSGAuthorizeResourceSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSGAuthorizeResourceSink_Impl, const OFFSET: isize>() -> ITSGAuthorizeResourceSink_Vtbl {
@@ -997,6 +1026,8 @@ pub trait ITSGPolicyEngine_Impl: Sized {
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn IsQuarantineEnabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITSGPolicyEngine {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITSGPolicyEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITSGPolicyEngine_Impl, const OFFSET: isize>() -> ITSGPolicyEngine_Vtbl {
@@ -1057,6 +1088,7 @@ pub trait ITsSbBaseNotifySink_Impl: Sized {
     fn OnError(&self, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnReportStatus(&self, messagetype: CLIENT_MESSAGE_TYPE, messageid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITsSbBaseNotifySink {}
 impl ITsSbBaseNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbBaseNotifySink_Impl, const OFFSET: isize>() -> ITsSbBaseNotifySink_Vtbl {
         unsafe extern "system" fn OnError<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbBaseNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1097,6 +1129,8 @@ pub trait ITsSbClientConnection_Impl: Sized {
     fn UserSidString(&self) -> ::windows::core::Result<*mut i8>;
     fn GetDisconnectedSession(&self) -> ::windows::core::Result<ITsSbSession>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbClientConnection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ITsSbClientConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbClientConnection_Impl, const OFFSET: isize>() -> ITsSbClientConnection_Vtbl {
@@ -1285,6 +1319,8 @@ impl ITsSbClientConnection_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbClientConnectionPropertySet_Impl: Sized + super::Com::StructuredStorage::IPropertyBag_Impl + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbClientConnectionPropertySet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ITsSbClientConnectionPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbClientConnectionPropertySet_Impl, const OFFSET: isize>() -> ITsSbClientConnectionPropertySet_Vtbl {
         Self { base__: ITsSbPropertySet_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1300,6 +1336,8 @@ pub trait ITsSbEnvironment_Impl: Sized {
     fn EnvironmentPropertySet(&self) -> ::windows::core::Result<ITsSbEnvironmentPropertySet>;
     fn SetEnvironmentPropertySet(&self, pval: &::core::option::Option<ITsSbEnvironmentPropertySet>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ITsSbEnvironment {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ITsSbEnvironment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbEnvironment_Impl, const OFFSET: isize>() -> ITsSbEnvironment_Vtbl {
@@ -1356,6 +1394,8 @@ impl ITsSbEnvironment_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbEnvironmentPropertySet_Impl: Sized + super::Com::StructuredStorage::IPropertyBag_Impl + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbEnvironmentPropertySet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ITsSbEnvironmentPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbEnvironmentPropertySet_Impl, const OFFSET: isize>() -> ITsSbEnvironmentPropertySet_Vtbl {
         Self { base__: ITsSbPropertySet_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1370,6 +1410,8 @@ pub trait ITsSbFilterPluginStore_Impl: Sized {
     fn EnumerateProperties(&self) -> ::windows::core::Result<ITsSbPropertySet>;
     fn DeleteProperties(&self, propertyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ITsSbFilterPluginStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ITsSbFilterPluginStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbFilterPluginStore_Impl, const OFFSET: isize>() -> ITsSbFilterPluginStore_Vtbl {
@@ -1411,6 +1453,8 @@ pub trait ITsSbGenericNotifySink_Impl: Sized {
     fn GetWaitTimeout(&self) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITsSbGenericNotifySink {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITsSbGenericNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbGenericNotifySink_Impl, const OFFSET: isize>() -> ITsSbGenericNotifySink_Vtbl {
         unsafe extern "system" fn OnCompleted<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbGenericNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1449,6 +1493,8 @@ pub trait ITsSbGlobalStore_Impl: Sized {
     fn EnumerateSessions(&self, providername: &super::super::Foundation::BSTR, targetname: &super::super::Foundation::BSTR, username: &super::super::Foundation::BSTR, userdomain: &super::super::Foundation::BSTR, poolname: &super::super::Foundation::BSTR, initialprogram: &super::super::Foundation::BSTR, psessionstate: *const TSSESSION_STATE, pdwcount: *mut u32, ppval: *mut *mut ::core::option::Option<ITsSbSession>) -> ::windows::core::Result<()>;
     fn GetFarmProperty(&self, farmname: &super::super::Foundation::BSTR, propertyname: &super::super::Foundation::BSTR, pvarvalue: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbGlobalStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITsSbGlobalStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbGlobalStore_Impl, const OFFSET: isize>() -> ITsSbGlobalStore_Vtbl {
@@ -1519,6 +1565,8 @@ pub trait ITsSbLoadBalanceResult_Impl: Sized {
     fn TargetName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITsSbLoadBalanceResult {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITsSbLoadBalanceResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbLoadBalanceResult_Impl, const OFFSET: isize>() -> ITsSbLoadBalanceResult_Vtbl {
         unsafe extern "system" fn TargetName<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbLoadBalanceResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1543,6 +1591,8 @@ pub trait ITsSbLoadBalancing_Impl: Sized + ITsSbPlugin_Impl {
     fn GetMostSuitableTarget(&self, pconnection: &::core::option::Option<ITsSbClientConnection>, plbsink: &::core::option::Option<ITsSbLoadBalancingNotifySink>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for ITsSbLoadBalancing {}
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ITsSbLoadBalancing_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbLoadBalancing_Impl, const OFFSET: isize>() -> ITsSbLoadBalancing_Vtbl {
         unsafe extern "system" fn GetMostSuitableTarget<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbLoadBalancing_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnection: ::windows::core::RawPtr, plbsink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1560,6 +1610,8 @@ impl ITsSbLoadBalancing_Vtbl {
 pub trait ITsSbLoadBalancingNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnGetMostSuitableTarget(&self, plbresult: &::core::option::Option<ITsSbLoadBalanceResult>, fisnewconnection: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITsSbLoadBalancingNotifySink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITsSbLoadBalancingNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbLoadBalancingNotifySink_Impl, const OFFSET: isize>() -> ITsSbLoadBalancingNotifySink_Vtbl {
@@ -1579,6 +1631,8 @@ pub trait ITsSbOrchestration_Impl: Sized + ITsSbPlugin_Impl {
     fn PrepareTargetForConnect(&self, pconnection: &::core::option::Option<ITsSbClientConnection>, porchestrationnotifysink: &::core::option::Option<ITsSbOrchestrationNotifySink>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for ITsSbOrchestration {}
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ITsSbOrchestration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbOrchestration_Impl, const OFFSET: isize>() -> ITsSbOrchestration_Vtbl {
         unsafe extern "system" fn PrepareTargetForConnect<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbOrchestration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnection: ::windows::core::RawPtr, porchestrationnotifysink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1595,6 +1649,7 @@ impl ITsSbOrchestration_Vtbl {
 pub trait ITsSbOrchestrationNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnReadyToConnect(&self, ptarget: &::core::option::Option<ITsSbTarget>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITsSbOrchestrationNotifySink {}
 impl ITsSbOrchestrationNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbOrchestrationNotifySink_Impl, const OFFSET: isize>() -> ITsSbOrchestrationNotifySink_Vtbl {
         unsafe extern "system" fn OnReadyToConnect<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbOrchestrationNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptarget: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1613,6 +1668,8 @@ pub trait ITsSbPlacement_Impl: Sized + ITsSbPlugin_Impl {
     fn QueryEnvironmentForTarget(&self, pconnection: &::core::option::Option<ITsSbClientConnection>, pplacementsink: &::core::option::Option<ITsSbPlacementNotifySink>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for ITsSbPlacement {}
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ITsSbPlacement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPlacement_Impl, const OFFSET: isize>() -> ITsSbPlacement_Vtbl {
         unsafe extern "system" fn QueryEnvironmentForTarget<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPlacement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnection: ::windows::core::RawPtr, pplacementsink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1629,6 +1686,7 @@ impl ITsSbPlacement_Vtbl {
 pub trait ITsSbPlacementNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnQueryEnvironmentCompleted(&self, penvironment: &::core::option::Option<ITsSbEnvironment>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITsSbPlacementNotifySink {}
 impl ITsSbPlacementNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPlacementNotifySink_Impl, const OFFSET: isize>() -> ITsSbPlacementNotifySink_Vtbl {
         unsafe extern "system" fn OnQueryEnvironmentCompleted<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPlacementNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, penvironment: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1650,6 +1708,8 @@ pub trait ITsSbPlugin_Impl: Sized {
     fn Initialize(&self, pprovider: &::core::option::Option<ITsSbProvider>, pnotifysink: &::core::option::Option<ITsSbPluginNotifySink>, ppropertyset: &::core::option::Option<ITsSbPluginPropertySet>) -> ::windows::core::Result<()>;
     fn Terminate(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for ITsSbPlugin {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ITsSbPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPlugin_Impl, const OFFSET: isize>() -> ITsSbPlugin_Vtbl {
@@ -1677,6 +1737,7 @@ pub trait ITsSbPluginNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnInitialized(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnTerminated(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITsSbPluginNotifySink {}
 impl ITsSbPluginNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPluginNotifySink_Impl, const OFFSET: isize>() -> ITsSbPluginNotifySink_Vtbl {
         unsafe extern "system" fn OnInitialized<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPluginNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -1702,6 +1763,8 @@ impl ITsSbPluginNotifySink_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbPluginPropertySet_Impl: Sized + super::Com::StructuredStorage::IPropertyBag_Impl + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbPluginPropertySet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ITsSbPluginPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPluginPropertySet_Impl, const OFFSET: isize>() -> ITsSbPluginPropertySet_Vtbl {
         Self { base__: ITsSbPropertySet_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1712,6 +1775,8 @@ impl ITsSbPluginPropertySet_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbPropertySet_Impl: Sized + super::Com::StructuredStorage::IPropertyBag_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbPropertySet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ITsSbPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbPropertySet_Impl, const OFFSET: isize>() -> ITsSbPropertySet_Vtbl {
@@ -1736,6 +1801,8 @@ pub trait ITsSbProvider_Impl: Sized {
     fn GetInstanceOfGlobalStore(&self) -> ::windows::core::Result<ITsSbGlobalStore>;
     fn CreateEnvironmentPropertySetObject(&self) -> ::windows::core::Result<ITsSbEnvironmentPropertySet>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ITsSbProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ITsSbProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbProvider_Impl, const OFFSET: isize>() -> ITsSbProvider_Vtbl {
@@ -1887,6 +1954,8 @@ pub trait ITsSbProvisioning_Impl: Sized + ITsSbPlugin_Impl {
     fn CancelJob(&self, jobguid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ITsSbProvisioning {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ITsSbProvisioning_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbProvisioning_Impl, const OFFSET: isize>() -> ITsSbProvisioning_Vtbl {
         unsafe extern "system" fn CreateVirtualMachines<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbProvisioning_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, jobxmlstring: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, jobguid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, psink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1930,6 +1999,8 @@ pub trait ITsSbProvisioningPluginNotifySink_Impl: Sized {
     fn LockVirtualMachine(&self, pvmnotifyentry: *const VM_NOTIFY_ENTRY) -> ::windows::core::Result<()>;
     fn OnVirtualMachineHostStatusChanged(&self, vmhost: &super::super::Foundation::BSTR, vmhostnotifystatus: VM_HOST_NOTIFY_STATUS, errorcode: ::windows::core::HRESULT, errordescr: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITsSbProvisioningPluginNotifySink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITsSbProvisioningPluginNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbProvisioningPluginNotifySink_Impl, const OFFSET: isize>() -> ITsSbProvisioningPluginNotifySink_Vtbl {
@@ -1982,6 +2053,7 @@ pub trait ITsSbResourceNotification_Impl: Sized {
     fn NotifyTargetChange(&self, targetchangetype: u32, ptarget: &::core::option::Option<ITsSbTarget>) -> ::windows::core::Result<()>;
     fn NotifyClientConnectionStateChange(&self, changetype: CONNECTION_CHANGE_NOTIFICATION, pconnection: &::core::option::Option<ITsSbClientConnection>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITsSbResourceNotification {}
 impl ITsSbResourceNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbResourceNotification_Impl, const OFFSET: isize>() -> ITsSbResourceNotification_Vtbl {
         unsafe extern "system" fn NotifySessionChange<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbResourceNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, changetype: TSSESSION_STATE, psession: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2017,6 +2089,8 @@ pub trait ITsSbResourceNotificationEx_Impl: Sized {
     fn NotifyClientConnectionStateChangeEx(&self, username: &super::super::Foundation::BSTR, domain: &super::super::Foundation::BSTR, initialprogram: &super::super::Foundation::BSTR, poolname: &super::super::Foundation::BSTR, targetname: &super::super::Foundation::BSTR, connectionchangetype: CONNECTION_CHANGE_NOTIFICATION) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITsSbResourceNotificationEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITsSbResourceNotificationEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbResourceNotificationEx_Impl, const OFFSET: isize>() -> ITsSbResourceNotificationEx_Vtbl {
         unsafe extern "system" fn NotifySessionChangeEx<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbResourceNotificationEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, username: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, domain: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, sessionid: u32, sessionstate: TSSESSION_STATE) -> ::windows::core::HRESULT {
@@ -2047,6 +2121,8 @@ impl ITsSbResourceNotificationEx_Vtbl {
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbResourcePlugin_Impl: Sized + ITsSbPlugin_Impl {}
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for ITsSbResourcePlugin {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl ITsSbResourcePlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbResourcePlugin_Impl, const OFFSET: isize>() -> ITsSbResourcePlugin_Vtbl {
@@ -2087,6 +2163,8 @@ pub trait ITsSbResourcePluginStore_Impl: Sized {
     fn GetServerState(&self, poolname: &super::super::Foundation::BSTR, serverfqdn: &super::super::Foundation::BSTR) -> ::windows::core::Result<TARGET_STATE>;
     fn SetServerDrainMode(&self, serverfqdn: &super::super::Foundation::BSTR, drainmode: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbResourcePluginStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITsSbResourcePluginStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbResourcePluginStore_Impl, const OFFSET: isize>() -> ITsSbResourcePluginStore_Vtbl {
@@ -2312,6 +2390,7 @@ pub trait ITsSbServiceNotification_Impl: Sized {
     fn NotifyServiceFailure(&self) -> ::windows::core::Result<()>;
     fn NotifyServiceSuccess(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITsSbServiceNotification {}
 impl ITsSbServiceNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbServiceNotification_Impl, const OFFSET: isize>() -> ITsSbServiceNotification_Vtbl {
         unsafe extern "system" fn NotifyServiceFailure<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbServiceNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2354,6 +2433,8 @@ pub trait ITsSbSession_Impl: Sized {
     fn ProtocolType(&self) -> ::windows::core::Result<u32>;
     fn SetProtocolType(&self, val: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITsSbSession {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITsSbSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbSession_Impl, const OFFSET: isize>() -> ITsSbSession_Vtbl {
@@ -2550,6 +2631,8 @@ pub trait ITsSbTarget_Impl: Sized {
     fn TargetLoad(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ITsSbTarget {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ITsSbTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTarget_Impl, const OFFSET: isize>() -> ITsSbTarget_Vtbl {
         unsafe extern "system" fn TargetName<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2737,6 +2820,8 @@ impl ITsSbTarget_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbTargetPropertySet_Impl: Sized + super::Com::StructuredStorage::IPropertyBag_Impl + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITsSbTargetPropertySet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl ITsSbTargetPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTargetPropertySet_Impl, const OFFSET: isize>() -> ITsSbTargetPropertySet_Vtbl {
         Self { base__: ITsSbPropertySet_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2757,6 +2842,8 @@ pub trait ITsSbTaskInfo_Impl: Sized {
     fn Plugin(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Status(&self) -> ::windows::core::Result<RDV_TASK_STATUS>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITsSbTaskInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITsSbTaskInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTaskInfo_Impl, const OFFSET: isize>() -> ITsSbTaskInfo_Vtbl {
@@ -2882,6 +2969,8 @@ pub trait ITsSbTaskPlugin_Impl: Sized + ITsSbPlugin_Impl {
     fn SetTaskQueue(&self, pszhostname: &super::super::Foundation::BSTR, sbtaskinfosize: u32, pitssbtaskinfo: *const ::core::option::Option<ITsSbTaskInfo>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ITsSbTaskPlugin {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ITsSbTaskPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTaskPlugin_Impl, const OFFSET: isize>() -> ITsSbTaskPlugin_Vtbl {
         unsafe extern "system" fn InitializeTaskPlugin<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTaskPlugin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pitssbtaskpluginnotifysink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2911,6 +3000,8 @@ pub trait ITsSbTaskPluginNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnUpdateTaskStatus(&self, sztargetname: &super::super::Foundation::BSTR, taskidentifier: &super::super::Foundation::BSTR, taskstatus: RDV_TASK_STATUS) -> ::windows::core::Result<()>;
     fn OnReportTasks(&self, szhostname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITsSbTaskPluginNotifySink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITsSbTaskPluginNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITsSbTaskPluginNotifySink_Impl, const OFFSET: isize>() -> ITsSbTaskPluginNotifySink_Vtbl {
@@ -2949,6 +3040,7 @@ impl ITsSbTaskPluginNotifySink_Vtbl {
 pub trait IWRdsEnhancedFastReconnectArbitrator_Impl: Sized {
     fn GetSessionForEnhancedFastReconnect(&self, psessionidarray: *const i32, dwsessioncount: u32) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IWRdsEnhancedFastReconnectArbitrator {}
 impl IWRdsEnhancedFastReconnectArbitrator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsEnhancedFastReconnectArbitrator_Impl, const OFFSET: isize>() -> IWRdsEnhancedFastReconnectArbitrator_Vtbl {
         unsafe extern "system" fn GetSessionForEnhancedFastReconnect<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsEnhancedFastReconnectArbitrator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psessionidarray: *const i32, dwsessioncount: u32, presultsessionid: *mut i32) -> ::windows::core::HRESULT {
@@ -2976,6 +3068,7 @@ pub trait IWRdsGraphicsChannel_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
     fn Open(&self, pchannelevents: &::core::option::Option<IWRdsGraphicsChannelEvents>, popencontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWRdsGraphicsChannel {}
 impl IWRdsGraphicsChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsGraphicsChannel_Impl, const OFFSET: isize>() -> IWRdsGraphicsChannel_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsGraphicsChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8, pcontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3012,6 +3105,8 @@ pub trait IWRdsGraphicsChannelEvents_Impl: Sized {
     fn OnDataSent(&self, pwritecontext: &::core::option::Option<::windows::core::IUnknown>, bcancelled: super::super::Foundation::BOOL, pbuffer: *const u8, cbbuffer: u32) -> ::windows::core::Result<()>;
     fn OnMetricsUpdate(&self, bandwidth: u32, rtt: u32, lastsentbyteindex: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsGraphicsChannelEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWRdsGraphicsChannelEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsGraphicsChannelEvents_Impl, const OFFSET: isize>() -> IWRdsGraphicsChannelEvents_Vtbl {
@@ -3056,6 +3151,7 @@ impl IWRdsGraphicsChannelEvents_Vtbl {
 pub trait IWRdsGraphicsChannelManager_Impl: Sized {
     fn CreateChannel(&self, pszchannelname: *const u8, channeltype: WRdsGraphicsChannelType) -> ::windows::core::Result<IWRdsGraphicsChannel>;
 }
+impl ::windows::core::RuntimeName for IWRdsGraphicsChannelManager {}
 impl IWRdsGraphicsChannelManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsGraphicsChannelManager_Impl, const OFFSET: isize>() -> IWRdsGraphicsChannelManager_Vtbl {
         unsafe extern "system" fn CreateChannel<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsGraphicsChannelManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszchannelname: *const u8, channeltype: WRdsGraphicsChannelType, ppvirtualchannel: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3102,6 +3198,8 @@ pub trait IWRdsProtocolConnection_Impl: Sized {
     fn GetShadowConnection(&self) -> ::windows::core::Result<IWRdsProtocolShadowConnection>;
     fn NotifyCommandProcessCreated(&self, sessionid: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsProtocolConnection {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWRdsProtocolConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolConnection_Impl, const OFFSET: isize>() -> IWRdsProtocolConnection_Vtbl {
@@ -3324,6 +3422,7 @@ pub trait IWRdsProtocolConnectionCallback_Impl: Sized {
     fn RedrawWindow(&self, rect: *const WTS_SMALL_RECT) -> ::windows::core::Result<()>;
     fn GetConnectionId(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IWRdsProtocolConnectionCallback {}
 impl IWRdsProtocolConnectionCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolConnectionCallback_Impl, const OFFSET: isize>() -> IWRdsProtocolConnectionCallback_Vtbl {
         unsafe extern "system" fn OnReady<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolConnectionCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3374,6 +3473,7 @@ pub trait IWRdsProtocolConnectionSettings_Impl: Sized {
     fn SetConnectionSetting(&self, propertyid: &::windows::core::GUID, ppropertyentriesin: *const WTS_PROPERTY_VALUE) -> ::windows::core::Result<()>;
     fn GetConnectionSetting(&self, propertyid: &::windows::core::GUID) -> ::windows::core::Result<WTS_PROPERTY_VALUE>;
 }
+impl ::windows::core::RuntimeName for IWRdsProtocolConnectionSettings {}
 impl IWRdsProtocolConnectionSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolConnectionSettings_Impl, const OFFSET: isize>() -> IWRdsProtocolConnectionSettings_Vtbl {
         unsafe extern "system" fn SetConnectionSetting<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolConnectionSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertyid: ::windows::core::GUID, ppropertyentriesin: *const WTS_PROPERTY_VALUE) -> ::windows::core::HRESULT {
@@ -3409,6 +3509,8 @@ pub trait IWRdsProtocolLicenseConnection_Impl: Sized {
     fn RequestClientLicense(&self, reserve1: *const u8, reserve2: u32, ppclientlicense: *mut u8, pcbclientlicense: *mut u32) -> ::windows::core::Result<()>;
     fn ProtocolComplete(&self, ulcomplete: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsProtocolLicenseConnection {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWRdsProtocolLicenseConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolLicenseConnection_Impl, const OFFSET: isize>() -> IWRdsProtocolLicenseConnection_Vtbl {
@@ -3449,6 +3551,7 @@ pub trait IWRdsProtocolListener_Impl: Sized {
     fn StartListen(&self, pcallback: &::core::option::Option<IWRdsProtocolListenerCallback>) -> ::windows::core::Result<()>;
     fn StopListen(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWRdsProtocolListener {}
 impl IWRdsProtocolListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolListener_Impl, const OFFSET: isize>() -> IWRdsProtocolListener_Vtbl {
         unsafe extern "system" fn GetSettings<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolListener_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wrdslistenersettinglevel: WRDS_LISTENER_SETTING_LEVEL, pwrdslistenersettings: *mut WRDS_LISTENER_SETTINGS) -> ::windows::core::HRESULT {
@@ -3488,6 +3591,8 @@ pub trait IWRdsProtocolListenerCallback_Impl: Sized {
     fn OnConnected(&self, pconnection: &::core::option::Option<IWRdsProtocolConnection>, pwrdsconnectionsettings: *const WRDS_CONNECTION_SETTINGS) -> ::windows::core::Result<IWRdsProtocolConnectionCallback>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsProtocolListenerCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWRdsProtocolListenerCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolListenerCallback_Impl, const OFFSET: isize>() -> IWRdsProtocolListenerCallback_Vtbl {
         unsafe extern "system" fn OnConnected<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolListenerCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnection: ::windows::core::RawPtr, pwrdsconnectionsettings: *const WRDS_CONNECTION_SETTINGS, pcallback: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3513,6 +3618,7 @@ pub trait IWRdsProtocolLogonErrorRedirector_Impl: Sized {
     fn RedirectMessage(&self, pszcaption: &::windows::core::PCWSTR, pszmessage: &::windows::core::PCWSTR, utype: u32) -> ::windows::core::Result<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>;
     fn RedirectLogonError(&self, ntsstatus: i32, ntssubstatus: i32, pszcaption: &::windows::core::PCWSTR, pszmessage: &::windows::core::PCWSTR, utype: u32) -> ::windows::core::Result<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>;
 }
+impl ::windows::core::RuntimeName for IWRdsProtocolLogonErrorRedirector {}
 impl IWRdsProtocolLogonErrorRedirector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolLogonErrorRedirector_Impl, const OFFSET: isize>() -> IWRdsProtocolLogonErrorRedirector_Vtbl {
         unsafe extern "system" fn OnBeginPainting<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolLogonErrorRedirector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3576,6 +3682,8 @@ pub trait IWRdsProtocolManager_Impl: Sized {
     fn NotifySettingsChange(&self, pwrdssettings: *const WRDS_SETTINGS) -> ::windows::core::Result<()>;
     fn Uninitialize(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsProtocolManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWRdsProtocolManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolManager_Impl, const OFFSET: isize>() -> IWRdsProtocolManager_Vtbl {
@@ -3647,6 +3755,8 @@ pub trait IWRdsProtocolSettings_Impl: Sized {
     fn MergeSettings(&self, pwrdssettings: *const WRDS_SETTINGS, wrdsconnectionsettinglevel: WRDS_CONNECTION_SETTING_LEVEL, pwrdsconnectionsettings: *mut WRDS_CONNECTION_SETTINGS) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsProtocolSettings {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWRdsProtocolSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolSettings_Impl, const OFFSET: isize>() -> IWRdsProtocolSettings_Vtbl {
         unsafe extern "system" fn GetSettings<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wrdssettingtype: WRDS_SETTING_TYPE, wrdssettinglevel: WRDS_SETTING_LEVEL, pwrdssettings: *mut WRDS_SETTINGS) -> ::windows::core::HRESULT {
@@ -3679,6 +3789,7 @@ pub trait IWRdsProtocolShadowCallback_Impl: Sized {
     fn StopShadow(&self) -> ::windows::core::Result<()>;
     fn InvokeTargetShadow(&self, ptargetservername: &::windows::core::PCWSTR, targetsessionid: u32, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWRdsProtocolShadowCallback {}
 impl IWRdsProtocolShadowCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolShadowCallback_Impl, const OFFSET: isize>() -> IWRdsProtocolShadowCallback_Vtbl {
         unsafe extern "system" fn StopShadow<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolShadowCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3708,6 +3819,7 @@ pub trait IWRdsProtocolShadowConnection_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn DoTarget(&self, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWRdsProtocolShadowConnection {}
 impl IWRdsProtocolShadowConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolShadowConnection_Impl, const OFFSET: isize>() -> IWRdsProtocolShadowConnection_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsProtocolShadowConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptargetservername: ::windows::core::PCWSTR, targetsessionid: u32, hotkeyvk: u8, hotkeymodifiers: u16, pshadowcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3743,6 +3855,8 @@ pub trait IWRdsWddmIddProps_Impl: Sized {
     fn OnDriverUnload(&self, sessionid: u32) -> ::windows::core::Result<()>;
     fn EnableWddmIdd(&self, enabled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWRdsWddmIddProps {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWRdsWddmIddProps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWRdsWddmIddProps_Impl, const OFFSET: isize>() -> IWRdsWddmIddProps_Vtbl {
@@ -3781,6 +3895,7 @@ impl IWRdsWddmIddProps_Vtbl {
 pub trait IWTSBitmapRenderService_Impl: Sized {
     fn GetMappedRenderer(&self, mappingid: u64, pmappedrenderercallback: &::core::option::Option<IWTSBitmapRendererCallback>) -> ::windows::core::Result<IWTSBitmapRenderer>;
 }
+impl ::windows::core::RuntimeName for IWTSBitmapRenderService {}
 impl IWTSBitmapRenderService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSBitmapRenderService_Impl, const OFFSET: isize>() -> IWTSBitmapRenderService_Vtbl {
         unsafe extern "system" fn GetMappedRenderer<Identity: ::windows::core::IUnknownImpl, Impl: IWTSBitmapRenderService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, mappingid: u64, pmappedrenderercallback: ::windows::core::RawPtr, ppmappedrenderer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3805,6 +3920,7 @@ pub trait IWTSBitmapRenderer_Impl: Sized {
     fn GetRendererStatistics(&self) -> ::windows::core::Result<BITMAP_RENDERER_STATISTICS>;
     fn RemoveMapping(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSBitmapRenderer {}
 impl IWTSBitmapRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSBitmapRenderer_Impl, const OFFSET: isize>() -> IWTSBitmapRenderer_Vtbl {
         unsafe extern "system" fn Render<Identity: ::windows::core::IUnknownImpl, Impl: IWTSBitmapRenderer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, imageformat: ::windows::core::GUID, dwwidth: u32, dwheight: u32, cbstride: i32, cbimagebuffer: u32, pimagebuffer: *const u8) -> ::windows::core::HRESULT {
@@ -3844,6 +3960,8 @@ pub trait IWTSBitmapRendererCallback_Impl: Sized {
     fn OnTargetSizeChanged(&self, rcnewsize: &super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWTSBitmapRendererCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWTSBitmapRendererCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSBitmapRendererCallback_Impl, const OFFSET: isize>() -> IWTSBitmapRendererCallback_Vtbl {
         unsafe extern "system" fn OnTargetSizeChanged<Identity: ::windows::core::IUnknownImpl, Impl: IWTSBitmapRendererCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rcnewsize: super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -3861,6 +3979,8 @@ impl IWTSBitmapRendererCallback_Vtbl {
 pub trait IWTSListener_Impl: Sized {
     fn GetConfiguration(&self) -> ::windows::core::Result<super::Com::StructuredStorage::IPropertyBag>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IWTSListener {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IWTSListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSListener_Impl, const OFFSET: isize>() -> IWTSListener_Vtbl {
@@ -3886,6 +4006,8 @@ pub trait IWTSListenerCallback_Impl: Sized {
     fn OnNewChannelConnection(&self, pchannel: &::core::option::Option<IWTSVirtualChannel>, data: &super::super::Foundation::BSTR, pbaccept: *mut super::super::Foundation::BOOL, ppcallback: *mut ::core::option::Option<IWTSVirtualChannelCallback>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWTSListenerCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWTSListenerCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSListenerCallback_Impl, const OFFSET: isize>() -> IWTSListenerCallback_Vtbl {
         unsafe extern "system" fn OnNewChannelConnection<Identity: ::windows::core::IUnknownImpl, Impl: IWTSListenerCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pchannel: ::windows::core::RawPtr, data: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pbaccept: *mut super::super::Foundation::BOOL, ppcallback: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3905,6 +4027,7 @@ pub trait IWTSPlugin_Impl: Sized {
     fn Disconnected(&self, dwdisconnectcode: u32) -> ::windows::core::Result<()>;
     fn Terminated(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSPlugin {}
 impl IWTSPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSPlugin_Impl, const OFFSET: isize>() -> IWTSPlugin_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWTSPlugin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pchannelmgr: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3942,6 +4065,7 @@ impl IWTSPlugin_Vtbl {
 pub trait IWTSPluginServiceProvider_Impl: Sized {
     fn GetService(&self, serviceid: &::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IWTSPluginServiceProvider {}
 impl IWTSPluginServiceProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSPluginServiceProvider_Impl, const OFFSET: isize>() -> IWTSPluginServiceProvider_Vtbl {
         unsafe extern "system" fn GetService<Identity: ::windows::core::IUnknownImpl, Impl: IWTSPluginServiceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, serviceid: ::windows::core::GUID, ppunkobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3987,6 +4111,8 @@ pub trait IWTSProtocolConnection_Impl: Sized {
     fn QueryProperty(&self, querytype: &::windows::core::GUID, ulnumentriesin: u32, ulnumentriesout: u32, ppropertyentriesin: *const WTS_PROPERTY_VALUE, ppropertyentriesout: *mut WTS_PROPERTY_VALUE) -> ::windows::core::Result<()>;
     fn GetShadowConnection(&self) -> ::windows::core::Result<IWTSProtocolShadowConnection>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWTSProtocolConnection {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWTSProtocolConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolConnection_Impl, const OFFSET: isize>() -> IWTSProtocolConnection_Vtbl {
@@ -4197,6 +4323,7 @@ pub trait IWTSProtocolConnectionCallback_Impl: Sized {
     fn RedrawWindow(&self, rect: *const WTS_SMALL_RECT) -> ::windows::core::Result<()>;
     fn DisplayIOCtl(&self, displayioctl: *const WTS_DISPLAY_IOCTL) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolConnectionCallback {}
 impl IWTSProtocolConnectionCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolConnectionCallback_Impl, const OFFSET: isize>() -> IWTSProtocolConnectionCallback_Vtbl {
         unsafe extern "system" fn OnReady<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolConnectionCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4245,6 +4372,8 @@ pub trait IWTSProtocolLicenseConnection_Impl: Sized {
     fn ProtocolComplete(&self, ulcomplete: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWTSProtocolLicenseConnection {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWTSProtocolLicenseConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolLicenseConnection_Impl, const OFFSET: isize>() -> IWTSProtocolLicenseConnection_Vtbl {
         unsafe extern "system" fn RequestLicensingCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolLicenseConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pplicensecapabilities: *mut WTS_LICENSE_CAPABILITIES, pcblicensecapabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -4283,6 +4412,7 @@ pub trait IWTSProtocolListener_Impl: Sized {
     fn StartListen(&self, pcallback: &::core::option::Option<IWTSProtocolListenerCallback>) -> ::windows::core::Result<()>;
     fn StopListen(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolListener {}
 impl IWTSProtocolListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolListener_Impl, const OFFSET: isize>() -> IWTSProtocolListener_Vtbl {
         unsafe extern "system" fn StartListen<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolListener_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4308,6 +4438,7 @@ impl IWTSProtocolListener_Vtbl {
 pub trait IWTSProtocolListenerCallback_Impl: Sized {
     fn OnConnected(&self, pconnection: &::core::option::Option<IWTSProtocolConnection>) -> ::windows::core::Result<IWTSProtocolConnectionCallback>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolListenerCallback {}
 impl IWTSProtocolListenerCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolListenerCallback_Impl, const OFFSET: isize>() -> IWTSProtocolListenerCallback_Vtbl {
         unsafe extern "system" fn OnConnected<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolListenerCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnection: ::windows::core::RawPtr, pcallback: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4333,6 +4464,7 @@ pub trait IWTSProtocolLogonErrorRedirector_Impl: Sized {
     fn RedirectMessage(&self, pszcaption: &::windows::core::PCWSTR, pszmessage: &::windows::core::PCWSTR, utype: u32) -> ::windows::core::Result<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>;
     fn RedirectLogonError(&self, ntsstatus: i32, ntssubstatus: i32, pszcaption: &::windows::core::PCWSTR, pszmessage: &::windows::core::PCWSTR, utype: u32) -> ::windows::core::Result<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolLogonErrorRedirector {}
 impl IWTSProtocolLogonErrorRedirector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolLogonErrorRedirector_Impl, const OFFSET: isize>() -> IWTSProtocolLogonErrorRedirector_Vtbl {
         unsafe extern "system" fn OnBeginPainting<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolLogonErrorRedirector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4392,6 +4524,7 @@ pub trait IWTSProtocolManager_Impl: Sized {
     fn NotifySessionOfServiceStop(&self, sessionid: *const WTS_SESSION_ID) -> ::windows::core::Result<()>;
     fn NotifySessionStateChange(&self, sessionid: *const WTS_SESSION_ID, eventid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolManager {}
 impl IWTSProtocolManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolManager_Impl, const OFFSET: isize>() -> IWTSProtocolManager_Vtbl {
         unsafe extern "system" fn CreateListener<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszlistenername: ::windows::core::PCWSTR, pprotocollistener: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4442,6 +4575,7 @@ pub trait IWTSProtocolShadowCallback_Impl: Sized {
     fn StopShadow(&self) -> ::windows::core::Result<()>;
     fn InvokeTargetShadow(&self, ptargetservername: &::windows::core::PCWSTR, targetsessionid: u32, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolShadowCallback {}
 impl IWTSProtocolShadowCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolShadowCallback_Impl, const OFFSET: isize>() -> IWTSProtocolShadowCallback_Vtbl {
         unsafe extern "system" fn StopShadow<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolShadowCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4471,6 +4605,7 @@ pub trait IWTSProtocolShadowConnection_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn DoTarget(&self, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSProtocolShadowConnection {}
 impl IWTSProtocolShadowConnection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolShadowConnection_Impl, const OFFSET: isize>() -> IWTSProtocolShadowConnection_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IWTSProtocolShadowConnection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptargetservername: ::windows::core::PCWSTR, targetsessionid: u32, hotkeyvk: u8, hotkeymodifiers: u16, pshadowcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4508,6 +4643,8 @@ pub trait IWTSSBPlugin_Impl: Sized {
     fn Terminated(&self) -> ::windows::core::Result<()>;
     fn WTSSBX_GetUserExternalSession(&self, username: &::windows::core::PCWSTR, domainname: &::windows::core::PCWSTR, applicationtype: &::windows::core::PCWSTR, redirectorinternalip: *const WTSSBX_IP_ADDRESS, psessionid: *mut u32, pmachineconnectinfo: *mut WTSSBX_MACHINE_CONNECT_INFO) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWTSSBPlugin {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWTSSBPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSSBPlugin_Impl, const OFFSET: isize>() -> IWTSSBPlugin_Vtbl {
@@ -4565,6 +4702,7 @@ pub trait IWTSVirtualChannel_Impl: Sized {
     fn Write(&self, cbsize: u32, pbuffer: *const u8, preserved: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSVirtualChannel {}
 impl IWTSVirtualChannel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSVirtualChannel_Impl, const OFFSET: isize>() -> IWTSVirtualChannel_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows::core::IUnknownImpl, Impl: IWTSVirtualChannel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8, preserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4587,6 +4725,7 @@ pub trait IWTSVirtualChannelCallback_Impl: Sized {
     fn OnDataReceived(&self, cbsize: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
     fn OnClose(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWTSVirtualChannelCallback {}
 impl IWTSVirtualChannelCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSVirtualChannelCallback_Impl, const OFFSET: isize>() -> IWTSVirtualChannelCallback_Vtbl {
         unsafe extern "system" fn OnDataReceived<Identity: ::windows::core::IUnknownImpl, Impl: IWTSVirtualChannelCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8) -> ::windows::core::HRESULT {
@@ -4612,6 +4751,7 @@ impl IWTSVirtualChannelCallback_Vtbl {
 pub trait IWTSVirtualChannelManager_Impl: Sized {
     fn CreateListener(&self, pszchannelname: *const u8, uflags: u32, plistenercallback: &::core::option::Option<IWTSListenerCallback>) -> ::windows::core::Result<IWTSListener>;
 }
+impl ::windows::core::RuntimeName for IWTSVirtualChannelManager {}
 impl IWTSVirtualChannelManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWTSVirtualChannelManager_Impl, const OFFSET: isize>() -> IWTSVirtualChannelManager_Vtbl {
         unsafe extern "system" fn CreateListener<Identity: ::windows::core::IUnknownImpl, Impl: IWTSVirtualChannelManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszchannelname: *const u8, uflags: u32, plistenercallback: ::windows::core::RawPtr, pplistener: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4637,6 +4777,8 @@ pub trait IWorkspace_Impl: Sized {
     fn StartRemoteApplication(&self, bstrworkspaceid: &super::super::Foundation::BSTR, psaparams: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn GetProcessId(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWorkspace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWorkspace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspace_Impl, const OFFSET: isize>() -> IWorkspace_Vtbl {
@@ -4683,6 +4825,8 @@ pub trait IWorkspace2_Impl: Sized + IWorkspace_Impl {
     fn StartRemoteApplicationEx(&self, bstrworkspaceid: &super::super::Foundation::BSTR, bstrrequestingappid: &super::super::Foundation::BSTR, bstrrequestingappfamilyname: &super::super::Foundation::BSTR, blaunchintoimmersiveclient: i16, bstrimmersiveclientactivationcontext: &super::super::Foundation::BSTR, psaparams: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWorkspace2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWorkspace2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspace2_Impl, const OFFSET: isize>() -> IWorkspace2_Vtbl {
         unsafe extern "system" fn StartRemoteApplicationEx<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspace2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrworkspaceid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrrequestingappid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrrequestingappfamilyname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, blaunchintoimmersiveclient: i16, bstrimmersiveclientactivationcontext: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, psaparams: *const super::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -4701,6 +4845,8 @@ pub trait IWorkspace3_Impl: Sized + IWorkspace_Impl + IWorkspace2_Impl {
     fn GetClaimsToken2(&self, bstrclaimshint: &super::super::Foundation::BSTR, bstruserhint: &super::super::Foundation::BSTR, claimcookie: u32, hwndcreduiparent: u32, rectcreduiparent: &super::super::Foundation::RECT) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetClaimsToken(&self, bstraccesstoken: &super::super::Foundation::BSTR, ullaccesstokenexpiration: u64, bstrrefreshtoken: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IWorkspace3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IWorkspace3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspace3_Impl, const OFFSET: isize>() -> IWorkspace3_Vtbl {
@@ -4736,6 +4882,8 @@ pub trait IWorkspaceClientExt_Impl: Sized {
     fn GetResourceDisplayName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn IssueDisconnect(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWorkspaceClientExt {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWorkspaceClientExt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceClientExt_Impl, const OFFSET: isize>() -> IWorkspaceClientExt_Vtbl {
@@ -4781,6 +4929,7 @@ pub trait IWorkspaceRegistration_Impl: Sized {
     fn AddResource(&self, punk: &::core::option::Option<IWorkspaceClientExt>) -> ::windows::core::Result<u32>;
     fn RemoveResource(&self, dwcookieconnection: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWorkspaceRegistration {}
 impl IWorkspaceRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceRegistration_Impl, const OFFSET: isize>() -> IWorkspaceRegistration_Vtbl {
         unsafe extern "system" fn AddResource<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceRegistration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: ::windows::core::RawPtr, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -4815,6 +4964,8 @@ pub trait IWorkspaceRegistration2_Impl: Sized + IWorkspaceRegistration_Impl {
     fn RemoveResourceEx(&self, dwcookieconnection: u32, correlationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWorkspaceRegistration2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWorkspaceRegistration2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceRegistration2_Impl, const OFFSET: isize>() -> IWorkspaceRegistration2_Vtbl {
         unsafe extern "system" fn AddResourceEx<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceRegistration2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: ::windows::core::RawPtr, bstreventloguploadaddress: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pdwcookie: *mut u32, correlationid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -4843,6 +4994,8 @@ pub trait IWorkspaceReportMessage_Impl: Sized {
     fn IsErrorMessageRegistered(&self, bstrwkspid: &super::super::Foundation::BSTR, dwerrortype: u32, bstrerrormessagetype: &super::super::Foundation::BSTR, dwerrorcode: u32) -> ::windows::core::Result<i16>;
     fn RegisterErrorEvent(&self, bstrwkspid: &super::super::Foundation::BSTR, dwerrortype: u32, bstrerrormessagetype: &super::super::Foundation::BSTR, dwerrorcode: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWorkspaceReportMessage {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWorkspaceReportMessage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceReportMessage_Impl, const OFFSET: isize>() -> IWorkspaceReportMessage_Vtbl {
@@ -4886,6 +5039,8 @@ pub trait IWorkspaceResTypeRegistry_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetResourceTypeInfo(&self, fmachinewide: i16, bstrfileextension: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ModifyResourceType(&self, fmachinewide: i16, bstrfileextension: &super::super::Foundation::BSTR, bstrlauncher: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWorkspaceResTypeRegistry {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWorkspaceResTypeRegistry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceResTypeRegistry_Impl, const OFFSET: isize>() -> IWorkspaceResTypeRegistry_Vtbl {
@@ -4949,6 +5104,8 @@ pub trait IWorkspaceScriptable_Impl: Sized + super::Com::IDispatch_Impl {
     fn OnAuthenticated(&self, bstrworkspaceid: &super::super::Foundation::BSTR, bstrusername: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn DisconnectWorkspaceByFriendlyName(&self, bstrworkspacefriendlyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWorkspaceScriptable {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWorkspaceScriptable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceScriptable_Impl, const OFFSET: isize>() -> IWorkspaceScriptable_Vtbl {
@@ -5020,6 +5177,8 @@ pub trait IWorkspaceScriptable2_Impl: Sized + super::Com::IDispatch_Impl + IWork
     fn ResourceDismissed(&self, bstrworkspaceid: &super::super::Foundation::BSTR, bstrworkspacefriendlyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWorkspaceScriptable2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWorkspaceScriptable2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceScriptable2_Impl, const OFFSET: isize>() -> IWorkspaceScriptable2_Vtbl {
         unsafe extern "system" fn StartWorkspaceEx<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceScriptable2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrworkspaceid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrworkspacefriendlyname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrredirectorname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrusername: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrappcontainer: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrworkspaceparams: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ltimeout: i32, lflags: i32) -> ::windows::core::HRESULT {
@@ -5046,6 +5205,8 @@ impl IWorkspaceScriptable2_Vtbl {
 pub trait IWorkspaceScriptable3_Impl: Sized + super::Com::IDispatch_Impl + IWorkspaceScriptable_Impl + IWorkspaceScriptable2_Impl {
     fn StartWorkspaceEx2(&self, bstrworkspaceid: &super::super::Foundation::BSTR, bstrworkspacefriendlyname: &super::super::Foundation::BSTR, bstrredirectorname: &super::super::Foundation::BSTR, bstrusername: &super::super::Foundation::BSTR, bstrpassword: &super::super::Foundation::BSTR, bstrappcontainer: &super::super::Foundation::BSTR, bstrworkspaceparams: &super::super::Foundation::BSTR, ltimeout: i32, lflags: i32, bstreventloguploadaddress: &super::super::Foundation::BSTR, correlationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWorkspaceScriptable3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWorkspaceScriptable3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWorkspaceScriptable3_Impl, const OFFSET: isize>() -> IWorkspaceScriptable3_Vtbl {
@@ -5084,6 +5245,8 @@ pub trait ItsPubPlugin_Impl: Sized {
     fn pluginVersion(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ResolveResource(&self, resourcetype: *mut u32, resourcelocation: ::windows::core::PWSTR, endpointname: ::windows::core::PWSTR, userid: &::windows::core::PCWSTR, alias: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ItsPubPlugin {}
 #[cfg(feature = "Win32_Foundation")]
 impl ItsPubPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ItsPubPlugin_Impl, const OFFSET: isize>() -> ItsPubPlugin_Vtbl {
@@ -5163,6 +5326,8 @@ pub trait ItsPubPlugin2_Impl: Sized + ItsPubPlugin_Impl {
     fn DeletePersonalDesktopAssignment(&self, userid: &::windows::core::PCWSTR, poolid: &::windows::core::PCWSTR, endpointname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ItsPubPlugin2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ItsPubPlugin2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ItsPubPlugin2_Impl, const OFFSET: isize>() -> ItsPubPlugin2_Vtbl {
         unsafe extern "system" fn GetResource2List<Identity: ::windows::core::IUnknownImpl, Impl: ItsPubPlugin2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, userid: ::windows::core::PCWSTR, pceapplistsize: *mut i32, resourcelist: *mut *mut pluginResource2) -> ::windows::core::HRESULT {
@@ -5205,6 +5370,8 @@ impl ItsPubPlugin2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ITSWkspEvents_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _ITSWkspEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _ITSWkspEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _ITSWkspEvents_Impl, const OFFSET: isize>() -> _ITSWkspEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
@@ -6,6 +6,8 @@ pub trait IWSMan_Impl: Sized + super::Com::IDispatch_Impl {
     fn Error(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSMan {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSMan_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSMan_Impl, const OFFSET: isize>() -> IWSMan_Vtbl {
         unsafe extern "system" fn CreateSession<Identity: ::windows::core::IUnknownImpl, Impl: IWSMan_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, connection: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, flags: i32, connectionoptions: ::windows::core::RawPtr, session: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -71,6 +73,8 @@ pub trait IWSManConnectionOptions_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetPassword(&self, password: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManConnectionOptions {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManConnectionOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManConnectionOptions_Impl, const OFFSET: isize>() -> IWSManConnectionOptions_Vtbl {
         unsafe extern "system" fn UserName<Identity: ::windows::core::IUnknownImpl, Impl: IWSManConnectionOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -111,6 +115,8 @@ pub trait IWSManConnectionOptionsEx_Impl: Sized + super::Com::IDispatch_Impl + I
     fn SetCertificateThumbprint(&self, thumbprint: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManConnectionOptionsEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManConnectionOptionsEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManConnectionOptionsEx_Impl, const OFFSET: isize>() -> IWSManConnectionOptionsEx_Vtbl {
         unsafe extern "system" fn CertificateThumbprint<Identity: ::windows::core::IUnknownImpl, Impl: IWSManConnectionOptionsEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, thumbprint: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -150,6 +156,8 @@ pub trait IWSManConnectionOptionsEx2_Impl: Sized + super::Com::IDispatch_Impl + 
     fn ProxyAuthenticationUseBasic(&self) -> ::windows::core::Result<i32>;
     fn ProxyAuthenticationUseDigest(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManConnectionOptionsEx2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManConnectionOptionsEx2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManConnectionOptionsEx2_Impl, const OFFSET: isize>() -> IWSManConnectionOptionsEx2_Vtbl {
@@ -258,6 +266,8 @@ pub trait IWSManEnumerator_Impl: Sized + super::Com::IDispatch_Impl {
     fn Error(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManEnumerator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManEnumerator_Impl, const OFFSET: isize>() -> IWSManEnumerator_Vtbl {
         unsafe extern "system" fn ReadItem<Identity: ::windows::core::IUnknownImpl, Impl: IWSManEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resource: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -327,6 +337,8 @@ pub trait IWSManEx_Impl: Sized + super::Com::IDispatch_Impl + IWSMan_Impl {
     fn EnumerationFlagHierarchyDeepBasePropsOnly(&self) -> ::windows::core::Result<i32>;
     fn EnumerationFlagReturnObject(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManEx_Impl, const OFFSET: isize>() -> IWSManEx_Vtbl {
@@ -583,6 +595,8 @@ pub trait IWSManEx2_Impl: Sized + super::Com::IDispatch_Impl + IWSMan_Impl + IWS
     fn SessionFlagUseClientCertificate(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManEx2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManEx2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManEx2_Impl, const OFFSET: isize>() -> IWSManEx2_Vtbl {
         unsafe extern "system" fn SessionFlagUseClientCertificate<Identity: ::windows::core::IUnknownImpl, Impl: IWSManEx2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: *mut i32) -> ::windows::core::HRESULT {
@@ -615,6 +629,8 @@ pub trait IWSManEx3_Impl: Sized + super::Com::IDispatch_Impl + IWSMan_Impl + IWS
     fn SessionFlagAllowNegotiateImplicitCredentials(&self) -> ::windows::core::Result<i32>;
     fn SessionFlagUseSsl(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManEx3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManEx3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManEx3_Impl, const OFFSET: isize>() -> IWSManEx3_Vtbl {
@@ -715,6 +731,8 @@ pub trait IWSManInternal_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConfigSDDL(&self, session: &::core::option::Option<super::Com::IDispatch>, resourceuri: &super::Com::VARIANT, flags: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManInternal {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManInternal_Impl, const OFFSET: isize>() -> IWSManInternal_Vtbl {
         unsafe extern "system" fn ConfigSDDL<Identity: ::windows::core::IUnknownImpl, Impl: IWSManInternal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, session: ::windows::core::RawPtr, resourceuri: ::core::mem::ManuallyDrop<super::Com::VARIANT>, flags: i32, resource: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -750,6 +768,8 @@ pub trait IWSManResourceLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn ClearOptions(&self) -> ::windows::core::Result<()>;
     fn Error(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManResourceLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManResourceLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManResourceLocator_Impl, const OFFSET: isize>() -> IWSManResourceLocator_Vtbl {
@@ -870,6 +890,7 @@ impl IWSManResourceLocator_Vtbl {
     }
 }
 pub trait IWSManResourceLocatorInternal_Impl: Sized {}
+impl ::windows::core::RuntimeName for IWSManResourceLocatorInternal {}
 impl IWSManResourceLocatorInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManResourceLocatorInternal_Impl, const OFFSET: isize>() -> IWSManResourceLocatorInternal_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -893,6 +914,8 @@ pub trait IWSManSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn Timeout(&self) -> ::windows::core::Result<i32>;
     fn SetTimeout(&self, value: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSManSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSManSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSManSession_Impl, const OFFSET: isize>() -> IWSManSession_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
@@ -5,6 +5,7 @@ pub trait DataSource_Impl: Sized {
     fn addDataSourceListener(&self, pdsl: &::core::option::Option<DataSourceListener>) -> ::windows::core::Result<()>;
     fn removeDataSourceListener(&self, pdsl: &::core::option::Option<DataSourceListener>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for DataSource {}
 impl DataSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DataSource_Impl, const OFFSET: isize>() -> DataSource_Vtbl {
         unsafe extern "system" fn getDataMember<Identity: ::windows::core::IUnknownImpl, Impl: DataSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrdm: *const u16, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -68,6 +69,7 @@ pub trait DataSourceListener_Impl: Sized {
     fn dataMemberAdded(&self, bstrdm: *const u16) -> ::windows::core::Result<()>;
     fn dataMemberRemoved(&self, bstrdm: *const u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for DataSourceListener {}
 impl DataSourceListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DataSourceListener_Impl, const OFFSET: isize>() -> DataSourceListener_Vtbl {
         unsafe extern "system" fn dataMemberChanged<Identity: ::windows::core::IUnknownImpl, Impl: DataSourceListener_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrdm: *const u16) -> ::windows::core::HRESULT {
@@ -99,6 +101,8 @@ impl DataSourceListener_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DataSourceObject_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DataSourceObject {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DataSourceObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DataSourceObject_Impl, const OFFSET: isize>() -> DataSourceObject_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -114,6 +118,8 @@ pub trait IAccessor_Impl: Sized {
     fn GetBindings(&self, haccessor: usize, pdwaccessorflags: *mut u32, pcbindings: *mut usize, prgbindings: *mut *mut DBBINDING) -> ::windows::core::Result<()>;
     fn ReleaseAccessor(&self, haccessor: usize) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAccessor {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAccessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessor_Impl, const OFFSET: isize>() -> IAccessor_Vtbl {
@@ -166,6 +172,8 @@ pub trait IAlterIndex_Impl: Sized {
     fn AlterIndex(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pindexid: *mut super::super::Storage::IndexServer::DBID, pnewindexid: *mut super::super::Storage::IndexServer::DBID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAlterIndex {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAlterIndex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAlterIndex_Impl, const OFFSET: isize>() -> IAlterIndex_Vtbl {
         unsafe extern "system" fn AlterIndex<Identity: ::windows::core::IUnknownImpl, Impl: IAlterIndex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, pindexid: *mut super::super::Storage::IndexServer::DBID, pnewindexid: *mut super::super::Storage::IndexServer::DBID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::HRESULT {
@@ -184,6 +192,8 @@ pub trait IAlterTable_Impl: Sized {
     fn AlterColumn(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pcolumnid: *mut super::super::Storage::IndexServer::DBID, dwcolumndescflags: u32, pcolumndesc: *mut DBCOLUMNDESC) -> ::windows::core::Result<()>;
     fn AlterTable(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pnewtableid: *mut super::super::Storage::IndexServer::DBID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAlterTable {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAlterTable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAlterTable_Impl, const OFFSET: isize>() -> IAlterTable_Vtbl {
@@ -212,6 +222,8 @@ pub trait IBindResource_Impl: Sized {
     fn Bind(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, pwszurl: &::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: &::core::option::Option<super::Com::IAuthenticate>, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBindResource {}
+#[cfg(feature = "Win32_System_Com")]
 impl IBindResource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBindResource_Impl, const OFFSET: isize>() -> IBindResource_Vtbl {
         unsafe extern "system" fn Bind<Identity: ::windows::core::IUnknownImpl, Impl: IBindResource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: ::windows::core::RawPtr, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -229,6 +241,7 @@ pub trait IChapteredRowset_Impl: Sized {
     fn AddRefChapter(&self, hchapter: usize) -> ::windows::core::Result<u32>;
     fn ReleaseChapter(&self, hchapter: usize) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IChapteredRowset {}
 impl IChapteredRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChapteredRowset_Impl, const OFFSET: isize>() -> IChapteredRowset_Vtbl {
         unsafe extern "system" fn AddRefChapter<Identity: ::windows::core::IUnknownImpl, Impl: IChapteredRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, pcrefcount: *mut u32) -> ::windows::core::HRESULT {
@@ -271,6 +284,8 @@ pub trait IColumnMapper_Impl: Sized {
     fn IsMapUpToDate(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for IColumnMapper {}
+#[cfg(feature = "Win32_Storage_IndexServer")]
 impl IColumnMapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnMapper_Impl, const OFFSET: isize>() -> IColumnMapper_Vtbl {
         unsafe extern "system" fn GetPropInfoFromName<Identity: ::windows::core::IUnknownImpl, Impl: IColumnMapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wcspropname: ::windows::core::PCWSTR, pppropid: *mut *mut super::super::Storage::IndexServer::DBID, pproptype: *mut u16, puiwidth: *mut u32) -> ::windows::core::HRESULT {
@@ -308,6 +323,7 @@ impl IColumnMapper_Vtbl {
 pub trait IColumnMapperCreator_Impl: Sized {
     fn GetColumnMapper(&self, wcsmachinename: &::windows::core::PCWSTR, wcscatalogname: &::windows::core::PCWSTR) -> ::windows::core::Result<IColumnMapper>;
 }
+impl ::windows::core::RuntimeName for IColumnMapperCreator {}
 impl IColumnMapperCreator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnMapperCreator_Impl, const OFFSET: isize>() -> IColumnMapperCreator_Vtbl {
         unsafe extern "system" fn GetColumnMapper<Identity: ::windows::core::IUnknownImpl, Impl: IColumnMapperCreator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wcsmachinename: ::windows::core::PCWSTR, wcscatalogname: ::windows::core::PCWSTR, ppcolumnmapper: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -332,6 +348,8 @@ pub trait IColumnsInfo_Impl: Sized {
     fn GetColumnInfo(&self, pccolumns: *mut usize, prginfo: *mut *mut DBCOLUMNINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
     fn MapColumnIDs(&self, ccolumnids: usize, rgcolumnids: *const super::super::Storage::IndexServer::DBID, rgcolumns: *mut usize) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IColumnsInfo {}
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 impl IColumnsInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnsInfo_Impl, const OFFSET: isize>() -> IColumnsInfo_Vtbl {
@@ -360,6 +378,8 @@ pub trait IColumnsInfo2_Impl: Sized + IColumnsInfo_Impl {
     fn GetRestrictedColumnInfo(&self, ccolumnidmasks: usize, rgcolumnidmasks: *const super::super::Storage::IndexServer::DBID, dwflags: u32, pccolumns: *mut usize, prgcolumnids: *mut *mut super::super::Storage::IndexServer::DBID, prgcolumninfo: *mut *mut DBCOLUMNINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IColumnsInfo2 {}
+#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 impl IColumnsInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnsInfo2_Impl, const OFFSET: isize>() -> IColumnsInfo2_Vtbl {
         unsafe extern "system" fn GetRestrictedColumnInfo<Identity: ::windows::core::IUnknownImpl, Impl: IColumnsInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ccolumnidmasks: usize, rgcolumnidmasks: *const super::super::Storage::IndexServer::DBID, dwflags: u32, pccolumns: *mut usize, prgcolumnids: *mut *mut super::super::Storage::IndexServer::DBID, prgcolumninfo: *mut *mut DBCOLUMNINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -378,6 +398,8 @@ pub trait IColumnsRowset_Impl: Sized {
     fn GetAvailableColumns(&self, pcoptcolumns: *mut usize, prgoptcolumns: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
     fn GetColumnsRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, coptcolumns: usize, rgoptcolumns: *const super::super::Storage::IndexServer::DBID, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, ppcolrowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IColumnsRowset {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IColumnsRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnsRowset_Impl, const OFFSET: isize>() -> IColumnsRowset_Vtbl {
@@ -406,6 +428,7 @@ pub trait ICommand_Impl: Sized {
     fn Execute(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, pparams: *mut DBPARAMS, pcrowsaffected: *mut isize, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetDBSession(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for ICommand {}
 impl ICommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommand_Impl, const OFFSET: isize>() -> ICommand_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: ICommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -448,6 +471,7 @@ pub trait ICommandCost_Impl: Sized {
     fn SetCostGoals(&self, pwszrowsetname: &::windows::core::PCWSTR, ccostgoals: u32, rgcostgoals: *const DBCOST) -> ::windows::core::Result<()>;
     fn SetCostLimits(&self, pwszrowsetname: &::windows::core::PCWSTR, ccostlimits: u32, prgcostlimits: *mut DBCOST, dwexecutionflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICommandCost {}
 impl ICommandCost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandCost_Impl, const OFFSET: isize>() -> ICommandCost_Vtbl {
         unsafe extern "system" fn GetAccumulatedCost<Identity: ::windows::core::IUnknownImpl, Impl: ICommandCost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszrowsetname: ::windows::core::PCWSTR, pccostlimits: *mut u32, prgcostlimits: *mut *mut DBCOST) -> ::windows::core::HRESULT {
@@ -502,6 +526,8 @@ pub trait ICommandPersist_Impl: Sized {
     fn SaveCommand(&self, pcommandid: *mut super::super::Storage::IndexServer::DBID, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for ICommandPersist {}
+#[cfg(feature = "Win32_Storage_IndexServer")]
 impl ICommandPersist_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandPersist_Impl, const OFFSET: isize>() -> ICommandPersist_Vtbl {
         unsafe extern "system" fn DeleteCommand<Identity: ::windows::core::IUnknownImpl, Impl: ICommandPersist_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcommandid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT {
@@ -540,6 +566,7 @@ pub trait ICommandPrepare_Impl: Sized {
     fn Prepare(&self, cexpectedruns: u32) -> ::windows::core::Result<()>;
     fn Unprepare(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICommandPrepare {}
 impl ICommandPrepare_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandPrepare_Impl, const OFFSET: isize>() -> ICommandPrepare_Vtbl {
         unsafe extern "system" fn Prepare<Identity: ::windows::core::IUnknownImpl, Impl: ICommandPrepare_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cexpectedruns: u32) -> ::windows::core::HRESULT {
@@ -568,6 +595,8 @@ pub trait ICommandProperties_Impl: Sized {
     fn SetProperties(&self, cpropertysets: u32, rgpropertysets: *const DBPROPSET) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICommandProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICommandProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandProperties_Impl, const OFFSET: isize>() -> ICommandProperties_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: ICommandProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT {
@@ -594,6 +623,7 @@ pub trait ICommandStream_Impl: Sized {
     fn GetCommandStream(&self, piid: *mut ::windows::core::GUID, pguiddialect: *mut ::windows::core::GUID, ppcommandstream: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetCommandStream(&self, riid: *const ::windows::core::GUID, rguiddialect: *const ::windows::core::GUID, pcommandstream: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICommandStream {}
 impl ICommandStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandStream_Impl, const OFFSET: isize>() -> ICommandStream_Vtbl {
         unsafe extern "system" fn GetCommandStream<Identity: ::windows::core::IUnknownImpl, Impl: ICommandStream_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piid: *mut ::windows::core::GUID, pguiddialect: *mut ::windows::core::GUID, ppcommandstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -620,6 +650,7 @@ pub trait ICommandText_Impl: Sized + ICommand_Impl {
     fn GetCommandText(&self, pguiddialect: *mut ::windows::core::GUID, ppwszcommand: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn SetCommandText(&self, rguiddialect: *const ::windows::core::GUID, pwszcommand: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICommandText {}
 impl ICommandText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandText_Impl, const OFFSET: isize>() -> ICommandText_Vtbl {
         unsafe extern "system" fn GetCommandText<Identity: ::windows::core::IUnknownImpl, Impl: ICommandText_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguiddialect: *mut ::windows::core::GUID, ppwszcommand: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -646,6 +677,7 @@ pub trait ICommandValidate_Impl: Sized {
     fn ValidateCompletely(&self) -> ::windows::core::Result<()>;
     fn ValidateSyntax(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICommandValidate {}
 impl ICommandValidate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandValidate_Impl, const OFFSET: isize>() -> ICommandValidate_Vtbl {
         unsafe extern "system" fn ValidateCompletely<Identity: ::windows::core::IUnknownImpl, Impl: ICommandValidate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -674,6 +706,8 @@ pub trait ICommandWithParameters_Impl: Sized {
     fn MapParameterNames(&self, cparamnames: usize, rgparamnames: *const ::windows::core::PWSTR, rgparamordinals: *mut isize) -> ::windows::core::Result<()>;
     fn SetParameterInfo(&self, cparams: usize, rgparamordinals: *const usize, rgparambindinfo: *const DBPARAMBINDINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ICommandWithParameters {}
 #[cfg(feature = "Win32_System_Com")]
 impl ICommandWithParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommandWithParameters_Impl, const OFFSET: isize>() -> ICommandWithParameters_Vtbl {
@@ -713,6 +747,8 @@ pub trait ICondition_Impl: Sized + super::Com::IPersist_Impl + super::Com::IPers
     fn GetInputTerms(&self, pppropertyterm: *mut ::core::option::Option<IRichChunk>, ppoperationterm: *mut ::core::option::Option<IRichChunk>, ppvalueterm: *mut ::core::option::Option<IRichChunk>) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<ICondition>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for ICondition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl ICondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICondition_Impl, const OFFSET: isize>() -> ICondition_Vtbl {
@@ -796,6 +832,8 @@ pub trait ICondition2_Impl: Sized + super::Com::IPersist_Impl + super::Com::IPer
     fn GetLeafConditionInfo(&self, ppropkey: *mut super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pcop: *mut Common::CONDITION_OPERATION, ppropvar: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ICondition2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ICondition2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICondition2_Impl, const OFFSET: isize>() -> ICondition2_Vtbl {
         unsafe extern "system" fn GetLocale<Identity: ::windows::core::IUnknownImpl, Impl: ICondition2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszlocalename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -831,6 +869,8 @@ pub trait IConditionFactory_Impl: Sized {
     fn MakeLeaf(&self, pszpropertyname: &::windows::core::PCWSTR, cop: Common::CONDITION_OPERATION, pszvaluetype: &::windows::core::PCWSTR, ppropvar: *const super::Com::StructuredStorage::PROPVARIANT, ppropertynameterm: &::core::option::Option<IRichChunk>, poperationterm: &::core::option::Option<IRichChunk>, pvalueterm: &::core::option::Option<IRichChunk>, fexpand: super::super::Foundation::BOOL) -> ::windows::core::Result<ICondition>;
     fn Resolve(&self, pc: &::core::option::Option<ICondition>, sqro: STRUCTURED_QUERY_RESOLVE_OPTION, pstreferencetime: *const super::super::Foundation::SYSTEMTIME) -> ::windows::core::Result<ICondition>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IConditionFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IConditionFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConditionFactory_Impl, const OFFSET: isize>() -> IConditionFactory_Vtbl {
@@ -902,6 +942,8 @@ pub trait IConditionFactory2_Impl: Sized + IConditionFactory_Impl {
     fn CreateLeaf(&self, propkey: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, cop: Common::CONDITION_OPERATION, propvar: *const super::Com::StructuredStorage::PROPVARIANT, pszsemantictype: &::windows::core::PCWSTR, pszlocalename: &::windows::core::PCWSTR, ppropertynameterm: &::core::option::Option<IRichChunk>, poperationterm: &::core::option::Option<IRichChunk>, pvalueterm: &::core::option::Option<IRichChunk>, cco: CONDITION_CREATION_OPTIONS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn ResolveCondition(&self, pc: &::core::option::Option<ICondition>, sqro: STRUCTURED_QUERY_RESOLVE_OPTION, pstreferencetime: *const super::super::Foundation::SYSTEMTIME, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IConditionFactory2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IConditionFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConditionFactory2_Impl, const OFFSET: isize>() -> IConditionFactory2_Vtbl {
@@ -975,6 +1017,8 @@ pub trait IConditionGenerator_Impl: Sized {
     fn DefaultPhrase(&self, pszvaluetype: &::windows::core::PCWSTR, ppropvar: *const super::Com::StructuredStorage::PROPVARIANT, fuseenglish: super::super::Foundation::BOOL) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IConditionGenerator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IConditionGenerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConditionGenerator_Impl, const OFFSET: isize>() -> IConditionGenerator_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IConditionGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pschemaprovider: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1033,6 +1077,7 @@ impl IConditionGenerator_Vtbl {
 pub trait IConvertType_Impl: Sized {
     fn CanConvert(&self, wfromtype: u16, wtotype: u16, dwconvertflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IConvertType {}
 impl IConvertType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConvertType_Impl, const OFFSET: isize>() -> IConvertType_Vtbl {
         unsafe extern "system" fn CanConvert<Identity: ::windows::core::IUnknownImpl, Impl: IConvertType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wfromtype: u16, wtotype: u16, dwconvertflags: u32) -> ::windows::core::HRESULT {
@@ -1050,6 +1095,8 @@ impl IConvertType_Vtbl {
 pub trait ICreateRow_Impl: Sized {
     fn CreateRow(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, pwszurl: &::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: &::core::option::Option<super::Com::IAuthenticate>, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppwsznewurl: *mut ::windows::core::PWSTR, ppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ICreateRow {}
 #[cfg(feature = "Win32_System_Com")]
 impl ICreateRow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateRow_Impl, const OFFSET: isize>() -> ICreateRow_Vtbl {
@@ -1069,6 +1116,7 @@ pub trait IDBAsynchNotify_Impl: Sized {
     fn OnProgress(&self, hchapter: usize, eoperation: u32, ulprogress: usize, ulprogressmax: usize, easynchphase: u32, pwszstatustext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn OnStop(&self, hchapter: usize, eoperation: u32, hrstatus: ::windows::core::HRESULT, pwszstatustext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDBAsynchNotify {}
 impl IDBAsynchNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBAsynchNotify_Impl, const OFFSET: isize>() -> IDBAsynchNotify_Vtbl {
         unsafe extern "system" fn OnLowResource<Identity: ::windows::core::IUnknownImpl, Impl: IDBAsynchNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwreserved: usize) -> ::windows::core::HRESULT {
@@ -1101,6 +1149,7 @@ pub trait IDBAsynchStatus_Impl: Sized {
     fn Abort(&self, hchapter: usize, eoperation: u32) -> ::windows::core::Result<()>;
     fn GetStatus(&self, hchapter: usize, eoperation: u32, pulprogress: *mut usize, pulprogressmax: *mut usize, peasynchphase: *mut u32, ppwszstatustext: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDBAsynchStatus {}
 impl IDBAsynchStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBAsynchStatus_Impl, const OFFSET: isize>() -> IDBAsynchStatus_Vtbl {
         unsafe extern "system" fn Abort<Identity: ::windows::core::IUnknownImpl, Impl: IDBAsynchStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, eoperation: u32) -> ::windows::core::HRESULT {
@@ -1128,6 +1177,8 @@ pub trait IDBBinderProperties_Impl: Sized + IDBProperties_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDBBinderProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDBBinderProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBBinderProperties_Impl, const OFFSET: isize>() -> IDBBinderProperties_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IDBBinderProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1144,6 +1195,7 @@ impl IDBBinderProperties_Vtbl {
 pub trait IDBCreateCommand_Impl: Sized {
     fn CreateCommand(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IDBCreateCommand {}
 impl IDBCreateCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBCreateCommand_Impl, const OFFSET: isize>() -> IDBCreateCommand_Vtbl {
         unsafe extern "system" fn CreateCommand<Identity: ::windows::core::IUnknownImpl, Impl: IDBCreateCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppcommand: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1166,6 +1218,7 @@ impl IDBCreateCommand_Vtbl {
 pub trait IDBCreateSession_Impl: Sized {
     fn CreateSession(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IDBCreateSession {}
 impl IDBCreateSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBCreateSession_Impl, const OFFSET: isize>() -> IDBCreateSession_Vtbl {
         unsafe extern "system" fn CreateSession<Identity: ::windows::core::IUnknownImpl, Impl: IDBCreateSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppdbsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1192,6 +1245,8 @@ pub trait IDBDataSourceAdmin_Impl: Sized {
     fn GetCreationProperties(&self, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertyinfosets: *mut u32, prgpropertyinfosets: *mut *mut DBPROPINFOSET, ppdescbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
     fn ModifyDataSource(&self, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDBDataSourceAdmin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDBDataSourceAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBDataSourceAdmin_Impl, const OFFSET: isize>() -> IDBDataSourceAdmin_Vtbl {
@@ -1233,6 +1288,8 @@ pub trait IDBInfo_Impl: Sized {
     fn GetLiteralInfo(&self, cliterals: u32, rgliterals: *const u32, pcliteralinfo: *mut u32, prgliteralinfo: *mut *mut DBLITERALINFO, ppcharbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDBInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDBInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBInfo_Impl, const OFFSET: isize>() -> IDBInfo_Vtbl {
         unsafe extern "system" fn GetKeywords<Identity: ::windows::core::IUnknownImpl, Impl: IDBInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszkeywords: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1265,6 +1322,7 @@ pub trait IDBInitialize_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
     fn Uninitialize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDBInitialize {}
 impl IDBInitialize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBInitialize_Impl, const OFFSET: isize>() -> IDBInitialize_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDBInitialize_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1292,6 +1350,8 @@ pub trait IDBPromptInitialize_Impl: Sized {
     fn PromptDataSource(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, hwndparent: super::super::Foundation::HWND, dwpromptoptions: u32, csourcetypefilter: u32, rgsourcetypefilter: *const u32, pwszszzproviderfilter: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppdatasource: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn PromptFileName(&self, hwndparent: super::super::Foundation::HWND, dwpromptoptions: u32, pwszinitialdirectory: &::windows::core::PCWSTR, pwszinitialfile: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDBPromptInitialize {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDBPromptInitialize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBPromptInitialize_Impl, const OFFSET: isize>() -> IDBPromptInitialize_Vtbl {
@@ -1328,6 +1388,8 @@ pub trait IDBProperties_Impl: Sized {
     fn SetProperties(&self, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDBProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDBProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBProperties_Impl, const OFFSET: isize>() -> IDBProperties_Vtbl {
         unsafe extern "system" fn GetProperties<Identity: ::windows::core::IUnknownImpl, Impl: IDBProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT {
@@ -1360,6 +1422,7 @@ pub trait IDBSchemaCommand_Impl: Sized {
     fn GetCommand(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, rguidschema: *const ::windows::core::GUID) -> ::windows::core::Result<ICommand>;
     fn GetSchemas(&self, pcschemas: *mut u32, prgschemas: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDBSchemaCommand {}
 impl IDBSchemaCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBSchemaCommand_Impl, const OFFSET: isize>() -> IDBSchemaCommand_Vtbl {
         unsafe extern "system" fn GetCommand<Identity: ::windows::core::IUnknownImpl, Impl: IDBSchemaCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, rguidschema: *const ::windows::core::GUID, ppcommand: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1394,6 +1457,8 @@ pub trait IDBSchemaRowset_Impl: Sized {
     fn GetSchemas(&self, pcschemas: *mut u32, prgschemas: *mut *mut ::windows::core::GUID, prgrestrictionsupport: *mut *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDBSchemaRowset {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDBSchemaRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDBSchemaRowset_Impl, const OFFSET: isize>() -> IDBSchemaRowset_Vtbl {
         unsafe extern "system" fn GetRowset<Identity: ::windows::core::IUnknownImpl, Impl: IDBSchemaRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, rguidschema: *const ::windows::core::GUID, crestrictions: u32, rgrestrictions: *const super::Com::VARIANT, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1422,6 +1487,8 @@ pub trait IDCInfo_Impl: Sized {
     fn SetInfo(&self, cinfo: u32, rginfo: *const DCINFO) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDCInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDCInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDCInfo_Impl, const OFFSET: isize>() -> IDCInfo_Vtbl {
         unsafe extern "system" fn GetInfo<Identity: ::windows::core::IUnknownImpl, Impl: IDCInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cinfo: u32, rgeinfotype: *const u32, prginfo: *mut *mut DCINFO) -> ::windows::core::HRESULT {
@@ -1449,6 +1516,7 @@ pub trait IDataConvert_Impl: Sized {
     fn CanConvert(&self, wsrctype: u16, wdsttype: u16) -> ::windows::core::Result<()>;
     fn GetConversionSize(&self, wsrctype: u16, wdsttype: u16, pcbsrclength: *const usize, pcbdstlength: *mut usize, psrc: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDataConvert {}
 impl IDataConvert_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataConvert_Impl, const OFFSET: isize>() -> IDataConvert_Vtbl {
         unsafe extern "system" fn DataConvert<Identity: ::windows::core::IUnknownImpl, Impl: IDataConvert_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wsrctype: u16, wdsttype: u16, cbsrclength: usize, pcbdstlength: *mut usize, psrc: *const ::core::ffi::c_void, pdst: *mut ::core::ffi::c_void, cbdstmaxlength: usize, dbssrcstatus: u32, pdbsstatus: *mut u32, bprecision: u8, bscale: u8, dwflags: u32) -> ::windows::core::HRESULT {
@@ -1501,6 +1569,8 @@ pub trait IDataInitialize_Impl: Sized {
     fn LoadStringFromStorage(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn WriteStringToStorage(&self, pwszfilename: &::windows::core::PCWSTR, pwszinitializationstring: &::windows::core::PCWSTR, dwcreationdisposition: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDataInitialize {}
 #[cfg(feature = "Win32_System_Com")]
 impl IDataInitialize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataInitialize_Impl, const OFFSET: isize>() -> IDataInitialize_Vtbl {
@@ -1574,6 +1644,8 @@ pub trait IDataSourceLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn PromptEdit(&self, ppadoconnection: *mut ::core::option::Option<super::Com::IDispatch>, pbsuccess: *mut i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDataSourceLocator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDataSourceLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataSourceLocator_Impl, const OFFSET: isize>() -> IDataSourceLocator_Vtbl {
         unsafe extern "system" fn hWnd<Identity: ::windows::core::IUnknownImpl, Impl: IDataSourceLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phwndparent: *mut i64) -> ::windows::core::HRESULT {
@@ -1630,6 +1702,7 @@ pub trait IEntity_Impl: Sized {
     fn GetNamedEntity(&self, pszvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<INamedEntity>;
     fn DefaultPhrase(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IEntity {}
 impl IEntity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEntity_Impl, const OFFSET: isize>() -> IEntity_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IEntity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1727,6 +1800,8 @@ pub trait IEnumItemProperties_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumItemProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumItemProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumItemProperties_Impl, const OFFSET: isize>() -> IEnumItemProperties_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumItemProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ITEMPROP, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1785,6 +1860,7 @@ pub trait IEnumSearchRoots_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSearchRoots>;
 }
+impl ::windows::core::RuntimeName for IEnumSearchRoots {}
 impl IEnumSearchRoots_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSearchRoots_Impl, const OFFSET: isize>() -> IEnumSearchRoots_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSearchRoots_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1831,6 +1907,7 @@ pub trait IEnumSearchScopeRules_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSearchScopeRules>;
 }
+impl ::windows::core::RuntimeName for IEnumSearchScopeRules {}
 impl IEnumSearchScopeRules_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSearchScopeRules_Impl, const OFFSET: isize>() -> IEnumSearchScopeRules_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSearchScopeRules_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, pprgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1878,6 +1955,7 @@ pub trait IEnumSubscription_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumSubscription>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IEnumSubscription {}
 impl IEnumSubscription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSubscription_Impl, const OFFSET: isize>() -> IEnumSubscription_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSubscription_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -1937,6 +2015,8 @@ pub trait IErrorLookup_Impl: Sized {
     fn ReleaseErrors(&self, dwdynamicerrorid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IErrorLookup {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IErrorLookup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IErrorLookup_Impl, const OFFSET: isize>() -> IErrorLookup_Vtbl {
         unsafe extern "system" fn GetErrorDescription<Identity: ::windows::core::IUnknownImpl, Impl: IErrorLookup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT, dwlookupid: u32, pdispparams: *const super::Com::DISPPARAMS, lcid: u32, pbstrsource: *mut super::super::Foundation::BSTR, pbstrdescription: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1974,6 +2054,8 @@ pub trait IErrorRecords_Impl: Sized {
     fn GetErrorParameters(&self, ulrecordnum: u32) -> ::windows::core::Result<super::Com::DISPPARAMS>;
     fn GetRecordCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IErrorRecords {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IErrorRecords_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IErrorRecords_Impl, const OFFSET: isize>() -> IErrorRecords_Vtbl {
@@ -2054,6 +2136,7 @@ impl IErrorRecords_Vtbl {
 pub trait IGetDataSource_Impl: Sized {
     fn GetDataSource(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IGetDataSource {}
 impl IGetDataSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetDataSource_Impl, const OFFSET: isize>() -> IGetDataSource_Vtbl {
         unsafe extern "system" fn GetDataSource<Identity: ::windows::core::IUnknownImpl, Impl: IGetDataSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppdatasource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2077,6 +2160,7 @@ pub trait IGetRow_Impl: Sized {
     fn GetRowFromHROW(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, hrow: usize, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetURLFromHROW(&self, hrow: usize) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IGetRow {}
 impl IGetRow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetRow_Impl, const OFFSET: isize>() -> IGetRow_Vtbl {
         unsafe extern "system" fn GetRowFromHROW<Identity: ::windows::core::IUnknownImpl, Impl: IGetRow_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, hrow: usize, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2114,6 +2198,7 @@ impl IGetRow_Vtbl {
 pub trait IGetSession_Impl: Sized {
     fn GetSession(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IGetSession {}
 impl IGetSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetSession_Impl, const OFFSET: isize>() -> IGetSession_Vtbl {
         unsafe extern "system" fn GetSession<Identity: ::windows::core::IUnknownImpl, Impl: IGetSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2136,6 +2221,7 @@ impl IGetSession_Vtbl {
 pub trait IGetSourceRow_Impl: Sized {
     fn GetSourceRow(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IGetSourceRow {}
 impl IGetSourceRow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetSourceRow_Impl, const OFFSET: isize>() -> IGetSourceRow_Vtbl {
         unsafe extern "system" fn GetSourceRow<Identity: ::windows::core::IUnknownImpl, Impl: IGetSourceRow_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pprow: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2160,6 +2246,8 @@ pub trait IIndexDefinition_Impl: Sized {
     fn CreateIndex(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, cindexcolumndescs: usize, rgindexcolumndescs: *const DBINDEXCOLUMNDESC, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, ppindexid: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
     fn DropIndex(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IIndexDefinition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IIndexDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIndexDefinition_Impl, const OFFSET: isize>() -> IIndexDefinition_Vtbl {
@@ -2188,6 +2276,8 @@ pub trait IInterval_Impl: Sized {
     fn GetLimits(&self, pilklower: *mut INTERVAL_LIMIT_KIND, ppropvarlower: *mut super::Com::StructuredStorage::PROPVARIANT, pilkupper: *mut INTERVAL_LIMIT_KIND, ppropvarupper: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IInterval {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IInterval_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInterval_Impl, const OFFSET: isize>() -> IInterval_Vtbl {
         unsafe extern "system" fn GetLimits<Identity: ::windows::core::IUnknownImpl, Impl: IInterval_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pilklower: *mut INTERVAL_LIMIT_KIND, ppropvarlower: *mut super::Com::StructuredStorage::PROPVARIANT, pilkupper: *mut INTERVAL_LIMIT_KIND, ppropvarupper: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -2207,6 +2297,8 @@ pub trait ILoadFilter_Impl: Sized {
     fn LoadIFilterFromStorage(&self, pstg: &::core::option::Option<super::Com::StructuredStorage::IStorage>, punkouter: &::core::option::Option<::windows::core::IUnknown>, pwcsoverride: &::windows::core::PCWSTR, fusedefault: super::super::Foundation::BOOL, pfilterclsid: *mut ::windows::core::GUID, searchdecsize: *mut i32, pwcssearchdesc: *mut *mut u16, ppifilt: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
     fn LoadIFilterFromStream(&self, pstm: &::core::option::Option<super::Com::IStream>, pfilteredsources: *const FILTERED_DATA_SOURCES, punkouter: &::core::option::Option<::windows::core::IUnknown>, fusedefault: super::super::Foundation::BOOL, pfilterclsid: *mut ::windows::core::GUID, searchdecsize: *mut i32, pwcssearchdesc: *mut *mut u16, ppifilt: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ILoadFilter {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ILoadFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILoadFilter_Impl, const OFFSET: isize>() -> ILoadFilter_Vtbl {
@@ -2241,6 +2333,8 @@ pub trait ILoadFilterWithPrivateComActivation_Impl: Sized + ILoadFilter_Impl {
     fn LoadIFilterWithPrivateComActivation(&self, filteredsources: *const FILTERED_DATA_SOURCES, usedefault: super::super::Foundation::BOOL, filterclsid: *mut ::windows::core::GUID, isfilterprivatecomactivated: *mut super::super::Foundation::BOOL, filterobj: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ILoadFilterWithPrivateComActivation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl ILoadFilterWithPrivateComActivation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILoadFilterWithPrivateComActivation_Impl, const OFFSET: isize>() -> ILoadFilterWithPrivateComActivation_Vtbl {
         unsafe extern "system" fn LoadIFilterWithPrivateComActivation<Identity: ::windows::core::IUnknownImpl, Impl: ILoadFilterWithPrivateComActivation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filteredsources: *const FILTERED_DATA_SOURCES, usedefault: super::super::Foundation::BOOL, filterclsid: *mut ::windows::core::GUID, isfilterprivatecomactivated: *mut super::super::Foundation::BOOL, filterobj: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2265,6 +2359,8 @@ pub trait IMDDataset_Impl: Sized {
     fn GetCellData(&self, haccessor: usize, ulstartcell: usize, ulendcell: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetSpecification(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMDDataset {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMDDataset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDDataset_Impl, const OFFSET: isize>() -> IMDDataset_Vtbl {
@@ -2316,6 +2412,7 @@ pub trait IMDFind_Impl: Sized {
     fn FindCell(&self, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pulcellordinal: *mut usize) -> ::windows::core::Result<()>;
     fn FindTuple(&self, ulaxisidentifier: u32, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pultupleordinal: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMDFind {}
 impl IMDFind_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDFind_Impl, const OFFSET: isize>() -> IMDFind_Vtbl {
         unsafe extern "system" fn FindCell<Identity: ::windows::core::IUnknownImpl, Impl: IMDFind_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pulcellordinal: *mut usize) -> ::windows::core::HRESULT {
@@ -2343,6 +2440,8 @@ pub trait IMDRangeRowset_Impl: Sized {
     fn GetRangeRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, ulstartcell: usize, ulendcell: usize, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMDRangeRowset {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMDRangeRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMDRangeRowset_Impl, const OFFSET: isize>() -> IMDRangeRowset_Vtbl {
         unsafe extern "system" fn GetRangeRowset<Identity: ::windows::core::IUnknownImpl, Impl: IMDRangeRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, ulstartcell: usize, ulendcell: usize, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2359,6 +2458,7 @@ impl IMDRangeRowset_Vtbl {
 pub trait IMetaData_Impl: Sized {
     fn GetData(&self, ppszkey: *mut ::windows::core::PWSTR, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMetaData {}
 impl IMetaData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMetaData_Impl, const OFFSET: isize>() -> IMetaData_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IMetaData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszkey: *mut ::windows::core::PWSTR, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2375,6 +2475,7 @@ impl IMetaData_Vtbl {
 pub trait IMultipleResults_Impl: Sized {
     fn GetResult(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, lresultflag: isize, riid: *const ::windows::core::GUID, pcrowsaffected: *mut isize, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMultipleResults {}
 impl IMultipleResults_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultipleResults_Impl, const OFFSET: isize>() -> IMultipleResults_Vtbl {
         unsafe extern "system" fn GetResult<Identity: ::windows::core::IUnknownImpl, Impl: IMultipleResults_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, lresultflag: isize, riid: *const ::windows::core::GUID, pcrowsaffected: *mut isize, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2392,6 +2493,7 @@ pub trait INamedEntity_Impl: Sized {
     fn GetValue(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn DefaultPhrase(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for INamedEntity {}
 impl INamedEntity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamedEntity_Impl, const OFFSET: isize>() -> INamedEntity_Vtbl {
         unsafe extern "system" fn GetValue<Identity: ::windows::core::IUnknownImpl, Impl: INamedEntity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -2429,6 +2531,7 @@ impl INamedEntity_Vtbl {
 pub trait INamedEntityCollector_Impl: Sized {
     fn Add(&self, beginspan: u32, endspan: u32, beginactual: u32, endactual: u32, ptype: &::core::option::Option<IEntity>, pszvalue: &::windows::core::PCWSTR, certainty: NAMED_ENTITY_CERTAINTY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INamedEntityCollector {}
 impl INamedEntityCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamedEntityCollector_Impl, const OFFSET: isize>() -> INamedEntityCollector_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: INamedEntityCollector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, beginspan: u32, endspan: u32, beginactual: u32, endactual: u32, ptype: ::windows::core::RawPtr, pszvalue: ::windows::core::PCWSTR, certainty: NAMED_ENTITY_CERTAINTY) -> ::windows::core::HRESULT {
@@ -2450,6 +2553,8 @@ pub trait IObjectAccessControl_Impl: Sized {
     fn SetObjectAccessRights(&self, pobject: *mut SEC_OBJECT, caccessentries: u32, prgaccessentries: *mut super::super::Security::Authorization::EXPLICIT_ACCESS_W) -> ::windows::core::Result<()>;
     fn SetObjectOwner(&self, pobject: *mut SEC_OBJECT, powner: *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer"))]
+impl ::windows::core::RuntimeName for IObjectAccessControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer"))]
 impl IObjectAccessControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectAccessControl_Impl, const OFFSET: isize>() -> IObjectAccessControl_Vtbl {
@@ -2497,6 +2602,8 @@ pub trait IOpLockStatus_Impl: Sized {
     fn IsOplockBroken(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetOplockEventHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpLockStatus {}
 #[cfg(feature = "Win32_Foundation")]
 impl IOpLockStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpLockStatus_Impl, const OFFSET: isize>() -> IOpLockStatus_Vtbl {
@@ -2549,6 +2656,8 @@ pub trait IOpenRowset_Impl: Sized {
     fn OpenRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IOpenRowset {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IOpenRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpenRowset_Impl, const OFFSET: isize>() -> IOpenRowset_Vtbl {
         unsafe extern "system" fn OpenRowset<Identity: ::windows::core::IUnknownImpl, Impl: IOpenRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2565,6 +2674,7 @@ impl IOpenRowset_Vtbl {
 pub trait IParentRowset_Impl: Sized {
     fn GetChildRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, iordinal: usize, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IParentRowset {}
 impl IParentRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IParentRowset_Impl, const OFFSET: isize>() -> IParentRowset_Vtbl {
         unsafe extern "system" fn GetChildRowset<Identity: ::windows::core::IUnknownImpl, Impl: IParentRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, iordinal: usize, riid: *const ::windows::core::GUID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2589,6 +2699,8 @@ pub trait IProtocolHandlerSite_Impl: Sized {
     fn GetFilter(&self, pclsidobj: *mut ::windows::core::GUID, pcwszcontenttype: &::windows::core::PCWSTR, pcwszextension: &::windows::core::PCWSTR, ppfilter: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for IProtocolHandlerSite {}
+#[cfg(feature = "Win32_Storage_IndexServer")]
 impl IProtocolHandlerSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProtocolHandlerSite_Impl, const OFFSET: isize>() -> IProtocolHandlerSite_Vtbl {
         unsafe extern "system" fn GetFilter<Identity: ::windows::core::IUnknownImpl, Impl: IProtocolHandlerSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclsidobj: *mut ::windows::core::GUID, pcwszcontenttype: ::windows::core::PCWSTR, pcwszextension: ::windows::core::PCWSTR, ppfilter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2606,6 +2718,8 @@ impl IProtocolHandlerSite_Vtbl {
 pub trait IProvideMoniker_Impl: Sized {
     fn GetMoniker(&self) -> ::windows::core::Result<super::Com::IMoniker>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IProvideMoniker {}
 #[cfg(feature = "Win32_System_Com")]
 impl IProvideMoniker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideMoniker_Impl, const OFFSET: isize>() -> IProvideMoniker_Vtbl {
@@ -2637,6 +2751,8 @@ pub trait IQueryParser_Impl: Sized {
     fn ParsePropertyValue(&self, pszpropertyname: &::windows::core::PCWSTR, pszinputstring: &::windows::core::PCWSTR) -> ::windows::core::Result<IQuerySolution>;
     fn RestatePropertyValueToString(&self, pcondition: &::core::option::Option<ICondition>, fuseenglish: super::super::Foundation::BOOL, ppszpropertyname: *mut ::windows::core::PWSTR, ppszquerystring: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IQueryParser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IQueryParser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryParser_Impl, const OFFSET: isize>() -> IQueryParser_Vtbl {
@@ -2733,6 +2849,8 @@ pub trait IQueryParserManager_Impl: Sized {
     fn SetOption(&self, option: QUERY_PARSER_MANAGER_OPTION, poptionvalue: *const super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IQueryParserManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IQueryParserManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryParserManager_Impl, const OFFSET: isize>() -> IQueryParserManager_Vtbl {
         unsafe extern "system" fn CreateLoadedParser<Identity: ::windows::core::IUnknownImpl, Impl: IQueryParserManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcatalog: ::windows::core::PCWSTR, langidforkeywords: u16, riid: *const ::windows::core::GUID, ppqueryparser: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2768,6 +2886,8 @@ pub trait IQuerySolution_Impl: Sized + IConditionFactory_Impl {
     fn GetLexicalData(&self, ppszinputstring: *mut ::windows::core::PWSTR, pptokens: *mut ::core::option::Option<ITokenCollection>, plcid: *mut u32, ppwordbreaker: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IQuerySolution {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IQuerySolution_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQuerySolution_Impl, const OFFSET: isize>() -> IQuerySolution_Vtbl {
         unsafe extern "system" fn GetQuery<Identity: ::windows::core::IUnknownImpl, Impl: IQuerySolution_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppquerynode: *mut ::windows::core::RawPtr, ppmaintype: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2800,6 +2920,7 @@ pub trait IReadData_Impl: Sized {
     fn ReadData(&self, hchapter: usize, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, haccessor: usize, crows: isize, pcrowsobtained: *mut usize, ppfixeddata: *mut *mut u8, pcbvariabletotal: *mut usize, ppvariabledata: *mut *mut u8) -> ::windows::core::Result<()>;
     fn ReleaseChapter(&self, hchapter: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReadData {}
 impl IReadData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReadData_Impl, const OFFSET: isize>() -> IReadData_Vtbl {
         unsafe extern "system" fn ReadData<Identity: ::windows::core::IUnknownImpl, Impl: IReadData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, haccessor: usize, crows: isize, pcrowsobtained: *mut usize, ppfixeddata: *mut *mut u8, pcbvariabletotal: *mut usize, ppvariabledata: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -2827,6 +2948,7 @@ pub trait IRegisterProvider_Impl: Sized {
     fn SetURLMapping(&self, pwszurl: &::windows::core::PCWSTR, dwreserved: usize, rclsidprovider: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn UnregisterProvider(&self, pwszurl: &::windows::core::PCWSTR, dwreserved: usize, rclsidprovider: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRegisterProvider {}
 impl IRegisterProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegisterProvider_Impl, const OFFSET: isize>() -> IRegisterProvider_Vtbl {
         unsafe extern "system" fn GetURLMapping<Identity: ::windows::core::IUnknownImpl, Impl: IRegisterProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwreserved: usize, pclsidprovider: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2869,6 +2991,8 @@ pub trait IRelationship_Impl: Sized {
     fn MetaData(&self, riid: *const ::windows::core::GUID, pmetadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn DefaultPhrase(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRelationship {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRelationship_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRelationship_Impl, const OFFSET: isize>() -> IRelationship_Vtbl {
@@ -2939,6 +3063,8 @@ pub trait IRichChunk_Impl: Sized {
     fn GetData(&self, pfirstpos: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR, pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IRichChunk {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IRichChunk_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRichChunk_Impl, const OFFSET: isize>() -> IRichChunk_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IRichChunk_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfirstpos: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR, pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -2958,6 +3084,8 @@ pub trait IRow_Impl: Sized {
     fn GetSourceRowset(&self, riid: *const ::windows::core::GUID, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>, phrow: *mut usize) -> ::windows::core::Result<()>;
     fn Open(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, pcolumnid: *const super::super::Storage::IndexServer::DBID, rguidcolumntype: *const ::windows::core::GUID, dwbindflags: u32, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for IRow {}
 #[cfg(feature = "Win32_Storage_IndexServer")]
 impl IRow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRow_Impl, const OFFSET: isize>() -> IRow_Vtbl {
@@ -2998,6 +3126,8 @@ pub trait IRowChange_Impl: Sized {
     fn SetColumns(&self, ccolumns: usize, rgcolumns: *const DBCOLUMNACCESS) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for IRowChange {}
+#[cfg(feature = "Win32_Storage_IndexServer")]
 impl IRowChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowChange_Impl, const OFFSET: isize>() -> IRowChange_Vtbl {
         unsafe extern "system" fn SetColumns<Identity: ::windows::core::IUnknownImpl, Impl: IRowChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ccolumns: usize, rgcolumns: *const DBCOLUMNACCESS) -> ::windows::core::HRESULT {
@@ -3018,6 +3148,7 @@ pub trait IRowPosition_Impl: Sized {
     fn Initialize(&self, prowset: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetRowPosition(&self, hchapter: usize, hrow: usize, dwpositionflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowPosition {}
 impl IRowPosition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowPosition_Impl, const OFFSET: isize>() -> IRowPosition_Vtbl {
         unsafe extern "system" fn ClearRowPosition<Identity: ::windows::core::IUnknownImpl, Impl: IRowPosition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3069,6 +3200,8 @@ pub trait IRowPositionChange_Impl: Sized {
     fn OnRowPositionChange(&self, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRowPositionChange {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRowPositionChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowPositionChange_Impl, const OFFSET: isize>() -> IRowPositionChange_Vtbl {
         unsafe extern "system" fn OnRowPositionChange<Identity: ::windows::core::IUnknownImpl, Impl: IRowPositionChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3087,6 +3220,8 @@ pub trait IRowSchemaChange_Impl: Sized + IRowChange_Impl {
     fn DeleteColumns(&self, ccolumns: usize, rgcolumnids: *const super::super::Storage::IndexServer::DBID, rgdwstatus: *mut u32) -> ::windows::core::Result<()>;
     fn AddColumns(&self, ccolumns: usize, rgnewcolumninfo: *const DBCOLUMNINFO, rgcolumns: *mut DBCOLUMNACCESS) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRowSchemaChange {}
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 impl IRowSchemaChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowSchemaChange_Impl, const OFFSET: isize>() -> IRowSchemaChange_Vtbl {
@@ -3117,6 +3252,7 @@ pub trait IRowset_Impl: Sized {
     fn ReleaseRows(&self, crows: usize, rghrows: *const usize, rgrowoptions: *mut u32, rgrefcounts: *mut u32, rgrowstatus: *mut u32) -> ::windows::core::Result<()>;
     fn RestartPosition(&self, hreserved: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowset {}
 impl IRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowset_Impl, const OFFSET: isize>() -> IRowset_Vtbl {
         unsafe extern "system" fn AddRefRows<Identity: ::windows::core::IUnknownImpl, Impl: IRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crows: usize, rghrows: *const usize, rgrefcounts: *mut u32, rgrowstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -3163,6 +3299,8 @@ pub trait IRowsetAsynch_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRowsetAsynch {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRowsetAsynch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetAsynch_Impl, const OFFSET: isize>() -> IRowsetAsynch_Vtbl {
         unsafe extern "system" fn RatioFinished<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetAsynch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puldenominator: *mut usize, pulnumerator: *mut usize, pcrows: *mut usize, pfnewrows: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3188,6 +3326,7 @@ impl IRowsetAsynch_Vtbl {
 pub trait IRowsetBookmark_Impl: Sized {
     fn PositionOnBookmark(&self, hchapter: usize, cbbookmark: usize, pbookmark: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetBookmark {}
 impl IRowsetBookmark_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetBookmark_Impl, const OFFSET: isize>() -> IRowsetBookmark_Vtbl {
         unsafe extern "system" fn PositionOnBookmark<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetBookmark_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, cbbookmark: usize, pbookmark: *const u8) -> ::windows::core::HRESULT {
@@ -3206,6 +3345,7 @@ pub trait IRowsetChange_Impl: Sized {
     fn SetData(&self, hrow: usize, haccessor: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn InsertRow(&self, hreserved: usize, haccessor: usize, pdata: *mut ::core::ffi::c_void, phrow: *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetChange {}
 impl IRowsetChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetChange_Impl, const OFFSET: isize>() -> IRowsetChange_Vtbl {
         unsafe extern "system" fn DeleteRows<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hreserved: usize, crows: usize, rghrows: *const usize, rgrowstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -3238,6 +3378,7 @@ pub trait IRowsetChangeExtInfo_Impl: Sized {
     fn GetOriginalRow(&self, hreserved: usize, hrow: usize, phroworiginal: *mut usize) -> ::windows::core::Result<()>;
     fn GetPendingColumns(&self, hreserved: usize, hrow: usize, ccolumnordinals: u32, rgiordinals: *const u32, rgcolumnstatus: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetChangeExtInfo {}
 impl IRowsetChangeExtInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetChangeExtInfo_Impl, const OFFSET: isize>() -> IRowsetChangeExtInfo_Vtbl {
         unsafe extern "system" fn GetOriginalRow<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetChangeExtInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hreserved: usize, hrow: usize, phroworiginal: *mut usize) -> ::windows::core::HRESULT {
@@ -3263,6 +3404,7 @@ impl IRowsetChangeExtInfo_Vtbl {
 pub trait IRowsetChapterMember_Impl: Sized {
     fn IsRowInChapter(&self, hchapter: usize, hrow: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetChapterMember {}
 impl IRowsetChapterMember_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetChapterMember_Impl, const OFFSET: isize>() -> IRowsetChapterMember_Vtbl {
         unsafe extern "system" fn IsRowInChapter<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetChapterMember_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, hrow: usize) -> ::windows::core::HRESULT {
@@ -3282,6 +3424,7 @@ pub trait IRowsetCopyRows_Impl: Sized {
     fn CopyRows(&self, hsourceid: u16, hreserved: usize, crows: isize, bflags: u32, pcrowscopied: *mut usize) -> ::windows::core::Result<()>;
     fn DefineSource(&self, prowsetsource: &::core::option::Option<IRowset>, ccolids: usize, rgsourcecolumns: *const isize, rgtargetcolumns: *const isize, phsourceid: *mut u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetCopyRows {}
 impl IRowsetCopyRows_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetCopyRows_Impl, const OFFSET: isize>() -> IRowsetCopyRows_Vtbl {
         unsafe extern "system" fn CloseSource<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetCopyRows_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hsourceid: u16) -> ::windows::core::HRESULT {
@@ -3322,6 +3465,8 @@ pub trait IRowsetCurrentIndex_Impl: Sized + IRowsetIndex_Impl {
     fn SetIndex(&self, pindexid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRowsetCurrentIndex {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRowsetCurrentIndex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetCurrentIndex_Impl, const OFFSET: isize>() -> IRowsetCurrentIndex_Vtbl {
         unsafe extern "system" fn GetIndex<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetCurrentIndex_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppindexid: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT {
@@ -3351,6 +3496,8 @@ pub trait IRowsetEvents_Impl: Sized {
     fn OnDeletedItem(&self, itemid: *const super::Com::StructuredStorage::PROPVARIANT, deleteditemstate: ROWSETEVENT_ITEMSTATE) -> ::windows::core::Result<()>;
     fn OnRowsetEvent(&self, eventtype: ROWSETEVENT_TYPE, eventdata: *const super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IRowsetEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IRowsetEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetEvents_Impl, const OFFSET: isize>() -> IRowsetEvents_Vtbl {
@@ -3392,6 +3539,8 @@ pub trait IRowsetFastLoad_Impl: Sized {
     fn Commit(&self, fdone: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRowsetFastLoad {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRowsetFastLoad_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetFastLoad_Impl, const OFFSET: isize>() -> IRowsetFastLoad_Vtbl {
         unsafe extern "system" fn InsertRow<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetFastLoad_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, haccessor: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3417,6 +3566,7 @@ impl IRowsetFastLoad_Vtbl {
 pub trait IRowsetFind_Impl: Sized {
     fn FindNextRow(&self, hchapter: usize, haccessor: usize, pfindvalue: *mut ::core::ffi::c_void, compareop: u32, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetFind {}
 impl IRowsetFind_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetFind_Impl, const OFFSET: isize>() -> IRowsetFind_Vtbl {
         unsafe extern "system" fn FindNextRow<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetFind_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, haccessor: usize, pfindvalue: *mut ::core::ffi::c_void, compareop: u32, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::HRESULT {
@@ -3433,6 +3583,7 @@ impl IRowsetFind_Vtbl {
 pub trait IRowsetIdentity_Impl: Sized {
     fn IsSameRow(&self, hthisrow: usize, hthatrow: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetIdentity {}
 impl IRowsetIdentity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetIdentity_Impl, const OFFSET: isize>() -> IRowsetIdentity_Vtbl {
         unsafe extern "system" fn IsSameRow<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetIdentity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hthisrow: usize, hthatrow: usize) -> ::windows::core::HRESULT {
@@ -3452,6 +3603,8 @@ pub trait IRowsetIndex_Impl: Sized {
     fn Seek(&self, haccessor: usize, ckeyvalues: usize, pdata: *mut ::core::ffi::c_void, dwseekoptions: u32) -> ::windows::core::Result<()>;
     fn SetRange(&self, haccessor: usize, cstartkeycolumns: usize, pstartdata: *mut ::core::ffi::c_void, cendkeycolumns: usize, penddata: *mut ::core::ffi::c_void, dwrangeoptions: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRowsetIndex {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRowsetIndex_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetIndex_Impl, const OFFSET: isize>() -> IRowsetIndex_Vtbl {
@@ -3487,6 +3640,8 @@ pub trait IRowsetInfo_Impl: Sized {
     fn GetReferencedRowset(&self, iordinal: usize, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetSpecification(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRowsetInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRowsetInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetInfo_Impl, const OFFSET: isize>() -> IRowsetInfo_Vtbl {
@@ -3531,6 +3686,7 @@ impl IRowsetInfo_Vtbl {
 pub trait IRowsetKeys_Impl: Sized {
     fn ListKeys(&self, pccolumns: *mut usize, prgcolumns: *mut *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetKeys {}
 impl IRowsetKeys_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetKeys_Impl, const OFFSET: isize>() -> IRowsetKeys_Vtbl {
         unsafe extern "system" fn ListKeys<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetKeys_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pccolumns: *mut usize, prgcolumns: *mut *mut usize) -> ::windows::core::HRESULT {
@@ -3550,6 +3706,7 @@ pub trait IRowsetLocate_Impl: Sized + IRowset_Impl {
     fn GetRowsByBookmark(&self, hreserved: usize, crows: usize, rgcbbookmarks: *const usize, rgpbookmarks: *const *const u8, rghrows: *mut usize, rgrowstatus: *mut u32) -> ::windows::core::Result<()>;
     fn Hash(&self, hreserved: usize, cbookmarks: usize, rgcbbookmarks: *const usize, rgpbookmarks: *const *const u8, rghashedvalues: *mut usize, rgbookmarkstatus: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetLocate {}
 impl IRowsetLocate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetLocate_Impl, const OFFSET: isize>() -> IRowsetLocate_Vtbl {
         unsafe extern "system" fn Compare<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetLocate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hreserved: usize, cbbookmark1: usize, pbookmark1: *const u8, cbbookmark2: usize, pbookmark2: *const u8, pcomparison: *mut u32) -> ::windows::core::HRESULT {
@@ -3587,6 +3744,7 @@ impl IRowsetLocate_Vtbl {
 pub trait IRowsetNewRowAfter_Impl: Sized {
     fn SetNewDataAfter(&self, hchapter: usize, cbbmprevious: u32, pbmprevious: *const u8, haccessor: usize, pdata: *mut u8, phrow: *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetNewRowAfter {}
 impl IRowsetNewRowAfter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetNewRowAfter_Impl, const OFFSET: isize>() -> IRowsetNewRowAfter_Vtbl {
         unsafe extern "system" fn SetNewDataAfter<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetNewRowAfter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, cbbmprevious: u32, pbmprevious: *const u8, haccessor: usize, pdata: *mut u8, phrow: *mut usize) -> ::windows::core::HRESULT {
@@ -3603,6 +3761,7 @@ impl IRowsetNewRowAfter_Vtbl {
 pub trait IRowsetNextRowset_Impl: Sized {
     fn GetNextRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IRowsetNextRowset {}
 impl IRowsetNextRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetNextRowset_Impl, const OFFSET: isize>() -> IRowsetNextRowset_Vtbl {
         unsafe extern "system" fn GetNextRowset<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetNextRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppnextrowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3628,6 +3787,8 @@ pub trait IRowsetNotify_Impl: Sized {
     fn OnRowChange(&self, prowset: &::core::option::Option<IRowset>, crows: usize, rghrows: *const usize, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn OnRowsetChange(&self, prowset: &::core::option::Option<IRowset>, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRowsetNotify {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRowsetNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetNotify_Impl, const OFFSET: isize>() -> IRowsetNotify_Vtbl {
@@ -3662,6 +3823,7 @@ pub trait IRowsetPrioritization_Impl: Sized {
     fn GetScopePriority(&self, priority: *mut PRIORITY_LEVEL, scopestatisticseventfrequency: *mut u32) -> ::windows::core::Result<()>;
     fn GetScopeStatistics(&self, indexeddocumentcount: *mut u32, oustandingaddcount: *mut u32, oustandingmodifycount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetPrioritization {}
 impl IRowsetPrioritization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetPrioritization_Impl, const OFFSET: isize>() -> IRowsetPrioritization_Vtbl {
         unsafe extern "system" fn SetScopePriority<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetPrioritization_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, priority: PRIORITY_LEVEL, scopestatisticseventfrequency: u32) -> ::windows::core::HRESULT {
@@ -3694,6 +3856,7 @@ pub trait IRowsetQueryStatus_Impl: Sized {
     fn GetStatus(&self, pdwstatus: *mut u32) -> ::windows::core::Result<()>;
     fn GetStatusEx(&self, pdwstatus: *mut u32, pcfiltereddocuments: *mut u32, pcdocumentstofilter: *mut u32, pdwratiofinisheddenominator: *mut usize, pdwratiofinishednumerator: *mut usize, cbbmk: usize, pbmk: *const u8, pirowbmk: *mut usize, pcrowstotal: *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetQueryStatus {}
 impl IRowsetQueryStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetQueryStatus_Impl, const OFFSET: isize>() -> IRowsetQueryStatus_Vtbl {
         unsafe extern "system" fn GetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetQueryStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT {
@@ -3722,6 +3885,8 @@ pub trait IRowsetRefresh_Impl: Sized {
     fn GetLastVisibleData(&self, hrow: usize, haccessor: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRowsetRefresh {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRowsetRefresh_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetRefresh_Impl, const OFFSET: isize>() -> IRowsetRefresh_Vtbl {
         unsafe extern "system" fn RefreshVisibleData<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetRefresh_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hchapter: usize, crows: usize, rghrows: *const usize, foverwrite: super::super::Foundation::BOOL, pcrowsrefreshed: *mut usize, prghrowsrefreshed: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::HRESULT {
@@ -3748,6 +3913,7 @@ pub trait IRowsetResynch_Impl: Sized {
     fn GetVisibleData(&self, hrow: usize, haccessor: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn ResynchRows(&self, crows: usize, rghrows: *const usize, pcrowsresynched: *mut usize, prghrowsresynched: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetResynch {}
 impl IRowsetResynch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetResynch_Impl, const OFFSET: isize>() -> IRowsetResynch_Vtbl {
         unsafe extern "system" fn GetVisibleData<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetResynch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrow: usize, haccessor: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3774,6 +3940,7 @@ pub trait IRowsetScroll_Impl: Sized + IRowset_Impl + IRowsetLocate_Impl {
     fn GetApproximatePosition(&self, hreserved: usize, cbbookmark: usize, pbookmark: *const u8, pulposition: *mut usize, pcrows: *mut usize) -> ::windows::core::Result<()>;
     fn GetRowsAtRatio(&self, hreserved1: usize, hreserved2: usize, ulnumerator: usize, uldenominator: usize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetScroll {}
 impl IRowsetScroll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetScroll_Impl, const OFFSET: isize>() -> IRowsetScroll_Vtbl {
         unsafe extern "system" fn GetApproximatePosition<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetScroll_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hreserved: usize, cbbookmark: usize, pbookmark: *const u8, pulposition: *mut usize, pcrows: *mut usize) -> ::windows::core::HRESULT {
@@ -3803,6 +3970,7 @@ pub trait IRowsetUpdate_Impl: Sized + IRowsetChange_Impl {
     fn Undo(&self, hreserved: usize, crows: usize, rghrows: *const usize, pcrowsundone: *mut usize, prgrowsundone: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::Result<()>;
     fn Update(&self, hreserved: usize, crows: usize, rghrows: *const usize, pcrows: *mut usize, prgrows: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetUpdate {}
 impl IRowsetUpdate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetUpdate_Impl, const OFFSET: isize>() -> IRowsetUpdate_Vtbl {
         unsafe extern "system" fn GetOriginalData<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetUpdate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hrow: usize, haccessor: usize, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3847,6 +4015,7 @@ pub trait IRowsetView_Impl: Sized {
     fn CreateView(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetView(&self, hchapter: usize, riid: *const ::windows::core::GUID, phchaptersource: *mut usize, ppview: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetView {}
 impl IRowsetView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetView_Impl, const OFFSET: isize>() -> IRowsetView_Vtbl {
         unsafe extern "system" fn CreateView<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppview: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3880,6 +4049,7 @@ pub trait IRowsetWatchAll_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn StopWatching(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetWatchAll {}
 impl IRowsetWatchAll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWatchAll_Impl, const OFFSET: isize>() -> IRowsetWatchAll_Vtbl {
         unsafe extern "system" fn Acknowledge<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWatchAll_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3911,6 +4081,7 @@ impl IRowsetWatchAll_Vtbl {
 pub trait IRowsetWatchNotify_Impl: Sized {
     fn OnChange(&self, prowset: &::core::option::Option<IRowset>, echangereason: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetWatchNotify {}
 impl IRowsetWatchNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWatchNotify_Impl, const OFFSET: isize>() -> IRowsetWatchNotify_Vtbl {
         unsafe extern "system" fn OnChange<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWatchNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prowset: ::windows::core::RawPtr, echangereason: u32) -> ::windows::core::HRESULT {
@@ -3932,6 +4103,7 @@ pub trait IRowsetWatchRegion_Impl: Sized + IRowsetWatchAll_Impl {
     fn Refresh(&self, pcchangesobtained: *mut usize, prgchanges: *mut *mut tagDBROWWATCHRANGE) -> ::windows::core::Result<()>;
     fn ShrinkWatchRegion(&self, hregion: usize, hchapter: usize, cbbookmark: usize, pbookmark: *mut u8, crows: isize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRowsetWatchRegion {}
 impl IRowsetWatchRegion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWatchRegion_Impl, const OFFSET: isize>() -> IRowsetWatchRegion_Vtbl {
         unsafe extern "system" fn CreateWatchRegion<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWatchRegion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwwatchmode: u32, phregion: *mut usize) -> ::windows::core::HRESULT {
@@ -3984,6 +4156,8 @@ pub trait IRowsetWithParameters_Impl: Sized {
     fn Requery(&self, pparams: *mut DBPARAMS, pulerrorparam: *mut u32, phreserved: *mut usize) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRowsetWithParameters {}
+#[cfg(feature = "Win32_System_Com")]
 impl IRowsetWithParameters_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWithParameters_Impl, const OFFSET: isize>() -> IRowsetWithParameters_Vtbl {
         unsafe extern "system" fn GetParameterInfo<Identity: ::windows::core::IUnknownImpl, Impl: IRowsetWithParameters_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcparams: *mut usize, prgparaminfo: *mut *mut DBPARAMINFO, ppnamesbuffer: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -4011,6 +4185,8 @@ pub trait ISQLErrorInfo_Impl: Sized {
     fn GetSQLInfo(&self, pbstrsqlstate: *mut super::super::Foundation::BSTR, plnativeerror: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISQLErrorInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISQLErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISQLErrorInfo_Impl, const OFFSET: isize>() -> ISQLErrorInfo_Vtbl {
         unsafe extern "system" fn GetSQLInfo<Identity: ::windows::core::IUnknownImpl, Impl: ISQLErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrsqlstate: *mut super::super::Foundation::BSTR, plnativeerror: *mut i32) -> ::windows::core::HRESULT {
@@ -4029,6 +4205,8 @@ pub trait ISQLGetDiagField_Impl: Sized {
     fn GetDiagField(&self, pdiaginfo: *mut KAGGETDIAG) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISQLGetDiagField {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISQLGetDiagField_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISQLGetDiagField_Impl, const OFFSET: isize>() -> ISQLGetDiagField_Vtbl {
         unsafe extern "system" fn GetDiagField<Identity: ::windows::core::IUnknownImpl, Impl: ISQLGetDiagField_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdiaginfo: *mut KAGGETDIAG) -> ::windows::core::HRESULT {
@@ -4045,6 +4223,7 @@ impl ISQLGetDiagField_Vtbl {
 pub trait ISQLRequestDiagFields_Impl: Sized {
     fn RequestDiagFields(&self, cdiagfields: u32, rgdiagfields: *const KAGREQDIAG) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISQLRequestDiagFields {}
 impl ISQLRequestDiagFields_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISQLRequestDiagFields_Impl, const OFFSET: isize>() -> ISQLRequestDiagFields_Vtbl {
         unsafe extern "system" fn RequestDiagFields<Identity: ::windows::core::IUnknownImpl, Impl: ISQLRequestDiagFields_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cdiagfields: u32, rgdiagfields: *const KAGREQDIAG) -> ::windows::core::HRESULT {
@@ -4061,6 +4240,7 @@ impl ISQLRequestDiagFields_Vtbl {
 pub trait ISQLServerErrorInfo_Impl: Sized {
     fn GetErrorInfo(&self, pperrorinfo: *mut *mut tagSSErrorInfo, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISQLServerErrorInfo {}
 impl ISQLServerErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISQLServerErrorInfo_Impl, const OFFSET: isize>() -> ISQLServerErrorInfo_Vtbl {
         unsafe extern "system" fn GetErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: ISQLServerErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pperrorinfo: *mut *mut tagSSErrorInfo, ppstringsbuffer: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -4077,6 +4257,7 @@ impl ISQLServerErrorInfo_Vtbl {
 pub trait ISchemaLocalizerSupport_Impl: Sized {
     fn Localize(&self, pszglobalstring: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISchemaLocalizerSupport {}
 impl ISchemaLocalizerSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaLocalizerSupport_Impl, const OFFSET: isize>() -> ISchemaLocalizerSupport_Vtbl {
         unsafe extern "system" fn Localize<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaLocalizerSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszglobalstring: ::windows::core::PCWSTR, ppszlocalstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -4101,6 +4282,8 @@ pub trait ISchemaLock_Impl: Sized {
     fn GetSchemaLock(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, lmmode: u32, phlockhandle: *mut super::super::Foundation::HANDLE, ptableversion: *mut u64) -> ::windows::core::Result<()>;
     fn ReleaseSchemaLock(&self, hlockhandle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
+impl ::windows::core::RuntimeName for ISchemaLock {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
 impl ISchemaLock_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaLock_Impl, const OFFSET: isize>() -> ISchemaLock_Vtbl {
@@ -4133,6 +4316,7 @@ pub trait ISchemaProvider_Impl: Sized {
     fn SaveBinary(&self, pszschemabinarypath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn LookupAuthoredNamedEntity(&self, pentity: &::core::option::Option<IEntity>, pszinputstring: &::windows::core::PCWSTR, ptokencollection: &::core::option::Option<ITokenCollection>, ctokensbegin: u32, pctokenslength: *mut u32, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISchemaProvider {}
 impl ISchemaProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaProvider_Impl, const OFFSET: isize>() -> ISchemaProvider_Vtbl {
         unsafe extern "system" fn Entities<Identity: ::windows::core::IUnknownImpl, Impl: ISchemaProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pentities: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4205,6 +4389,8 @@ pub trait IScopedOperations_Impl: Sized + IBindResource_Impl {
     fn OpenRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IScopedOperations {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IScopedOperations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScopedOperations_Impl, const OFFSET: isize>() -> IScopedOperations_Vtbl {
         unsafe extern "system" fn Copy<Identity: ::windows::core::IUnknownImpl, Impl: IScopedOperations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, crows: usize, rgpwszsourceurls: *const ::windows::core::PWSTR, rgpwszdesturls: *const ::windows::core::PWSTR, dwcopyflags: u32, pauthenticate: ::windows::core::RawPtr, rgdwstatus: *mut u32, rgpwsznewurls: *mut ::windows::core::PWSTR, ppstringsbuffer: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -4268,6 +4454,8 @@ pub trait ISearchCatalogManager_Impl: Sized {
     fn DiacriticSensitivity(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetCrawlScopeManager(&self) -> ::windows::core::Result<ISearchCrawlScopeManager>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISearchCatalogManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISearchCatalogManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCatalogManager_Impl, const OFFSET: isize>() -> ISearchCatalogManager_Vtbl {
@@ -4518,6 +4706,8 @@ pub trait ISearchCatalogManager2_Impl: Sized + ISearchCatalogManager_Impl {
     fn PrioritizeMatchingURLs(&self, pszpattern: &::windows::core::PCWSTR, dwprioritizeflags: PRIORITIZE_FLAGS) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISearchCatalogManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISearchCatalogManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCatalogManager2_Impl, const OFFSET: isize>() -> ISearchCatalogManager2_Vtbl {
         unsafe extern "system" fn PrioritizeMatchingURLs<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCatalogManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpattern: ::windows::core::PCWSTR, dwprioritizeflags: PRIORITIZE_FLAGS) -> ::windows::core::HRESULT {
@@ -4550,6 +4740,8 @@ pub trait ISearchCrawlScopeManager_Impl: Sized {
     fn GetParentScopeVersionId(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<i32>;
     fn RemoveDefaultScopeRule(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchCrawlScopeManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISearchCrawlScopeManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCrawlScopeManager_Impl, const OFFSET: isize>() -> ISearchCrawlScopeManager_Vtbl {
@@ -4698,6 +4890,8 @@ pub trait ISearchCrawlScopeManager2_Impl: Sized + ISearchCrawlScopeManager_Impl 
     fn GetVersion(&self, plversion: *mut *mut i32, phfilemapping: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchCrawlScopeManager2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISearchCrawlScopeManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCrawlScopeManager2_Impl, const OFFSET: isize>() -> ISearchCrawlScopeManager2_Vtbl {
         unsafe extern "system" fn GetVersion<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCrawlScopeManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plversion: *mut *mut i32, phfilemapping: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -4717,6 +4911,8 @@ pub trait ISearchItemsChangedSink_Impl: Sized {
     fn StoppedMonitoringScope(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn OnItemsChanged(&self, dwnumberofchanges: u32, rgdatachangeentries: *const SEARCH_ITEM_CHANGE, rgdwdocids: *mut u32, rghrcompletioncodes: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISearchItemsChangedSink {}
 #[cfg(feature = "Win32_System_Com")]
 impl ISearchItemsChangedSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchItemsChangedSink_Impl, const OFFSET: isize>() -> ISearchItemsChangedSink_Vtbl {
@@ -4754,6 +4950,8 @@ pub trait ISearchLanguageSupport_Impl: Sized {
     fn LoadStemmer(&self, lcid: u32, riid: *const ::windows::core::GUID, ppstemmer: *mut *mut ::core::ffi::c_void, plcidused: *mut u32) -> ::windows::core::Result<()>;
     fn IsPrefixNormalized(&self, pwcsquerytoken: &::windows::core::PCWSTR, cwcquerytoken: u32, pwcsdocumenttoken: &::windows::core::PCWSTR, cwcdocumenttoken: u32) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchLanguageSupport {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISearchLanguageSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchLanguageSupport_Impl, const OFFSET: isize>() -> ISearchLanguageSupport_Vtbl {
@@ -4823,6 +5021,8 @@ pub trait ISearchManager_Impl: Sized {
     fn LocalBypass(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn PortNumber(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISearchManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISearchManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchManager_Impl, const OFFSET: isize>() -> ISearchManager_Vtbl {
@@ -4972,6 +5172,8 @@ pub trait ISearchManager2_Impl: Sized + ISearchManager_Impl {
     fn DeleteCatalog(&self, pszcatalog: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISearchManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISearchManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchManager2_Impl, const OFFSET: isize>() -> ISearchManager2_Vtbl {
         unsafe extern "system" fn CreateCatalog<Identity: ::windows::core::IUnknownImpl, Impl: ISearchManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcatalog: ::windows::core::PCWSTR, ppcatalogmanager: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5004,6 +5206,7 @@ pub trait ISearchNotifyInlineSite_Impl: Sized {
     fn OnItemIndexedStatusChange(&self, sipstatus: SEARCH_INDEXING_PHASE, dwnumentries: u32, rgitemstatusentries: *const SEARCH_ITEM_INDEXING_STATUS) -> ::windows::core::Result<()>;
     fn OnCatalogStatusChange(&self, guidcatalogresetsignature: *const ::windows::core::GUID, guidcheckpointsignature: *const ::windows::core::GUID, dwlastcheckpointnumber: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISearchNotifyInlineSite {}
 impl ISearchNotifyInlineSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchNotifyInlineSite_Impl, const OFFSET: isize>() -> ISearchNotifyInlineSite_Vtbl {
         unsafe extern "system" fn OnItemIndexedStatusChange<Identity: ::windows::core::IUnknownImpl, Impl: ISearchNotifyInlineSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sipstatus: SEARCH_INDEXING_PHASE, dwnumentries: u32, rgitemstatusentries: *const SEARCH_ITEM_INDEXING_STATUS) -> ::windows::core::HRESULT {
@@ -5031,6 +5234,7 @@ pub trait ISearchPersistentItemsChangedSink_Impl: Sized {
     fn StoppedMonitoringScope(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn OnItemsChanged(&self, dwnumberofchanges: u32, datachangeentries: *const SEARCH_ITEM_PERSISTENT_CHANGE, hrcompletioncodes: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISearchPersistentItemsChangedSink {}
 impl ISearchPersistentItemsChangedSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchPersistentItemsChangedSink_Impl, const OFFSET: isize>() -> ISearchPersistentItemsChangedSink_Vtbl {
         unsafe extern "system" fn StartedMonitoringScope<Identity: ::windows::core::IUnknownImpl, Impl: ISearchPersistentItemsChangedSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -5066,6 +5270,8 @@ pub trait ISearchProtocol_Impl: Sized {
     fn CloseAccessor(&self, paccessor: &::core::option::Option<IUrlAccessor>) -> ::windows::core::Result<()>;
     fn ShutDown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchProtocol {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISearchProtocol_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchProtocol_Impl, const OFFSET: isize>() -> ISearchProtocol_Vtbl {
@@ -5106,6 +5312,8 @@ pub trait ISearchProtocol2_Impl: Sized + ISearchProtocol_Impl {
     fn CreateAccessorEx(&self, pcwszurl: &::windows::core::PCWSTR, pauthenticationinfo: *mut AUTHENTICATION_INFO, pincrementalaccessinfo: *mut INCREMENTAL_ACCESS_INFO, piteminfo: *mut ITEM_INFO, puserdata: *const super::Com::BLOB, ppaccessor: *mut ::core::option::Option<IUrlAccessor>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISearchProtocol2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISearchProtocol2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchProtocol2_Impl, const OFFSET: isize>() -> ISearchProtocol2_Vtbl {
         unsafe extern "system" fn CreateAccessorEx<Identity: ::windows::core::IUnknownImpl, Impl: ISearchProtocol2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcwszurl: ::windows::core::PCWSTR, pauthenticationinfo: *mut AUTHENTICATION_INFO, pincrementalaccessinfo: *mut INCREMENTAL_ACCESS_INFO, piteminfo: *mut ITEM_INFO, puserdata: *const super::Com::BLOB, ppaccessor: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5124,6 +5332,7 @@ pub trait ISearchProtocolThreadContext_Impl: Sized {
     fn ThreadShutdown(&self) -> ::windows::core::Result<()>;
     fn ThreadIdle(&self, dwtimeelaspedsincelastcallinms: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISearchProtocolThreadContext {}
 impl ISearchProtocolThreadContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchProtocolThreadContext_Impl, const OFFSET: isize>() -> ISearchProtocolThreadContext_Vtbl {
         unsafe extern "system" fn ThreadInit<Identity: ::windows::core::IUnknownImpl, Impl: ISearchProtocolThreadContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5176,6 +5385,8 @@ pub trait ISearchQueryHelper_Impl: Sized {
     fn SetQueryMaxResults(&self, cmaxresults: i32) -> ::windows::core::Result<()>;
     fn QueryMaxResults(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISearchQueryHelper {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISearchQueryHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchQueryHelper_Impl, const OFFSET: isize>() -> ISearchQueryHelper_Vtbl {
@@ -5386,6 +5597,8 @@ pub trait ISearchQueryHits_Impl: Sized {
     fn NextHitOffset(&self, pcregion: *mut u32, paregion: *mut *mut super::super::Storage::IndexServer::FILTERREGION) -> i32;
 }
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISearchQueryHits {}
+#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 impl ISearchQueryHits_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchQueryHits_Impl, const OFFSET: isize>() -> ISearchQueryHits_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: ISearchQueryHits_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pflt: ::windows::core::RawPtr, ulflags: u32) -> i32 {
@@ -5439,6 +5652,8 @@ pub trait ISearchRoot_Impl: Sized {
     fn SetPassword(&self, pszpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Password(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchRoot {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISearchRoot_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchRoot_Impl, const OFFSET: isize>() -> ISearchRoot_Vtbl {
@@ -5656,6 +5871,8 @@ pub trait ISearchScopeRule_Impl: Sized {
     fn FollowFlags(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchScopeRule {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISearchScopeRule_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchScopeRule_Impl, const OFFSET: isize>() -> ISearchScopeRule_Vtbl {
         unsafe extern "system" fn PatternOrURL<Identity: ::windows::core::IUnknownImpl, Impl: ISearchScopeRule_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszpatternorurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -5719,6 +5936,8 @@ pub trait ISearchViewChangedSink_Impl: Sized {
     fn OnChange(&self, pdwdocid: *const i32, pchange: *const SEARCH_ITEM_CHANGE, pfinview: *const super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISearchViewChangedSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISearchViewChangedSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchViewChangedSink_Impl, const OFFSET: isize>() -> ISearchViewChangedSink_Vtbl {
         unsafe extern "system" fn OnChange<Identity: ::windows::core::IUnknownImpl, Impl: ISearchViewChangedSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwdocid: *const i32, pchange: *const SEARCH_ITEM_CHANGE, pfinview: *const super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5738,6 +5957,8 @@ pub trait ISecurityInfo_Impl: Sized {
     fn GetObjectTypes(&self, cobjecttypes: *mut u32, rgobjecttypes: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetPermissions(&self, objecttype: &::windows::core::GUID, ppermissions: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Security_Authorization")]
+impl ::windows::core::RuntimeName for ISecurityInfo {}
 #[cfg(feature = "Win32_Security_Authorization")]
 impl ISecurityInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISecurityInfo_Impl, const OFFSET: isize>() -> ISecurityInfo_Vtbl {
@@ -5770,6 +5991,7 @@ impl ISecurityInfo_Vtbl {
 pub trait IService_Impl: Sized {
     fn InvokeService(&self, punkinner: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IService {}
 impl IService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IService_Impl, const OFFSET: isize>() -> IService_Vtbl {
         unsafe extern "system" fn InvokeService<Identity: ::windows::core::IUnknownImpl, Impl: IService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkinner: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5788,6 +6010,8 @@ pub trait ISessionProperties_Impl: Sized {
     fn GetProperties(&self, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
     fn SetProperties(&self, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISessionProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISessionProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISessionProperties_Impl, const OFFSET: isize>() -> ISessionProperties_Vtbl {
@@ -5816,6 +6040,7 @@ pub trait ISimpleCommandCreator_Impl: Sized {
     fn VerifyCatalog(&self, pwszmachine: &::windows::core::PCWSTR, pwszcatalogname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetDefaultCatalog(&self, pwszcatalogname: &::windows::core::PCWSTR, cwcin: u32, pcwcout: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISimpleCommandCreator {}
 impl ISimpleCommandCreator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleCommandCreator_Impl, const OFFSET: isize>() -> ISimpleCommandCreator_Vtbl {
         unsafe extern "system" fn CreateICommand<Identity: ::windows::core::IUnknownImpl, Impl: ISimpleCommandCreator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppiunknown: *mut *mut ::core::ffi::c_void, pouterunk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5849,6 +6074,8 @@ pub trait ISourcesRowset_Impl: Sized {
     fn GetSourcesRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, cpropertysets: u32, rgproperties: *mut DBPROPSET, ppsourcesrowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISourcesRowset {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISourcesRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISourcesRowset_Impl, const OFFSET: isize>() -> ISourcesRowset_Vtbl {
         unsafe extern "system" fn GetSourcesRowset<Identity: ::windows::core::IUnknownImpl, Impl: ISourcesRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, cpropertysets: u32, rgproperties: *mut DBPROPSET, ppsourcesrowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5868,6 +6095,8 @@ pub trait IStemmer_Impl: Sized {
     fn GenerateWordForms(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32, pstemsink: &::core::option::Option<IWordFormSink>) -> ::windows::core::Result<()>;
     fn GetLicenseToUse(&self, ppwcslicense: *const *const u16) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStemmer {}
 #[cfg(feature = "Win32_Foundation")]
 impl IStemmer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStemmer_Impl, const OFFSET: isize>() -> IStemmer_Vtbl {
@@ -5907,6 +6136,8 @@ pub trait ISubscriptionItem_Impl: Sized {
     fn EnumProperties(&self) -> ::windows::core::Result<IEnumItemProperties>;
     fn NotifyChanged(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISubscriptionItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISubscriptionItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISubscriptionItem_Impl, const OFFSET: isize>() -> ISubscriptionItem_Vtbl {
@@ -5989,6 +6220,8 @@ pub trait ISubscriptionMgr_Impl: Sized {
     fn ShowSubscriptionProperties(&self, pwszurl: &::windows::core::PCWSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn CreateSubscription(&self, hwnd: super::super::Foundation::HWND, pwszurl: &::windows::core::PCWSTR, pwszfriendlyname: &::windows::core::PCWSTR, dwflags: u32, substype: SUBSCRIPTIONTYPE, pinfo: *mut SUBSCRIPTIONINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISubscriptionMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISubscriptionMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISubscriptionMgr_Impl, const OFFSET: isize>() -> ISubscriptionMgr_Vtbl {
@@ -6077,6 +6310,8 @@ pub trait ISubscriptionMgr2_Impl: Sized + ISubscriptionMgr_Impl {
     fn AbortAll(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISubscriptionMgr2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISubscriptionMgr2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISubscriptionMgr2_Impl, const OFFSET: isize>() -> ISubscriptionMgr2_Vtbl {
         unsafe extern "system" fn GetItemFromURL<Identity: ::windows::core::IUnknownImpl, Impl: ISubscriptionMgr2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, ppsubscriptionitem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6152,6 +6387,8 @@ pub trait ITableCreation_Impl: Sized + ITableDefinition_Impl {
     fn GetTableDefinition(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pccolumndescs: *mut usize, prgcolumndescs: *mut *mut DBCOLUMNDESC, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET, pcconstraintdescs: *mut u32, prgconstraintdescs: *mut *mut DBCONSTRAINTDESC, ppwszstringbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITableCreation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITableCreation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableCreation_Impl, const OFFSET: isize>() -> ITableCreation_Vtbl {
         unsafe extern "system" fn GetTableDefinition<Identity: ::windows::core::IUnknownImpl, Impl: ITableCreation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptableid: *const super::super::Storage::IndexServer::DBID, pccolumndescs: *mut usize, prgcolumndescs: *mut *mut DBCOLUMNDESC, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET, pcconstraintdescs: *mut u32, prgconstraintdescs: *mut *mut DBCONSTRAINTDESC, ppwszstringbuffer: *mut *mut u16) -> ::windows::core::HRESULT {
@@ -6172,6 +6409,8 @@ pub trait ITableDefinition_Impl: Sized {
     fn AddColumn(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pcolumndesc: *const DBCOLUMNDESC) -> ::windows::core::Result<*mut super::super::Storage::IndexServer::DBID>;
     fn DropColumn(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pcolumnid: *const super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITableDefinition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITableDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableDefinition_Impl, const OFFSET: isize>() -> ITableDefinition_Vtbl {
@@ -6220,6 +6459,8 @@ pub trait ITableDefinitionWithConstraints_Impl: Sized + ITableDefinition_Impl + 
     fn DropConstraint(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pconstraintid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITableDefinitionWithConstraints {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITableDefinitionWithConstraints_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableDefinitionWithConstraints_Impl, const OFFSET: isize>() -> ITableDefinitionWithConstraints_Vtbl {
         unsafe extern "system" fn AddConstraint<Identity: ::windows::core::IUnknownImpl, Impl: ITableDefinitionWithConstraints_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, pconstraintdesc: *mut DBCONSTRAINTDESC) -> ::windows::core::HRESULT {
@@ -6256,6 +6497,8 @@ pub trait ITableRename_Impl: Sized {
     fn RenameTable(&self, poldtableid: *mut super::super::Storage::IndexServer::DBID, poldindexid: *mut super::super::Storage::IndexServer::DBID, pnewtableid: *mut super::super::Storage::IndexServer::DBID, pnewindexid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for ITableRename {}
+#[cfg(feature = "Win32_Storage_IndexServer")]
 impl ITableRename_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableRename_Impl, const OFFSET: isize>() -> ITableRename_Vtbl {
         unsafe extern "system" fn RenameColumn<Identity: ::windows::core::IUnknownImpl, Impl: ITableRename_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, poldcolumnid: *mut super::super::Storage::IndexServer::DBID, pnewcolumnid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT {
@@ -6282,6 +6525,7 @@ pub trait ITokenCollection_Impl: Sized {
     fn NumberOfTokens(&self, pcount: *const u32) -> ::windows::core::Result<()>;
     fn GetToken(&self, i: u32, pbegin: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITokenCollection {}
 impl ITokenCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITokenCollection_Impl, const OFFSET: isize>() -> ITokenCollection_Vtbl {
         unsafe extern "system" fn NumberOfTokens<Identity: ::windows::core::IUnknownImpl, Impl: ITokenCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *const u32) -> ::windows::core::HRESULT {
@@ -6309,6 +6553,8 @@ pub trait ITransactionJoin_Impl: Sized {
     fn GetOptionsObject(&self) -> ::windows::core::Result<super::DistributedTransactionCoordinator::ITransactionOptions>;
     fn JoinTransaction(&self, punktransactioncoord: &::core::option::Option<::windows::core::IUnknown>, isolevel: i32, isoflags: u32, potheroptions: &::core::option::Option<super::DistributedTransactionCoordinator::ITransactionOptions>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
+impl ::windows::core::RuntimeName for ITransactionJoin {}
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 impl ITransactionJoin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionJoin_Impl, const OFFSET: isize>() -> ITransactionJoin_Vtbl {
@@ -6343,6 +6589,8 @@ pub trait ITransactionLocal_Impl: Sized + super::DistributedTransactionCoordinat
     fn GetOptionsObject(&self) -> ::windows::core::Result<super::DistributedTransactionCoordinator::ITransactionOptions>;
     fn StartTransaction(&self, isolevel: i32, isoflags: u32, potheroptions: &::core::option::Option<super::DistributedTransactionCoordinator::ITransactionOptions>) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_DistributedTransactionCoordinator"))]
+impl ::windows::core::RuntimeName for ITransactionLocal {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_DistributedTransactionCoordinator"))]
 impl ITransactionLocal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionLocal_Impl, const OFFSET: isize>() -> ITransactionLocal_Vtbl {
@@ -6383,6 +6631,8 @@ pub trait ITransactionObject_Impl: Sized {
     fn GetTransactionObject(&self, ultransactionlevel: u32) -> ::windows::core::Result<super::DistributedTransactionCoordinator::ITransaction>;
 }
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
+impl ::windows::core::RuntimeName for ITransactionObject {}
+#[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 impl ITransactionObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionObject_Impl, const OFFSET: isize>() -> ITransactionObject_Vtbl {
         unsafe extern "system" fn GetTransactionObject<Identity: ::windows::core::IUnknownImpl, Impl: ITransactionObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ultransactionlevel: u32, pptransactionobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6410,6 +6660,8 @@ pub trait ITrusteeAdmin_Impl: Sized {
     fn SetTrusteeProperties(&self, ptrustee: *mut super::super::Security::Authorization::TRUSTEE_W, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
     fn GetTrusteeProperties(&self, ptrustee: *mut super::super::Security::Authorization::TRUSTEE_W, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITrusteeAdmin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITrusteeAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITrusteeAdmin_Impl, const OFFSET: isize>() -> ITrusteeAdmin_Vtbl {
@@ -6460,6 +6712,8 @@ pub trait ITrusteeGroupAdmin_Impl: Sized {
     fn GetMemberships(&self, ptrustee: *mut super::super::Security::Authorization::TRUSTEE_W, pcmemberships: *mut u32, prgmemberships: *mut *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization"))]
+impl ::windows::core::RuntimeName for ITrusteeGroupAdmin {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization"))]
 impl ITrusteeGroupAdmin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITrusteeGroupAdmin_Impl, const OFFSET: isize>() -> ITrusteeGroupAdmin_Vtbl {
         unsafe extern "system" fn AddMember<Identity: ::windows::core::IUnknownImpl, Impl: ITrusteeGroupAdmin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmembershiptrustee: *mut super::super::Security::Authorization::TRUSTEE_W, pmembertrustee: *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::HRESULT {
@@ -6509,6 +6763,8 @@ pub trait IUMS_Impl: Sized {
     fn SqlUmsFIsPremptive(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUMS {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUMS_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUMS_Impl, const OFFSET: isize>() -> IUMS_Vtbl {
         unsafe extern "system" fn SqlUmsSuspend<Identity: ::windows::core::IUnknownImpl, Impl: IUMS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ticks: u32) {
@@ -6551,6 +6807,7 @@ impl IUMS_Vtbl {
 pub trait IUMSInitialize_Impl: Sized {
     fn Initialize(&self, pums: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUMSInitialize {}
 impl IUMSInitialize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUMSInitialize_Impl, const OFFSET: isize>() -> IUMSInitialize_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IUMSInitialize_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pums: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6580,6 +6837,8 @@ pub trait IUrlAccessor_Impl: Sized {
     fn BindToStream(&self) -> ::windows::core::Result<super::Com::IStream>;
     fn BindToFilter(&self) -> ::windows::core::Result<super::super::Storage::IndexServer::IFilter>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IUrlAccessor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl IUrlAccessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUrlAccessor_Impl, const OFFSET: isize>() -> IUrlAccessor_Vtbl {
@@ -6712,6 +6971,8 @@ pub trait IUrlAccessor2_Impl: Sized + IUrlAccessor_Impl {
     fn GetCodePage(&self, wszcodepage: ::windows::core::PWSTR, dwsize: u32, pdwlength: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IUrlAccessor2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl IUrlAccessor2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUrlAccessor2_Impl, const OFFSET: isize>() -> IUrlAccessor2_Vtbl {
         unsafe extern "system" fn GetDisplayUrl<Identity: ::windows::core::IUnknownImpl, Impl: IUrlAccessor2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszdocurl: ::windows::core::PWSTR, dwsize: u32, pdwlength: *mut u32) -> ::windows::core::HRESULT {
@@ -6745,6 +7006,8 @@ pub trait IUrlAccessor3_Impl: Sized + IUrlAccessor_Impl + IUrlAccessor2_Impl {
     fn GetImpersonationSidBlobs(&self, pcwszurl: &::windows::core::PCWSTR, pcsidcount: *mut u32, ppsidblobs: *mut *mut super::Com::BLOB) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IUrlAccessor3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 impl IUrlAccessor3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUrlAccessor3_Impl, const OFFSET: isize>() -> IUrlAccessor3_Vtbl {
         unsafe extern "system" fn GetImpersonationSidBlobs<Identity: ::windows::core::IUnknownImpl, Impl: IUrlAccessor3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcwszurl: ::windows::core::PCWSTR, pcsidcount: *mut u32, ppsidblobs: *mut *mut super::Com::BLOB) -> ::windows::core::HRESULT {
@@ -6763,6 +7026,8 @@ pub trait IUrlAccessor4_Impl: Sized + IUrlAccessor_Impl + IUrlAccessor2_Impl + I
     fn ShouldIndexItemContent(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn ShouldIndexProperty(&self, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IUrlAccessor4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IUrlAccessor4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUrlAccessor4_Impl, const OFFSET: isize>() -> IUrlAccessor4_Vtbl {
@@ -6802,6 +7067,7 @@ pub trait IViewChapter_Impl: Sized {
     fn GetSpecification(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn OpenViewChapter(&self, hsource: usize) -> ::windows::core::Result<usize>;
 }
+impl ::windows::core::RuntimeName for IViewChapter {}
 impl IViewChapter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewChapter_Impl, const OFFSET: isize>() -> IViewChapter_Vtbl {
         unsafe extern "system" fn GetSpecification<Identity: ::windows::core::IUnknownImpl, Impl: IViewChapter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6843,6 +7109,8 @@ pub trait IViewFilter_Impl: Sized {
     fn SetFilter(&self, haccessor: usize, crows: usize, compareops: *const u32, pcriteriadata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IViewFilter {}
+#[cfg(feature = "Win32_System_Com")]
 impl IViewFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewFilter_Impl, const OFFSET: isize>() -> IViewFilter_Vtbl {
         unsafe extern "system" fn GetFilter<Identity: ::windows::core::IUnknownImpl, Impl: IViewFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, haccessor: usize, pcrows: *mut usize, pcompareops: *mut *mut u32, pcriteriadata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6875,6 +7143,7 @@ pub trait IViewRowset_Impl: Sized {
     fn GetSpecification(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn OpenViewRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IViewRowset {}
 impl IViewRowset_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewRowset_Impl, const OFFSET: isize>() -> IViewRowset_Vtbl {
         unsafe extern "system" fn GetSpecification<Identity: ::windows::core::IUnknownImpl, Impl: IViewRowset_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6913,6 +7182,7 @@ pub trait IViewSort_Impl: Sized {
     fn GetSortOrder(&self, pcvalues: *mut usize, prgcolumns: *mut *mut usize, prgorders: *mut *mut u32) -> ::windows::core::Result<()>;
     fn SetSortOrder(&self, cvalues: usize, rgcolumns: *const usize, rgorders: *const u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IViewSort {}
 impl IViewSort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewSort_Impl, const OFFSET: isize>() -> IViewSort_Vtbl {
         unsafe extern "system" fn GetSortOrder<Identity: ::windows::core::IUnknownImpl, Impl: IViewSort_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcvalues: *mut usize, prgcolumns: *mut *mut usize, prgorders: *mut *mut u32) -> ::windows::core::HRESULT {
@@ -6942,6 +7212,8 @@ pub trait IWordBreaker_Impl: Sized {
     fn ComposePhrase(&self, pwcnoun: &::windows::core::PCWSTR, cwcnoun: u32, pwcmodifier: &::windows::core::PCWSTR, cwcmodifier: u32, ulattachmenttype: u32, pwcphrase: &::windows::core::PCWSTR, pcwcphrase: *mut u32) -> ::windows::core::Result<()>;
     fn GetLicenseToUse(&self, ppwcslicense: *const *const u16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
+impl ::windows::core::RuntimeName for IWordBreaker {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
 impl IWordBreaker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWordBreaker_Impl, const OFFSET: isize>() -> IWordBreaker_Vtbl {
@@ -6981,6 +7253,7 @@ pub trait IWordFormSink_Impl: Sized {
     fn PutAltWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
     fn PutWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWordFormSink {}
 impl IWordFormSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWordFormSink_Impl, const OFFSET: isize>() -> IWordFormSink_Vtbl {
         unsafe extern "system" fn PutAltWord<Identity: ::windows::core::IUnknownImpl, Impl: IWordFormSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwcinbuf: ::windows::core::PCWSTR, cwc: u32) -> ::windows::core::HRESULT {
@@ -7011,6 +7284,8 @@ pub trait IWordSink_Impl: Sized {
     fn EndAltPhrase(&self) -> ::windows::core::Result<()>;
     fn PutBreak(&self, breaktype: super::super::Storage::IndexServer::WORDREP_BREAK_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Storage_IndexServer")]
+impl ::windows::core::RuntimeName for IWordSink {}
 #[cfg(feature = "Win32_Storage_IndexServer")]
 impl IWordSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWordSink_Impl, const OFFSET: isize>() -> IWordSink_Vtbl {
@@ -7069,6 +7344,8 @@ pub trait OLEDBSimpleProvider_Impl: Sized {
     fn getEstimatedRows(&self) -> ::windows::core::Result<isize>;
     fn stopTransfer(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for OLEDBSimpleProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl OLEDBSimpleProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: OLEDBSimpleProvider_Impl, const OFFSET: isize>() -> OLEDBSimpleProvider_Vtbl {
@@ -7234,6 +7511,7 @@ pub trait OLEDBSimpleProviderListener_Impl: Sized {
     fn rowsAvailable(&self, irow: isize, crows: isize) -> ::windows::core::Result<()>;
     fn transferComplete(&self, xfer: OSPXFER) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for OLEDBSimpleProviderListener {}
 impl OLEDBSimpleProviderListener_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: OLEDBSimpleProviderListener_Impl, const OFFSET: isize>() -> OLEDBSimpleProviderListener_Vtbl {
         unsafe extern "system" fn aboutToChangeCell<Identity: ::windows::core::IUnknownImpl, Impl: OLEDBSimpleProviderListener_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, irow: isize, icolumn: isize) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/impl.rs
@@ -3,6 +3,8 @@ pub trait IWSCDefaultProduct_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetDefaultProduct(&self, etype: SECURITY_PRODUCT_TYPE, pguid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSCDefaultProduct {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSCDefaultProduct_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSCDefaultProduct_Impl, const OFFSET: isize>() -> IWSCDefaultProduct_Vtbl {
         unsafe extern "system" fn SetDefaultProduct<Identity: ::windows::core::IUnknownImpl, Impl: IWSCDefaultProduct_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, etype: SECURITY_PRODUCT_TYPE, pguid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -22,6 +24,8 @@ pub trait IWSCProductList_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
     fn get_Item(&self, index: u32) -> ::windows::core::Result<IWscProduct>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWSCProductList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWSCProductList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWSCProductList_Impl, const OFFSET: isize>() -> IWSCProductList_Vtbl {
@@ -73,6 +77,8 @@ pub trait IWscProduct_Impl: Sized + super::Com::IDispatch_Impl {
     fn ProductGuid(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn ProductIsDefault(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWscProduct {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWscProduct_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWscProduct_Impl, const OFFSET: isize>() -> IWscProduct_Vtbl {
@@ -178,6 +184,8 @@ pub trait IWscProduct2_Impl: Sized + super::Com::IDispatch_Impl + IWscProduct_Im
     fn FirewallPublicProfileSubstatus(&self) -> ::windows::core::Result<WSC_SECURITY_PRODUCT_SUBSTATUS>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWscProduct2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWscProduct2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWscProduct2_Impl, const OFFSET: isize>() -> IWscProduct2_Vtbl {
         unsafe extern "system" fn AntivirusScanSubstatus<Identity: ::windows::core::IUnknownImpl, Impl: IWscProduct2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pestatus: *mut WSC_SECURITY_PRODUCT_SUBSTATUS) -> ::windows::core::HRESULT {
@@ -264,6 +272,8 @@ impl IWscProduct2_Vtbl {
 pub trait IWscProduct3_Impl: Sized + super::Com::IDispatch_Impl + IWscProduct_Impl + IWscProduct2_Impl {
     fn AntivirusDaysUntilExpired(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWscProduct3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWscProduct3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWscProduct3_Impl, const OFFSET: isize>() -> IWscProduct3_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
@@ -2,6 +2,7 @@ pub trait IWsbApplicationAsync_Impl: Sized {
     fn QueryStatus(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
     fn Abort(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWsbApplicationAsync {}
 impl IWsbApplicationAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWsbApplicationAsync_Impl, const OFFSET: isize>() -> IWsbApplicationAsync_Vtbl {
         unsafe extern "system" fn QueryStatus<Identity: ::windows::core::IUnknownImpl, Impl: IWsbApplicationAsync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phrresult: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -33,6 +34,7 @@ impl IWsbApplicationAsync_Vtbl {
 pub trait IWsbApplicationBackupSupport_Impl: Sized {
     fn CheckConsistency(&self, wszwritermetadata: &::windows::core::PCWSTR, wszcomponentname: &::windows::core::PCWSTR, wszcomponentlogicalpath: &::windows::core::PCWSTR, cvolumes: u32, rgwszsourcevolumepath: *const ::windows::core::PWSTR, rgwszsnapshotvolumepath: *const ::windows::core::PWSTR) -> ::windows::core::Result<IWsbApplicationAsync>;
 }
+impl ::windows::core::RuntimeName for IWsbApplicationBackupSupport {}
 impl IWsbApplicationBackupSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWsbApplicationBackupSupport_Impl, const OFFSET: isize>() -> IWsbApplicationBackupSupport_Vtbl {
         unsafe extern "system" fn CheckConsistency<Identity: ::windows::core::IUnknownImpl, Impl: IWsbApplicationBackupSupport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszwritermetadata: ::windows::core::PCWSTR, wszcomponentname: ::windows::core::PCWSTR, wszcomponentlogicalpath: ::windows::core::PCWSTR, cvolumes: u32, rgwszsourcevolumepath: *const ::windows::core::PWSTR, rgwszsnapshotvolumepath: *const ::windows::core::PWSTR, ppasync: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -59,6 +61,8 @@ pub trait IWsbApplicationRestoreSupport_Impl: Sized {
     fn OrderComponents(&self, ccomponents: u32, rgcomponentname: *const ::windows::core::PWSTR, rgcomponentlogicalpaths: *const ::windows::core::PWSTR, prgcomponentname: *mut *mut ::windows::core::PWSTR, prgcomponentlogicalpath: *mut *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn IsRollForwardSupported(&self) -> ::windows::core::Result<u8>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWsbApplicationRestoreSupport {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWsbApplicationRestoreSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWsbApplicationRestoreSupport_Impl, const OFFSET: isize>() -> IWsbApplicationRestoreSupport_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
@@ -5,6 +5,8 @@ pub trait IItemEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IItemEnumerator {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IItemEnumerator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IItemEnumerator_Impl, const OFFSET: isize>() -> IItemEnumerator_Vtbl {
         unsafe extern "system" fn Current<Identity: ::windows::core::IUnknownImpl, Impl: IItemEnumerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, item: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -55,6 +57,8 @@ pub trait ISettingsContext_Impl: Sized {
     fn GetStoredSettings(&self, pidentity: &::core::option::Option<ISettingsIdentity>, ppaddedsettings: *mut ::core::option::Option<IItemEnumerator>, ppmodifiedsettings: *mut ::core::option::Option<IItemEnumerator>, ppdeletedsettings: *mut ::core::option::Option<IItemEnumerator>) -> ::windows::core::Result<()>;
     fn RevertSetting(&self, pidentity: &::core::option::Option<ISettingsIdentity>, pwzsetting: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISettingsContext {}
 #[cfg(feature = "Win32_System_Com")]
 impl ISettingsContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsContext_Impl, const OFFSET: isize>() -> ISettingsContext_Vtbl {
@@ -139,6 +143,8 @@ pub trait ISettingsEngine_Impl: Sized {
     fn ApplySettingsContext(&self, settingscontext: &::core::option::Option<ISettingsContext>, pppwzidentities: *mut *mut ::windows::core::PWSTR, pcidentities: *mut usize) -> ::windows::core::Result<()>;
     fn GetSettingsContext(&self) -> ::windows::core::Result<ISettingsContext>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISettingsEngine {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISettingsEngine_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsEngine_Impl, const OFFSET: isize>() -> ISettingsEngine_Vtbl {
@@ -314,6 +320,8 @@ pub trait ISettingsIdentity_Impl: Sized {
     fn SetFlags(&self, flags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISettingsIdentity {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISettingsIdentity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsIdentity_Impl, const OFFSET: isize>() -> ISettingsIdentity_Vtbl {
         unsafe extern "system" fn GetAttribute<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsIdentity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, reserved: *const ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -385,6 +393,8 @@ pub trait ISettingsItem_Impl: Sized {
     fn GetRestriction(&self, restrictionfacet: WcmRestrictionFacets) -> ::windows::core::Result<super::Com::VARIANT>;
     fn GetKeyValue(&self) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISettingsItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISettingsItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsItem_Impl, const OFFSET: isize>() -> ISettingsItem_Vtbl {
@@ -635,6 +645,8 @@ pub trait ISettingsNamespace_Impl: Sized {
     fn GetAttribute(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<super::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISettingsNamespace {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISettingsNamespace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsNamespace_Impl, const OFFSET: isize>() -> ISettingsNamespace_Vtbl {
         unsafe extern "system" fn GetIdentity<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsNamespace_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, settingsid: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -732,6 +744,8 @@ pub trait ISettingsResult_Impl: Sized {
     fn GetColumn(&self) -> ::windows::core::Result<u32>;
     fn GetSource(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISettingsResult {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISettingsResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsResult_Impl, const OFFSET: isize>() -> ISettingsResult_Vtbl {
@@ -839,6 +853,8 @@ pub trait ITargetInfo_Impl: Sized {
     fn SetSchemaHiveMountName(&self, pwzmountname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetSchemaHiveMountName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITargetInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITargetInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITargetInfo_Impl, const OFFSET: isize>() -> ITargetInfo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
@@ -3,6 +3,8 @@ pub trait ISideShowBulkCapabilities_Impl: Sized + ISideShowCapabilities_Impl {
     fn GetCapabilities(&self, in_keycollection: &::core::option::Option<ISideShowKeyCollection>, inout_pvalues: *mut ::core::option::Option<ISideShowPropVariantCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISideShowBulkCapabilities {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISideShowBulkCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowBulkCapabilities_Impl, const OFFSET: isize>() -> ISideShowBulkCapabilities_Vtbl {
         unsafe extern "system" fn GetCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowBulkCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, in_keycollection: ::windows::core::RawPtr, inout_pvalues: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21,6 +23,8 @@ pub trait ISideShowCapabilities_Impl: Sized {
     fn GetCapability(&self, in_keycapability: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, inout_pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISideShowCapabilities {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISideShowCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowCapabilities_Impl, const OFFSET: isize>() -> ISideShowCapabilities_Vtbl {
         unsafe extern "system" fn GetCapability<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, in_keycapability: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, inout_pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -38,6 +42,7 @@ pub trait ISideShowCapabilitiesCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, in_dwindex: u32) -> ::windows::core::Result<ISideShowCapabilities>;
 }
+impl ::windows::core::RuntimeName for ISideShowCapabilitiesCollection {}
 impl ISideShowCapabilitiesCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowCapabilitiesCollection_Impl, const OFFSET: isize>() -> ISideShowCapabilitiesCollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowCapabilitiesCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, out_pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -78,6 +83,8 @@ pub trait ISideShowContent_Impl: Sized {
     fn ContentId(&self) -> ::windows::core::Result<u32>;
     fn DifferentiateContent(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISideShowContent {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISideShowContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowContent_Impl, const OFFSET: isize>() -> ISideShowContent_Vtbl {
@@ -126,6 +133,7 @@ pub trait ISideShowContentManager_Impl: Sized {
     fn SetEventSink(&self, in_pievents: &::core::option::Option<ISideShowEvents>) -> ::windows::core::Result<()>;
     fn GetDeviceCapabilities(&self) -> ::windows::core::Result<ISideShowCapabilitiesCollection>;
 }
+impl ::windows::core::RuntimeName for ISideShowContentManager {}
 impl ISideShowContentManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowContentManager_Impl, const OFFSET: isize>() -> ISideShowContentManager_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowContentManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, in_picontent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -178,6 +186,7 @@ pub trait ISideShowEvents_Impl: Sized {
     fn DeviceAdded(&self, in_pidevice: &::core::option::Option<ISideShowCapabilities>) -> ::windows::core::Result<()>;
     fn DeviceRemoved(&self, in_pidevice: &::core::option::Option<ISideShowCapabilities>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISideShowEvents {}
 impl ISideShowEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowEvents_Impl, const OFFSET: isize>() -> ISideShowEvents_Vtbl {
         unsafe extern "system" fn ContentMissing<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, in_contentid: u32, out_ppicontent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -226,6 +235,8 @@ pub trait ISideShowKeyCollection_Impl: Sized {
     fn GetCount(&self, pcelems: *const u32) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, dwindex: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for ISideShowKeyCollection {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ISideShowKeyCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowKeyCollection_Impl, const OFFSET: isize>() -> ISideShowKeyCollection_Vtbl {
@@ -280,6 +291,8 @@ pub trait ISideShowNotification_Impl: Sized {
     fn ExpirationTime(&self) -> ::windows::core::Result<super::super::Foundation::SYSTEMTIME>;
     fn SetExpirationTime(&self, in_ptime: *const super::super::Foundation::SYSTEMTIME) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ISideShowNotification {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ISideShowNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowNotification_Impl, const OFFSET: isize>() -> ISideShowNotification_Vtbl {
@@ -386,6 +399,7 @@ pub trait ISideShowNotificationManager_Impl: Sized {
     fn Revoke(&self, in_notificationid: u32) -> ::windows::core::Result<()>;
     fn RevokeAll(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISideShowNotificationManager {}
 impl ISideShowNotificationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowNotificationManager_Impl, const OFFSET: isize>() -> ISideShowNotificationManager_Vtbl {
         unsafe extern "system" fn Show<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowNotificationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, in_pinotification: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -422,6 +436,8 @@ pub trait ISideShowPropVariantCollection_Impl: Sized {
     fn GetCount(&self, pcelems: *const u32) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, dwindex: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for ISideShowPropVariantCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl ISideShowPropVariantCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowPropVariantCollection_Impl, const OFFSET: isize>() -> ISideShowPropVariantCollection_Vtbl {
@@ -467,6 +483,7 @@ pub trait ISideShowSession_Impl: Sized {
     fn RegisterContent(&self, in_applicationid: *const ::windows::core::GUID, in_endpointid: *const ::windows::core::GUID) -> ::windows::core::Result<ISideShowContentManager>;
     fn RegisterNotifications(&self, in_applicationid: *const ::windows::core::GUID) -> ::windows::core::Result<ISideShowNotificationManager>;
 }
+impl ::windows::core::RuntimeName for ISideShowSession {}
 impl ISideShowSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowSession_Impl, const OFFSET: isize>() -> ISideShowSession_Vtbl {
         unsafe extern "system" fn RegisterContent<Identity: ::windows::core::IUnknownImpl, Impl: ISideShowSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, in_applicationid: *const ::windows::core::GUID, in_endpointid: *const ::windows::core::GUID, out_ppicontent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
@@ -5,6 +5,8 @@ pub trait IAction_Impl: Sized + super::Com::IDispatch_Impl {
     fn Type(&self, ptype: *mut TASK_ACTION_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAction_Impl, const OFFSET: isize>() -> IAction_Vtbl {
         unsafe extern "system" fn Id<Identity: ::windows::core::IUnknownImpl, Impl: IAction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -46,6 +48,8 @@ pub trait IActionCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Context(&self, pcontext: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetContext(&self, context: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IActionCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IActionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActionCollection_Impl, const OFFSET: isize>() -> IActionCollection_Vtbl {
@@ -141,6 +145,8 @@ pub trait IBootTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Impl 
     fn SetDelay(&self, delay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IBootTrigger {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IBootTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBootTrigger_Impl, const OFFSET: isize>() -> IBootTrigger_Vtbl {
         unsafe extern "system" fn Delay<Identity: ::windows::core::IUnknownImpl, Impl: IBootTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -166,6 +172,8 @@ pub trait IComHandlerAction_Impl: Sized + super::Com::IDispatch_Impl + IAction_I
     fn Data(&self, pdata: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetData(&self, data: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComHandlerAction {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComHandlerAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComHandlerAction_Impl, const OFFSET: isize>() -> IComHandlerAction_Vtbl {
@@ -208,6 +216,8 @@ pub trait IDailyTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Impl
     fn RandomDelay(&self, prandomdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetRandomDelay(&self, randomdelay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDailyTrigger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDailyTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDailyTrigger_Impl, const OFFSET: isize>() -> IDailyTrigger_Vtbl {
@@ -266,6 +276,8 @@ pub trait IEmailAction_Impl: Sized + super::Com::IDispatch_Impl + IAction_Impl {
     fn Attachments(&self, pattachements: *mut *mut super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn SetAttachments(&self, pattachements: *mut super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEmailAction {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEmailAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEmailAction_Impl, const OFFSET: isize>() -> IEmailAction_Vtbl {
@@ -409,6 +421,7 @@ pub trait IEnumWorkItems_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumWorkItems>;
 }
+impl ::windows::core::RuntimeName for IEnumWorkItems {}
 impl IEnumWorkItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWorkItems_Impl, const OFFSET: isize>() -> IEnumWorkItems_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWorkItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgpwsznames: *mut *mut ::windows::core::PWSTR, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -458,6 +471,8 @@ pub trait IEventTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Impl
     fn ValueQueries(&self) -> ::windows::core::Result<ITaskNamedValueCollection>;
     fn SetValueQueries(&self, pnamedxpaths: &::core::option::Option<ITaskNamedValueCollection>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEventTrigger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEventTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEventTrigger_Impl, const OFFSET: isize>() -> IEventTrigger_Vtbl {
@@ -521,6 +536,8 @@ pub trait IExecAction_Impl: Sized + super::Com::IDispatch_Impl + IAction_Impl {
     fn SetWorkingDirectory(&self, workingdirectory: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IExecAction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IExecAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExecAction_Impl, const OFFSET: isize>() -> IExecAction_Vtbl {
         unsafe extern "system" fn Path<Identity: ::windows::core::IUnknownImpl, Impl: IExecAction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppath: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -573,6 +590,8 @@ pub trait IExecAction2_Impl: Sized + super::Com::IDispatch_Impl + IAction_Impl +
     fn SetHideAppWindow(&self, hideappwindow: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IExecAction2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IExecAction2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExecAction2_Impl, const OFFSET: isize>() -> IExecAction2_Vtbl {
         unsafe extern "system" fn HideAppWindow<Identity: ::windows::core::IUnknownImpl, Impl: IExecAction2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phideappwindow: *mut i16) -> ::windows::core::HRESULT {
@@ -606,6 +625,8 @@ pub trait IIdleSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn RestartOnIdle(&self, prestart: *mut i16) -> ::windows::core::Result<()>;
     fn SetRestartOnIdle(&self, restart: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IIdleSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IIdleSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdleSettings_Impl, const OFFSET: isize>() -> IIdleSettings_Vtbl {
@@ -668,6 +689,8 @@ impl IIdleSettings_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IIdleTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IIdleTrigger {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IIdleTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdleTrigger_Impl, const OFFSET: isize>() -> IIdleTrigger_Vtbl {
         Self { base__: ITrigger_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -683,6 +706,8 @@ pub trait ILogonTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Impl
     fn UserId(&self, puser: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetUserId(&self, user: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ILogonTrigger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ILogonTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILogonTrigger_Impl, const OFFSET: isize>() -> ILogonTrigger_Vtbl {
@@ -727,6 +752,8 @@ pub trait IMaintenanceSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetExclusive(&self, value: i16) -> ::windows::core::Result<()>;
     fn Exclusive(&self, target: *mut i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMaintenanceSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMaintenanceSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMaintenanceSettings_Impl, const OFFSET: isize>() -> IMaintenanceSettings_Vtbl {
@@ -787,6 +814,8 @@ pub trait IMonthlyDOWTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger
     fn RandomDelay(&self, prandomdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetRandomDelay(&self, randomdelay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMonthlyDOWTrigger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMonthlyDOWTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMonthlyDOWTrigger_Impl, const OFFSET: isize>() -> IMonthlyDOWTrigger_Vtbl {
@@ -870,6 +899,8 @@ pub trait IMonthlyTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Im
     fn SetRandomDelay(&self, randomdelay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMonthlyTrigger {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMonthlyTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMonthlyTrigger_Impl, const OFFSET: isize>() -> IMonthlyTrigger_Vtbl {
         unsafe extern "system" fn DaysOfMonth<Identity: ::windows::core::IUnknownImpl, Impl: IMonthlyTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdays: *mut i32) -> ::windows::core::HRESULT {
@@ -936,6 +967,8 @@ pub trait INetworkSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetId(&self, id: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INetworkSettings {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INetworkSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkSettings_Impl, const OFFSET: isize>() -> INetworkSettings_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: INetworkSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -985,6 +1018,8 @@ pub trait IPrincipal_Impl: Sized + super::Com::IDispatch_Impl {
     fn RunLevel(&self, prunlevel: *mut TASK_RUNLEVEL_TYPE) -> ::windows::core::Result<()>;
     fn SetRunLevel(&self, runlevel: TASK_RUNLEVEL_TYPE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrincipal {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrincipal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrincipal_Impl, const OFFSET: isize>() -> IPrincipal_Vtbl {
@@ -1077,6 +1112,8 @@ pub trait IPrincipal2_Impl: Sized + super::Com::IDispatch_Impl {
     fn AddRequiredPrivilege(&self, privilege: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPrincipal2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPrincipal2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrincipal2_Impl, const OFFSET: isize>() -> IPrincipal2_Vtbl {
         unsafe extern "system" fn ProcessTokenSidType<Identity: ::windows::core::IUnknownImpl, Impl: IPrincipal2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprocesstokensidtype: *mut TASK_PROCESSTOKENSID_TYPE) -> ::windows::core::HRESULT {
@@ -1122,6 +1159,8 @@ pub trait IProvideTaskPage_Impl: Sized {
     fn GetPage(&self, tptype: TASKPAGE, fpersistchanges: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::UI::Controls::HPROPSHEETPAGE>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
+impl ::windows::core::RuntimeName for IProvideTaskPage {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl IProvideTaskPage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProvideTaskPage_Impl, const OFFSET: isize>() -> IProvideTaskPage_Vtbl {
         unsafe extern "system" fn GetPage<Identity: ::windows::core::IUnknownImpl, Impl: IProvideTaskPage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tptype: TASKPAGE, fpersistchanges: super::super::Foundation::BOOL, phpage: *mut super::super::UI::Controls::HPROPSHEETPAGE) -> ::windows::core::HRESULT {
@@ -1162,6 +1201,8 @@ pub trait IRegisteredTask_Impl: Sized + super::Com::IDispatch_Impl {
     fn Stop(&self, flags: i32) -> ::windows::core::Result<()>;
     fn GetRunTimes(&self, pststart: *const super::super::Foundation::SYSTEMTIME, pstend: *const super::super::Foundation::SYSTEMTIME, pcount: *mut u32, pruntimes: *mut *mut super::super::Foundation::SYSTEMTIME) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRegisteredTask {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRegisteredTask_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegisteredTask_Impl, const OFFSET: isize>() -> IRegisteredTask_Vtbl {
@@ -1372,6 +1413,8 @@ pub trait IRegisteredTaskCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRegisteredTaskCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRegisteredTaskCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegisteredTaskCollection_Impl, const OFFSET: isize>() -> IRegisteredTaskCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IRegisteredTaskCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1439,6 +1482,8 @@ pub trait IRegistrationInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Source(&self, psource: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetSource(&self, source: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRegistrationInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRegistrationInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegistrationInfo_Impl, const OFFSET: isize>() -> IRegistrationInfo_Vtbl {
@@ -1564,6 +1609,8 @@ pub trait IRegistrationTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigg
     fn SetDelay(&self, delay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRegistrationTrigger {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRegistrationTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegistrationTrigger_Impl, const OFFSET: isize>() -> IRegistrationTrigger_Vtbl {
         unsafe extern "system" fn Delay<Identity: ::windows::core::IUnknownImpl, Impl: IRegistrationTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1591,6 +1638,8 @@ pub trait IRepetitionPattern_Impl: Sized + super::Com::IDispatch_Impl {
     fn StopAtDurationEnd(&self, pstop: *mut i16) -> ::windows::core::Result<()>;
     fn SetStopAtDurationEnd(&self, stop: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRepetitionPattern {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRepetitionPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRepetitionPattern_Impl, const OFFSET: isize>() -> IRepetitionPattern_Vtbl {
@@ -1649,6 +1698,8 @@ pub trait IRunningTask_Impl: Sized + super::Com::IDispatch_Impl {
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn EnginePID(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRunningTask {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRunningTask_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRunningTask_Impl, const OFFSET: isize>() -> IRunningTask_Vtbl {
@@ -1751,6 +1802,8 @@ pub trait IRunningTaskCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRunningTaskCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRunningTaskCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRunningTaskCollection_Impl, const OFFSET: isize>() -> IRunningTaskCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IRunningTaskCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut i32) -> ::windows::core::HRESULT {
@@ -1829,6 +1882,8 @@ pub trait IScheduledWorkItem_Impl: Sized {
     fn SetAccountInformation(&self, pwszaccountname: &::windows::core::PCWSTR, pwszpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetAccountInformation(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IScheduledWorkItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl IScheduledWorkItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScheduledWorkItem_Impl, const OFFSET: isize>() -> IScheduledWorkItem_Vtbl {
@@ -2096,6 +2151,8 @@ pub trait ISessionStateChangeTrigger_Impl: Sized + super::Com::IDispatch_Impl + 
     fn SetStateChange(&self, r#type: TASK_SESSION_STATE_CHANGE_TYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISessionStateChangeTrigger {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISessionStateChangeTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISessionStateChangeTrigger_Impl, const OFFSET: isize>() -> ISessionStateChangeTrigger_Vtbl {
         unsafe extern "system" fn Delay<Identity: ::windows::core::IUnknownImpl, Impl: ISessionStateChangeTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2150,6 +2207,8 @@ pub trait IShowMessageAction_Impl: Sized + super::Com::IDispatch_Impl + IAction_
     fn SetMessageBody(&self, messagebody: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShowMessageAction {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShowMessageAction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShowMessageAction_Impl, const OFFSET: isize>() -> IShowMessageAction_Vtbl {
         unsafe extern "system" fn Title<Identity: ::windows::core::IUnknownImpl, Impl: IShowMessageAction_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptitle: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2199,6 +2258,8 @@ pub trait ITask_Impl: Sized + IScheduledWorkItem_Impl {
     fn SetMaxRunTime(&self, dwmaxruntimems: u32) -> ::windows::core::Result<()>;
     fn GetMaxRunTime(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITask {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITask_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITask_Impl, const OFFSET: isize>() -> ITask_Vtbl {
@@ -2335,6 +2396,8 @@ pub trait ITaskDefinition_Impl: Sized + super::Com::IDispatch_Impl {
     fn XmlText(&self, pxml: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetXmlText(&self, xml: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskDefinition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskDefinition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskDefinition_Impl, const OFFSET: isize>() -> ITaskDefinition_Vtbl {
@@ -2476,6 +2539,8 @@ pub trait ITaskFolder_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityDescriptor(&self, securityinformation: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetSecurityDescriptor(&self, sddl: &super::super::Foundation::BSTR, flags: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskFolder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskFolder_Impl, const OFFSET: isize>() -> ITaskFolder_Vtbl {
@@ -2632,6 +2697,8 @@ pub trait ITaskFolderCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskFolderCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskFolderCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskFolderCollection_Impl, const OFFSET: isize>() -> ITaskFolderCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ITaskFolderCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2686,6 +2753,8 @@ pub trait ITaskHandler_Impl: Sized {
     fn Resume(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITaskHandler {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITaskHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskHandler_Impl, const OFFSET: isize>() -> ITaskHandler_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: ITaskHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phandlerservices: *mut ::core::ffi::c_void, data: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -2732,6 +2801,8 @@ pub trait ITaskHandlerStatus_Impl: Sized {
     fn TaskCompleted(&self, taskerrcode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITaskHandlerStatus {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITaskHandlerStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskHandlerStatus_Impl, const OFFSET: isize>() -> ITaskHandlerStatus_Vtbl {
         unsafe extern "system" fn UpdateStatus<Identity: ::windows::core::IUnknownImpl, Impl: ITaskHandlerStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, percentcomplete: i16, statusmessage: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -2763,6 +2834,8 @@ pub trait ITaskNamedValueCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Remove(&self, index: i32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskNamedValueCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskNamedValueCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskNamedValueCollection_Impl, const OFFSET: isize>() -> ITaskNamedValueCollection_Vtbl {
@@ -2836,6 +2909,8 @@ pub trait ITaskNamedValuePair_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetValue(&self, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskNamedValuePair {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskNamedValuePair_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskNamedValuePair_Impl, const OFFSET: isize>() -> ITaskNamedValuePair_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: ITaskNamedValuePair_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pname: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2880,6 +2955,7 @@ pub trait ITaskScheduler_Impl: Sized {
     fn AddWorkItem(&self, pwsztaskname: &::windows::core::PCWSTR, pworkitem: &::core::option::Option<IScheduledWorkItem>) -> ::windows::core::Result<()>;
     fn IsOfType(&self, pwszname: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITaskScheduler {}
 impl ITaskScheduler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskScheduler_Impl, const OFFSET: isize>() -> ITaskScheduler_Vtbl {
         unsafe extern "system" fn SetTargetComputer<Identity: ::windows::core::IUnknownImpl, Impl: ITaskScheduler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszcomputer: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -2974,6 +3050,8 @@ pub trait ITaskService_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectedDomain(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn HighestVersion(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskService_Impl, const OFFSET: isize>() -> ITaskService_Vtbl {
@@ -3130,6 +3208,8 @@ pub trait ITaskSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn NetworkSettings(&self) -> ::windows::core::Result<INetworkSettings>;
     fn SetNetworkSettings(&self, pnetworksettings: &::core::option::Option<INetworkSettings>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskSettings_Impl, const OFFSET: isize>() -> ITaskSettings_Vtbl {
@@ -3401,6 +3481,8 @@ pub trait ITaskSettings2_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetUseUnifiedSchedulingEngine(&self, useunifiedengine: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskSettings2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskSettings2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskSettings2_Impl, const OFFSET: isize>() -> ITaskSettings2_Vtbl {
         unsafe extern "system" fn DisallowStartOnRemoteAppSession<Identity: ::windows::core::IUnknownImpl, Impl: ITaskSettings2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdisallowstart: *mut i16) -> ::windows::core::HRESULT {
@@ -3447,6 +3529,8 @@ pub trait ITaskSettings3_Impl: Sized + super::Com::IDispatch_Impl + ITaskSetting
     fn Volatile(&self, pvolatile: *mut i16) -> ::windows::core::Result<()>;
     fn SetVolatile(&self, volatile: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITaskSettings3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITaskSettings3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskSettings3_Impl, const OFFSET: isize>() -> ITaskSettings3_Vtbl {
@@ -3529,6 +3613,7 @@ pub trait ITaskTrigger_Impl: Sized {
     fn GetTrigger(&self) -> ::windows::core::Result<TASK_TRIGGER>;
     fn GetTriggerString(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ITaskTrigger {}
 impl ITaskTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskTrigger_Impl, const OFFSET: isize>() -> ITaskTrigger_Vtbl {
         unsafe extern "system" fn SetTrigger<Identity: ::windows::core::IUnknownImpl, Impl: ITaskTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptrigger: *const TASK_TRIGGER) -> ::windows::core::HRESULT {
@@ -3576,6 +3661,8 @@ pub trait ITaskVariables_Impl: Sized {
     fn GetContext(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITaskVariables {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITaskVariables_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskVariables_Impl, const OFFSET: isize>() -> ITaskVariables_Vtbl {
         unsafe extern "system" fn GetInput<Identity: ::windows::core::IUnknownImpl, Impl: ITaskVariables_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinput: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3622,6 +3709,8 @@ pub trait ITimeTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Impl 
     fn SetRandomDelay(&self, randomdelay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITimeTrigger {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITimeTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITimeTrigger_Impl, const OFFSET: isize>() -> ITimeTrigger_Vtbl {
         unsafe extern "system" fn RandomDelay<Identity: ::windows::core::IUnknownImpl, Impl: ITimeTrigger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prandomdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -3660,6 +3749,8 @@ pub trait ITrigger_Impl: Sized + super::Com::IDispatch_Impl {
     fn Enabled(&self, penabled: *mut i16) -> ::windows::core::Result<()>;
     fn SetEnabled(&self, enabled: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITrigger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITrigger_Impl, const OFFSET: isize>() -> ITrigger_Vtbl {
@@ -3765,6 +3856,8 @@ pub trait ITriggerCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITriggerCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITriggerCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITriggerCollection_Impl, const OFFSET: isize>() -> ITriggerCollection_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: ITriggerCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut i32) -> ::windows::core::HRESULT {
@@ -3838,6 +3931,8 @@ pub trait IWeeklyTrigger_Impl: Sized + super::Com::IDispatch_Impl + ITrigger_Imp
     fn RandomDelay(&self, prandomdelay: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn SetRandomDelay(&self, randomdelay: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWeeklyTrigger {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWeeklyTrigger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWeeklyTrigger_Impl, const OFFSET: isize>() -> IWeeklyTrigger_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/TransactionServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TransactionServer/impl.rs
@@ -6,6 +6,8 @@ pub trait ICatalog_Impl: Sized + super::Com::IDispatch_Impl {
     fn MinorVersion(&self, retval: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICatalog {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICatalog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICatalog_Impl, const OFFSET: isize>() -> ICatalog_Vtbl {
         unsafe extern "system" fn GetCollection<Identity: ::windows::core::IUnknownImpl, Impl: ICatalog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrcollname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, ppcatalogcollection: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -60,6 +62,8 @@ pub trait IComponentUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetCLSIDs(&self, bstrdllfile: &super::super::Foundation::BSTR, bstrtypelibfile: &super::super::Foundation::BSTR, aclsids: *mut *mut super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IComponentUtil {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IComponentUtil_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComponentUtil_Impl, const OFFSET: isize>() -> IComponentUtil_Vtbl {
         unsafe extern "system" fn InstallComponent<Identity: ::windows::core::IUnknownImpl, Impl: IComponentUtil_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrdllfile: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrtypelibfile: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrproxystubdllfile: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -101,6 +105,8 @@ pub trait IPackageUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn ShutdownPackage(&self, bstrpackageid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPackageUtil {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPackageUtil_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPackageUtil_Impl, const OFFSET: isize>() -> IPackageUtil_Vtbl {
         unsafe extern "system" fn InstallPackage<Identity: ::windows::core::IUnknownImpl, Impl: IPackageUtil_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrpackagefile: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrinstallpath: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, loptions: i32) -> ::windows::core::HRESULT {
@@ -135,6 +141,8 @@ pub trait IRemoteComponentUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn InstallRemoteComponentByName(&self, bstrserver: &super::super::Foundation::BSTR, bstrpackagename: &super::super::Foundation::BSTR, bstrprogid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRemoteComponentUtil {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRemoteComponentUtil_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteComponentUtil_Impl, const OFFSET: isize>() -> IRemoteComponentUtil_Vtbl {
         unsafe extern "system" fn InstallRemoteComponent<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteComponentUtil_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrserver: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrpackageid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrclsid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -162,6 +170,8 @@ pub trait IRoleAssociationUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn AssociateRole(&self, bstrroleid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn AssociateRoleByName(&self, bstrrolename: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRoleAssociationUtil {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRoleAssociationUtil_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRoleAssociationUtil_Impl, const OFFSET: isize>() -> IRoleAssociationUtil_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
@@ -9,6 +9,8 @@ pub trait IAutomaticUpdates_Impl: Sized + super::Com::IDispatch_Impl {
     fn EnableService(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAutomaticUpdates {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAutomaticUpdates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdates_Impl, const OFFSET: isize>() -> IAutomaticUpdates_Vtbl {
         unsafe extern "system" fn DetectNow<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdates_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -78,6 +80,8 @@ pub trait IAutomaticUpdates2_Impl: Sized + super::Com::IDispatch_Impl + IAutomat
     fn Results(&self) -> ::windows::core::Result<IAutomaticUpdatesResults>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAutomaticUpdates2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAutomaticUpdates2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdates2_Impl, const OFFSET: isize>() -> IAutomaticUpdates2_Vtbl {
         unsafe extern "system" fn Results<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdates2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -102,6 +106,8 @@ pub trait IAutomaticUpdatesResults_Impl: Sized + super::Com::IDispatch_Impl {
     fn LastSearchSuccessDate(&self) -> ::windows::core::Result<super::Com::VARIANT>;
     fn LastInstallationSuccessDate(&self) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAutomaticUpdatesResults {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAutomaticUpdatesResults_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdatesResults_Impl, const OFFSET: isize>() -> IAutomaticUpdatesResults_Vtbl {
@@ -150,6 +156,8 @@ pub trait IAutomaticUpdatesSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAutomaticUpdatesSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAutomaticUpdatesSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdatesSettings_Impl, const OFFSET: isize>() -> IAutomaticUpdatesSettings_Vtbl {
@@ -258,6 +266,8 @@ pub trait IAutomaticUpdatesSettings2_Impl: Sized + super::Com::IDispatch_Impl + 
     fn CheckPermission(&self, usertype: AutomaticUpdatesUserType, permissiontype: AutomaticUpdatesPermissionType) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAutomaticUpdatesSettings2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAutomaticUpdatesSettings2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdatesSettings2_Impl, const OFFSET: isize>() -> IAutomaticUpdatesSettings2_Vtbl {
         unsafe extern "system" fn IncludeRecommendedUpdates<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdatesSettings2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -305,6 +315,8 @@ pub trait IAutomaticUpdatesSettings3_Impl: Sized + super::Com::IDispatch_Impl + 
     fn FeaturedUpdatesEnabled(&self) -> ::windows::core::Result<i16>;
     fn SetFeaturedUpdatesEnabled(&self, value: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAutomaticUpdatesSettings3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAutomaticUpdatesSettings3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutomaticUpdatesSettings3_Impl, const OFFSET: isize>() -> IAutomaticUpdatesSettings3_Vtbl {
@@ -364,6 +376,8 @@ pub trait ICategory_Impl: Sized + super::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Updates(&self) -> ::windows::core::Result<IUpdateCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICategory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICategory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICategory_Impl, const OFFSET: isize>() -> ICategory_Vtbl {
@@ -490,6 +504,8 @@ pub trait ICategoryCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICategoryCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICategoryCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICategoryCollection_Impl, const OFFSET: isize>() -> ICategoryCollection_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: ICategoryCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -541,6 +557,8 @@ pub trait IDownloadCompletedCallback_Impl: Sized {
     fn Invoke(&self, downloadjob: &::core::option::Option<IDownloadJob>, callbackargs: &::core::option::Option<IDownloadCompletedCallbackArgs>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDownloadCompletedCallback {}
+#[cfg(feature = "Win32_System_Com")]
 impl IDownloadCompletedCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadCompletedCallback_Impl, const OFFSET: isize>() -> IDownloadCompletedCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadCompletedCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, downloadjob: ::windows::core::RawPtr, callbackargs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -556,6 +574,8 @@ impl IDownloadCompletedCallback_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDownloadCompletedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDownloadCompletedCallbackArgs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDownloadCompletedCallbackArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadCompletedCallbackArgs_Impl, const OFFSET: isize>() -> IDownloadCompletedCallbackArgs_Vtbl {
@@ -574,6 +594,8 @@ pub trait IDownloadJob_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetProgress(&self) -> ::windows::core::Result<IDownloadProgress>;
     fn RequestAbort(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDownloadJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDownloadJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadJob_Impl, const OFFSET: isize>() -> IDownloadJob_Vtbl {
@@ -657,6 +679,8 @@ pub trait IDownloadProgress_Impl: Sized + super::Com::IDispatch_Impl {
     fn CurrentUpdateDownloadPhase(&self) -> ::windows::core::Result<DownloadPhase>;
     fn CurrentUpdatePercentComplete(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDownloadProgress {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDownloadProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadProgress_Impl, const OFFSET: isize>() -> IDownloadProgress_Vtbl {
@@ -781,6 +805,8 @@ pub trait IDownloadProgressChangedCallback_Impl: Sized {
     fn Invoke(&self, downloadjob: &::core::option::Option<IDownloadJob>, callbackargs: &::core::option::Option<IDownloadProgressChangedCallbackArgs>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDownloadProgressChangedCallback {}
+#[cfg(feature = "Win32_System_Com")]
 impl IDownloadProgressChangedCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadProgressChangedCallback_Impl, const OFFSET: isize>() -> IDownloadProgressChangedCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadProgressChangedCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, downloadjob: ::windows::core::RawPtr, callbackargs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -798,6 +824,8 @@ impl IDownloadProgressChangedCallback_Vtbl {
 pub trait IDownloadProgressChangedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {
     fn Progress(&self) -> ::windows::core::Result<IDownloadProgress>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDownloadProgressChangedCallbackArgs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDownloadProgressChangedCallbackArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadProgressChangedCallbackArgs_Impl, const OFFSET: isize>() -> IDownloadProgressChangedCallbackArgs_Vtbl {
@@ -824,6 +852,8 @@ pub trait IDownloadResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn ResultCode(&self) -> ::windows::core::Result<OperationResultCode>;
     fn GetUpdateResult(&self, updateindex: i32) -> ::windows::core::Result<IUpdateDownloadResult>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDownloadResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDownloadResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDownloadResult_Impl, const OFFSET: isize>() -> IDownloadResult_Vtbl {
@@ -878,6 +908,8 @@ pub trait IImageInformation_Impl: Sized + super::Com::IDispatch_Impl {
     fn Source(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Width(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IImageInformation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IImageInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImageInformation_Impl, const OFFSET: isize>() -> IImageInformation_Vtbl {
@@ -942,6 +974,8 @@ pub trait IInstallationAgent_Impl: Sized + super::Com::IDispatch_Impl {
     fn RecordInstallationResult(&self, installationresultcookie: &super::super::Foundation::BSTR, hresult: i32, extendedreportingdata: &::core::option::Option<IStringCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationAgent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationAgent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationAgent_Impl, const OFFSET: isize>() -> IInstallationAgent_Vtbl {
         unsafe extern "system" fn RecordInstallationResult<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationAgent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, installationresultcookie: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, hresult: i32, extendedreportingdata: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -965,6 +999,8 @@ pub trait IInstallationBehavior_Impl: Sized + super::Com::IDispatch_Impl {
     fn RebootBehavior(&self) -> ::windows::core::Result<InstallationRebootBehavior>;
     fn RequiresNetworkConnectivity(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationBehavior {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationBehavior_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationBehavior_Impl, const OFFSET: isize>() -> IInstallationBehavior_Vtbl {
@@ -1029,6 +1065,8 @@ pub trait IInstallationCompletedCallback_Impl: Sized {
     fn Invoke(&self, installationjob: &::core::option::Option<IInstallationJob>, callbackargs: &::core::option::Option<IInstallationCompletedCallbackArgs>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IInstallationCompletedCallback {}
+#[cfg(feature = "Win32_System_Com")]
 impl IInstallationCompletedCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationCompletedCallback_Impl, const OFFSET: isize>() -> IInstallationCompletedCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationCompletedCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, installationjob: ::windows::core::RawPtr, callbackargs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1044,6 +1082,8 @@ impl IInstallationCompletedCallback_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationCompletedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationCompletedCallbackArgs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationCompletedCallbackArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationCompletedCallbackArgs_Impl, const OFFSET: isize>() -> IInstallationCompletedCallbackArgs_Vtbl {
@@ -1062,6 +1102,8 @@ pub trait IInstallationJob_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetProgress(&self) -> ::windows::core::Result<IInstallationProgress>;
     fn RequestAbort(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationJob_Impl, const OFFSET: isize>() -> IInstallationJob_Vtbl {
@@ -1141,6 +1183,8 @@ pub trait IInstallationProgress_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetUpdateResult(&self, updateindex: i32) -> ::windows::core::Result<IUpdateInstallationResult>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationProgress {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationProgress_Impl, const OFFSET: isize>() -> IInstallationProgress_Vtbl {
         unsafe extern "system" fn CurrentUpdateIndex<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationProgress_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -1204,6 +1248,8 @@ pub trait IInstallationProgressChangedCallback_Impl: Sized {
     fn Invoke(&self, installationjob: &::core::option::Option<IInstallationJob>, callbackargs: &::core::option::Option<IInstallationProgressChangedCallbackArgs>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IInstallationProgressChangedCallback {}
+#[cfg(feature = "Win32_System_Com")]
 impl IInstallationProgressChangedCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationProgressChangedCallback_Impl, const OFFSET: isize>() -> IInstallationProgressChangedCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationProgressChangedCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, installationjob: ::windows::core::RawPtr, callbackargs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1221,6 +1267,8 @@ impl IInstallationProgressChangedCallback_Vtbl {
 pub trait IInstallationProgressChangedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {
     fn Progress(&self) -> ::windows::core::Result<IInstallationProgress>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationProgressChangedCallbackArgs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationProgressChangedCallbackArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationProgressChangedCallbackArgs_Impl, const OFFSET: isize>() -> IInstallationProgressChangedCallbackArgs_Vtbl {
@@ -1248,6 +1296,8 @@ pub trait IInstallationResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn ResultCode(&self) -> ::windows::core::Result<OperationResultCode>;
     fn GetUpdateResult(&self, updateindex: i32) -> ::windows::core::Result<IUpdateInstallationResult>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInstallationResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInstallationResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInstallationResult_Impl, const OFFSET: isize>() -> IInstallationResult_Vtbl {
@@ -1312,6 +1362,8 @@ pub trait IInvalidProductLicenseException_Impl: Sized + super::Com::IDispatch_Im
     fn Product(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInvalidProductLicenseException {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInvalidProductLicenseException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInvalidProductLicenseException_Impl, const OFFSET: isize>() -> IInvalidProductLicenseException_Vtbl {
         unsafe extern "system" fn Product<Identity: ::windows::core::IUnknownImpl, Impl: IInvalidProductLicenseException_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1336,6 +1388,8 @@ pub trait ISearchCompletedCallback_Impl: Sized {
     fn Invoke(&self, searchjob: &::core::option::Option<ISearchJob>, callbackargs: &::core::option::Option<ISearchCompletedCallbackArgs>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISearchCompletedCallback {}
+#[cfg(feature = "Win32_System_Com")]
 impl ISearchCompletedCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCompletedCallback_Impl, const OFFSET: isize>() -> ISearchCompletedCallback_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCompletedCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, searchjob: ::windows::core::RawPtr, callbackargs: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1352,6 +1406,8 @@ impl ISearchCompletedCallback_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISearchCompletedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISearchCompletedCallbackArgs {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISearchCompletedCallbackArgs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchCompletedCallbackArgs_Impl, const OFFSET: isize>() -> ISearchCompletedCallbackArgs_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1367,6 +1423,8 @@ pub trait ISearchJob_Impl: Sized + super::Com::IDispatch_Impl {
     fn CleanUp(&self) -> ::windows::core::Result<()>;
     fn RequestAbort(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISearchJob {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISearchJob_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchJob_Impl, const OFFSET: isize>() -> ISearchJob_Vtbl {
@@ -1421,6 +1479,8 @@ pub trait ISearchResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn Updates(&self) -> ::windows::core::Result<IUpdateCollection>;
     fn Warnings(&self) -> ::windows::core::Result<IUpdateExceptionCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISearchResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISearchResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchResult_Impl, const OFFSET: isize>() -> ISearchResult_Vtbl {
@@ -1493,6 +1553,8 @@ pub trait IStringCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Insert(&self, index: i32, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, index: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IStringCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IStringCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStringCollection_Impl, const OFFSET: isize>() -> IStringCollection_Vtbl {
@@ -1606,6 +1668,8 @@ pub trait ISystemInformation_Impl: Sized + super::Com::IDispatch_Impl {
     fn RebootRequired(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISystemInformation {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISystemInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISystemInformation_Impl, const OFFSET: isize>() -> ISystemInformation_Vtbl {
         unsafe extern "system" fn OemHardwareSupportLink<Identity: ::windows::core::IUnknownImpl, Impl: ISystemInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1688,6 +1752,8 @@ pub trait IUpdate_Impl: Sized + super::Com::IDispatch_Impl {
     fn DownloadPriority(&self) -> ::windows::core::Result<DownloadPriority>;
     fn DownloadContents(&self) -> ::windows::core::Result<IUpdateDownloadContentCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdate {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate_Impl, const OFFSET: isize>() -> IUpdate_Vtbl {
@@ -2229,6 +2295,8 @@ pub trait IUpdate2_Impl: Sized + super::Com::IDispatch_Impl + IUpdate_Impl {
     fn CopyToCache(&self, pfiles: &::core::option::Option<IStringCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdate2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdate2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate2_Impl, const OFFSET: isize>() -> IUpdate2_Vtbl {
         unsafe extern "system" fn RebootRequired<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -2286,6 +2354,8 @@ pub trait IUpdate3_Impl: Sized + super::Com::IDispatch_Impl + IUpdate_Impl + IUp
     fn BrowseOnly(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdate3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdate3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate3_Impl, const OFFSET: isize>() -> IUpdate3_Vtbl {
         unsafe extern "system" fn BrowseOnly<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -2309,6 +2379,8 @@ impl IUpdate3_Vtbl {
 pub trait IUpdate4_Impl: Sized + super::Com::IDispatch_Impl + IUpdate_Impl + IUpdate2_Impl + IUpdate3_Impl {
     fn PerUser(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdate4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdate4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate4_Impl, const OFFSET: isize>() -> IUpdate4_Vtbl {
@@ -2334,6 +2406,8 @@ pub trait IUpdate5_Impl: Sized + super::Com::IDispatch_Impl + IUpdate_Impl + IUp
     fn AutoSelection(&self) -> ::windows::core::Result<AutoSelectionMode>;
     fn AutoDownload(&self) -> ::windows::core::Result<AutoDownloadMode>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdate5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdate5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdate5_Impl, const OFFSET: isize>() -> IUpdate5_Vtbl {
@@ -2382,6 +2456,8 @@ pub trait IUpdateCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Insert(&self, index: i32, value: &::core::option::Option<IUpdate>) -> ::windows::core::Result<()>;
     fn RemoveAt(&self, index: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateCollection_Impl, const OFFSET: isize>() -> IUpdateCollection_Vtbl {
@@ -2494,6 +2570,8 @@ pub trait IUpdateDownloadContent_Impl: Sized + super::Com::IDispatch_Impl {
     fn DownloadUrl(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateDownloadContent {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateDownloadContent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloadContent_Impl, const OFFSET: isize>() -> IUpdateDownloadContent_Vtbl {
         unsafe extern "system" fn DownloadUrl<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloadContent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2517,6 +2595,8 @@ impl IUpdateDownloadContent_Vtbl {
 pub trait IUpdateDownloadContent2_Impl: Sized + super::Com::IDispatch_Impl + IUpdateDownloadContent_Impl {
     fn IsDeltaCompressedContent(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateDownloadContent2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateDownloadContent2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloadContent2_Impl, const OFFSET: isize>() -> IUpdateDownloadContent2_Vtbl {
@@ -2546,6 +2626,8 @@ pub trait IUpdateDownloadContentCollection_Impl: Sized + super::Com::IDispatch_I
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateDownloadContentCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateDownloadContentCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloadContentCollection_Impl, const OFFSET: isize>() -> IUpdateDownloadContentCollection_Vtbl {
@@ -2599,6 +2681,8 @@ pub trait IUpdateDownloadResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn ResultCode(&self) -> ::windows::core::Result<OperationResultCode>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateDownloadResult {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateDownloadResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloadResult_Impl, const OFFSET: isize>() -> IUpdateDownloadResult_Vtbl {
         unsafe extern "system" fn HResult<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloadResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -2647,6 +2731,8 @@ pub trait IUpdateDownloader_Impl: Sized + super::Com::IDispatch_Impl {
     fn Download(&self) -> ::windows::core::Result<IDownloadResult>;
     fn EndDownload(&self, value: &::core::option::Option<IDownloadJob>) -> ::windows::core::Result<IDownloadResult>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateDownloader {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateDownloader_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateDownloader_Impl, const OFFSET: isize>() -> IUpdateDownloader_Vtbl {
@@ -2773,6 +2859,8 @@ pub trait IUpdateException_Impl: Sized + super::Com::IDispatch_Impl {
     fn Context(&self) -> ::windows::core::Result<UpdateExceptionContext>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateException {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateException_Impl, const OFFSET: isize>() -> IUpdateException_Vtbl {
         unsafe extern "system" fn Message<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateException_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2825,6 +2913,8 @@ pub trait IUpdateExceptionCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateExceptionCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateExceptionCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateExceptionCollection_Impl, const OFFSET: isize>() -> IUpdateExceptionCollection_Vtbl {
@@ -2889,6 +2979,8 @@ pub trait IUpdateHistoryEntry_Impl: Sized + super::Com::IDispatch_Impl {
     fn UninstallationNotes(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SupportUrl(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateHistoryEntry {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateHistoryEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateHistoryEntry_Impl, const OFFSET: isize>() -> IUpdateHistoryEntry_Vtbl {
@@ -3073,6 +3165,8 @@ pub trait IUpdateHistoryEntry2_Impl: Sized + super::Com::IDispatch_Impl + IUpdat
     fn Categories(&self) -> ::windows::core::Result<ICategoryCollection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateHistoryEntry2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateHistoryEntry2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateHistoryEntry2_Impl, const OFFSET: isize>() -> IUpdateHistoryEntry2_Vtbl {
         unsafe extern "system" fn Categories<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateHistoryEntry2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3098,6 +3192,8 @@ pub trait IUpdateHistoryEntryCollection_Impl: Sized + super::Com::IDispatch_Impl
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateHistoryEntryCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateHistoryEntryCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateHistoryEntryCollection_Impl, const OFFSET: isize>() -> IUpdateHistoryEntryCollection_Vtbl {
@@ -3151,6 +3247,8 @@ pub trait IUpdateIdentity_Impl: Sized + super::Com::IDispatch_Impl {
     fn UpdateID(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateIdentity {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateIdentity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateIdentity_Impl, const OFFSET: isize>() -> IUpdateIdentity_Vtbl {
         unsafe extern "system" fn RevisionNumber<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateIdentity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -3191,6 +3289,8 @@ pub trait IUpdateInstallationResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn RebootRequired(&self) -> ::windows::core::Result<i16>;
     fn ResultCode(&self) -> ::windows::core::Result<OperationResultCode>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateInstallationResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateInstallationResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstallationResult_Impl, const OFFSET: isize>() -> IUpdateInstallationResult_Vtbl {
@@ -3262,6 +3362,8 @@ pub trait IUpdateInstaller_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetAllowSourcePrompts(&self, value: i16) -> ::windows::core::Result<()>;
     fn RebootRequiredBeforeInstallation(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateInstaller {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateInstaller_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller_Impl, const OFFSET: isize>() -> IUpdateInstaller_Vtbl {
@@ -3495,6 +3597,8 @@ pub trait IUpdateInstaller2_Impl: Sized + super::Com::IDispatch_Impl + IUpdateIn
     fn SetForceQuiet(&self, value: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateInstaller2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateInstaller2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller2_Impl, const OFFSET: isize>() -> IUpdateInstaller2_Vtbl {
         unsafe extern "system" fn ForceQuiet<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -3529,6 +3633,8 @@ pub trait IUpdateInstaller3_Impl: Sized + super::Com::IDispatch_Impl + IUpdateIn
     fn SetAttemptCloseAppsIfNecessary(&self, value: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateInstaller3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateInstaller3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller3_Impl, const OFFSET: isize>() -> IUpdateInstaller3_Vtbl {
         unsafe extern "system" fn AttemptCloseAppsIfNecessary<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -3562,6 +3668,8 @@ pub trait IUpdateInstaller4_Impl: Sized + super::Com::IDispatch_Impl + IUpdateIn
     fn Commit(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateInstaller4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateInstaller4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller4_Impl, const OFFSET: isize>() -> IUpdateInstaller4_Vtbl {
         unsafe extern "system" fn Commit<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateInstaller4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -3578,6 +3686,7 @@ impl IUpdateInstaller4_Vtbl {
 pub trait IUpdateLockdown_Impl: Sized {
     fn LockDown(&self, flags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUpdateLockdown {}
 impl IUpdateLockdown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateLockdown_Impl, const OFFSET: isize>() -> IUpdateLockdown_Vtbl {
         unsafe extern "system" fn LockDown<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateLockdown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: i32) -> ::windows::core::HRESULT {
@@ -3612,6 +3721,8 @@ pub trait IUpdateSearcher_Impl: Sized + super::Com::IDispatch_Impl {
     fn ServiceID(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetServiceID(&self, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateSearcher {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateSearcher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSearcher_Impl, const OFFSET: isize>() -> IUpdateSearcher_Vtbl {
@@ -3809,6 +3920,8 @@ pub trait IUpdateSearcher2_Impl: Sized + super::Com::IDispatch_Impl + IUpdateSea
     fn SetIgnoreDownloadPriority(&self, value: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateSearcher2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateSearcher2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSearcher2_Impl, const OFFSET: isize>() -> IUpdateSearcher2_Vtbl {
         unsafe extern "system" fn IgnoreDownloadPriority<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSearcher2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -3842,6 +3955,8 @@ pub trait IUpdateSearcher3_Impl: Sized + super::Com::IDispatch_Impl + IUpdateSea
     fn SearchScope(&self) -> ::windows::core::Result<SearchScope>;
     fn SetSearchScope(&self, value: SearchScope) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateSearcher3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateSearcher3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSearcher3_Impl, const OFFSET: isize>() -> IUpdateSearcher3_Vtbl {
@@ -3887,6 +4002,8 @@ pub trait IUpdateService_Impl: Sized + super::Com::IDispatch_Impl {
     fn ServiceUrl(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetupPrefix(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateService_Impl, const OFFSET: isize>() -> IUpdateService_Vtbl {
@@ -4059,6 +4176,8 @@ pub trait IUpdateService2_Impl: Sized + super::Com::IDispatch_Impl + IUpdateServ
     fn IsDefaultAUService(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateService2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateService2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateService2_Impl, const OFFSET: isize>() -> IUpdateService2_Vtbl {
         unsafe extern "system" fn IsDefaultAUService<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateService2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -4084,6 +4203,8 @@ pub trait IUpdateServiceCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateServiceCollection {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateServiceCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateServiceCollection_Impl, const OFFSET: isize>() -> IUpdateServiceCollection_Vtbl {
@@ -4141,6 +4262,8 @@ pub trait IUpdateServiceManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn AddScanPackageService(&self, servicename: &super::super::Foundation::BSTR, scanfilelocation: &super::super::Foundation::BSTR, flags: i32) -> ::windows::core::Result<IUpdateService>;
     fn SetOption(&self, optionname: &super::super::Foundation::BSTR, optionvalue: &super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateServiceManager {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateServiceManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateServiceManager_Impl, const OFFSET: isize>() -> IUpdateServiceManager_Vtbl {
@@ -4220,6 +4343,8 @@ pub trait IUpdateServiceManager2_Impl: Sized + super::Com::IDispatch_Impl + IUpd
     fn AddService2(&self, serviceid: &super::super::Foundation::BSTR, flags: i32, authorizationcabpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<IUpdateServiceRegistration>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateServiceManager2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateServiceManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateServiceManager2_Impl, const OFFSET: isize>() -> IUpdateServiceManager2_Vtbl {
         unsafe extern "system" fn ClientApplicationID<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateServiceManager2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4279,6 +4404,8 @@ pub trait IUpdateServiceRegistration_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsPendingRegistrationWithAU(&self) -> ::windows::core::Result<i16>;
     fn Service(&self) -> ::windows::core::Result<IUpdateService2>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateServiceRegistration {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateServiceRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateServiceRegistration_Impl, const OFFSET: isize>() -> IUpdateServiceRegistration_Vtbl {
@@ -4349,6 +4476,8 @@ pub trait IUpdateSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateUpdateDownloader(&self) -> ::windows::core::Result<IUpdateDownloader>;
     fn CreateUpdateInstaller(&self) -> ::windows::core::Result<IUpdateInstaller>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateSession {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSession_Impl, const OFFSET: isize>() -> IUpdateSession_Vtbl {
@@ -4450,6 +4579,8 @@ pub trait IUpdateSession2_Impl: Sized + super::Com::IDispatch_Impl + IUpdateSess
     fn SetUserLocale(&self, lcid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateSession2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateSession2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSession2_Impl, const OFFSET: isize>() -> IUpdateSession2_Vtbl {
         unsafe extern "system" fn UserLocale<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSession2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut u32) -> ::windows::core::HRESULT {
@@ -4483,6 +4614,8 @@ pub trait IUpdateSession3_Impl: Sized + super::Com::IDispatch_Impl + IUpdateSess
     fn CreateUpdateServiceManager(&self) -> ::windows::core::Result<IUpdateServiceManager2>;
     fn QueryHistory(&self, criteria: &super::super::Foundation::BSTR, startindex: i32, count: i32) -> ::windows::core::Result<IUpdateHistoryEntryCollection>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUpdateSession3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUpdateSession3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateSession3_Impl, const OFFSET: isize>() -> IUpdateSession3_Vtbl {
@@ -4535,6 +4668,8 @@ pub trait IWebProxy_Impl: Sized + super::Com::IDispatch_Impl {
     fn AutoDetect(&self) -> ::windows::core::Result<i16>;
     fn SetAutoDetect(&self, value: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWebProxy {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWebProxy_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebProxy_Impl, const OFFSET: isize>() -> IWebProxy_Vtbl {
@@ -4678,6 +4813,8 @@ pub trait IWindowsDriverUpdate_Impl: Sized + super::Com::IDispatch_Impl + IUpdat
     fn DeviceStatus(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate_Impl, const OFFSET: isize>() -> IWindowsDriverUpdate_Vtbl {
         unsafe extern "system" fn DriverClass<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4792,6 +4929,8 @@ pub trait IWindowsDriverUpdate2_Impl: Sized + super::Com::IDispatch_Impl + IUpda
     fn CopyToCache(&self, pfiles: &::core::option::Option<IStringCollection>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdate2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdate2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate2_Impl, const OFFSET: isize>() -> IWindowsDriverUpdate2_Vtbl {
         unsafe extern "system" fn RebootRequired<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -4849,6 +4988,8 @@ pub trait IWindowsDriverUpdate3_Impl: Sized + super::Com::IDispatch_Impl + IUpda
     fn BrowseOnly(&self) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdate3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdate3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate3_Impl, const OFFSET: isize>() -> IWindowsDriverUpdate3_Vtbl {
         unsafe extern "system" fn BrowseOnly<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i16) -> ::windows::core::HRESULT {
@@ -4873,6 +5014,8 @@ pub trait IWindowsDriverUpdate4_Impl: Sized + super::Com::IDispatch_Impl + IUpda
     fn WindowsDriverUpdateEntries(&self) -> ::windows::core::Result<IWindowsDriverUpdateEntryCollection>;
     fn PerUser(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdate4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdate4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate4_Impl, const OFFSET: isize>() -> IWindowsDriverUpdate4_Vtbl {
@@ -4913,6 +5056,8 @@ pub trait IWindowsDriverUpdate5_Impl: Sized + super::Com::IDispatch_Impl + IUpda
     fn AutoSelection(&self) -> ::windows::core::Result<AutoSelectionMode>;
     fn AutoDownload(&self) -> ::windows::core::Result<AutoDownloadMode>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdate5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdate5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdate5_Impl, const OFFSET: isize>() -> IWindowsDriverUpdate5_Vtbl {
@@ -4959,6 +5104,8 @@ pub trait IWindowsDriverUpdateEntry_Impl: Sized + super::Com::IDispatch_Impl {
     fn DeviceProblemNumber(&self) -> ::windows::core::Result<i32>;
     fn DeviceStatus(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdateEntry {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdateEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdateEntry_Impl, const OFFSET: isize>() -> IWindowsDriverUpdateEntry_Vtbl {
@@ -5073,6 +5220,8 @@ pub trait IWindowsDriverUpdateEntryCollection_Impl: Sized + super::Com::IDispatc
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsDriverUpdateEntryCollection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsDriverUpdateEntryCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdateEntryCollection_Impl, const OFFSET: isize>() -> IWindowsDriverUpdateEntryCollection_Vtbl {
         unsafe extern "system" fn get_Item<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDriverUpdateEntryCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5123,6 +5272,8 @@ impl IWindowsDriverUpdateEntryCollection_Vtbl {
 pub trait IWindowsUpdateAgentInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetInfo(&self, varinfoidentifier: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWindowsUpdateAgentInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWindowsUpdateAgentInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsUpdateAgentInfo_Impl, const OFFSET: isize>() -> IWindowsUpdateAgentInfo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
@@ -3,6 +3,8 @@ pub trait IWaaSAssessor_Impl: Sized {
     fn GetOSUpdateAssessment(&self) -> ::windows::core::Result<OSUpdateAssessment>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWaaSAssessor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWaaSAssessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWaaSAssessor_Impl, const OFFSET: isize>() -> IWaaSAssessor_Vtbl {
         unsafe extern "system" fn GetOSUpdateAssessment<Identity: ::windows::core::IUnknownImpl, Impl: IWaaSAssessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result: *mut OSUpdateAssessment) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/impl.rs
@@ -1,9 +1,7 @@
 pub trait IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Impl: Sized {
     fn CreateFromWin32Handle(&self, win32handle: u64, enableaboutdata: u8, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusAttachmentFactoryInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusAttachmentFactoryInterop {}
 impl IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Impl, const OFFSET: isize>() -> IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Vtbl {
         unsafe extern "system" fn CreateFromWin32Handle<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, win32handle: u64, enableaboutdata: u8, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -23,9 +21,7 @@ impl IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Vtbl {
 pub trait IWindowsDevicesAllJoynBusAttachmentInterop_Impl: Sized {
     fn Win32Handle(&self) -> ::windows::core::Result<u64>;
 }
-impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusAttachmentInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusAttachmentInterop {}
 impl IWindowsDevicesAllJoynBusAttachmentInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusAttachmentInterop_Impl, const OFFSET: isize>() -> IWindowsDevicesAllJoynBusAttachmentInterop_Vtbl {
         unsafe extern "system" fn Win32Handle<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusAttachmentInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut u64) -> ::windows::core::HRESULT {
@@ -51,9 +47,7 @@ impl IWindowsDevicesAllJoynBusAttachmentInterop_Vtbl {
 pub trait IWindowsDevicesAllJoynBusObjectFactoryInterop_Impl: Sized {
     fn CreateFromWin32Handle(&self, win32handle: u64, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusObjectFactoryInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusObjectFactoryInterop {}
 impl IWindowsDevicesAllJoynBusObjectFactoryInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusObjectFactoryInterop_Impl, const OFFSET: isize>() -> IWindowsDevicesAllJoynBusObjectFactoryInterop_Vtbl {
         unsafe extern "system" fn CreateFromWin32Handle<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusObjectFactoryInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, win32handle: u64, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -75,9 +69,7 @@ pub trait IWindowsDevicesAllJoynBusObjectInterop_Impl: Sized {
     fn AddPropertySetHandler(&self, context: *const ::core::ffi::c_void, interfacename: &::windows::core::HSTRING, callback: isize) -> ::windows::core::Result<()>;
     fn Win32Handle(&self) -> ::windows::core::Result<u64>;
 }
-impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusObjectInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IWindowsDevicesAllJoynBusObjectInterop {}
 impl IWindowsDevicesAllJoynBusObjectInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusObjectInterop_Impl, const OFFSET: isize>() -> IWindowsDevicesAllJoynBusObjectInterop_Vtbl {
         unsafe extern "system" fn AddPropertyGetHandler<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsDevicesAllJoynBusObjectInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, interfacename: ::core::mem::ManuallyDrop<::windows::core::HSTRING>, callback: isize) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
@@ -3,9 +3,7 @@ pub trait ICompositionCapabilitiesInteropFactory_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::super::Foundation::HWND) -> ::windows::core::Result<super::super::super::super::UI::Composition::CompositionCapabilities>;
 }
 #[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
-impl ::windows::core::RuntimeName for ICompositionCapabilitiesInteropFactory {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ICompositionCapabilitiesInteropFactory {}
 #[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
 impl ICompositionCapabilitiesInteropFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionCapabilitiesInteropFactory_Impl, const OFFSET: isize>() -> ICompositionCapabilitiesInteropFactory_Vtbl {
@@ -38,6 +36,8 @@ pub trait ICompositionDrawingSurfaceInterop_Impl: Sized {
     fn ResumeDraw(&self) -> ::windows::core::Result<()>;
     fn SuspendDraw(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICompositionDrawingSurfaceInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICompositionDrawingSurfaceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionDrawingSurfaceInterop_Impl, const OFFSET: isize>() -> ICompositionDrawingSurfaceInterop_Vtbl {
@@ -90,6 +90,8 @@ pub trait ICompositionDrawingSurfaceInterop2_Impl: Sized + ICompositionDrawingSu
     fn CopySurface(&self, destinationresource: &::core::option::Option<::windows::core::IUnknown>, destinationoffsetx: i32, destinationoffsety: i32, sourcerectangle: *const super::super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICompositionDrawingSurfaceInterop2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICompositionDrawingSurfaceInterop2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionDrawingSurfaceInterop2_Impl, const OFFSET: isize>() -> ICompositionDrawingSurfaceInterop2_Vtbl {
         unsafe extern "system" fn CopySurface<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionDrawingSurfaceInterop2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, destinationresource: *mut ::core::ffi::c_void, destinationoffsetx: i32, destinationoffsety: i32, sourcerectangle: *const super::super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -107,6 +109,7 @@ pub trait ICompositionGraphicsDeviceInterop_Impl: Sized {
     fn GetRenderingDevice(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetRenderingDevice(&self, value: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICompositionGraphicsDeviceInterop {}
 impl ICompositionGraphicsDeviceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionGraphicsDeviceInterop_Impl, const OFFSET: isize>() -> ICompositionGraphicsDeviceInterop_Vtbl {
         unsafe extern "system" fn GetRenderingDevice<Identity: ::windows::core::IUnknownImpl, Impl: ICompositionGraphicsDeviceInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -140,6 +143,8 @@ pub trait ICompositorDesktopInterop_Impl: Sized {
     fn CreateDesktopWindowTarget(&self, hwndtarget: super::super::super::Foundation::HWND, istopmost: super::super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::super::super::UI::Composition::Desktop::DesktopWindowTarget>;
     fn EnsureOnThread(&self, threadid: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "UI_Composition_Desktop", feature = "Win32_Foundation"))]
+impl ::windows::core::RuntimeName for ICompositorDesktopInterop {}
 #[cfg(all(feature = "UI_Composition_Desktop", feature = "Win32_Foundation"))]
 impl ICompositorDesktopInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositorDesktopInterop_Impl, const OFFSET: isize>() -> ICompositorDesktopInterop_Vtbl {
@@ -175,6 +180,8 @@ pub trait ICompositorInterop_Impl: Sized {
     fn CreateCompositionSurfaceForSwapChain(&self, swapchain: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<super::super::super::super::UI::Composition::ICompositionSurface>;
     fn CreateGraphicsDevice(&self, renderingdevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<super::super::super::super::UI::Composition::CompositionGraphicsDevice>;
 }
+#[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
+impl ::windows::core::RuntimeName for ICompositorInterop {}
 #[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
 impl ICompositorInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICompositorInterop_Impl, const OFFSET: isize>() -> ICompositorInterop_Vtbl {
@@ -227,6 +234,8 @@ pub trait IDesktopWindowTargetInterop_Impl: Sized {
     fn Hwnd(&self) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDesktopWindowTargetInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDesktopWindowTargetInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWindowTargetInterop_Impl, const OFFSET: isize>() -> IDesktopWindowTargetInterop_Vtbl {
         unsafe extern "system" fn Hwnd<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWindowTargetInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -249,6 +258,7 @@ impl IDesktopWindowTargetInterop_Vtbl {
 pub trait ISwapChainInterop_Impl: Sized {
     fn SetSwapChain(&self, swapchain: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISwapChainInterop {}
 impl ISwapChainInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainInterop_Impl, const OFFSET: isize>() -> ISwapChainInterop_Vtbl {
         unsafe extern "system" fn SetSwapChain<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, swapchain: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -266,6 +276,8 @@ impl ISwapChainInterop_Vtbl {
 pub trait IVisualInteractionSourceInterop_Impl: Sized {
     fn TryRedirectForManipulation(&self, pointerinfo: *const super::super::super::UI::Input::Pointer::POINTER_INFO) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IVisualInteractionSourceInterop {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IVisualInteractionSourceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualInteractionSourceInterop_Impl, const OFFSET: isize>() -> IVisualInteractionSourceInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/CoreInputView/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/CoreInputView/impl.rs
@@ -3,9 +3,7 @@ pub trait ICoreFrameworkInputViewInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, coreframeworkinputview: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ICoreFrameworkInputViewInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ICoreFrameworkInputViewInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICoreFrameworkInputViewInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreFrameworkInputViewInterop_Impl, const OFFSET: isize>() -> ICoreFrameworkInputViewInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/impl.rs
@@ -1,6 +1,7 @@
 pub trait IDirect3DDxgiInterfaceAccess_Impl: Sized {
     fn GetInterface(&self, iid: *const ::windows::core::GUID, p: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDirect3DDxgiInterfaceAccess {}
 impl IDirect3DDxgiInterfaceAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDxgiInterfaceAccess_Impl, const OFFSET: isize>() -> IDirect3DDxgiInterfaceAccess_Vtbl {
         unsafe extern "system" fn GetInterface<Identity: ::windows::core::IUnknownImpl, Impl: IDirect3DDxgiInterfaceAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, p: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
@@ -4,6 +4,8 @@ pub trait IDisplayDeviceInterop_Impl: Sized {
     fn OpenSharedHandle(&self, nthandle: super::super::super::Foundation::HANDLE, riid: &::windows::core::GUID) -> ::windows::core::Result<*mut ::core::ffi::c_void>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
+impl ::windows::core::RuntimeName for IDisplayDeviceInterop {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl IDisplayDeviceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayDeviceInterop_Impl, const OFFSET: isize>() -> IDisplayDeviceInterop_Vtbl {
         unsafe extern "system" fn CreateSharedHandle<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayDeviceInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobject: *mut ::core::ffi::c_void, psecurityattributes: *const super::super::super::Security::SECURITY_ATTRIBUTES, access: u32, name: ::core::mem::ManuallyDrop<::windows::core::HSTRING>, phandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -43,6 +45,8 @@ pub trait IDisplayPathInterop_Impl: Sized {
     fn CreateSourcePresentationHandle(&self) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
     fn GetSourceId(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDisplayPathInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDisplayPathInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayPathInterop_Impl, const OFFSET: isize>() -> IDisplayPathInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/impl.rs
@@ -4,6 +4,8 @@ pub trait IGraphicsCaptureItemInterop_Impl: Sized {
     fn CreateForMonitor(&self, monitor: super::super::super::super::Graphics::Gdi::HMONITOR, riid: *const ::windows::core::GUID, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IGraphicsCaptureItemInterop {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IGraphicsCaptureItemInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGraphicsCaptureItemInterop_Impl, const OFFSET: isize>() -> IGraphicsCaptureItemInterop_Vtbl {
         unsafe extern "system" fn CreateForWindow<Identity: ::windows::core::IUnknownImpl, Impl: IGraphicsCaptureItemInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, window: super::super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
@@ -4,6 +4,8 @@ pub trait IGeometrySource2DInterop_Impl: Sized {
     fn TryGetGeometryUsingFactory(&self, factory: &::core::option::Option<super::super::super::super::Graphics::Direct2D::ID2D1Factory>) -> ::windows::core::Result<super::super::super::super::Graphics::Direct2D::ID2D1Geometry>;
 }
 #[cfg(feature = "Win32_Graphics_Direct2D")]
+impl ::windows::core::RuntimeName for IGeometrySource2DInterop {}
+#[cfg(feature = "Win32_Graphics_Direct2D")]
 impl IGeometrySource2DInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGeometrySource2DInterop_Impl, const OFFSET: isize>() -> IGeometrySource2DInterop_Vtbl {
         unsafe extern "system" fn GetGeometry<Identity: ::windows::core::IUnknownImpl, Impl: IGeometrySource2DInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -47,6 +49,8 @@ pub trait IGraphicsEffectD2D1Interop_Impl: Sized {
     fn GetSource(&self, index: u32) -> ::windows::core::Result<super::super::super::super::super::Graphics::Effects::IGraphicsEffectSource>;
     fn GetSourceCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Foundation", feature = "Graphics_Effects"))]
+impl ::windows::core::RuntimeName for IGraphicsEffectD2D1Interop {}
 #[cfg(all(feature = "Foundation", feature = "Graphics_Effects"))]
 impl IGraphicsEffectD2D1Interop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGraphicsEffectD2D1Interop_Impl, const OFFSET: isize>() -> IGraphicsEffectD2D1Interop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/impl.rs
@@ -1,9 +1,7 @@
 pub trait ISoftwareBitmapNative_Impl: Sized {
     fn GetData(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for ISoftwareBitmapNative {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ISoftwareBitmapNative {}
 impl ISoftwareBitmapNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISoftwareBitmapNative_Impl, const OFFSET: isize>() -> ISoftwareBitmapNative_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: ISoftwareBitmapNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -23,9 +21,7 @@ pub trait ISoftwareBitmapNativeFactory_Impl: Sized {
     fn CreateFromMF2DBuffer2(&self, data: &::core::option::Option<super::super::super::super::Media::MediaFoundation::IMF2DBuffer2>, subtype: *const ::windows::core::GUID, width: u32, height: u32, forcereadonly: super::super::super::super::Foundation::BOOL, mindisplayaperture: *const super::super::super::super::Media::MediaFoundation::MFVideoArea, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Imaging", feature = "Win32_Media_MediaFoundation"))]
-impl ::windows::core::RuntimeName for ISoftwareBitmapNativeFactory {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ISoftwareBitmapNativeFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Imaging", feature = "Win32_Media_MediaFoundation"))]
 impl ISoftwareBitmapNativeFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISoftwareBitmapNativeFactory_Impl, const OFFSET: isize>() -> ISoftwareBitmapNativeFactory_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/impl.rs
@@ -7,9 +7,7 @@ pub trait IHolographicCameraInterop_Impl: Sized {
     fn UnacquireDirect3D12BufferResource(&self, presourcetounacquire: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::windows::core::RuntimeName for IHolographicCameraInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IHolographicCameraInterop {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IHolographicCameraInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHolographicCameraInterop_Impl, const OFFSET: isize>() -> IHolographicCameraInterop_Vtbl {
@@ -69,9 +67,7 @@ pub trait IHolographicCameraRenderingParametersInterop_Impl: Sized {
     fn CommitDirect3D12ResourceWithDepthData(&self, pcolorresourcetocommit: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, pcolorresourcefence: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Fence>, colorresourcefencesignalvalue: u64, pdepthresourcetocommit: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, pdepthresourcefence: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Fence>, depthresourcefencesignalvalue: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::windows::core::RuntimeName for IHolographicCameraRenderingParametersInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IHolographicCameraRenderingParametersInterop {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IHolographicCameraRenderingParametersInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHolographicCameraRenderingParametersInterop_Impl, const OFFSET: isize>() -> IHolographicCameraRenderingParametersInterop_Vtbl {
@@ -104,9 +100,7 @@ pub trait IHolographicQuadLayerInterop_Impl: Sized {
     fn UnacquireDirect3D12BufferResource(&self, presourcetounacquire: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl ::windows::core::RuntimeName for IHolographicQuadLayerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IHolographicQuadLayerInterop {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl IHolographicQuadLayerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHolographicQuadLayerInterop_Impl, const OFFSET: isize>() -> IHolographicQuadLayerInterop_Vtbl {
@@ -165,9 +159,7 @@ pub trait IHolographicQuadLayerUpdateParametersInterop_Impl: Sized {
     fn CommitDirect3D12Resource(&self, pcolorresourcetocommit: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, pcolorresourcefence: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Fence>, colorresourcefencesignalvalue: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl ::windows::core::RuntimeName for IHolographicQuadLayerUpdateParametersInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IHolographicQuadLayerUpdateParametersInterop {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl IHolographicQuadLayerUpdateParametersInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHolographicQuadLayerUpdateParametersInterop_Impl, const OFFSET: isize>() -> IHolographicQuadLayerUpdateParametersInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
@@ -3,6 +3,8 @@ pub trait IIsolatedEnvironmentInterop_Impl: Sized {
     fn GetHostHwndInterop(&self, containerhwnd: super::super::super::Foundation::HWND) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IIsolatedEnvironmentInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl IIsolatedEnvironmentInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIsolatedEnvironmentInterop_Impl, const OFFSET: isize>() -> IIsolatedEnvironmentInterop_Vtbl {
         unsafe extern "system" fn GetHostHwndInterop<Identity: ::windows::core::IUnknownImpl, Impl: IIsolatedEnvironmentInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, containerhwnd: super::super::super::Foundation::HWND, hosthwnd: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
@@ -3,6 +3,8 @@ pub trait ILearningModelDeviceFactoryNative_Impl: Sized {
     fn CreateFromD3D12CommandQueue(&self, value: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12CommandQueue>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ILearningModelDeviceFactoryNative {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ILearningModelDeviceFactoryNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILearningModelDeviceFactoryNative_Impl, const OFFSET: isize>() -> ILearningModelDeviceFactoryNative_Vtbl {
         unsafe extern "system" fn CreateFromD3D12CommandQueue<Identity: ::windows::core::IUnknownImpl, Impl: ILearningModelDeviceFactoryNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: ::windows::core::RawPtr, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -30,6 +32,8 @@ pub trait ILearningModelOperatorProviderNative_Impl: Sized {
     fn GetRegistry(&self) -> ::windows::core::Result<super::super::super::AI::MachineLearning::WinML::IMLOperatorRegistry>;
 }
 #[cfg(feature = "Win32_AI_MachineLearning_WinML")]
+impl ::windows::core::RuntimeName for ILearningModelOperatorProviderNative {}
+#[cfg(feature = "Win32_AI_MachineLearning_WinML")]
 impl ILearningModelOperatorProviderNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILearningModelOperatorProviderNative_Impl, const OFFSET: isize>() -> ILearningModelOperatorProviderNative_Vtbl {
         unsafe extern "system" fn GetRegistry<Identity: ::windows::core::IUnknownImpl, Impl: ILearningModelOperatorProviderNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppoperatorregistry: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -52,6 +56,7 @@ impl ILearningModelOperatorProviderNative_Vtbl {
 pub trait ILearningModelSessionOptionsNative_Impl: Sized {
     fn SetIntraOpNumThreadsOverride(&self, intraopnumthreads: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILearningModelSessionOptionsNative {}
 impl ILearningModelSessionOptionsNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILearningModelSessionOptionsNative_Impl, const OFFSET: isize>() -> ILearningModelSessionOptionsNative_Vtbl {
         unsafe extern "system" fn SetIntraOpNumThreadsOverride<Identity: ::windows::core::IUnknownImpl, Impl: ILearningModelSessionOptionsNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, intraopnumthreads: u32) -> ::windows::core::HRESULT {
@@ -73,6 +78,8 @@ pub trait ITensorNative_Impl: Sized {
     fn GetBuffer(&self, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::Result<()>;
     fn GetD3D12Resource(&self) -> ::windows::core::Result<super::super::super::Graphics::Direct3D12::ID3D12Resource>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ITensorNative {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ITensorNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITensorNative_Impl, const OFFSET: isize>() -> ITensorNative_Vtbl {
@@ -106,6 +113,8 @@ impl ITensorNative_Vtbl {
 pub trait ITensorStaticsNative_Impl: Sized {
     fn CreateFromD3D12Resource(&self, value: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, shape: *mut i64, shapecount: i32, result: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+impl ::windows::core::RuntimeName for ITensorStaticsNative {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ITensorStaticsNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITensorStaticsNative_Impl, const OFFSET: isize>() -> ITensorStaticsNative_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/impl.rs
@@ -1,9 +1,7 @@
 pub trait IAudioFrameNative_Impl: Sized {
     fn GetData(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IAudioFrameNative {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IAudioFrameNative {}
 impl IAudioFrameNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioFrameNative_Impl, const OFFSET: isize>() -> IAudioFrameNative_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IAudioFrameNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -22,9 +20,7 @@ pub trait IAudioFrameNativeFactory_Impl: Sized {
     fn CreateFromMFSample(&self, data: &::core::option::Option<super::super::super::Media::MediaFoundation::IMFSample>, forcereadonly: super::super::super::Foundation::BOOL, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
-impl ::windows::core::RuntimeName for IAudioFrameNativeFactory {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IAudioFrameNativeFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 impl IAudioFrameNativeFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAudioFrameNativeFactory_Impl, const OFFSET: isize>() -> IAudioFrameNativeFactory_Vtbl {
@@ -46,9 +42,7 @@ pub trait IVideoFrameNative_Impl: Sized {
     fn GetData(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IVideoFrameNative {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IVideoFrameNative {}
 impl IVideoFrameNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVideoFrameNative_Impl, const OFFSET: isize>() -> IVideoFrameNative_Vtbl {
         unsafe extern "system" fn GetData<Identity: ::windows::core::IUnknownImpl, Impl: IVideoFrameNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -76,9 +70,7 @@ pub trait IVideoFrameNativeFactory_Impl: Sized {
     fn CreateFromMFSample(&self, data: &::core::option::Option<super::super::super::Media::MediaFoundation::IMFSample>, subtype: *const ::windows::core::GUID, width: u32, height: u32, forcereadonly: super::super::super::Foundation::BOOL, mindisplayaperture: *const super::super::super::Media::MediaFoundation::MFVideoArea, device: &::core::option::Option<super::super::super::Media::MediaFoundation::IMFDXGIDeviceManager>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
-impl ::windows::core::RuntimeName for IVideoFrameNativeFactory {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IVideoFrameNativeFactory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 impl IVideoFrameNativeFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVideoFrameNativeFactory_Impl, const OFFSET: isize>() -> IVideoFrameNativeFactory_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/impl.rs
@@ -4,6 +4,8 @@ pub trait IPdfRendererNative_Impl: Sized {
     fn RenderPageToDeviceContext(&self, pdfpage: &::core::option::Option<::windows::core::IUnknown>, pd2ddevicecontext: &::core::option::Option<super::super::super::Graphics::Direct2D::ID2D1DeviceContext>, prenderparams: *const PDF_RENDER_PARAMS) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi"))]
+impl ::windows::core::RuntimeName for IPdfRendererNative {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi"))]
 impl IPdfRendererNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPdfRendererNative_Impl, const OFFSET: isize>() -> IPdfRendererNative_Vtbl {
         unsafe extern "system" fn RenderPageToSurface<Identity: ::windows::core::IUnknownImpl, Impl: IPdfRendererNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdfpage: *mut ::core::ffi::c_void, psurface: ::windows::core::RawPtr, offset: super::super::super::Foundation::POINT, prenderparams: *const PDF_RENDER_PARAMS) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
@@ -4,9 +4,7 @@ pub trait IPrintManagerInterop_Impl: Sized {
     fn ShowPrintUIForWindowAsync(&self, appwindow: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IPrintManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IPrintManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPrintManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintManagerInterop_Impl, const OFFSET: isize>() -> IPrintManagerInterop_Vtbl {
@@ -36,6 +34,8 @@ pub trait IPrintWorkflowConfigurationNative_Impl: Sized {
     fn DriverProperties(&self) -> ::windows::core::Result<super::super::super::Graphics::Printing::IPrinterPropertyBag>;
     fn UserProperties(&self) -> ::windows::core::Result<super::super::super::Graphics::Printing::IPrinterPropertyBag>;
 }
+#[cfg(all(feature = "Win32_Graphics_Printing", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintWorkflowConfigurationNative {}
 #[cfg(all(feature = "Win32_Graphics_Printing", feature = "Win32_System_Com"))]
 impl IPrintWorkflowConfigurationNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowConfigurationNative_Impl, const OFFSET: isize>() -> IPrintWorkflowConfigurationNative_Vtbl {
@@ -89,6 +89,8 @@ pub trait IPrintWorkflowObjectModelSourceFileContentNative_Impl: Sized {
     fn ObjectFactory(&self) -> ::windows::core::Result<super::super::super::Storage::Xps::IXpsOMObjectFactory1>;
 }
 #[cfg(feature = "Win32_Storage_Xps")]
+impl ::windows::core::RuntimeName for IPrintWorkflowObjectModelSourceFileContentNative {}
+#[cfg(feature = "Win32_Storage_Xps")]
 impl IPrintWorkflowObjectModelSourceFileContentNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowObjectModelSourceFileContentNative_Impl, const OFFSET: isize>() -> IPrintWorkflowObjectModelSourceFileContentNative_Vtbl {
         unsafe extern "system" fn StartXpsOMGeneration<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowObjectModelSourceFileContentNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, receiver: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -122,6 +124,8 @@ pub trait IPrintWorkflowXpsObjectModelTargetPackageNative_Impl: Sized {
     fn DocumentPackageTarget(&self) -> ::windows::core::Result<super::super::super::Storage::Xps::IXpsDocumentPackageTarget>;
 }
 #[cfg(feature = "Win32_Storage_Xps")]
+impl ::windows::core::RuntimeName for IPrintWorkflowXpsObjectModelTargetPackageNative {}
+#[cfg(feature = "Win32_Storage_Xps")]
 impl IPrintWorkflowXpsObjectModelTargetPackageNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowXpsObjectModelTargetPackageNative_Impl, const OFFSET: isize>() -> IPrintWorkflowXpsObjectModelTargetPackageNative_Vtbl {
         unsafe extern "system" fn DocumentPackageTarget<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowXpsObjectModelTargetPackageNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -149,6 +153,8 @@ pub trait IPrintWorkflowXpsReceiver_Impl: Sized {
     fn AddPage(&self, documentid: u32, pageid: u32, pagereference: &::core::option::Option<super::super::super::Storage::Xps::IXpsOMPageReference>, pageuri: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Storage_Xps", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintWorkflowXpsReceiver {}
 #[cfg(all(feature = "Win32_Storage_Xps", feature = "Win32_System_Com"))]
 impl IPrintWorkflowXpsReceiver_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowXpsReceiver_Impl, const OFFSET: isize>() -> IPrintWorkflowXpsReceiver_Vtbl {
@@ -195,6 +201,8 @@ pub trait IPrintWorkflowXpsReceiver2_Impl: Sized + IPrintWorkflowXpsReceiver_Imp
     fn Failed(&self, xpserror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Storage_Xps", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IPrintWorkflowXpsReceiver2 {}
+#[cfg(all(feature = "Win32_Storage_Xps", feature = "Win32_System_Com"))]
 impl IPrintWorkflowXpsReceiver2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowXpsReceiver2_Impl, const OFFSET: isize>() -> IPrintWorkflowXpsReceiver2_Vtbl {
         unsafe extern "system" fn Failed<Identity: ::windows::core::IUnknownImpl, Impl: IPrintWorkflowXpsReceiver2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, xpserror: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -214,9 +222,7 @@ pub trait IPrinting3DManagerInterop_Impl: Sized {
     fn ShowPrintUIForWindowAsync(&self, appwindow: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IPrinting3DManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IPrinting3DManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPrinting3DManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrinting3DManagerInterop_Impl, const OFFSET: isize>() -> IPrinting3DManagerInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/impl.rs
@@ -3,6 +3,8 @@ pub trait IDDEInitializer_Impl: Sized {
     fn Initialize(&self, fileextensionorprotocol: &::windows::core::PCWSTR, method: CreateProcessMethod, currentdirectory: &::windows::core::PCWSTR, exectarget: &::core::option::Option<super::super::super::UI::Shell::IShellItem>, site: &::core::option::Option<::windows::core::IUnknown>, application: &::windows::core::PCWSTR, targetfile: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, verb: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell")]
+impl ::windows::core::RuntimeName for IDDEInitializer {}
+#[cfg(feature = "Win32_UI_Shell")]
 impl IDDEInitializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDDEInitializer_Impl, const OFFSET: isize>() -> IDDEInitializer_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDDEInitializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fileextensionorprotocol: ::windows::core::PCWSTR, method: CreateProcessMethod, currentdirectory: ::windows::core::PCWSTR, exectarget: ::windows::core::RawPtr, site: *mut ::core::ffi::c_void, application: ::windows::core::PCWSTR, targetfile: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, verb: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
@@ -1,6 +1,7 @@
 pub trait IOplockBreakingHandler_Impl: Sized {
     fn OplockBreaking(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IOplockBreakingHandler {}
 impl IOplockBreakingHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOplockBreakingHandler_Impl, const OFFSET: isize>() -> IOplockBreakingHandler_Vtbl {
         unsafe extern "system" fn OplockBreaking<Identity: ::windows::core::IUnknownImpl, Impl: IOplockBreakingHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17,6 +18,7 @@ impl IOplockBreakingHandler_Vtbl {
 pub trait IRandomAccessStreamFileAccessMode_Impl: Sized {
     fn GetMode(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IRandomAccessStreamFileAccessMode {}
 impl IRandomAccessStreamFileAccessMode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRandomAccessStreamFileAccessMode_Impl, const OFFSET: isize>() -> IRandomAccessStreamFileAccessMode_Vtbl {
         unsafe extern "system" fn GetMode<Identity: ::windows::core::IUnknownImpl, Impl: IRandomAccessStreamFileAccessMode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fileaccessmode: *mut u32) -> ::windows::core::HRESULT {
@@ -40,6 +42,8 @@ impl IRandomAccessStreamFileAccessMode_Vtbl {
 pub trait IStorageFolderHandleAccess_Impl: Sized {
     fn Create(&self, filename: &::windows::core::PCWSTR, creationoptions: HANDLE_CREATION_OPTIONS, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: &::core::option::Option<IOplockBreakingHandler>) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStorageFolderHandleAccess {}
 #[cfg(feature = "Win32_Foundation")]
 impl IStorageFolderHandleAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorageFolderHandleAccess_Impl, const OFFSET: isize>() -> IStorageFolderHandleAccess_Vtbl {
@@ -65,6 +69,8 @@ pub trait IStorageItemHandleAccess_Impl: Sized {
     fn Create(&self, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: &::core::option::Option<IOplockBreakingHandler>) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStorageItemHandleAccess {}
+#[cfg(feature = "Win32_Foundation")]
 impl IStorageItemHandleAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorageItemHandleAccess_Impl, const OFFSET: isize>() -> IStorageItemHandleAccess_Vtbl {
         unsafe extern "system" fn Create<Identity: ::windows::core::IUnknownImpl, Impl: IStorageItemHandleAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: ::windows::core::RawPtr, interophandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT {
@@ -87,6 +93,7 @@ impl IStorageItemHandleAccess_Vtbl {
 pub trait IUnbufferedFileHandleOplockCallback_Impl: Sized {
     fn OnBrokenCallback(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUnbufferedFileHandleOplockCallback {}
 impl IUnbufferedFileHandleOplockCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUnbufferedFileHandleOplockCallback_Impl, const OFFSET: isize>() -> IUnbufferedFileHandleOplockCallback_Vtbl {
         unsafe extern "system" fn OnBrokenCallback<Identity: ::windows::core::IUnknownImpl, Impl: IUnbufferedFileHandleOplockCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -104,6 +111,7 @@ pub trait IUnbufferedFileHandleProvider_Impl: Sized {
     fn OpenUnbufferedFileHandle(&self, oplockbreakcallback: &::core::option::Option<IUnbufferedFileHandleOplockCallback>) -> ::windows::core::Result<usize>;
     fn CloseUnbufferedFileHandle(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUnbufferedFileHandleProvider {}
 impl IUnbufferedFileHandleProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUnbufferedFileHandleProvider_Impl, const OFFSET: isize>() -> IUnbufferedFileHandleProvider_Vtbl {
         unsafe extern "system" fn OpenUnbufferedFileHandle<Identity: ::windows::core::IUnknownImpl, Impl: IUnbufferedFileHandleProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, oplockbreakcallback: ::windows::core::RawPtr, filehandle: *mut usize) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Xaml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Xaml/impl.rs
@@ -4,6 +4,8 @@ pub trait IDesktopWindowXamlSourceNative_Impl: Sized {
     fn WindowHandle(&self) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDesktopWindowXamlSourceNative {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDesktopWindowXamlSourceNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWindowXamlSourceNative_Impl, const OFFSET: isize>() -> IDesktopWindowXamlSourceNative_Vtbl {
         unsafe extern "system" fn AttachToWindow<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWindowXamlSourceNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parentwnd: super::super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -37,6 +39,8 @@ pub trait IDesktopWindowXamlSourceNative2_Impl: Sized + IDesktopWindowXamlSource
     fn PreTranslateMessage(&self, message: *const super::super::super::UI::WindowsAndMessaging::MSG, result: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IDesktopWindowXamlSourceNative2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IDesktopWindowXamlSourceNative2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWindowXamlSourceNative2_Impl, const OFFSET: isize>() -> IDesktopWindowXamlSourceNative2_Vtbl {
         unsafe extern "system" fn PreTranslateMessage<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWindowXamlSourceNative2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, message: *const super::super::super::UI::WindowsAndMessaging::MSG, result: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -53,6 +57,7 @@ impl IDesktopWindowXamlSourceNative2_Vtbl {
 pub trait IFindReferenceTargetsCallback_Impl: Sized {
     fn FoundTrackerTarget(&self, target: &::core::option::Option<IReferenceTrackerTarget>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFindReferenceTargetsCallback {}
 impl IFindReferenceTargetsCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFindReferenceTargetsCallback_Impl, const OFFSET: isize>() -> IFindReferenceTargetsCallback_Vtbl {
         unsafe extern "system" fn FoundTrackerTarget<Identity: ::windows::core::IUnknownImpl, Impl: IFindReferenceTargetsCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, target: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -75,6 +80,7 @@ pub trait IReferenceTracker_Impl: Sized {
     fn ReleaseFromTrackerSource(&self) -> ::windows::core::Result<()>;
     fn PegFromTrackerSource(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReferenceTracker {}
 impl IReferenceTracker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTracker_Impl, const OFFSET: isize>() -> IReferenceTracker_Vtbl {
         unsafe extern "system" fn ConnectFromTrackerSource<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTracker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -134,6 +140,7 @@ impl IReferenceTracker_Vtbl {
     }
 }
 pub trait IReferenceTrackerExtension_Impl: Sized {}
+impl ::windows::core::RuntimeName for IReferenceTrackerExtension {}
 impl IReferenceTrackerExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerExtension_Impl, const OFFSET: isize>() -> IReferenceTrackerExtension_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -150,6 +157,7 @@ pub trait IReferenceTrackerHost_Impl: Sized {
     fn AddMemoryPressure(&self, bytesallocated: u64) -> ::windows::core::Result<()>;
     fn RemoveMemoryPressure(&self, bytesallocated: u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReferenceTrackerHost {}
 impl IReferenceTrackerHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerHost_Impl, const OFFSET: isize>() -> IReferenceTrackerHost_Vtbl {
         unsafe extern "system" fn DisconnectUnusedReferenceSources<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, options: XAML_REFERENCETRACKER_DISCONNECT) -> ::windows::core::HRESULT {
@@ -208,6 +216,7 @@ pub trait IReferenceTrackerManager_Impl: Sized {
     fn ReferenceTrackingCompleted(&self) -> ::windows::core::Result<()>;
     fn SetReferenceTrackerHost(&self, value: &::core::option::Option<IReferenceTrackerHost>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReferenceTrackerManager {}
 impl IReferenceTrackerManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerManager_Impl, const OFFSET: isize>() -> IReferenceTrackerManager_Vtbl {
         unsafe extern "system" fn ReferenceTrackingStarted<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -248,6 +257,7 @@ pub trait IReferenceTrackerTarget_Impl: Sized {
     fn Peg(&self) -> ::windows::core::Result<()>;
     fn Unpeg(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReferenceTrackerTarget {}
 impl IReferenceTrackerTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerTarget_Impl, const OFFSET: isize>() -> IReferenceTrackerTarget_Vtbl {
         unsafe extern "system" fn AddRefFromReferenceTracker<Identity: ::windows::core::IUnknownImpl, Impl: IReferenceTrackerTarget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
@@ -285,6 +295,7 @@ impl IReferenceTrackerTarget_Vtbl {
 pub trait ISurfaceImageSourceManagerNative_Impl: Sized {
     fn FlushAllSurfacesWithDevice(&self, device: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISurfaceImageSourceManagerNative {}
 impl ISurfaceImageSourceManagerNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISurfaceImageSourceManagerNative_Impl, const OFFSET: isize>() -> ISurfaceImageSourceManagerNative_Vtbl {
         unsafe extern "system" fn FlushAllSurfacesWithDevice<Identity: ::windows::core::IUnknownImpl, Impl: ISurfaceImageSourceManagerNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -307,6 +318,8 @@ pub trait ISurfaceImageSourceNative_Impl: Sized {
     fn BeginDraw(&self, updaterect: &super::super::super::Foundation::RECT, surface: *mut ::core::option::Option<super::super::super::Graphics::Dxgi::IDXGISurface>, offset: *mut super::super::super::Foundation::POINT) -> ::windows::core::Result<()>;
     fn EndDraw(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi"))]
+impl ::windows::core::RuntimeName for ISurfaceImageSourceNative {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi"))]
 impl ISurfaceImageSourceNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISurfaceImageSourceNative_Impl, const OFFSET: isize>() -> ISurfaceImageSourceNative_Vtbl {
@@ -344,6 +357,8 @@ pub trait ISurfaceImageSourceNativeWithD2D_Impl: Sized {
     fn SuspendDraw(&self) -> ::windows::core::Result<()>;
     fn ResumeDraw(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISurfaceImageSourceNativeWithD2D {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISurfaceImageSourceNativeWithD2D_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISurfaceImageSourceNativeWithD2D_Impl, const OFFSET: isize>() -> ISurfaceImageSourceNativeWithD2D_Vtbl {
@@ -390,6 +405,8 @@ pub trait ISwapChainBackgroundPanelNative_Impl: Sized {
     fn SetSwapChain(&self, swapchain: &::core::option::Option<super::super::super::Graphics::Dxgi::IDXGISwapChain>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi")]
+impl ::windows::core::RuntimeName for ISwapChainBackgroundPanelNative {}
+#[cfg(feature = "Win32_Graphics_Dxgi")]
 impl ISwapChainBackgroundPanelNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainBackgroundPanelNative_Impl, const OFFSET: isize>() -> ISwapChainBackgroundPanelNative_Vtbl {
         unsafe extern "system" fn SetSwapChain<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainBackgroundPanelNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, swapchain: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -408,6 +425,8 @@ pub trait ISwapChainPanelNative_Impl: Sized {
     fn SetSwapChain(&self, swapchain: &::core::option::Option<super::super::super::Graphics::Dxgi::IDXGISwapChain>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi")]
+impl ::windows::core::RuntimeName for ISwapChainPanelNative {}
+#[cfg(feature = "Win32_Graphics_Dxgi")]
 impl ISwapChainPanelNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainPanelNative_Impl, const OFFSET: isize>() -> ISwapChainPanelNative_Vtbl {
         unsafe extern "system" fn SetSwapChain<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainPanelNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, swapchain: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -425,6 +444,8 @@ impl ISwapChainPanelNative_Vtbl {
 pub trait ISwapChainPanelNative2_Impl: Sized + ISwapChainPanelNative_Impl {
     fn SetSwapChainHandle(&self, swapchainhandle: super::super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi"))]
+impl ::windows::core::RuntimeName for ISwapChainPanelNative2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi"))]
 impl ISwapChainPanelNative2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISwapChainPanelNative2_Impl, const OFFSET: isize>() -> ISwapChainPanelNative2_Vtbl {
@@ -445,6 +466,7 @@ pub trait ITrackerOwner_Impl: Sized {
     fn SetTrackerValue(&self, handle: *const TrackerHandle__, value: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn TryGetSafeTrackerValue(&self, handle: *const TrackerHandle__, returnvalue: *mut ::core::option::Option<::windows::core::IUnknown>) -> u8;
 }
+impl ::windows::core::RuntimeName for ITrackerOwner {}
 impl ITrackerOwner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITrackerOwner_Impl, const OFFSET: isize>() -> ITrackerOwner_Vtbl {
         unsafe extern "system" fn CreateTrackerHandle<Identity: ::windows::core::IUnknownImpl, Impl: ITrackerOwner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, returnvalue: *mut *mut TrackerHandle__) -> ::windows::core::HRESULT {
@@ -494,6 +516,8 @@ pub trait IVirtualSurfaceImageSourceNative_Impl: Sized + ISurfaceImageSourceNati
     fn RegisterForUpdatesNeeded(&self, callback: &::core::option::Option<IVirtualSurfaceUpdatesCallbackNative>) -> ::windows::core::Result<()>;
     fn Resize(&self, newwidth: i32, newheight: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi"))]
+impl ::windows::core::RuntimeName for IVirtualSurfaceImageSourceNative {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi"))]
 impl IVirtualSurfaceImageSourceNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVirtualSurfaceImageSourceNative_Impl, const OFFSET: isize>() -> IVirtualSurfaceImageSourceNative_Vtbl {
@@ -556,6 +580,7 @@ impl IVirtualSurfaceImageSourceNative_Vtbl {
 pub trait IVirtualSurfaceUpdatesCallbackNative_Impl: Sized {
     fn UpdatesNeeded(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVirtualSurfaceUpdatesCallbackNative {}
 impl IVirtualSurfaceUpdatesCallbackNative_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVirtualSurfaceUpdatesCallbackNative_Impl, const OFFSET: isize>() -> IVirtualSurfaceUpdatesCallbackNative_Vtbl {
         unsafe extern "system" fn UpdatesNeeded<Identity: ::windows::core::IUnknownImpl, Impl: IVirtualSurfaceUpdatesCallbackNative_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
@@ -5,9 +5,7 @@ pub trait IAccountsSettingsPaneInterop_Impl: Sized {
     fn ShowAddAccountForWindowAsync(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, asyncaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IAccountsSettingsPaneInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IAccountsSettingsPaneInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAccountsSettingsPaneInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccountsSettingsPaneInterop_Impl, const OFFSET: isize>() -> IAccountsSettingsPaneInterop_Vtbl {
@@ -40,9 +38,7 @@ impl IAccountsSettingsPaneInterop_Vtbl {
 pub trait IActivationFactory_Impl: Sized {
     fn ActivateInstance(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
-impl ::windows::core::RuntimeName for IActivationFactory {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IActivationFactory {}
 impl IActivationFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActivationFactory_Impl, const OFFSET: isize>() -> IActivationFactory_Vtbl {
         unsafe extern "system" fn ActivateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IActivationFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, instance: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -68,6 +64,7 @@ impl IActivationFactory_Vtbl {
 pub trait IAgileReference_Impl: Sized {
     fn Resolve(&self, riid: *const ::windows::core::GUID, ppvobjectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAgileReference {}
 impl IAgileReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAgileReference_Impl, const OFFSET: isize>() -> IAgileReference_Vtbl {
         unsafe extern "system" fn Resolve<Identity: ::windows::core::IUnknownImpl, Impl: IAgileReference_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobjectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -84,6 +81,7 @@ impl IAgileReference_Vtbl {
 pub trait IApartmentShutdown_Impl: Sized {
     fn OnUninitialize(&self, ui64apartmentidentifier: u64);
 }
+impl ::windows::core::RuntimeName for IApartmentShutdown {}
 impl IApartmentShutdown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApartmentShutdown_Impl, const OFFSET: isize>() -> IApartmentShutdown_Vtbl {
         unsafe extern "system" fn OnUninitialize<Identity: ::windows::core::IUnknownImpl, Impl: IApartmentShutdown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ui64apartmentidentifier: u64) {
@@ -100,6 +98,7 @@ impl IApartmentShutdown_Vtbl {
 pub trait IAppServiceConnectionExtendedExecution_Impl: Sized {
     fn OpenForExtendedExecutionAsync(&self, riid: *const ::windows::core::GUID, operation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAppServiceConnectionExtendedExecution {}
 impl IAppServiceConnectionExtendedExecution_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppServiceConnectionExtendedExecution_Impl, const OFFSET: isize>() -> IAppServiceConnectionExtendedExecution_Vtbl {
         unsafe extern "system" fn OpenForExtendedExecutionAsync<Identity: ::windows::core::IUnknownImpl, Impl: IAppServiceConnectionExtendedExecution_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, operation: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -119,6 +118,7 @@ impl IAppServiceConnectionExtendedExecution_Vtbl {
 pub trait IBufferByteAccess_Impl: Sized {
     fn Buffer(&self) -> ::windows::core::Result<*mut u8>;
 }
+impl ::windows::core::RuntimeName for IBufferByteAccess {}
 impl IBufferByteAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBufferByteAccess_Impl, const OFFSET: isize>() -> IBufferByteAccess_Vtbl {
         unsafe extern "system" fn Buffer<Identity: ::windows::core::IUnknownImpl, Impl: IBufferByteAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -145,6 +145,7 @@ pub trait ICastingController_Impl: Sized {
     fn Advise(&self, eventhandler: &::core::option::Option<ICastingEventHandler>) -> ::windows::core::Result<u32>;
     fn UnAdvise(&self, cookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICastingController {}
 impl ICastingController_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICastingController_Impl, const OFFSET: isize>() -> ICastingController_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: ICastingController_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, castingengine: *mut ::core::ffi::c_void, castingsource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -195,6 +196,7 @@ pub trait ICastingEventHandler_Impl: Sized {
     fn OnStateChanged(&self, newstate: CASTING_CONNECTION_STATE) -> ::windows::core::Result<()>;
     fn OnError(&self, errorstatus: CASTING_CONNECTION_ERROR_STATUS, errormessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICastingEventHandler {}
 impl ICastingEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICastingEventHandler_Impl, const OFFSET: isize>() -> ICastingEventHandler_Vtbl {
         unsafe extern "system" fn OnStateChanged<Identity: ::windows::core::IUnknownImpl, Impl: ICastingEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newstate: CASTING_CONNECTION_STATE) -> ::windows::core::HRESULT {
@@ -222,6 +224,8 @@ pub trait ICastingSourceInfo_Impl: Sized {
     fn GetController(&self) -> ::windows::core::Result<ICastingController>;
     fn GetProperties(&self) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::INamedPropertyStore>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for ICastingSourceInfo {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ICastingSourceInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICastingSourceInfo_Impl, const OFFSET: isize>() -> ICastingSourceInfo_Vtbl {
@@ -261,6 +265,7 @@ pub trait ICoreInputInterop_Impl: Sized {
     fn SetInputSource(&self, value: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetMessageHandled(&self, value: u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICoreInputInterop {}
 impl ICoreInputInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreInputInterop_Impl, const OFFSET: isize>() -> ICoreInputInterop_Vtbl {
         unsafe extern "system" fn SetInputSource<Identity: ::windows::core::IUnknownImpl, Impl: ICoreInputInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -293,9 +298,7 @@ pub trait ICoreWindowAdapterInterop_Impl: Sized {
     fn TitleBarClientAdapter(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetWindowClientAdapter(&self, value: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for ICoreWindowAdapterInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ICoreWindowAdapterInterop {}
 impl ICoreWindowAdapterInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreWindowAdapterInterop_Impl, const OFFSET: isize>() -> ICoreWindowAdapterInterop_Vtbl {
         unsafe extern "system" fn AppActivationClientAdapter<Identity: ::windows::core::IUnknownImpl, Impl: ICoreWindowAdapterInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -402,6 +405,8 @@ pub trait ICoreWindowComponentInterop_Impl: Sized {
     fn GetViewInstanceId(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICoreWindowComponentInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICoreWindowComponentInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreWindowComponentInterop_Impl, const OFFSET: isize>() -> ICoreWindowComponentInterop_Vtbl {
         unsafe extern "system" fn ConfigureComponentInput<Identity: ::windows::core::IUnknownImpl, Impl: ICoreWindowComponentInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hostviewinstanceid: u32, hwndhost: super::super::Foundation::HWND, inputsourcevisual: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -436,6 +441,8 @@ pub trait ICoreWindowInterop_Impl: Sized {
     fn SetMessageHandled(&self, value: u8) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICoreWindowInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICoreWindowInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreWindowInterop_Impl, const OFFSET: isize>() -> ICoreWindowInterop_Vtbl {
         unsafe extern "system" fn WindowHandle<Identity: ::windows::core::IUnknownImpl, Impl: ICoreWindowInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -469,9 +476,7 @@ pub trait ICorrelationVectorInformation_Impl: Sized {
     fn NextCorrelationVectorForThread(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn SetNextCorrelationVectorForThread(&self, cv: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for ICorrelationVectorInformation {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ICorrelationVectorInformation {}
 impl ICorrelationVectorInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICorrelationVectorInformation_Impl, const OFFSET: isize>() -> ICorrelationVectorInformation_Vtbl {
         unsafe extern "system" fn LastCorrelationVectorForThread<Identity: ::windows::core::IUnknownImpl, Impl: ICorrelationVectorInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cv: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT {
@@ -515,6 +520,7 @@ impl ICorrelationVectorInformation_Vtbl {
 pub trait ICorrelationVectorSource_Impl: Sized {
     fn CorrelationVector(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
+impl ::windows::core::RuntimeName for ICorrelationVectorSource {}
 impl ICorrelationVectorSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICorrelationVectorSource_Impl, const OFFSET: isize>() -> ICorrelationVectorSource_Vtbl {
         unsafe extern "system" fn CorrelationVector<Identity: ::windows::core::IUnknownImpl, Impl: ICorrelationVectorSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cv: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT {
@@ -539,9 +545,7 @@ pub trait IDragDropManagerInterop_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IDragDropManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IDragDropManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDragDropManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDragDropManagerInterop_Impl, const OFFSET: isize>() -> IDragDropManagerInterop_Vtbl {
@@ -564,9 +568,7 @@ pub trait IHolographicSpaceInterop_Impl: Sized {
     fn CreateForWindow(&self, window: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, holographicspace: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IHolographicSpaceInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IHolographicSpaceInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IHolographicSpaceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHolographicSpaceInterop_Impl, const OFFSET: isize>() -> IHolographicSpaceInterop_Vtbl {
@@ -589,9 +591,7 @@ pub trait IInputPaneInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, inputpane: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IInputPaneInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IInputPaneInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInputPaneInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputPaneInterop_Impl, const OFFSET: isize>() -> IInputPaneInterop_Vtbl {
@@ -609,6 +609,7 @@ impl IInputPaneInterop_Vtbl {
 pub trait ILanguageExceptionErrorInfo_Impl: Sized {
     fn GetLanguageException(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for ILanguageExceptionErrorInfo {}
 impl ILanguageExceptionErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionErrorInfo_Impl, const OFFSET: isize>() -> ILanguageExceptionErrorInfo_Vtbl {
         unsafe extern "system" fn GetLanguageException<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, languageexception: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -633,6 +634,7 @@ pub trait ILanguageExceptionErrorInfo2_Impl: Sized + ILanguageExceptionErrorInfo
     fn CapturePropagationContext(&self, languageexception: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetPropagationContextHead(&self) -> ::windows::core::Result<ILanguageExceptionErrorInfo2>;
 }
+impl ::windows::core::RuntimeName for ILanguageExceptionErrorInfo2 {}
 impl ILanguageExceptionErrorInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionErrorInfo2_Impl, const OFFSET: isize>() -> ILanguageExceptionErrorInfo2_Vtbl {
         unsafe extern "system" fn GetPreviousLanguageExceptionErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionErrorInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, previouslanguageexceptionerrorinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -676,6 +678,7 @@ impl ILanguageExceptionErrorInfo2_Vtbl {
 pub trait ILanguageExceptionStackBackTrace_Impl: Sized {
     fn GetStackBackTrace(&self, maxframestocapture: u32, stackbacktrace: *mut usize, framescaptured: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILanguageExceptionStackBackTrace {}
 impl ILanguageExceptionStackBackTrace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionStackBackTrace_Impl, const OFFSET: isize>() -> ILanguageExceptionStackBackTrace_Vtbl {
         unsafe extern "system" fn GetStackBackTrace<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionStackBackTrace_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, maxframestocapture: u32, stackbacktrace: *mut usize, framescaptured: *mut u32) -> ::windows::core::HRESULT {
@@ -692,6 +695,7 @@ impl ILanguageExceptionStackBackTrace_Vtbl {
 pub trait ILanguageExceptionTransform_Impl: Sized {
     fn GetTransformedRestrictedErrorInfo(&self) -> ::windows::core::Result<IRestrictedErrorInfo>;
 }
+impl ::windows::core::RuntimeName for ILanguageExceptionTransform {}
 impl ILanguageExceptionTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionTransform_Impl, const OFFSET: isize>() -> ILanguageExceptionTransform_Vtbl {
         unsafe extern "system" fn GetTransformedRestrictedErrorInfo<Identity: ::windows::core::IUnknownImpl, Impl: ILanguageExceptionTransform_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, restrictederrorinfo: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -717,6 +721,7 @@ impl ILanguageExceptionTransform_Vtbl {
 pub trait IMemoryBufferByteAccess_Impl: Sized {
     fn GetBuffer(&self, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMemoryBufferByteAccess {}
 impl IMemoryBufferByteAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMemoryBufferByteAccess_Impl, const OFFSET: isize>() -> IMemoryBufferByteAccess_Vtbl {
         unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl, Impl: IMemoryBufferByteAccess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::HRESULT {
@@ -733,9 +738,7 @@ impl IMemoryBufferByteAccess_Vtbl {
 pub trait IMessageDispatcher_Impl: Sized {
     fn PumpMessages(&self) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IMessageDispatcher {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IMessageDispatcher {}
 impl IMessageDispatcher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMessageDispatcher_Impl, const OFFSET: isize>() -> IMessageDispatcher_Vtbl {
         unsafe extern "system" fn PumpMessages<Identity: ::windows::core::IUnknownImpl, Impl: IMessageDispatcher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -755,9 +758,7 @@ pub trait IPlayToManagerInterop_Impl: Sized {
     fn ShowPlayToUIForWindow(&self, appwindow: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IPlayToManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IPlayToManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPlayToManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPlayToManagerInterop_Impl, const OFFSET: isize>() -> IPlayToManagerInterop_Vtbl {
@@ -786,6 +787,8 @@ pub trait IRestrictedErrorInfo_Impl: Sized {
     fn GetErrorDetails(&self, description: *mut super::super::Foundation::BSTR, error: *mut ::windows::core::HRESULT, restricteddescription: *mut super::super::Foundation::BSTR, capabilitysid: *mut super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetReference(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRestrictedErrorInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRestrictedErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRestrictedErrorInfo_Impl, const OFFSET: isize>() -> IRestrictedErrorInfo_Vtbl {
@@ -818,6 +821,7 @@ impl IRestrictedErrorInfo_Vtbl {
 pub trait IRoMetaDataLocator_Impl: Sized {
     fn Locate(&self, nameelement: &::windows::core::PCWSTR, metadatadestination: &::core::option::Option<IRoSimpleMetaDataBuilder>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRoMetaDataLocator {}
 impl IRoMetaDataLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRoMetaDataLocator_Impl, const OFFSET: isize>() -> IRoMetaDataLocator_Vtbl {
         unsafe extern "system" fn Locate<Identity: ::windows::core::IUnknownImpl, Impl: IRoMetaDataLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nameelement: ::windows::core::PCWSTR, metadatadestination: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -843,6 +847,7 @@ pub trait IRoSimpleMetaDataBuilder_Impl: Sized {
     fn SetParameterizedInterface(&self, piid: &::windows::core::GUID, numargs: u32) -> ::windows::core::Result<()>;
     fn SetParameterizedDelegate(&self, piid: &::windows::core::GUID, numargs: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRoSimpleMetaDataBuilder {}
 impl IRoSimpleMetaDataBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>() -> IRoSimpleMetaDataBuilder_Vtbl {
         unsafe extern "system" fn SetWinRtInterface<Identity: ::windows::core::IUnknownImpl, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -917,6 +922,8 @@ pub trait IShareWindowCommandEventArgsInterop_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShareWindowCommandEventArgsInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl IShareWindowCommandEventArgsInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShareWindowCommandEventArgsInterop_Impl, const OFFSET: isize>() -> IShareWindowCommandEventArgsInterop_Vtbl {
         unsafe extern "system" fn GetWindow<Identity: ::windows::core::IUnknownImpl, Impl: IShareWindowCommandEventArgsInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -941,6 +948,8 @@ pub trait IShareWindowCommandSourceInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, sharewindowcommandsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShareWindowCommandSourceInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl IShareWindowCommandSourceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShareWindowCommandSourceInterop_Impl, const OFFSET: isize>() -> IShareWindowCommandSourceInterop_Vtbl {
         unsafe extern "system" fn GetForWindow<Identity: ::windows::core::IUnknownImpl, Impl: IShareWindowCommandSourceInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, sharewindowcommandsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -959,9 +968,7 @@ pub trait ISpatialInteractionManagerInterop_Impl: Sized {
     fn GetForWindow(&self, window: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, spatialinteractionmanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ISpatialInteractionManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ISpatialInteractionManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISpatialInteractionManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpatialInteractionManagerInterop_Impl, const OFFSET: isize>() -> ISpatialInteractionManagerInterop_Vtbl {
@@ -984,9 +991,7 @@ pub trait ISystemMediaTransportControlsInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, mediatransportcontrol: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ISystemMediaTransportControlsInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for ISystemMediaTransportControlsInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISystemMediaTransportControlsInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISystemMediaTransportControlsInterop_Impl, const OFFSET: isize>() -> ISystemMediaTransportControlsInterop_Vtbl {
@@ -1009,9 +1014,7 @@ pub trait IUIViewSettingsInterop_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IUIViewSettingsInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IUIViewSettingsInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIViewSettingsInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIViewSettingsInterop_Impl, const OFFSET: isize>() -> IUIViewSettingsInterop_Vtbl {
@@ -1034,9 +1037,7 @@ pub trait IUserActivityInterop_Impl: Sized {
     fn CreateSessionForWindow(&self, window: super::super::Foundation::HWND, iid: *const ::windows::core::GUID, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IUserActivityInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IUserActivityInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUserActivityInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserActivityInterop_Impl, const OFFSET: isize>() -> IUserActivityInterop_Vtbl {
@@ -1059,9 +1060,7 @@ pub trait IUserActivityRequestManagerInterop_Impl: Sized {
     fn GetForWindow(&self, window: super::super::Foundation::HWND, iid: *const ::windows::core::GUID, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IUserActivityRequestManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IUserActivityRequestManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUserActivityRequestManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserActivityRequestManagerInterop_Impl, const OFFSET: isize>() -> IUserActivityRequestManagerInterop_Vtbl {
@@ -1082,9 +1081,7 @@ impl IUserActivityRequestManagerInterop_Vtbl {
 pub trait IUserActivitySourceHostInterop_Impl: Sized {
     fn SetActivitySourceHost(&self, activitysourcehost: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IUserActivitySourceHostInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IUserActivitySourceHostInterop {}
 impl IUserActivitySourceHostInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserActivitySourceHostInterop_Impl, const OFFSET: isize>() -> IUserActivitySourceHostInterop_Vtbl {
         unsafe extern "system" fn SetActivitySourceHost<Identity: ::windows::core::IUnknownImpl, Impl: IUserActivitySourceHostInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, activitysourcehost: ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT {
@@ -1106,9 +1103,7 @@ pub trait IUserConsentVerifierInterop_Impl: Sized {
     fn RequestVerificationForWindowAsync(&self, appwindow: super::super::Foundation::HWND, message: &::windows::core::HSTRING, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IUserConsentVerifierInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IUserConsentVerifierInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUserConsentVerifierInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserConsentVerifierInterop_Impl, const OFFSET: isize>() -> IUserConsentVerifierInterop_Vtbl {
@@ -1129,6 +1124,7 @@ impl IUserConsentVerifierInterop_Vtbl {
 pub trait IWeakReference_Impl: Sized {
     fn Resolve(&self, riid: *const ::windows::core::GUID, objectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWeakReference {}
 impl IWeakReference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWeakReference_Impl, const OFFSET: isize>() -> IWeakReference_Vtbl {
         unsafe extern "system" fn Resolve<Identity: ::windows::core::IUnknownImpl, Impl: IWeakReference_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, objectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1145,6 +1141,7 @@ impl IWeakReference_Vtbl {
 pub trait IWeakReferenceSource_Impl: Sized {
     fn GetWeakReference(&self) -> ::windows::core::Result<IWeakReference>;
 }
+impl ::windows::core::RuntimeName for IWeakReferenceSource {}
 impl IWeakReferenceSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWeakReferenceSource_Impl, const OFFSET: isize>() -> IWeakReferenceSource_Vtbl {
         unsafe extern "system" fn GetWeakReference<Identity: ::windows::core::IUnknownImpl, Impl: IWeakReferenceSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, weakreference: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1170,9 +1167,7 @@ pub trait IWebAuthenticationCoreManagerInterop_Impl: Sized {
     fn RequestTokenWithWebAccountForWindowAsync(&self, appwindow: super::super::Foundation::HWND, request: &::core::option::Option<::windows::core::IInspectable>, webaccount: &::core::option::Option<::windows::core::IInspectable>, riid: *const ::windows::core::GUID, asyncinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IWebAuthenticationCoreManagerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IWebAuthenticationCoreManagerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWebAuthenticationCoreManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebAuthenticationCoreManagerInterop_Impl, const OFFSET: isize>() -> IWebAuthenticationCoreManagerInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
@@ -10,6 +10,8 @@ pub trait ICameraUIControl_Impl: Sized {
     fn RemoveCapturedItem(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ICameraUIControl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ICameraUIControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICameraUIControl_Impl, const OFFSET: isize>() -> ICameraUIControl_Vtbl {
         unsafe extern "system" fn Show<Identity: ::windows::core::IUnknownImpl, Impl: ICameraUIControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwindow: *mut ::core::ffi::c_void, mode: CameraUIControlMode, selectionmode: CameraUIControlLinearSelectionMode, capturemode: CameraUIControlCaptureMode, photoformat: CameraUIControlPhotoFormat, videoformat: CameraUIControlVideoFormat, bhasclosebutton: super::super::Foundation::BOOL, peventcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -99,6 +101,7 @@ pub trait ICameraUIControlEventCallback_Impl: Sized {
     fn OnItemDeleted(&self, pszpath: &::windows::core::PCWSTR);
     fn OnClosed(&self);
 }
+impl ::windows::core::RuntimeName for ICameraUIControlEventCallback {}
 impl ICameraUIControlEventCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICameraUIControlEventCallback_Impl, const OFFSET: isize>() -> ICameraUIControlEventCallback_Vtbl {
         unsafe extern "system" fn OnStartupComplete<Identity: ::windows::core::IUnknownImpl, Impl: ICameraUIControlEventCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
@@ -144,6 +147,8 @@ pub trait IClipServiceNotificationHelper_Impl: Sized {
     fn ShowToast(&self, titletext: &super::super::Foundation::BSTR, bodytext: &super::super::Foundation::BSTR, packagename: &super::super::Foundation::BSTR, appid: &super::super::Foundation::BSTR, launchcommand: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IClipServiceNotificationHelper {}
+#[cfg(feature = "Win32_Foundation")]
 impl IClipServiceNotificationHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClipServiceNotificationHelper_Impl, const OFFSET: isize>() -> IClipServiceNotificationHelper_Vtbl {
         unsafe extern "system" fn ShowToast<Identity: ::windows::core::IUnknownImpl, Impl: IClipServiceNotificationHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, titletext: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bodytext: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, packagename: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, appid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, launchcommand: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -160,6 +165,7 @@ impl IClipServiceNotificationHelper_Vtbl {
 pub trait IContainerActivationHelper_Impl: Sized {
     fn CanActivateClientVM(&self) -> ::windows::core::Result<i16>;
 }
+impl ::windows::core::RuntimeName for IContainerActivationHelper {}
 impl IContainerActivationHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContainerActivationHelper_Impl, const OFFSET: isize>() -> IContainerActivationHelper_Vtbl {
         unsafe extern "system" fn CanActivateClientVM<Identity: ::windows::core::IUnknownImpl, Impl: IContainerActivationHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, isallowed: *mut i16) -> ::windows::core::HRESULT {
@@ -184,6 +190,8 @@ pub trait IDefaultBrowserSyncSettings_Impl: Sized {
     fn IsEnabled(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDefaultBrowserSyncSettings {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDefaultBrowserSyncSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultBrowserSyncSettings_Impl, const OFFSET: isize>() -> IDefaultBrowserSyncSettings_Vtbl {
         unsafe extern "system" fn IsEnabled<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultBrowserSyncSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
@@ -200,6 +208,7 @@ impl IDefaultBrowserSyncSettings_Vtbl {
 pub trait IDeleteBrowsingHistory_Impl: Sized {
     fn DeleteBrowsingHistory(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDeleteBrowsingHistory {}
 impl IDeleteBrowsingHistory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeleteBrowsingHistory_Impl, const OFFSET: isize>() -> IDeleteBrowsingHistory_Vtbl {
         unsafe extern "system" fn DeleteBrowsingHistory<Identity: ::windows::core::IUnknownImpl, Impl: IDeleteBrowsingHistory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -220,6 +229,8 @@ pub trait IEditionUpgradeBroker_Impl: Sized {
     fn ShowProductKeyUI(&self) -> ::windows::core::Result<()>;
     fn CanUpgrade(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEditionUpgradeBroker {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEditionUpgradeBroker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEditionUpgradeBroker_Impl, const OFFSET: isize>() -> IEditionUpgradeBroker_Vtbl {
@@ -263,6 +274,8 @@ pub trait IEditionUpgradeHelper_Impl: Sized {
     fn GetOsProductContentId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetGenuineLocalStatus(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEditionUpgradeHelper {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEditionUpgradeHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEditionUpgradeHelper_Impl, const OFFSET: isize>() -> IEditionUpgradeHelper_Vtbl {
@@ -326,6 +339,8 @@ impl IEditionUpgradeHelper_Vtbl {
 pub trait IWindowsLockModeHelper_Impl: Sized {
     fn GetSMode(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWindowsLockModeHelper {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWindowsLockModeHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowsLockModeHelper_Impl, const OFFSET: isize>() -> IWindowsLockModeHelper_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
@@ -6,6 +6,8 @@ pub trait IAsynchronousDataRetriever_Impl: Sized {
     fn LoadChangeData(&self, ploadchangecontext: &::core::option::Option<ILoadChangeContext>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAsynchronousDataRetriever {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAsynchronousDataRetriever_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAsynchronousDataRetriever_Impl, const OFFSET: isize>() -> IAsynchronousDataRetriever_Vtbl {
         unsafe extern "system" fn GetIdParameters<Identity: ::windows::core::IUnknownImpl, Impl: IAsynchronousDataRetriever_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::HRESULT {
@@ -50,6 +52,7 @@ pub trait IChangeConflict_Impl: Sized {
     fn GetResolveActionForChangeUnit(&self, pchangeunit: &::core::option::Option<ISyncChangeUnit>, presolveaction: *mut SYNC_RESOLVE_ACTION) -> ::windows::core::Result<()>;
     fn SetResolveActionForChangeUnit(&self, pchangeunit: &::core::option::Option<ISyncChangeUnit>, resolveaction: SYNC_RESOLVE_ACTION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IChangeConflict {}
 impl IChangeConflict_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChangeConflict_Impl, const OFFSET: isize>() -> IChangeConflict_Vtbl {
         unsafe extern "system" fn GetDestinationProviderConflictingChange<Identity: ::windows::core::IUnknownImpl, Impl: IChangeConflict_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppconflictingchange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -137,6 +140,7 @@ pub trait IChangeUnitException_Impl: Sized {
     fn GetChangeUnitId(&self, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetClockVector(&self, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IChangeUnitException {}
 impl IChangeUnitException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChangeUnitException_Impl, const OFFSET: isize>() -> IChangeUnitException_Vtbl {
         unsafe extern "system" fn GetItemId<Identity: ::windows::core::IUnknownImpl, Impl: IChangeUnitException_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -170,6 +174,7 @@ pub trait IChangeUnitListFilterInfo_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetChangeUnitIdCount(&self, pdwchangeunitidcount: *mut u32) -> ::windows::core::Result<()>;
     fn GetChangeUnitId(&self, dwchangeunitidindex: u32, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IChangeUnitListFilterInfo {}
 impl IChangeUnitListFilterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IChangeUnitListFilterInfo_Impl, const OFFSET: isize>() -> IChangeUnitListFilterInfo_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IChangeUnitListFilterInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppbchangeunitids: *const *const u8, dwchangeunitcount: u32) -> ::windows::core::HRESULT {
@@ -202,6 +207,7 @@ pub trait IClockVector_Impl: Sized {
     fn GetClockVectorElements(&self, riid: *const ::windows::core::GUID, ppienumclockvector: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetClockVectorElementCount(&self, pdwcount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IClockVector {}
 impl IClockVector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClockVector_Impl, const OFFSET: isize>() -> IClockVector_Vtbl {
         unsafe extern "system" fn GetClockVectorElements<Identity: ::windows::core::IUnknownImpl, Impl: IClockVector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppienumclockvector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -228,6 +234,7 @@ pub trait IClockVectorElement_Impl: Sized {
     fn GetReplicaKey(&self, pdwreplicakey: *mut u32) -> ::windows::core::Result<()>;
     fn GetTickCount(&self, pulltickcount: *mut u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IClockVectorElement {}
 impl IClockVectorElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClockVectorElement_Impl, const OFFSET: isize>() -> IClockVectorElement_Vtbl {
         unsafe extern "system" fn GetReplicaKey<Identity: ::windows::core::IUnknownImpl, Impl: IClockVectorElement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwreplicakey: *mut u32) -> ::windows::core::HRESULT {
@@ -255,6 +262,7 @@ pub trait ICombinedFilterInfo_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetFilterInfo(&self, dwfilterindex: u32) -> ::windows::core::Result<ISyncFilterInfo>;
     fn GetFilterCombinationType(&self, pfiltercombinationtype: *mut FILTER_COMBINATION_TYPE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICombinedFilterInfo {}
 impl ICombinedFilterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICombinedFilterInfo_Impl, const OFFSET: isize>() -> ICombinedFilterInfo_Vtbl {
         unsafe extern "system" fn GetFilterCount<Identity: ::windows::core::IUnknownImpl, Impl: ICombinedFilterInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwfiltercount: *mut u32) -> ::windows::core::HRESULT {
@@ -303,6 +311,7 @@ pub trait IConstraintConflict_Impl: Sized {
     fn GetConstraintConflictReason(&self, pconstraintconflictreason: *mut CONSTRAINT_CONFLICT_REASON) -> ::windows::core::Result<()>;
     fn IsTemporary(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IConstraintConflict {}
 impl IConstraintConflict_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConstraintConflict_Impl, const OFFSET: isize>() -> IConstraintConflict_Vtbl {
         unsafe extern "system" fn GetDestinationProviderConflictingChange<Identity: ::windows::core::IUnknownImpl, Impl: IConstraintConflict_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppconflictingchange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -424,6 +433,7 @@ impl IConstraintConflict_Vtbl {
 pub trait IConstructReplicaKeyMap_Impl: Sized {
     fn FindOrAddReplica(&self, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IConstructReplicaKeyMap {}
 impl IConstructReplicaKeyMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConstructReplicaKeyMap_Impl, const OFFSET: isize>() -> IConstructReplicaKeyMap_Vtbl {
         unsafe extern "system" fn FindOrAddReplica<Identity: ::windows::core::IUnknownImpl, Impl: IConstructReplicaKeyMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::HRESULT {
@@ -444,6 +454,7 @@ pub trait ICoreFragment_Impl: Sized {
     fn GetColumnCount(&self, pcolumncount: *mut u32) -> ::windows::core::Result<()>;
     fn GetRangeCount(&self, prangecount: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICoreFragment {}
 impl ICoreFragment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreFragment_Impl, const OFFSET: isize>() -> ICoreFragment_Vtbl {
         unsafe extern "system" fn NextColumn<Identity: ::windows::core::IUnknownImpl, Impl: ICoreFragment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pchangeunitid: *mut u8, pchangeunitidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -488,6 +499,7 @@ pub trait ICoreFragmentInspector_Impl: Sized {
     fn NextCoreFragments(&self, requestedcount: u32, ppicorefragments: *mut ::core::option::Option<ICoreFragment>, pfetchedcount: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICoreFragmentInspector {}
 impl ICoreFragmentInspector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoreFragmentInspector_Impl, const OFFSET: isize>() -> ICoreFragmentInspector_Vtbl {
         unsafe extern "system" fn NextCoreFragments<Identity: ::windows::core::IUnknownImpl, Impl: ICoreFragmentInspector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requestedcount: u32, ppicorefragments: *mut ::windows::core::RawPtr, pfetchedcount: *mut u32) -> ::windows::core::HRESULT {
@@ -513,6 +525,7 @@ impl ICoreFragmentInspector_Vtbl {
 pub trait ICustomFilterInfo_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetSyncFilter(&self) -> ::windows::core::Result<ISyncFilter>;
 }
+impl ::windows::core::RuntimeName for ICustomFilterInfo {}
 impl ICustomFilterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICustomFilterInfo_Impl, const OFFSET: isize>() -> ICustomFilterInfo_Vtbl {
         unsafe extern "system" fn GetSyncFilter<Identity: ::windows::core::IUnknownImpl, Impl: ICustomFilterInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisyncfilter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -536,6 +549,7 @@ pub trait IDataRetrieverCallback_Impl: Sized {
     fn LoadChangeDataComplete(&self, punkdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn LoadChangeDataError(&self, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDataRetrieverCallback {}
 impl IDataRetrieverCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataRetrieverCallback_Impl, const OFFSET: isize>() -> IDataRetrieverCallback_Vtbl {
         unsafe extern "system" fn LoadChangeDataComplete<Identity: ::windows::core::IUnknownImpl, Impl: IDataRetrieverCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -564,6 +578,7 @@ pub trait IEnumChangeUnitExceptions_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumChangeUnitExceptions>;
 }
+impl ::windows::core::RuntimeName for IEnumChangeUnitExceptions {}
 impl IEnumChangeUnitExceptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumChangeUnitExceptions_Impl, const OFFSET: isize>() -> IEnumChangeUnitExceptions_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumChangeUnitExceptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cexceptions: u32, ppchangeunitexception: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -610,6 +625,7 @@ pub trait IEnumClockVector_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumClockVector>;
 }
+impl ::windows::core::RuntimeName for IEnumClockVector {}
 impl IEnumClockVector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumClockVector_Impl, const OFFSET: isize>() -> IEnumClockVector_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumClockVector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cclockvectorelements: u32, ppiclockvectorelements: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -656,6 +672,7 @@ pub trait IEnumFeedClockVector_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumFeedClockVector>;
 }
+impl ::windows::core::RuntimeName for IEnumFeedClockVector {}
 impl IEnumFeedClockVector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFeedClockVector_Impl, const OFFSET: isize>() -> IEnumFeedClockVector_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFeedClockVector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cclockvectorelements: u32, ppiclockvectorelements: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -699,6 +716,7 @@ impl IEnumFeedClockVector_Vtbl {
 pub trait IEnumItemIds_Impl: Sized {
     fn Next(&self, pbitemid: *mut u8, pcbitemidsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumItemIds {}
 impl IEnumItemIds_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumItemIds_Impl, const OFFSET: isize>() -> IEnumItemIds_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumItemIds_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbitemidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -718,6 +736,7 @@ pub trait IEnumRangeExceptions_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumRangeExceptions>;
 }
+impl ::windows::core::RuntimeName for IEnumRangeExceptions {}
 impl IEnumRangeExceptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRangeExceptions_Impl, const OFFSET: isize>() -> IEnumRangeExceptions_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRangeExceptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cexceptions: u32, pprangeexception: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -764,6 +783,7 @@ pub trait IEnumSingleItemExceptions_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSingleItemExceptions>;
 }
+impl ::windows::core::RuntimeName for IEnumSingleItemExceptions {}
 impl IEnumSingleItemExceptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSingleItemExceptions_Impl, const OFFSET: isize>() -> IEnumSingleItemExceptions_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSingleItemExceptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cexceptions: u32, ppsingleitemexception: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -810,6 +830,7 @@ pub trait IEnumSyncChangeUnits_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncChangeUnits>;
 }
+impl ::windows::core::RuntimeName for IEnumSyncChangeUnits {}
 impl IEnumSyncChangeUnits_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncChangeUnits_Impl, const OFFSET: isize>() -> IEnumSyncChangeUnits_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncChangeUnits_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cchanges: u32, ppchangeunit: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -856,6 +877,7 @@ pub trait IEnumSyncChanges_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncChanges>;
 }
+impl ::windows::core::RuntimeName for IEnumSyncChanges {}
 impl IEnumSyncChanges_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncChanges_Impl, const OFFSET: isize>() -> IEnumSyncChanges_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncChanges_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cchanges: u32, ppchange: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -903,6 +925,8 @@ pub trait IEnumSyncProviderConfigUIInfos_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncProviderConfigUIInfos>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IEnumSyncProviderConfigUIInfos {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IEnumSyncProviderConfigUIInfos_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncProviderConfigUIInfos_Impl, const OFFSET: isize>() -> IEnumSyncProviderConfigUIInfos_Vtbl {
@@ -952,6 +976,8 @@ pub trait IEnumSyncProviderInfos_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncProviderInfos>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IEnumSyncProviderInfos {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IEnumSyncProviderInfos_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncProviderInfos_Impl, const OFFSET: isize>() -> IEnumSyncProviderInfos_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncProviderInfos_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cinstances: u32, ppsyncproviderinfo: *mut ::windows::core::RawPtr, pcfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -998,6 +1024,8 @@ pub trait IFeedClockVector_Impl: Sized + IClockVector_Impl {
     fn IsNoConflictsSpecified(&self, pfisnoconflictsspecified: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFeedClockVector {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFeedClockVector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedClockVector_Impl, const OFFSET: isize>() -> IFeedClockVector_Vtbl {
         unsafe extern "system" fn GetUpdateCount<Identity: ::windows::core::IUnknownImpl, Impl: IFeedClockVector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwupdatecount: *mut u32) -> ::windows::core::HRESULT {
@@ -1024,6 +1052,7 @@ pub trait IFeedClockVectorElement_Impl: Sized + IClockVectorElement_Impl {
     fn GetSyncTime(&self, psynctime: *mut SYNC_TIME) -> ::windows::core::Result<()>;
     fn GetFlags(&self, pbflags: *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFeedClockVectorElement {}
 impl IFeedClockVectorElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFeedClockVectorElement_Impl, const OFFSET: isize>() -> IFeedClockVectorElement_Vtbl {
         unsafe extern "system" fn GetSyncTime<Identity: ::windows::core::IUnknownImpl, Impl: IFeedClockVectorElement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psynctime: *mut SYNC_TIME) -> ::windows::core::HRESULT {
@@ -1052,6 +1081,7 @@ pub trait IFilterKeyMap_Impl: Sized {
     fn GetFilter(&self, dwfilterkey: u32) -> ::windows::core::Result<ISyncFilter>;
     fn Serialize(&self, pbfilterkeymap: *mut u8, pcbfilterkeymap: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFilterKeyMap {}
 impl IFilterKeyMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterKeyMap_Impl, const OFFSET: isize>() -> IFilterKeyMap_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IFilterKeyMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT {
@@ -1095,6 +1125,7 @@ impl IFilterKeyMap_Vtbl {
 pub trait IFilterRequestCallback_Impl: Sized {
     fn RequestFilter(&self, pfilter: &::core::option::Option<::windows::core::IUnknown>, filteringtype: FILTERING_TYPE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFilterRequestCallback {}
 impl IFilterRequestCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterRequestCallback_Impl, const OFFSET: isize>() -> IFilterRequestCallback_Vtbl {
         unsafe extern "system" fn RequestFilter<Identity: ::windows::core::IUnknownImpl, Impl: IFilterRequestCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void, filteringtype: FILTERING_TYPE) -> ::windows::core::HRESULT {
@@ -1112,6 +1143,7 @@ pub trait IFilterTrackingProvider_Impl: Sized {
     fn SpecifyTrackedFilters(&self, pcallback: &::core::option::Option<IFilterTrackingRequestCallback>) -> ::windows::core::Result<()>;
     fn AddTrackedFilter(&self, pfilter: &::core::option::Option<ISyncFilter>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFilterTrackingProvider {}
 impl IFilterTrackingProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterTrackingProvider_Impl, const OFFSET: isize>() -> IFilterTrackingProvider_Vtbl {
         unsafe extern "system" fn SpecifyTrackedFilters<Identity: ::windows::core::IUnknownImpl, Impl: IFilterTrackingProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1137,6 +1169,7 @@ impl IFilterTrackingProvider_Vtbl {
 pub trait IFilterTrackingRequestCallback_Impl: Sized {
     fn RequestTrackedFilter(&self, pfilter: &::core::option::Option<ISyncFilter>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFilterTrackingRequestCallback {}
 impl IFilterTrackingRequestCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterTrackingRequestCallback_Impl, const OFFSET: isize>() -> IFilterTrackingRequestCallback_Vtbl {
         unsafe extern "system" fn RequestTrackedFilter<Identity: ::windows::core::IUnknownImpl, Impl: IFilterTrackingRequestCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfilter: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1155,6 +1188,8 @@ pub trait IFilterTrackingSyncChangeBuilder_Impl: Sized {
     fn AddFilterChange(&self, dwfilterkey: u32, pfilterchange: *const SYNC_FILTER_CHANGE) -> ::windows::core::Result<()>;
     fn SetAllChangeUnitsPresentFlag(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFilterTrackingSyncChangeBuilder {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFilterTrackingSyncChangeBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFilterTrackingSyncChangeBuilder_Impl, const OFFSET: isize>() -> IFilterTrackingSyncChangeBuilder_Vtbl {
@@ -1183,6 +1218,8 @@ pub trait IForgottenKnowledge_Impl: Sized + ISyncKnowledge_Impl {
     fn ForgetToVersion(&self, pknowledge: &::core::option::Option<ISyncKnowledge>, pversion: *const SYNC_VERSION) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IForgottenKnowledge {}
+#[cfg(feature = "Win32_Foundation")]
 impl IForgottenKnowledge_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IForgottenKnowledge_Impl, const OFFSET: isize>() -> IForgottenKnowledge_Vtbl {
         unsafe extern "system" fn ForgetToVersion<Identity: ::windows::core::IUnknownImpl, Impl: IForgottenKnowledge_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pknowledge: ::windows::core::RawPtr, pversion: *const SYNC_VERSION) -> ::windows::core::HRESULT {
@@ -1206,6 +1243,8 @@ pub trait IKnowledgeSyncProvider_Impl: Sized + ISyncProvider_Impl {
     fn ProcessFullEnumerationChangeBatch(&self, resolutionpolicy: CONFLICT_RESOLUTION_POLICY, psourcechangebatch: &::core::option::Option<ISyncFullEnumerationChangeBatch>, punkdataretriever: &::core::option::Option<::windows::core::IUnknown>, pcallback: &::core::option::Option<ISyncCallback>, psyncsessionstatistics: *mut SYNC_SESSION_STATISTICS) -> ::windows::core::Result<()>;
     fn EndSession(&self, psessionstate: &::core::option::Option<ISyncSessionState>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IKnowledgeSyncProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IKnowledgeSyncProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKnowledgeSyncProvider_Impl, const OFFSET: isize>() -> IKnowledgeSyncProvider_Vtbl {
@@ -1264,6 +1303,7 @@ pub trait ILoadChangeContext_Impl: Sized {
     fn SetRecoverableErrorOnChange(&self, hrerror: ::windows::core::HRESULT, perrordata: &::core::option::Option<IRecoverableErrorData>) -> ::windows::core::Result<()>;
     fn SetRecoverableErrorOnChangeUnit(&self, hrerror: ::windows::core::HRESULT, pchangeunit: &::core::option::Option<ISyncChangeUnit>, perrordata: &::core::option::Option<IRecoverableErrorData>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILoadChangeContext {}
 impl ILoadChangeContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILoadChangeContext_Impl, const OFFSET: isize>() -> ILoadChangeContext_Vtbl {
         unsafe extern "system" fn GetSyncChange<Identity: ::windows::core::IUnknownImpl, Impl: ILoadChangeContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsyncchange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1301,6 +1341,7 @@ impl ILoadChangeContext_Vtbl {
 pub trait IProviderConverter_Impl: Sized {
     fn Initialize(&self, pisyncprovider: &::core::option::Option<ISyncProvider>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IProviderConverter {}
 impl IProviderConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProviderConverter_Impl, const OFFSET: isize>() -> IProviderConverter_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IProviderConverter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pisyncprovider: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1319,6 +1360,7 @@ pub trait IRangeException_Impl: Sized {
     fn GetClosedRangeEnd(&self, pbclosedrangeend: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetClockVector(&self, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRangeException {}
 impl IRangeException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRangeException_Impl, const OFFSET: isize>() -> IRangeException_Vtbl {
         unsafe extern "system" fn GetClosedRangeStart<Identity: ::windows::core::IUnknownImpl, Impl: IRangeException_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbclosedrangestart: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1354,6 +1396,7 @@ pub trait IRecoverableError_Impl: Sized {
     fn GetRecoverableErrorDataForChange(&self, phrerror: *mut ::windows::core::HRESULT, pperrordata: *mut ::core::option::Option<IRecoverableErrorData>) -> ::windows::core::Result<()>;
     fn GetRecoverableErrorDataForChangeUnit(&self, pchangeunit: &::core::option::Option<ISyncChangeUnit>, phrerror: *mut ::windows::core::HRESULT, pperrordata: *mut ::core::option::Option<IRecoverableErrorData>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRecoverableError {}
 impl IRecoverableError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRecoverableError_Impl, const OFFSET: isize>() -> IRecoverableError_Vtbl {
         unsafe extern "system" fn GetStage<Identity: ::windows::core::IUnknownImpl, Impl: IRecoverableError_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstage: *mut SYNC_PROGRESS_STAGE) -> ::windows::core::HRESULT {
@@ -1405,6 +1448,7 @@ pub trait IRecoverableErrorData_Impl: Sized {
     fn GetItemDisplayName(&self, pszitemdisplayname: &::windows::core::PCWSTR, pcchitemdisplayname: *mut u32) -> ::windows::core::Result<()>;
     fn GetErrorDescription(&self, pszerrordescription: &::windows::core::PCWSTR, pccherrordescription: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRecoverableErrorData {}
 impl IRecoverableErrorData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRecoverableErrorData_Impl, const OFFSET: isize>() -> IRecoverableErrorData_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IRecoverableErrorData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcszitemdisplayname: ::windows::core::PCWSTR, pcszerrordescription: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1439,6 +1483,8 @@ pub trait IRegisteredSyncProvider_Impl: Sized {
     fn GetInstanceId(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IRegisteredSyncProvider {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IRegisteredSyncProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegisteredSyncProvider_Impl, const OFFSET: isize>() -> IRegisteredSyncProvider_Vtbl {
@@ -1479,6 +1525,7 @@ pub trait IReplicaKeyMap_Impl: Sized {
     fn LookupReplicaId(&self, dwreplicakey: u32, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn Serialize(&self, pbreplicakeymap: *mut u8, pcbreplicakeymap: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReplicaKeyMap {}
 impl IReplicaKeyMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReplicaKeyMap_Impl, const OFFSET: isize>() -> IReplicaKeyMap_Vtbl {
         unsafe extern "system" fn LookupReplicaKey<Identity: ::windows::core::IUnknownImpl, Impl: IReplicaKeyMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::HRESULT {
@@ -1510,6 +1557,7 @@ impl IReplicaKeyMap_Vtbl {
 pub trait IRequestFilteredSync_Impl: Sized {
     fn SpecifyFilter(&self, pcallback: &::core::option::Option<IFilterRequestCallback>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRequestFilteredSync {}
 impl IRequestFilteredSync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRequestFilteredSync_Impl, const OFFSET: isize>() -> IRequestFilteredSync_Vtbl {
         unsafe extern "system" fn SpecifyFilter<Identity: ::windows::core::IUnknownImpl, Impl: IRequestFilteredSync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcallback: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1527,6 +1575,7 @@ pub trait ISingleItemException_Impl: Sized {
     fn GetItemId(&self, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetClockVector(&self, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISingleItemException {}
 impl ISingleItemException_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISingleItemException_Impl, const OFFSET: isize>() -> ISingleItemException_Vtbl {
         unsafe extern "system" fn GetItemId<Identity: ::windows::core::IUnknownImpl, Impl: ISingleItemException_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1552,6 +1601,7 @@ impl ISingleItemException_Vtbl {
 pub trait ISupportFilteredSync_Impl: Sized {
     fn AddFilter(&self, pfilter: &::core::option::Option<::windows::core::IUnknown>, filteringtype: FILTERING_TYPE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISupportFilteredSync {}
 impl ISupportFilteredSync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISupportFilteredSync_Impl, const OFFSET: isize>() -> ISupportFilteredSync_Vtbl {
         unsafe extern "system" fn AddFilter<Identity: ::windows::core::IUnknownImpl, Impl: ISupportFilteredSync_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void, filteringtype: FILTERING_TYPE) -> ::windows::core::HRESULT {
@@ -1569,6 +1619,7 @@ pub trait ISupportLastWriteTime_Impl: Sized {
     fn GetItemChangeTime(&self, pbitemid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::Result<()>;
     fn GetChangeUnitChangeTime(&self, pbitemid: *const u8, pbchangeunitid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISupportLastWriteTime {}
 impl ISupportLastWriteTime_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISupportLastWriteTime_Impl, const OFFSET: isize>() -> ISupportLastWriteTime_Vtbl {
         unsafe extern "system" fn GetItemChangeTime<Identity: ::windows::core::IUnknownImpl, Impl: ISupportLastWriteTime_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbitemid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::HRESULT {
@@ -1598,6 +1649,7 @@ pub trait ISyncCallback_Impl: Sized {
     fn OnFullEnumerationNeeded(&self, pfullenumerationaction: *mut SYNC_FULL_ENUMERATION_ACTION) -> ::windows::core::Result<()>;
     fn OnRecoverableError(&self, precoverableerror: &::core::option::Option<IRecoverableError>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncCallback {}
 impl ISyncCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncCallback_Impl, const OFFSET: isize>() -> ISyncCallback_Vtbl {
         unsafe extern "system" fn OnProgress<Identity: ::windows::core::IUnknownImpl, Impl: ISyncCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, provider: SYNC_PROVIDER_ROLE, syncstage: SYNC_PROGRESS_STAGE, dwcompletedwork: u32, dwtotalwork: u32) -> ::windows::core::HRESULT {
@@ -1642,6 +1694,7 @@ pub trait ISyncCallback2_Impl: Sized + ISyncCallback_Impl {
     fn OnChangeApplied(&self, dwchangesapplied: u32, dwchangesfailed: u32) -> ::windows::core::Result<()>;
     fn OnChangeFailed(&self, dwchangesapplied: u32, dwchangesfailed: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncCallback2 {}
 impl ISyncCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncCallback2_Impl, const OFFSET: isize>() -> ISyncCallback2_Vtbl {
         unsafe extern "system" fn OnChangeApplied<Identity: ::windows::core::IUnknownImpl, Impl: ISyncCallback2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwchangesapplied: u32, dwchangesfailed: u32) -> ::windows::core::HRESULT {
@@ -1676,6 +1729,7 @@ pub trait ISyncChange_Impl: Sized {
     fn GetLearnedKnowledge(&self) -> ::windows::core::Result<ISyncKnowledge>;
     fn SetWorkEstimate(&self, dwwork: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncChange {}
 impl ISyncChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChange_Impl, const OFFSET: isize>() -> ISyncChange_Vtbl {
         unsafe extern "system" fn GetOwnerReplicaId<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -1771,6 +1825,8 @@ pub trait ISyncChangeBatch_Impl: Sized + ISyncChangeBatchBase_Impl {
     fn AddLoggedConflict(&self, pbownerreplicaid: *const u8, pbitemid: *const u8, pchangeversion: *const SYNC_VERSION, pcreationversion: *const SYNC_VERSION, dwflags: u32, dwworkforchange: u32, pconflictknowledge: &::core::option::Option<ISyncKnowledge>) -> ::windows::core::Result<ISyncChangeBuilder>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeBatch {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeBatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatch_Impl, const OFFSET: isize>() -> ISyncChangeBatch_Vtbl {
         unsafe extern "system" fn BeginUnorderedGroup<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1810,6 +1866,8 @@ pub trait ISyncChangeBatch2_Impl: Sized + ISyncChangeBatchBase_Impl + ISyncChang
     fn AddMergeTombstoneMetadataToGroup(&self, pbownerreplicaid: *const u8, pbwinneritemid: *const u8, pbitemid: *const u8, pchangeversion: *const SYNC_VERSION, pcreationversion: *const SYNC_VERSION, dwworkforchange: u32) -> ::windows::core::Result<ISyncChangeBuilder>;
     fn AddMergeTombstoneLoggedConflict(&self, pbownerreplicaid: *const u8, pbwinneritemid: *const u8, pbitemid: *const u8, pchangeversion: *const SYNC_VERSION, pcreationversion: *const SYNC_VERSION, dwworkforchange: u32, pconflictknowledge: &::core::option::Option<ISyncKnowledge>) -> ::windows::core::Result<ISyncChangeBuilder>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeBatch2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeBatch2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatch2_Impl, const OFFSET: isize>() -> ISyncChangeBatch2_Vtbl {
@@ -1852,6 +1910,8 @@ pub trait ISyncChangeBatchAdvanced_Impl: Sized {
     fn GetUpperBoundItemId(&self, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetBatchLevelKnowledgeShouldBeApplied(&self, pfbatchknowledgeshouldbeapplied: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeBatchAdvanced {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeBatchAdvanced_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchAdvanced_Impl, const OFFSET: isize>() -> ISyncChangeBatchAdvanced_Vtbl {
@@ -1916,6 +1976,8 @@ pub trait ISyncChangeBatchBase_Impl: Sized {
     fn SetRemainingWorkEstimateForSession(&self, dwremainingworkforsession: u32) -> ::windows::core::Result<()>;
     fn Serialize(&self, pbchangebatch: *mut u8, pcbchangebatch: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeBatchBase {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeBatchBase_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchBase_Impl, const OFFSET: isize>() -> ISyncChangeBatchBase_Vtbl {
@@ -2046,6 +2108,8 @@ pub trait ISyncChangeBatchBase2_Impl: Sized + ISyncChangeBatchBase_Impl {
     fn SerializeWithOptions(&self, targetformatversion: SYNC_SERIALIZATION_VERSION, dwflags: u32, pbbuffer: *mut u8, pdwserializedsize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeBatchBase2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeBatchBase2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchBase2_Impl, const OFFSET: isize>() -> ISyncChangeBatchBase2_Vtbl {
         unsafe extern "system" fn SerializeWithOptions<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchBase2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetformatversion: SYNC_SERIALIZATION_VERSION, dwflags: u32, pbbuffer: *mut u8, pdwserializedsize: *mut u32) -> ::windows::core::HRESULT {
@@ -2069,6 +2133,7 @@ pub trait ISyncChangeBatchWithFilterKeyMap_Impl: Sized {
     fn GetFilteredReplicaLearnedForgottenKnowledgeAfterRecoveryComplete(&self, pdestinationknowledge: &::core::option::Option<ISyncKnowledge>, pnewmoveins: &::core::option::Option<IEnumItemIds>) -> ::windows::core::Result<ISyncKnowledge>;
     fn GetLearnedFilterForgottenKnowledgeAfterRecoveryComplete(&self, pdestinationknowledge: &::core::option::Option<ISyncKnowledge>, pnewmoveins: &::core::option::Option<IEnumItemIds>, dwfilterkey: u32) -> ::windows::core::Result<ISyncKnowledge>;
 }
+impl ::windows::core::RuntimeName for ISyncChangeBatchWithFilterKeyMap {}
 impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchWithFilterKeyMap_Impl, const OFFSET: isize>() -> ISyncChangeBatchWithFilterKeyMap_Vtbl {
         unsafe extern "system" fn GetFilterKeyMap<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchWithFilterKeyMap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppifilterkeymap: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2170,6 +2235,8 @@ pub trait ISyncChangeBatchWithPrerequisite_Impl: Sized + ISyncChangeBatchBase_Im
     fn GetLearnedForgottenKnowledge(&self) -> ::windows::core::Result<IForgottenKnowledge>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeBatchWithPrerequisite {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeBatchWithPrerequisite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchWithPrerequisite_Impl, const OFFSET: isize>() -> ISyncChangeBatchWithPrerequisite_Vtbl {
         unsafe extern "system" fn SetPrerequisiteKnowledge<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBatchWithPrerequisite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprerequisiteknowledge: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2213,6 +2280,7 @@ impl ISyncChangeBatchWithPrerequisite_Vtbl {
 pub trait ISyncChangeBuilder_Impl: Sized {
     fn AddChangeUnitMetadata(&self, pbchangeunitid: *const u8, pchangeunitversion: *const SYNC_VERSION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncChangeBuilder {}
 impl ISyncChangeBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBuilder_Impl, const OFFSET: isize>() -> ISyncChangeBuilder_Vtbl {
         unsafe extern "system" fn AddChangeUnitMetadata<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbchangeunitid: *const u8, pchangeunitversion: *const SYNC_VERSION) -> ::windows::core::HRESULT {
@@ -2231,6 +2299,7 @@ pub trait ISyncChangeUnit_Impl: Sized {
     fn GetChangeUnitId(&self, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetChangeUnitVersion(&self, pbcurrentreplicaid: *const u8, pversion: *mut SYNC_VERSION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncChangeUnit {}
 impl ISyncChangeUnit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeUnit_Impl, const OFFSET: isize>() -> ISyncChangeUnit_Vtbl {
         unsafe extern "system" fn GetItemChange<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeUnit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsyncchange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2277,6 +2346,8 @@ pub trait ISyncChangeWithFilterKeyMap_Impl: Sized {
     fn GetFilteredReplicaLearnedForgottenKnowledgeAfterRecoveryComplete(&self, pdestinationknowledge: &::core::option::Option<ISyncKnowledge>, pnewmoveins: &::core::option::Option<IEnumItemIds>) -> ::windows::core::Result<ISyncKnowledge>;
     fn GetLearnedFilterForgottenKnowledgeAfterRecoveryComplete(&self, pdestinationknowledge: &::core::option::Option<ISyncKnowledge>, pnewmoveins: &::core::option::Option<IEnumItemIds>, dwfilterkey: u32) -> ::windows::core::Result<ISyncKnowledge>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncChangeWithFilterKeyMap {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncChangeWithFilterKeyMap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeWithFilterKeyMap_Impl, const OFFSET: isize>() -> ISyncChangeWithFilterKeyMap_Vtbl {
@@ -2382,6 +2453,7 @@ pub trait ISyncChangeWithPrerequisite_Impl: Sized {
     fn GetPrerequisiteKnowledge(&self) -> ::windows::core::Result<ISyncKnowledge>;
     fn GetLearnedKnowledgeWithPrerequisite(&self, pdestinationknowledge: &::core::option::Option<ISyncKnowledge>) -> ::windows::core::Result<ISyncKnowledge>;
 }
+impl ::windows::core::RuntimeName for ISyncChangeWithPrerequisite {}
 impl ISyncChangeWithPrerequisite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeWithPrerequisite_Impl, const OFFSET: isize>() -> ISyncChangeWithPrerequisite_Vtbl {
         unsafe extern "system" fn GetPrerequisiteKnowledge<Identity: ::windows::core::IUnknownImpl, Impl: ISyncChangeWithPrerequisite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppprerequisiteknowledge: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2419,6 +2491,7 @@ impl ISyncChangeWithPrerequisite_Vtbl {
 pub trait ISyncConstraintCallback_Impl: Sized {
     fn OnConstraintConflict(&self, pconflict: &::core::option::Option<IConstraintConflict>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncConstraintCallback {}
 impl ISyncConstraintCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncConstraintCallback_Impl, const OFFSET: isize>() -> ISyncConstraintCallback_Vtbl {
         unsafe extern "system" fn OnConstraintConflict<Identity: ::windows::core::IUnknownImpl, Impl: ISyncConstraintCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconflict: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2438,6 +2511,7 @@ pub trait ISyncDataConverter_Impl: Sized {
     fn ConvertDataFromProviderFormat(&self, pdatacontext: &::core::option::Option<ILoadChangeContext>, punkdatain: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn ConvertDataToProviderFormat(&self, pdatacontext: &::core::option::Option<ILoadChangeContext>, punkdataout: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for ISyncDataConverter {}
 impl ISyncDataConverter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncDataConverter_Impl, const OFFSET: isize>() -> ISyncDataConverter_Vtbl {
         unsafe extern "system" fn ConvertDataRetrieverFromProviderFormat<Identity: ::windows::core::IUnknownImpl, Impl: ISyncDataConverter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkdataretrieverin: *mut ::core::ffi::c_void, penumsyncchanges: ::windows::core::RawPtr, ppunkdataout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2500,6 +2574,7 @@ pub trait ISyncFilter_Impl: Sized {
     fn IsIdentical(&self, psyncfilter: &::core::option::Option<ISyncFilter>) -> ::windows::core::Result<()>;
     fn Serialize(&self, pbsyncfilter: *mut u8, pcbsyncfilter: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncFilter {}
 impl ISyncFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilter_Impl, const OFFSET: isize>() -> ISyncFilter_Vtbl {
         unsafe extern "system" fn IsIdentical<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psyncfilter: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2525,6 +2600,7 @@ impl ISyncFilter_Vtbl {
 pub trait ISyncFilterDeserializer_Impl: Sized {
     fn DeserializeSyncFilter(&self, pbsyncfilter: *const u8, dwcbsyncfilter: u32) -> ::windows::core::Result<ISyncFilter>;
 }
+impl ::windows::core::RuntimeName for ISyncFilterDeserializer {}
 impl ISyncFilterDeserializer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilterDeserializer_Impl, const OFFSET: isize>() -> ISyncFilterDeserializer_Vtbl {
         unsafe extern "system" fn DeserializeSyncFilter<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilterDeserializer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbsyncfilter: *const u8, dwcbsyncfilter: u32, ppisyncfilter: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2547,6 +2623,7 @@ impl ISyncFilterDeserializer_Vtbl {
 pub trait ISyncFilterInfo_Impl: Sized {
     fn Serialize(&self, pbbuffer: *mut u8, pcbbuffer: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncFilterInfo {}
 impl ISyncFilterInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilterInfo_Impl, const OFFSET: isize>() -> ISyncFilterInfo_Vtbl {
         unsafe extern "system" fn Serialize<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilterInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbbuffer: *mut u8, pcbbuffer: *mut u32) -> ::windows::core::HRESULT {
@@ -2563,6 +2640,7 @@ impl ISyncFilterInfo_Vtbl {
 pub trait ISyncFilterInfo2_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetFlags(&self, pdwflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncFilterInfo2 {}
 impl ISyncFilterInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilterInfo2_Impl, const OFFSET: isize>() -> ISyncFilterInfo2_Vtbl {
         unsafe extern "system" fn GetFlags<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFilterInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -2580,6 +2658,7 @@ pub trait ISyncFullEnumerationChange_Impl: Sized {
     fn GetLearnedKnowledgeAfterRecoveryComplete(&self) -> ::windows::core::Result<ISyncKnowledge>;
     fn GetLearnedForgottenKnowledge(&self) -> ::windows::core::Result<IForgottenKnowledge>;
 }
+impl ::windows::core::RuntimeName for ISyncFullEnumerationChange {}
 impl ISyncFullEnumerationChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFullEnumerationChange_Impl, const OFFSET: isize>() -> ISyncFullEnumerationChange_Vtbl {
         unsafe extern "system" fn GetLearnedKnowledgeAfterRecoveryComplete<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFullEnumerationChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pplearnedknowledge: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2621,6 +2700,8 @@ pub trait ISyncFullEnumerationChangeBatch_Impl: Sized + ISyncChangeBatchBase_Imp
     fn GetClosedUpperBoundItemId(&self, pbclosedupperbounditemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncFullEnumerationChangeBatch {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncFullEnumerationChangeBatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFullEnumerationChangeBatch_Impl, const OFFSET: isize>() -> ISyncFullEnumerationChangeBatch_Vtbl {
         unsafe extern "system" fn GetLearnedKnowledgeAfterRecoveryComplete<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFullEnumerationChangeBatch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pplearnedknowledgeafterrecoverycomplete: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2659,6 +2740,8 @@ impl ISyncFullEnumerationChangeBatch_Vtbl {
 pub trait ISyncFullEnumerationChangeBatch2_Impl: Sized + ISyncChangeBatchBase_Impl + ISyncFullEnumerationChangeBatch_Impl {
     fn AddMergeTombstoneMetadataToGroup(&self, pbownerreplicaid: *const u8, pbwinneritemid: *const u8, pbitemid: *const u8, pchangeversion: *const SYNC_VERSION, pcreationversion: *const SYNC_VERSION, dwworkforchange: u32) -> ::windows::core::Result<ISyncChangeBuilder>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncFullEnumerationChangeBatch2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncFullEnumerationChangeBatch2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncFullEnumerationChangeBatch2_Impl, const OFFSET: isize>() -> ISyncFullEnumerationChangeBatch2_Vtbl {
@@ -2709,6 +2792,8 @@ pub trait ISyncKnowledge_Impl: Sized {
     fn FindClockVectorForChangeUnit(&self, pbitemid: *const u8, pbchangeunitid: *const u8, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetVersion(&self, pdwversion: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncKnowledge {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncKnowledge_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncKnowledge_Impl, const OFFSET: isize>() -> ISyncKnowledge_Vtbl {
@@ -2918,6 +3003,8 @@ pub trait ISyncKnowledge2_Impl: Sized + ISyncKnowledge_Impl {
     fn CompareToKnowledgeCookie(&self, pknowledgecookie: &::core::option::Option<::windows::core::IUnknown>, presult: *mut KNOWLEDGE_COOKIE_COMPARISON_RESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncKnowledge2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncKnowledge2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncKnowledge2_Impl, const OFFSET: isize>() -> ISyncKnowledge2_Vtbl {
         unsafe extern "system" fn GetIdParameters<Identity: ::windows::core::IUnknownImpl, Impl: ISyncKnowledge2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::HRESULT {
@@ -3039,6 +3126,7 @@ impl ISyncKnowledge2_Vtbl {
 pub trait ISyncMergeTombstoneChange_Impl: Sized {
     fn GetWinnerItemId(&self, pbwinneritemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncMergeTombstoneChange {}
 impl ISyncMergeTombstoneChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMergeTombstoneChange_Impl, const OFFSET: isize>() -> ISyncMergeTombstoneChange_Vtbl {
         unsafe extern "system" fn GetWinnerItemId<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMergeTombstoneChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbwinneritemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT {
@@ -3056,6 +3144,8 @@ impl ISyncMergeTombstoneChange_Vtbl {
 pub trait ISyncProvider_Impl: Sized {
     fn GetIdParameters(&self, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncProvider_Impl, const OFFSET: isize>() -> ISyncProvider_Vtbl {
@@ -3077,6 +3167,8 @@ pub trait ISyncProviderConfigUI_Impl: Sized {
     fn CreateAndRegisterNewSyncProvider(&self, hwndparent: super::super::Foundation::HWND, punkcontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<ISyncProviderInfo>;
     fn ModifySyncProvider(&self, hwndparent: super::super::Foundation::HWND, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pproviderinfo: &::core::option::Option<ISyncProviderInfo>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISyncProviderConfigUI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISyncProviderConfigUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncProviderConfigUI_Impl, const OFFSET: isize>() -> ISyncProviderConfigUI_Vtbl {
@@ -3129,6 +3221,8 @@ pub trait ISyncProviderConfigUIInfo_Impl: Sized + super::super::UI::Shell::Prope
     fn GetSyncProviderConfigUI(&self, dwclscontext: u32) -> ::windows::core::Result<ISyncProviderConfigUI>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISyncProviderConfigUIInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISyncProviderConfigUIInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncProviderConfigUIInfo_Impl, const OFFSET: isize>() -> ISyncProviderConfigUIInfo_Vtbl {
         unsafe extern "system" fn GetSyncProviderConfigUI<Identity: ::windows::core::IUnknownImpl, Impl: ISyncProviderConfigUIInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwclscontext: u32, ppsyncproviderconfigui: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3155,6 +3249,8 @@ impl ISyncProviderConfigUIInfo_Vtbl {
 pub trait ISyncProviderInfo_Impl: Sized + super::super::UI::Shell::PropertiesSystem::IPropertyStore_Impl {
     fn GetSyncProvider(&self, dwclscontext: u32) -> ::windows::core::Result<IRegisteredSyncProvider>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISyncProviderInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISyncProviderInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncProviderInfo_Impl, const OFFSET: isize>() -> ISyncProviderInfo_Vtbl {
@@ -3197,6 +3293,8 @@ pub trait ISyncProviderRegistration_Impl: Sized {
     fn RevokeEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn GetChange(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<ISyncRegistrationChange>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISyncProviderRegistration {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISyncProviderRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncProviderRegistration_Impl, const OFFSET: isize>() -> ISyncProviderRegistration_Vtbl {
@@ -3374,6 +3472,7 @@ pub trait ISyncRegistrationChange_Impl: Sized {
     fn GetEvent(&self) -> ::windows::core::Result<SYNC_REGISTRATION_EVENT>;
     fn GetInstanceId(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for ISyncRegistrationChange {}
 impl ISyncRegistrationChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncRegistrationChange_Impl, const OFFSET: isize>() -> ISyncRegistrationChange_Vtbl {
         unsafe extern "system" fn GetEvent<Identity: ::windows::core::IUnknownImpl, Impl: ISyncRegistrationChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psreevent: *mut SYNC_REGISTRATION_EVENT) -> ::windows::core::HRESULT {
@@ -3411,6 +3510,7 @@ impl ISyncRegistrationChange_Vtbl {
 pub trait ISyncSessionExtendedErrorInfo_Impl: Sized {
     fn GetSyncProviderWithError(&self) -> ::windows::core::Result<ISyncProvider>;
 }
+impl ::windows::core::RuntimeName for ISyncSessionExtendedErrorInfo {}
 impl ISyncSessionExtendedErrorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncSessionExtendedErrorInfo_Impl, const OFFSET: isize>() -> ISyncSessionExtendedErrorInfo_Vtbl {
         unsafe extern "system" fn GetSyncProviderWithError<Identity: ::windows::core::IUnknownImpl, Impl: ISyncSessionExtendedErrorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppproviderwitherror: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3440,6 +3540,8 @@ pub trait ISyncSessionState_Impl: Sized {
     fn SetForgottenKnowledgeRecoveryRange(&self, prange: *const SYNC_RANGE) -> ::windows::core::Result<()>;
     fn OnProgress(&self, provider: SYNC_PROVIDER_ROLE, syncstage: SYNC_PROGRESS_STAGE, dwcompletedwork: u32, dwtotalwork: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncSessionState {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncSessionState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncSessionState_Impl, const OFFSET: isize>() -> ISyncSessionState_Vtbl {
@@ -3499,6 +3601,8 @@ pub trait ISyncSessionState2_Impl: Sized + ISyncSessionState_Impl {
     fn GetSessionErrorStatus(&self, phrsessionerror: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncSessionState2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncSessionState2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncSessionState2_Impl, const OFFSET: isize>() -> ISyncSessionState2_Vtbl {
         unsafe extern "system" fn SetProviderWithError<Identity: ::windows::core::IUnknownImpl, Impl: ISyncSessionState2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fself: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3526,6 +3630,8 @@ pub trait ISynchronousDataRetriever_Impl: Sized {
     fn GetIdParameters(&self, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::Result<()>;
     fn LoadChangeData(&self, ploadchangecontext: &::core::option::Option<ILoadChangeContext>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISynchronousDataRetriever {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISynchronousDataRetriever_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronousDataRetriever_Impl, const OFFSET: isize>() -> ISynchronousDataRetriever_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
@@ -5,6 +5,7 @@ pub trait IEnumWbemClassObject_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumWbemClassObject>;
     fn Skip(&self, ltimeout: i32, ncount: u32) -> ::windows::core::HRESULT;
 }
+impl ::windows::core::RuntimeName for IEnumWbemClassObject {}
 impl IEnumWbemClassObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWbemClassObject_Impl, const OFFSET: isize>() -> IEnumWbemClassObject_Vtbl {
         unsafe extern "system" fn Reset<Identity: ::windows::core::IUnknownImpl, Impl: IEnumWbemClassObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -56,6 +57,7 @@ pub trait IMofCompiler_Impl: Sized {
     fn CompileBuffer(&self, buffsize: i32, pbuffer: *const u8, serverandnamespace: &::windows::core::PCWSTR, user: &::windows::core::PCWSTR, authority: &::windows::core::PCWSTR, password: &::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::Result<()>;
     fn CreateBMOF(&self, textfilename: &::windows::core::PCWSTR, bmoffilename: &::windows::core::PCWSTR, serverandnamespace: &::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMofCompiler {}
 impl IMofCompiler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMofCompiler_Impl, const OFFSET: isize>() -> IMofCompiler_Vtbl {
         unsafe extern "system" fn CompileFile<Identity: ::windows::core::IUnknownImpl, Impl: IMofCompiler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, serverandnamespace: ::windows::core::PCWSTR, user: ::windows::core::PCWSTR, authority: ::windows::core::PCWSTR, password: ::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::HRESULT {
@@ -127,6 +129,8 @@ pub trait ISWbemDateTime_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetFileTime(&self, bislocal: i16) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetFileTime(&self, strfiletime: &super::super::Foundation::BSTR, bislocal: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemDateTime {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemDateTime_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemDateTime_Impl, const OFFSET: isize>() -> ISWbemDateTime_Vtbl {
@@ -504,6 +508,8 @@ pub trait ISWbemEventSource_Impl: Sized + super::Com::IDispatch_Impl {
     fn Security_(&self) -> ::windows::core::Result<ISWbemSecurity>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemEventSource {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemEventSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemEventSource_Impl, const OFFSET: isize>() -> ISWbemEventSource_Vtbl {
         unsafe extern "system" fn NextEvent<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemEventSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, itimeoutms: i32, objwbemobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -541,6 +547,8 @@ impl ISWbemEventSource_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemLastError_Impl: Sized + super::Com::IDispatch_Impl + ISWbemObject_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemLastError {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemLastError_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemLastError_Impl, const OFFSET: isize>() -> ISWbemLastError_Vtbl {
         Self { base__: ISWbemObject_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -554,6 +562,8 @@ pub trait ISWbemLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectServer(&self, strserver: &super::super::Foundation::BSTR, strnamespace: &super::super::Foundation::BSTR, struser: &super::super::Foundation::BSTR, strpassword: &super::super::Foundation::BSTR, strlocale: &super::super::Foundation::BSTR, strauthority: &super::super::Foundation::BSTR, isecurityflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<ISWbemServices>;
     fn Security_(&self) -> ::windows::core::Result<ISWbemSecurity>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemLocator {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemLocator_Impl, const OFFSET: isize>() -> ISWbemLocator_Vtbl {
@@ -597,6 +607,8 @@ pub trait ISWbemMethod_Impl: Sized + super::Com::IDispatch_Impl {
     fn OutParameters(&self) -> ::windows::core::Result<ISWbemObject>;
     fn Qualifiers_(&self) -> ::windows::core::Result<ISWbemQualifierSet>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemMethod {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemMethod_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemMethod_Impl, const OFFSET: isize>() -> ISWbemMethod_Vtbl {
@@ -675,6 +687,8 @@ pub trait ISWbemMethodSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemMethodSet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemMethodSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemMethodSet_Impl, const OFFSET: isize>() -> ISWbemMethodSet_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemMethodSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -728,6 +742,8 @@ pub trait ISWbemNamedValue_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemNamedValue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemNamedValue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemNamedValue_Impl, const OFFSET: isize>() -> ISWbemNamedValue_Vtbl {
         unsafe extern "system" fn Value<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemNamedValue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, varvalue: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -778,6 +794,8 @@ pub trait ISWbemNamedValueSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn Clone(&self) -> ::windows::core::Result<ISWbemNamedValueSet>;
     fn DeleteAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemNamedValueSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemNamedValueSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemNamedValueSet_Impl, const OFFSET: isize>() -> ISWbemNamedValueSet_Vtbl {
@@ -889,6 +907,8 @@ pub trait ISWbemObject_Impl: Sized + super::Com::IDispatch_Impl {
     fn Path_(&self) -> ::windows::core::Result<ISWbemObjectPath>;
     fn Security_(&self) -> ::windows::core::Result<ISWbemSecurity>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemObject_Impl, const OFFSET: isize>() -> ISWbemObject_Vtbl {
@@ -1189,6 +1209,8 @@ pub trait ISWbemObjectEx_Impl: Sized + super::Com::IDispatch_Impl + ISWbemObject
     fn SetFromText_(&self, bstext: &super::super::Foundation::BSTR, iobjecttextformat: WbemObjectTextFormatEnum, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemObjectEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemObjectEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemObjectEx_Impl, const OFFSET: isize>() -> ISWbemObjectEx_Vtbl {
         unsafe extern "system" fn Refresh_<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemObjectEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iflags: i32, objwbemnamedvalueset: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1261,6 +1283,8 @@ pub trait ISWbemObjectPath_Impl: Sized + super::Com::IDispatch_Impl {
     fn Authority(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SetAuthority(&self, strauthority: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemObjectPath {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemObjectPath_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemObjectPath_Impl, const OFFSET: isize>() -> ISWbemObjectPath_Vtbl {
@@ -1497,6 +1521,8 @@ pub trait ISWbemObjectSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn ItemIndex(&self, lindex: i32) -> ::windows::core::Result<ISWbemObject>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemObjectSet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemObjectSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemObjectSet_Impl, const OFFSET: isize>() -> ISWbemObjectSet_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemObjectSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1576,6 +1602,8 @@ pub trait ISWbemPrivilege_Impl: Sized + super::Com::IDispatch_Impl {
     fn Identifier(&self) -> ::windows::core::Result<WbemPrivilegeEnum>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemPrivilege {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemPrivilege_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemPrivilege_Impl, const OFFSET: isize>() -> ISWbemPrivilege_Vtbl {
         unsafe extern "system" fn IsEnabled<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemPrivilege_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bisenabled: *mut i16) -> ::windows::core::HRESULT {
@@ -1650,6 +1678,8 @@ pub trait ISWbemPrivilegeSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn DeleteAll(&self) -> ::windows::core::Result<()>;
     fn AddAsString(&self, strprivilege: &super::super::Foundation::BSTR, bisenabled: i16) -> ::windows::core::Result<ISWbemPrivilege>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemPrivilegeSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemPrivilegeSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemPrivilegeSet_Impl, const OFFSET: isize>() -> ISWbemPrivilegeSet_Vtbl {
@@ -1744,6 +1774,8 @@ pub trait ISWbemProperty_Impl: Sized + super::Com::IDispatch_Impl {
     fn Qualifiers_(&self) -> ::windows::core::Result<ISWbemQualifierSet>;
     fn IsArray(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemProperty_Impl, const OFFSET: isize>() -> ISWbemProperty_Vtbl {
@@ -1854,6 +1886,8 @@ pub trait ISWbemPropertySet_Impl: Sized + super::Com::IDispatch_Impl {
     fn Remove(&self, strname: &super::super::Foundation::BSTR, iflags: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemPropertySet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemPropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemPropertySet_Impl, const OFFSET: isize>() -> ISWbemPropertySet_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemPropertySet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1932,6 +1966,8 @@ pub trait ISWbemQualifier_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetIsOverridable(&self, bisoverridable: i16) -> ::windows::core::Result<()>;
     fn IsAmended(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemQualifier {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemQualifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemQualifier_Impl, const OFFSET: isize>() -> ISWbemQualifier_Vtbl {
@@ -2060,6 +2096,8 @@ pub trait ISWbemQualifierSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn Remove(&self, strname: &super::super::Foundation::BSTR, iflags: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemQualifierSet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemQualifierSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemQualifierSet_Impl, const OFFSET: isize>() -> ISWbemQualifierSet_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemQualifierSet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2133,6 +2171,8 @@ pub trait ISWbemRefreshableItem_Impl: Sized + super::Com::IDispatch_Impl {
     fn ObjectSet(&self) -> ::windows::core::Result<ISWbemObjectSet>;
     fn Remove(&self, iflags: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemRefreshableItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemRefreshableItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemRefreshableItem_Impl, const OFFSET: isize>() -> ISWbemRefreshableItem_Vtbl {
@@ -2223,6 +2263,8 @@ pub trait ISWbemRefresher_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetAutoReconnect(&self, bcount: i16) -> ::windows::core::Result<()>;
     fn DeleteAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemRefresher {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemRefresher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemRefresher_Impl, const OFFSET: isize>() -> ISWbemRefresher_Vtbl {
@@ -2339,6 +2381,8 @@ pub trait ISWbemSecurity_Impl: Sized + super::Com::IDispatch_Impl {
     fn Privileges(&self) -> ::windows::core::Result<ISWbemPrivilegeSet>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemSecurity {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemSecurity_Impl, const OFFSET: isize>() -> ISWbemSecurity_Vtbl {
         unsafe extern "system" fn ImpersonationLevel<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemSecurity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iimpersonationlevel: *mut WbemImpersonationLevelEnum) -> ::windows::core::HRESULT {
@@ -2419,6 +2463,8 @@ pub trait ISWbemServices_Impl: Sized + super::Com::IDispatch_Impl {
     fn ExecMethodAsync(&self, objwbemsink: &::core::option::Option<super::Com::IDispatch>, strobjectpath: &super::super::Foundation::BSTR, strmethodname: &super::super::Foundation::BSTR, objwbeminparameters: &::core::option::Option<super::Com::IDispatch>, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>, objwbemasynccontext: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
     fn Security_(&self) -> ::windows::core::Result<ISWbemSecurity>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemServices_Impl, const OFFSET: isize>() -> ISWbemServices_Vtbl {
@@ -2649,6 +2695,8 @@ pub trait ISWbemServicesEx_Impl: Sized + super::Com::IDispatch_Impl + ISWbemServ
     fn PutAsync(&self, objwbemsink: &::core::option::Option<ISWbemSink>, objwbemobject: &::core::option::Option<ISWbemObjectEx>, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>, objwbemasynccontext: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemServicesEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemServicesEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemServicesEx_Impl, const OFFSET: isize>() -> ISWbemServicesEx_Vtbl {
         unsafe extern "system" fn Put<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemServicesEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, objwbemobject: ::windows::core::RawPtr, iflags: i32, objwbemnamedvalueset: ::windows::core::RawPtr, objwbemobjectpath: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2678,6 +2726,8 @@ pub trait ISWbemSink_Impl: Sized + super::Com::IDispatch_Impl {
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemSink_Impl, const OFFSET: isize>() -> ISWbemSink_Vtbl {
         unsafe extern "system" fn Cancel<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2694,6 +2744,8 @@ impl ISWbemSink_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemSinkEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISWbemSinkEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISWbemSinkEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISWbemSinkEvents_Impl, const OFFSET: isize>() -> ISWbemSinkEvents_Vtbl {
         Self { base__: super::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -2705,6 +2757,7 @@ impl ISWbemSinkEvents_Vtbl {
 pub trait IUnsecuredApartment_Impl: Sized {
     fn CreateObjectStub(&self, pobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IUnsecuredApartment {}
 impl IUnsecuredApartment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUnsecuredApartment_Impl, const OFFSET: isize>() -> IUnsecuredApartment_Vtbl {
         unsafe extern "system" fn CreateObjectStub<Identity: ::windows::core::IUnknownImpl, Impl: IUnsecuredApartment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pobject: *mut ::core::ffi::c_void, ppstub: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2730,6 +2783,8 @@ pub trait IWMIExtension_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetWMIObject(&self) -> ::windows::core::Result<ISWbemObject>;
     fn GetWMIServices(&self) -> ::windows::core::Result<ISWbemServices>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWMIExtension {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWMIExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWMIExtension_Impl, const OFFSET: isize>() -> IWMIExtension_Vtbl {
@@ -2780,6 +2835,7 @@ impl IWMIExtension_Vtbl {
 pub trait IWbemAddressResolution_Impl: Sized {
     fn Resolve(&self, wsznamespacepath: &::windows::core::PCWSTR, wszaddresstype: ::windows::core::PWSTR, pdwaddresslength: *mut u32, pabbinaryaddress: *mut *mut u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemAddressResolution {}
 impl IWbemAddressResolution_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemAddressResolution_Impl, const OFFSET: isize>() -> IWbemAddressResolution_Vtbl {
         unsafe extern "system" fn Resolve<Identity: ::windows::core::IUnknownImpl, Impl: IWbemAddressResolution_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wsznamespacepath: ::windows::core::PCWSTR, wszaddresstype: ::windows::core::PWSTR, pdwaddresslength: *mut u32, pabbinaryaddress: *mut *mut u8) -> ::windows::core::HRESULT {
@@ -2797,6 +2853,7 @@ pub trait IWbemBackupRestore_Impl: Sized {
     fn Backup(&self, strbackuptofile: &::windows::core::PCWSTR, lflags: i32) -> ::windows::core::Result<()>;
     fn Restore(&self, strrestorefromfile: &::windows::core::PCWSTR, lflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemBackupRestore {}
 impl IWbemBackupRestore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemBackupRestore_Impl, const OFFSET: isize>() -> IWbemBackupRestore_Vtbl {
         unsafe extern "system" fn Backup<Identity: ::windows::core::IUnknownImpl, Impl: IWbemBackupRestore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strbackuptofile: ::windows::core::PCWSTR, lflags: i32) -> ::windows::core::HRESULT {
@@ -2823,6 +2880,7 @@ pub trait IWbemBackupRestoreEx_Impl: Sized + IWbemBackupRestore_Impl {
     fn Pause(&self) -> ::windows::core::Result<()>;
     fn Resume(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemBackupRestoreEx {}
 impl IWbemBackupRestoreEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemBackupRestoreEx_Impl, const OFFSET: isize>() -> IWbemBackupRestoreEx_Vtbl {
         unsafe extern "system" fn Pause<Identity: ::windows::core::IUnknownImpl, Impl: IWbemBackupRestoreEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2852,6 +2910,8 @@ pub trait IWbemCallResult_Impl: Sized {
     fn GetResultServices(&self, ltimeout: i32) -> ::windows::core::Result<IWbemServices>;
     fn GetCallStatus(&self, ltimeout: i32) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemCallResult {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWbemCallResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemCallResult_Impl, const OFFSET: isize>() -> IWbemCallResult_Vtbl {
@@ -2938,6 +2998,8 @@ pub trait IWbemClassObject_Impl: Sized {
     fn GetMethodQualifierSet(&self, wszmethod: &::windows::core::PCWSTR) -> ::windows::core::Result<IWbemQualifierSet>;
     fn GetMethodOrigin(&self, wszmethodname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemClassObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemClassObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemClassObject_Impl, const OFFSET: isize>() -> IWbemClassObject_Vtbl {
@@ -3160,6 +3222,8 @@ pub trait IWbemClientConnectionTransport_Impl: Sized {
     fn Cancel(&self, lflags: i32, phandler: &::core::option::Option<IWbemObjectSink>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemClientConnectionTransport {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWbemClientConnectionTransport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemClientConnectionTransport_Impl, const OFFSET: isize>() -> IWbemClientConnectionTransport_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IWbemClientConnectionTransport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, straddresstype: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strobject: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, struser: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strlocale: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lflags: i32, pctx: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void, pcallres: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3195,6 +3259,8 @@ pub trait IWbemClientTransport_Impl: Sized {
     fn ConnectServer(&self, straddresstype: &super::super::Foundation::BSTR, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strnetworkresource: &super::super::Foundation::BSTR, struser: &super::super::Foundation::BSTR, strpassword: &super::super::Foundation::BSTR, strlocale: &super::super::Foundation::BSTR, lsecurityflags: i32, strauthority: &super::super::Foundation::BSTR, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemClientTransport {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWbemClientTransport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemClientTransport_Impl, const OFFSET: isize>() -> IWbemClientTransport_Vtbl {
         unsafe extern "system" fn ConnectServer<Identity: ::windows::core::IUnknownImpl, Impl: IWbemClientTransport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, straddresstype: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strnetworkresource: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, struser: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strlocale: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lsecurityflags: i32, strauthority: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pctx: ::windows::core::RawPtr, ppnamespace: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3221,6 +3287,7 @@ pub trait IWbemConfigureRefresher_Impl: Sized {
     fn Remove(&self, lid: i32, lflags: i32) -> ::windows::core::Result<()>;
     fn AddEnum(&self, pnamespace: &::core::option::Option<IWbemServices>, wszclassname: &::windows::core::PCWSTR, lflags: i32, pcontext: &::core::option::Option<IWbemContext>, ppenum: *mut ::core::option::Option<IWbemHiPerfEnum>, plid: *mut i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemConfigureRefresher {}
 impl IWbemConfigureRefresher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemConfigureRefresher_Impl, const OFFSET: isize>() -> IWbemConfigureRefresher_Vtbl {
         unsafe extern "system" fn AddObjectByPath<Identity: ::windows::core::IUnknownImpl, Impl: IWbemConfigureRefresher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnamespace: ::windows::core::RawPtr, wszpath: ::windows::core::PCWSTR, lflags: i32, pcontext: ::windows::core::RawPtr, pprefreshable: *mut ::windows::core::RawPtr, plid: *mut i32) -> ::windows::core::HRESULT {
@@ -3264,6 +3331,7 @@ impl IWbemConfigureRefresher_Vtbl {
 pub trait IWbemConnectorLogin_Impl: Sized {
     fn ConnectorLogin(&self, wsznetworkresource: &::windows::core::PCWSTR, wszpreferredlocale: &::windows::core::PCWSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemConnectorLogin {}
 impl IWbemConnectorLogin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemConnectorLogin_Impl, const OFFSET: isize>() -> IWbemConnectorLogin_Vtbl {
         unsafe extern "system" fn ConnectorLogin<Identity: ::windows::core::IUnknownImpl, Impl: IWbemConnectorLogin_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wsznetworkresource: ::windows::core::PCWSTR, wszpreferredlocale: ::windows::core::PCWSTR, lflags: i32, pctx: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3283,6 +3351,7 @@ pub trait IWbemConstructClassObject_Impl: Sized {
     fn SetMethodOrigin(&self, wszmethodname: &::windows::core::PCWSTR, loriginindex: i32) -> ::windows::core::Result<()>;
     fn SetServerNamespace(&self, wszserver: &::windows::core::PCWSTR, wsznamespace: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemConstructClassObject {}
 impl IWbemConstructClassObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemConstructClassObject_Impl, const OFFSET: isize>() -> IWbemConstructClassObject_Vtbl {
         unsafe extern "system" fn SetInheritanceChain<Identity: ::windows::core::IUnknownImpl, Impl: IWbemConstructClassObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lnumantecedents: i32, awszantecedents: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -3329,6 +3398,8 @@ pub trait IWbemContext_Impl: Sized {
     fn DeleteValue(&self, wszname: &::windows::core::PCWSTR, lflags: i32) -> ::windows::core::Result<()>;
     fn DeleteAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemContext_Impl, const OFFSET: isize>() -> IWbemContext_Vtbl {
@@ -3416,6 +3487,7 @@ pub trait IWbemDecoupledBasicEventProvider_Impl: Sized + IWbemDecoupledRegistrar
     fn GetSink(&self, a_flags: i32, a_context: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemObjectSink>;
     fn GetService(&self, a_flags: i32, a_context: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
 }
+impl ::windows::core::RuntimeName for IWbemDecoupledBasicEventProvider {}
 impl IWbemDecoupledBasicEventProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemDecoupledBasicEventProvider_Impl, const OFFSET: isize>() -> IWbemDecoupledBasicEventProvider_Vtbl {
         unsafe extern "system" fn GetSink<Identity: ::windows::core::IUnknownImpl, Impl: IWbemDecoupledBasicEventProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, a_flags: i32, a_context: ::windows::core::RawPtr, a_sink: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3454,6 +3526,7 @@ pub trait IWbemDecoupledRegistrar_Impl: Sized {
     fn Register(&self, a_flags: i32, a_context: &::core::option::Option<IWbemContext>, a_user: &::windows::core::PCWSTR, a_locale: &::windows::core::PCWSTR, a_scope: &::windows::core::PCWSTR, a_registration: &::windows::core::PCWSTR, piunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UnRegister(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemDecoupledRegistrar {}
 impl IWbemDecoupledRegistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemDecoupledRegistrar_Impl, const OFFSET: isize>() -> IWbemDecoupledRegistrar_Vtbl {
         unsafe extern "system" fn Register<Identity: ::windows::core::IUnknownImpl, Impl: IWbemDecoupledRegistrar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, a_flags: i32, a_context: ::windows::core::RawPtr, a_user: ::windows::core::PCWSTR, a_locale: ::windows::core::PCWSTR, a_scope: ::windows::core::PCWSTR, a_registration: ::windows::core::PCWSTR, piunknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3479,6 +3552,7 @@ impl IWbemDecoupledRegistrar_Vtbl {
 pub trait IWbemEventConsumerProvider_Impl: Sized {
     fn FindConsumer(&self, plogicalconsumer: &::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<IWbemUnboundObjectSink>;
 }
+impl ::windows::core::RuntimeName for IWbemEventConsumerProvider {}
 impl IWbemEventConsumerProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventConsumerProvider_Impl, const OFFSET: isize>() -> IWbemEventConsumerProvider_Vtbl {
         unsafe extern "system" fn FindConsumer<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventConsumerProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plogicalconsumer: ::windows::core::RawPtr, ppconsumer: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3501,6 +3575,7 @@ impl IWbemEventConsumerProvider_Vtbl {
 pub trait IWbemEventProvider_Impl: Sized {
     fn ProvideEvents(&self, psink: &::core::option::Option<IWbemObjectSink>, lflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemEventProvider {}
 impl IWbemEventProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventProvider_Impl, const OFFSET: isize>() -> IWbemEventProvider_Vtbl {
         unsafe extern "system" fn ProvideEvents<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psink: ::windows::core::RawPtr, lflags: i32) -> ::windows::core::HRESULT {
@@ -3518,6 +3593,7 @@ pub trait IWbemEventProviderQuerySink_Impl: Sized {
     fn NewQuery(&self, dwid: u32, wszquerylanguage: *const u16, wszquery: *const u16) -> ::windows::core::Result<()>;
     fn CancelQuery(&self, dwid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemEventProviderQuerySink {}
 impl IWbemEventProviderQuerySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventProviderQuerySink_Impl, const OFFSET: isize>() -> IWbemEventProviderQuerySink_Vtbl {
         unsafe extern "system" fn NewQuery<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventProviderQuerySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwid: u32, wszquerylanguage: *const u16, wszquery: *const u16) -> ::windows::core::HRESULT {
@@ -3543,6 +3619,7 @@ impl IWbemEventProviderQuerySink_Vtbl {
 pub trait IWbemEventProviderSecurity_Impl: Sized {
     fn AccessCheck(&self, wszquerylanguage: *const u16, wszquery: *const u16, lsidlength: i32, psid: *const u8) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemEventProviderSecurity {}
 impl IWbemEventProviderSecurity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventProviderSecurity_Impl, const OFFSET: isize>() -> IWbemEventProviderSecurity_Vtbl {
         unsafe extern "system" fn AccessCheck<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventProviderSecurity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszquerylanguage: *const u16, wszquery: *const u16, lsidlength: i32, psid: *const u8) -> ::windows::core::HRESULT {
@@ -3563,6 +3640,8 @@ pub trait IWbemEventSink_Impl: Sized + IWbemObjectSink_Impl {
     fn GetRestrictedSink(&self, lnumqueries: i32, awszqueries: *const ::windows::core::PWSTR, pcallback: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IWbemEventSink>;
     fn SetBatchingParameters(&self, lflags: i32, dwmaxbuffersize: u32, dwmaxsendlatency: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemEventSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWbemEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemEventSink_Impl, const OFFSET: isize>() -> IWbemEventSink_Vtbl {
@@ -3610,6 +3689,7 @@ pub trait IWbemHiPerfEnum_Impl: Sized {
     fn GetObjects(&self, lflags: i32, unumobjects: u32, apobj: *mut ::core::option::Option<IWbemObjectAccess>, pureturned: *mut u32) -> ::windows::core::Result<()>;
     fn RemoveAll(&self, lflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemHiPerfEnum {}
 impl IWbemHiPerfEnum_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemHiPerfEnum_Impl, const OFFSET: isize>() -> IWbemHiPerfEnum_Vtbl {
         unsafe extern "system" fn AddObjects<Identity: ::windows::core::IUnknownImpl, Impl: IWbemHiPerfEnum_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, unumobjects: u32, apids: *const i32, apobj: *const ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3652,6 +3732,7 @@ pub trait IWbemHiPerfProvider_Impl: Sized {
     fn CreateRefreshableEnum(&self, pnamespace: &::core::option::Option<IWbemServices>, wszclass: &::windows::core::PCWSTR, prefresher: &::core::option::Option<IWbemRefresher>, lflags: i32, pcontext: &::core::option::Option<IWbemContext>, phiperfenum: &::core::option::Option<IWbemHiPerfEnum>) -> ::windows::core::Result<i32>;
     fn GetObjects(&self, pnamespace: &::core::option::Option<IWbemServices>, lnumobjects: i32, apobj: *mut ::core::option::Option<IWbemObjectAccess>, lflags: i32, pcontext: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemHiPerfProvider {}
 impl IWbemHiPerfProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemHiPerfProvider_Impl, const OFFSET: isize>() -> IWbemHiPerfProvider_Vtbl {
         unsafe extern "system" fn QueryInstances<Identity: ::windows::core::IUnknownImpl, Impl: IWbemHiPerfProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pnamespace: ::windows::core::RawPtr, wszclass: ::windows::core::PCWSTR, lflags: i32, pctx: ::windows::core::RawPtr, psink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3716,6 +3797,7 @@ pub trait IWbemLevel1Login_Impl: Sized {
     fn WBEMLogin(&self, wszpreferredlocale: &::windows::core::PCWSTR, accesstoken: *const u8, lflags: i32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
     fn NTLMLogin(&self, wsznetworkresource: &::windows::core::PCWSTR, wszpreferredlocale: &::windows::core::PCWSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
 }
+impl ::windows::core::RuntimeName for IWbemLevel1Login {}
 impl IWbemLevel1Login_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemLevel1Login_Impl, const OFFSET: isize>() -> IWbemLevel1Login_Vtbl {
         unsafe extern "system" fn EstablishPosition<Identity: ::windows::core::IUnknownImpl, Impl: IWbemLevel1Login_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszlocalelist: ::windows::core::PCWSTR, dwnumlocales: u32, reserved: *mut u32) -> ::windows::core::HRESULT {
@@ -3779,6 +3861,8 @@ pub trait IWbemLocator_Impl: Sized {
     fn ConnectServer(&self, strnetworkresource: &super::super::Foundation::BSTR, struser: &super::super::Foundation::BSTR, strpassword: &super::super::Foundation::BSTR, strlocale: &super::super::Foundation::BSTR, lsecurityflags: i32, strauthority: &super::super::Foundation::BSTR, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemLocator {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWbemLocator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemLocator_Impl, const OFFSET: isize>() -> IWbemLocator_Vtbl {
         unsafe extern "system" fn ConnectServer<Identity: ::windows::core::IUnknownImpl, Impl: IWbemLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strnetworkresource: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, struser: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strpassword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strlocale: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, lsecurityflags: i32, strauthority: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pctx: ::windows::core::RawPtr, ppnamespace: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3811,6 +3895,8 @@ pub trait IWbemObjectAccess_Impl: Sized + IWbemClassObject_Impl {
     fn Lock(&self, lflags: i32) -> ::windows::core::Result<()>;
     fn Unlock(&self, lflags: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemObjectAccess {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemObjectAccess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemObjectAccess_Impl, const OFFSET: isize>() -> IWbemObjectAccess_Vtbl {
@@ -3900,6 +3986,8 @@ pub trait IWbemObjectSink_Impl: Sized {
     fn SetStatus(&self, lflags: i32, hresult: ::windows::core::HRESULT, strparam: &super::super::Foundation::BSTR, pobjparam: &::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemObjectSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl IWbemObjectSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemObjectSink_Impl, const OFFSET: isize>() -> IWbemObjectSink_Vtbl {
         unsafe extern "system" fn Indicate<Identity: ::windows::core::IUnknownImpl, Impl: IWbemObjectSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lobjectcount: i32, apobjarray: *const ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3930,6 +4018,8 @@ pub trait IWbemObjectSinkEx_Impl: Sized + IWbemObjectSink_Impl {
     fn WriteProgress(&self, stractivity: &super::super::Foundation::BSTR, strcurrentoperation: &super::super::Foundation::BSTR, strstatusdescription: &super::super::Foundation::BSTR, upercentcomplete: u32, usecondsremaining: u32) -> ::windows::core::Result<()>;
     fn WriteStreamParameter(&self, strname: &super::super::Foundation::BSTR, vtvalue: *const super::Com::VARIANT, ultype: u32, ulflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemObjectSinkEx {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemObjectSinkEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemObjectSinkEx_Impl, const OFFSET: isize>() -> IWbemObjectSinkEx_Vtbl {
@@ -3988,6 +4078,8 @@ pub trait IWbemObjectTextSrc_Impl: Sized {
     fn GetText(&self, lflags: i32, pobj: &::core::option::Option<IWbemClassObject>, uobjtextformat: u32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn CreateFromText(&self, lflags: i32, strtext: &super::super::Foundation::BSTR, uobjtextformat: u32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemClassObject>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemObjectTextSrc {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWbemObjectTextSrc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemObjectTextSrc_Impl, const OFFSET: isize>() -> IWbemObjectTextSrc_Vtbl {
@@ -4052,6 +4144,8 @@ pub trait IWbemPath_Impl: Sized {
     fn IsLocal(&self, wszmachine: &::windows::core::PCWSTR) -> super::super::Foundation::BOOL;
     fn IsSameClassName(&self, wszclass: &::windows::core::PCWSTR) -> super::super::Foundation::BOOL;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemPath {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWbemPath_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemPath_Impl, const OFFSET: isize>() -> IWbemPath_Vtbl {
@@ -4257,6 +4351,8 @@ pub trait IWbemPathKeyList_Impl: Sized {
     fn GetText(&self, lflags: i32, pubufflength: *mut u32, psztext: ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemPathKeyList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemPathKeyList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemPathKeyList_Impl, const OFFSET: isize>() -> IWbemPathKeyList_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IWbemPathKeyList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pukeycount: *mut u32) -> ::windows::core::HRESULT {
@@ -4345,6 +4441,8 @@ pub trait IWbemPropertyProvider_Impl: Sized {
     fn PutProperty(&self, lflags: i32, strlocale: &super::super::Foundation::BSTR, strclassmapping: &super::super::Foundation::BSTR, strinstmapping: &super::super::Foundation::BSTR, strpropmapping: &super::super::Foundation::BSTR, pvvalue: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemPropertyProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemPropertyProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemPropertyProvider_Impl, const OFFSET: isize>() -> IWbemPropertyProvider_Vtbl {
         unsafe extern "system" fn GetProperty<Identity: ::windows::core::IUnknownImpl, Impl: IWbemPropertyProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, strlocale: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strclassmapping: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strinstmapping: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, strpropmapping: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pvvalue: *mut super::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4376,6 +4474,7 @@ impl IWbemPropertyProvider_Vtbl {
 pub trait IWbemProviderIdentity_Impl: Sized {
     fn SetRegistrationObject(&self, lflags: i32, pprovreg: &::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemProviderIdentity {}
 impl IWbemProviderIdentity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemProviderIdentity_Impl, const OFFSET: isize>() -> IWbemProviderIdentity_Vtbl {
         unsafe extern "system" fn SetRegistrationObject<Identity: ::windows::core::IUnknownImpl, Impl: IWbemProviderIdentity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, pprovreg: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4392,6 +4491,7 @@ impl IWbemProviderIdentity_Vtbl {
 pub trait IWbemProviderInit_Impl: Sized {
     fn Initialize(&self, wszuser: &::windows::core::PCWSTR, lflags: i32, wsznamespace: &::windows::core::PCWSTR, wszlocale: &::windows::core::PCWSTR, pnamespace: &::core::option::Option<IWbemServices>, pctx: &::core::option::Option<IWbemContext>, pinitsink: &::core::option::Option<IWbemProviderInitSink>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemProviderInit {}
 impl IWbemProviderInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemProviderInit_Impl, const OFFSET: isize>() -> IWbemProviderInit_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWbemProviderInit_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszuser: ::windows::core::PCWSTR, lflags: i32, wsznamespace: ::windows::core::PCWSTR, wszlocale: ::windows::core::PCWSTR, pnamespace: ::windows::core::RawPtr, pctx: ::windows::core::RawPtr, pinitsink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4408,6 +4508,7 @@ impl IWbemProviderInit_Vtbl {
 pub trait IWbemProviderInitSink_Impl: Sized {
     fn SetStatus(&self, lstatus: i32, lflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemProviderInitSink {}
 impl IWbemProviderInitSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemProviderInitSink_Impl, const OFFSET: isize>() -> IWbemProviderInitSink_Vtbl {
         unsafe extern "system" fn SetStatus<Identity: ::windows::core::IUnknownImpl, Impl: IWbemProviderInitSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lstatus: i32, lflags: i32) -> ::windows::core::HRESULT {
@@ -4431,6 +4532,8 @@ pub trait IWbemQualifierSet_Impl: Sized {
     fn Next(&self, lflags: i32, pstrname: *mut super::super::Foundation::BSTR, pval: *mut super::Com::VARIANT, plflavor: *mut i32) -> ::windows::core::Result<()>;
     fn EndEnumeration(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWbemQualifierSet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWbemQualifierSet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemQualifierSet_Impl, const OFFSET: isize>() -> IWbemQualifierSet_Vtbl {
@@ -4499,6 +4602,7 @@ pub trait IWbemQuery_Impl: Sized {
     fn FreeMemory(&self, pmem: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetQueryInfo(&self, uanalysistype: u32, uinfoid: u32, ubufsize: u32, pdestbuf: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemQuery {}
 impl IWbemQuery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemQuery_Impl, const OFFSET: isize>() -> IWbemQuery_Vtbl {
         unsafe extern "system" fn Empty<Identity: ::windows::core::IUnknownImpl, Impl: IWbemQuery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4554,6 +4658,7 @@ impl IWbemQuery_Vtbl {
 pub trait IWbemRefresher_Impl: Sized {
     fn Refresh(&self, lflags: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemRefresher {}
 impl IWbemRefresher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemRefresher_Impl, const OFFSET: isize>() -> IWbemRefresher_Vtbl {
         unsafe extern "system" fn Refresh<Identity: ::windows::core::IUnknownImpl, Impl: IWbemRefresher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32) -> ::windows::core::HRESULT {
@@ -4593,6 +4698,8 @@ pub trait IWbemServices_Impl: Sized {
     fn ExecMethod(&self, strobjectpath: &super::super::Foundation::BSTR, strmethodname: &super::super::Foundation::BSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, pinparams: &::core::option::Option<IWbemClassObject>, ppoutparams: *mut ::core::option::Option<IWbemClassObject>, ppcallresult: *mut ::core::option::Option<IWbemCallResult>) -> ::windows::core::Result<()>;
     fn ExecMethodAsync(&self, strobjectpath: &super::super::Foundation::BSTR, strmethodname: &super::super::Foundation::BSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, pinparams: &::core::option::Option<IWbemClassObject>, presponsehandler: &::core::option::Option<IWbemObjectSink>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemServices {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWbemServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemServices_Impl, const OFFSET: isize>() -> IWbemServices_Vtbl {
@@ -4775,6 +4882,7 @@ impl IWbemServices_Vtbl {
 pub trait IWbemShutdown_Impl: Sized {
     fn Shutdown(&self, ureason: i32, umaxmilliseconds: u32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemShutdown {}
 impl IWbemShutdown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemShutdown_Impl, const OFFSET: isize>() -> IWbemShutdown_Vtbl {
         unsafe extern "system" fn Shutdown<Identity: ::windows::core::IUnknownImpl, Impl: IWbemShutdown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ureason: i32, umaxmilliseconds: u32, pctx: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4793,6 +4901,8 @@ pub trait IWbemStatusCodeText_Impl: Sized {
     fn GetErrorCodeText(&self, hres: ::windows::core::HRESULT, localeid: u32, lflags: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetFacilityCodeText(&self, hres: ::windows::core::HRESULT, localeid: u32, lflags: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWbemStatusCodeText {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWbemStatusCodeText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemStatusCodeText_Impl, const OFFSET: isize>() -> IWbemStatusCodeText_Vtbl {
@@ -4831,6 +4941,7 @@ impl IWbemStatusCodeText_Vtbl {
 pub trait IWbemTransport_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemTransport {}
 impl IWbemTransport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemTransport_Impl, const OFFSET: isize>() -> IWbemTransport_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IWbemTransport_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4847,6 +4958,7 @@ impl IWbemTransport_Vtbl {
 pub trait IWbemUnboundObjectSink_Impl: Sized {
     fn IndicateToConsumer(&self, plogicalconsumer: &::core::option::Option<IWbemClassObject>, lnumobjects: i32, apobjects: *const ::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IWbemUnboundObjectSink {}
 impl IWbemUnboundObjectSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemUnboundObjectSink_Impl, const OFFSET: isize>() -> IWbemUnboundObjectSink_Vtbl {
         unsafe extern "system" fn IndicateToConsumer<Identity: ::windows::core::IUnknownImpl, Impl: IWbemUnboundObjectSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plogicalconsumer: ::windows::core::RawPtr, lnumobjects: i32, apobjects: *const ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4863,6 +4975,7 @@ impl IWbemUnboundObjectSink_Vtbl {
 pub trait IWbemUnsecuredApartment_Impl: Sized + IUnsecuredApartment_Impl {
     fn CreateSinkStub(&self, psink: &::core::option::Option<IWbemObjectSink>, dwflags: u32, wszreserved: &::windows::core::PCWSTR) -> ::windows::core::Result<IWbemObjectSink>;
 }
+impl ::windows::core::RuntimeName for IWbemUnsecuredApartment {}
 impl IWbemUnsecuredApartment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWbemUnsecuredApartment_Impl, const OFFSET: isize>() -> IWbemUnsecuredApartment_Vtbl {
         unsafe extern "system" fn CreateSinkStub<Identity: ::windows::core::IUnknownImpl, Impl: IWbemUnsecuredApartment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psink: ::windows::core::RawPtr, dwflags: u32, wszreserved: ::windows::core::PCWSTR, ppstub: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
@@ -1,6 +1,7 @@
 pub trait IAccIdentity_Impl: Sized {
     fn GetIdentityString(&self, dwidchild: u32, ppidstring: *mut *mut u8, pdwidstringlen: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAccIdentity {}
 impl IAccIdentity_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccIdentity_Impl, const OFFSET: isize>() -> IAccIdentity_Vtbl {
         unsafe extern "system" fn GetIdentityString<Identity: ::windows::core::IUnknownImpl, Impl: IAccIdentity_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwidchild: u32, ppidstring: *mut *mut u8, pdwidstringlen: *mut u32) -> ::windows::core::HRESULT {
@@ -18,6 +19,8 @@ impl IAccIdentity_Vtbl {
 pub trait IAccPropServer_Impl: Sized {
     fn GetPropValue(&self, pidstring: *const u8, dwidstringlen: u32, idprop: &::windows::core::GUID, pvarvalue: *mut super::super::System::Com::VARIANT, pfhasprop: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAccPropServer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAccPropServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccPropServer_Impl, const OFFSET: isize>() -> IAccPropServer_Vtbl {
@@ -50,6 +53,8 @@ pub trait IAccPropServices_Impl: Sized {
     fn ComposeHmenuIdentityString(&self, hmenu: super::WindowsAndMessaging::HMENU, idchild: u32, ppidstring: *mut *mut u8, pdwidstringlen: *mut u32) -> ::windows::core::Result<()>;
     fn DecomposeHmenuIdentityString(&self, pidstring: *const u8, dwidstringlen: u32, phmenu: *mut super::WindowsAndMessaging::HMENU, pidchild: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IAccPropServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IAccPropServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccPropServices_Impl, const OFFSET: isize>() -> IAccPropServices_Vtbl {
@@ -175,6 +180,8 @@ pub trait IAccessible_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn put_accName(&self, varchild: &super::super::System::Com::VARIANT, szname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn put_accValue(&self, varchild: &super::super::System::Com::VARIANT, szvalue: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAccessible {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAccessible_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessible_Impl, const OFFSET: isize>() -> IAccessible_Vtbl {
@@ -410,6 +417,8 @@ pub trait IAccessibleEx_Impl: Sized {
     fn ConvertReturnedElement(&self, pin: &::core::option::Option<IRawElementProviderSimple>) -> ::windows::core::Result<IAccessibleEx>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAccessibleEx {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAccessibleEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleEx_Impl, const OFFSET: isize>() -> IAccessibleEx_Vtbl {
         unsafe extern "system" fn GetObjectForChild<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, idchild: i32, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -467,6 +476,8 @@ pub trait IAccessibleHandler_Impl: Sized {
     fn AccessibleObjectFromID(&self, hwnd: i32, lobjectid: i32) -> ::windows::core::Result<IAccessible>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAccessibleHandler {}
+#[cfg(feature = "Win32_System_Com")]
 impl IAccessibleHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleHandler_Impl, const OFFSET: isize>() -> IAccessibleHandler_Vtbl {
         unsafe extern "system" fn AccessibleObjectFromID<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: i32, lobjectid: i32, piaccessible: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -491,6 +502,8 @@ pub trait IAccessibleHostingElementProviders_Impl: Sized {
     fn GetEmbeddedFragmentRoots(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetObjectIdForProvider(&self, pprovider: &::core::option::Option<IRawElementProviderSimple>) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAccessibleHostingElementProviders {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAccessibleHostingElementProviders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleHostingElementProviders_Impl, const OFFSET: isize>() -> IAccessibleHostingElementProviders_Vtbl {
@@ -533,6 +546,8 @@ pub trait IAccessibleWindowlessSite_Impl: Sized {
     fn QueryObjectIdRanges(&self, prangesowner: &::core::option::Option<IAccessibleHandler>) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetParentAccessible(&self) -> ::windows::core::Result<IAccessible>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAccessibleWindowlessSite {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAccessibleWindowlessSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleWindowlessSite_Impl, const OFFSET: isize>() -> IAccessibleWindowlessSite_Vtbl {
@@ -594,6 +609,8 @@ pub trait IAnnotationProvider_Impl: Sized {
     fn DateTime(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Target(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAnnotationProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAnnotationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnnotationProvider_Impl, const OFFSET: isize>() -> IAnnotationProvider_Vtbl {
@@ -668,6 +685,7 @@ impl IAnnotationProvider_Vtbl {
 pub trait ICustomNavigationProvider_Impl: Sized {
     fn Navigate(&self, direction: NavigateDirection) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+impl ::windows::core::RuntimeName for ICustomNavigationProvider {}
 impl ICustomNavigationProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICustomNavigationProvider_Impl, const OFFSET: isize>() -> ICustomNavigationProvider_Vtbl {
         unsafe extern "system" fn Navigate<Identity: ::windows::core::IUnknownImpl, Impl: ICustomNavigationProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, direction: NavigateDirection, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -691,6 +709,7 @@ pub trait IDockProvider_Impl: Sized {
     fn SetDockPosition(&self, dockposition: DockPosition) -> ::windows::core::Result<()>;
     fn DockPosition(&self) -> ::windows::core::Result<DockPosition>;
 }
+impl ::windows::core::RuntimeName for IDockProvider {}
 impl IDockProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDockProvider_Impl, const OFFSET: isize>() -> IDockProvider_Vtbl {
         unsafe extern "system" fn SetDockPosition<Identity: ::windows::core::IUnknownImpl, Impl: IDockProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dockposition: DockPosition) -> ::windows::core::HRESULT {
@@ -726,6 +745,8 @@ pub trait IDragProvider_Impl: Sized {
     fn DropEffects(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetGrabbedItems(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDragProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDragProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDragProvider_Impl, const OFFSET: isize>() -> IDragProvider_Vtbl {
@@ -791,6 +812,8 @@ pub trait IDropTargetProvider_Impl: Sized {
     fn DropTargetEffects(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDropTargetProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDropTargetProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDropTargetProvider_Impl, const OFFSET: isize>() -> IDropTargetProvider_Vtbl {
         unsafe extern "system" fn DropTargetEffect<Identity: ::windows::core::IUnknownImpl, Impl: IDropTargetProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -830,6 +853,7 @@ pub trait IExpandCollapseProvider_Impl: Sized {
     fn Collapse(&self) -> ::windows::core::Result<()>;
     fn ExpandCollapseState(&self) -> ::windows::core::Result<ExpandCollapseState>;
 }
+impl ::windows::core::RuntimeName for IExpandCollapseProvider {}
 impl IExpandCollapseProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExpandCollapseProvider_Impl, const OFFSET: isize>() -> IExpandCollapseProvider_Vtbl {
         unsafe extern "system" fn Expand<Identity: ::windows::core::IUnknownImpl, Impl: IExpandCollapseProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -871,6 +895,7 @@ pub trait IGridItemProvider_Impl: Sized {
     fn ColumnSpan(&self) -> ::windows::core::Result<i32>;
     fn ContainingGrid(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+impl ::windows::core::RuntimeName for IGridItemProvider {}
 impl IGridItemProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGridItemProvider_Impl, const OFFSET: isize>() -> IGridItemProvider_Vtbl {
         unsafe extern "system" fn Row<Identity: ::windows::core::IUnknownImpl, Impl: IGridItemProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT {
@@ -946,6 +971,7 @@ pub trait IGridProvider_Impl: Sized {
     fn RowCount(&self) -> ::windows::core::Result<i32>;
     fn ColumnCount(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IGridProvider {}
 impl IGridProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGridProvider_Impl, const OFFSET: isize>() -> IGridProvider_Vtbl {
         unsafe extern "system" fn GetItem<Identity: ::windows::core::IUnknownImpl, Impl: IGridProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, row: i32, column: i32, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -995,6 +1021,7 @@ impl IGridProvider_Vtbl {
 pub trait IInvokeProvider_Impl: Sized {
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInvokeProvider {}
 impl IInvokeProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInvokeProvider_Impl, const OFFSET: isize>() -> IInvokeProvider_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IInvokeProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1012,6 +1039,8 @@ impl IInvokeProvider_Vtbl {
 pub trait IItemContainerProvider_Impl: Sized {
     fn FindItemByProperty(&self, pstartafter: &::core::option::Option<IRawElementProviderSimple>, propertyid: i32, value: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IItemContainerProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IItemContainerProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IItemContainerProvider_Impl, const OFFSET: isize>() -> IItemContainerProvider_Vtbl {
@@ -1049,6 +1078,8 @@ pub trait ILegacyIAccessibleProvider_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn DefaultAction(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ILegacyIAccessibleProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ILegacyIAccessibleProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILegacyIAccessibleProvider_Impl, const OFFSET: isize>() -> ILegacyIAccessibleProvider_Vtbl {
@@ -1218,6 +1249,8 @@ pub trait IMultipleViewProvider_Impl: Sized {
     fn GetSupportedViews(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IMultipleViewProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IMultipleViewProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMultipleViewProvider_Impl, const OFFSET: isize>() -> IMultipleViewProvider_Vtbl {
         unsafe extern "system" fn GetViewName<Identity: ::windows::core::IUnknownImpl, Impl: IMultipleViewProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, viewid: i32, pretval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -1273,6 +1306,7 @@ impl IMultipleViewProvider_Vtbl {
 pub trait IObjectModelProvider_Impl: Sized {
     fn GetUnderlyingObjectModel(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IObjectModelProvider {}
 impl IObjectModelProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectModelProvider_Impl, const OFFSET: isize>() -> IObjectModelProvider_Vtbl {
         unsafe extern "system" fn GetUnderlyingObjectModel<Identity: ::windows::core::IUnknownImpl, Impl: IObjectModelProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1297,6 +1331,8 @@ pub trait IProxyProviderWinEventHandler_Impl: Sized {
     fn RespondToWinEvent(&self, idwinevent: u32, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, psink: &::core::option::Option<IProxyProviderWinEventSink>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IProxyProviderWinEventHandler {}
+#[cfg(feature = "Win32_Foundation")]
 impl IProxyProviderWinEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProxyProviderWinEventHandler_Impl, const OFFSET: isize>() -> IProxyProviderWinEventHandler_Vtbl {
         unsafe extern "system" fn RespondToWinEvent<Identity: ::windows::core::IUnknownImpl, Impl: IProxyProviderWinEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, idwinevent: u32, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, psink: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1316,6 +1352,8 @@ pub trait IProxyProviderWinEventSink_Impl: Sized {
     fn AddAutomationEvent(&self, pprovider: &::core::option::Option<IRawElementProviderSimple>, id: i32) -> ::windows::core::Result<()>;
     fn AddStructureChangedEvent(&self, pprovider: &::core::option::Option<IRawElementProviderSimple>, structurechangetype: StructureChangeType, runtimeid: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IProxyProviderWinEventSink {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IProxyProviderWinEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProxyProviderWinEventSink_Impl, const OFFSET: isize>() -> IProxyProviderWinEventSink_Vtbl {
@@ -1355,6 +1393,8 @@ pub trait IRangeValueProvider_Impl: Sized {
     fn LargeChange(&self) -> ::windows::core::Result<f64>;
     fn SmallChange(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRangeValueProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRangeValueProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRangeValueProvider_Impl, const OFFSET: isize>() -> IRangeValueProvider_Vtbl {
@@ -1450,6 +1490,8 @@ pub trait IRawElementProviderAdviseEvents_Impl: Sized {
     fn AdviseEventRemoved(&self, eventid: i32, propertyids: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRawElementProviderAdviseEvents {}
+#[cfg(feature = "Win32_System_Com")]
 impl IRawElementProviderAdviseEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderAdviseEvents_Impl, const OFFSET: isize>() -> IRawElementProviderAdviseEvents_Vtbl {
         unsafe extern "system" fn AdviseEventAdded<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderAdviseEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventid: i32, propertyids: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -1481,6 +1523,8 @@ pub trait IRawElementProviderFragment_Impl: Sized {
     fn SetFocus(&self) -> ::windows::core::Result<()>;
     fn FragmentRoot(&self) -> ::windows::core::Result<IRawElementProviderFragmentRoot>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRawElementProviderFragment {}
 #[cfg(feature = "Win32_System_Com")]
 impl IRawElementProviderFragment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderFragment_Impl, const OFFSET: isize>() -> IRawElementProviderFragment_Vtbl {
@@ -1562,6 +1606,7 @@ pub trait IRawElementProviderFragmentRoot_Impl: Sized {
     fn ElementProviderFromPoint(&self, x: f64, y: f64) -> ::windows::core::Result<IRawElementProviderFragment>;
     fn GetFocus(&self) -> ::windows::core::Result<IRawElementProviderFragment>;
 }
+impl ::windows::core::RuntimeName for IRawElementProviderFragmentRoot {}
 impl IRawElementProviderFragmentRoot_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderFragmentRoot_Impl, const OFFSET: isize>() -> IRawElementProviderFragmentRoot_Vtbl {
         unsafe extern "system" fn ElementProviderFromPoint<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderFragmentRoot_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, x: f64, y: f64, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1601,6 +1646,8 @@ pub trait IRawElementProviderHostingAccessibles_Impl: Sized {
     fn GetEmbeddedAccessibles(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRawElementProviderHostingAccessibles {}
+#[cfg(feature = "Win32_System_Com")]
 impl IRawElementProviderHostingAccessibles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderHostingAccessibles_Impl, const OFFSET: isize>() -> IRawElementProviderHostingAccessibles_Vtbl {
         unsafe extern "system" fn GetEmbeddedAccessibles<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderHostingAccessibles_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -1624,6 +1671,8 @@ impl IRawElementProviderHostingAccessibles_Vtbl {
 pub trait IRawElementProviderHwndOverride_Impl: Sized {
     fn GetOverrideProviderForHwnd(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRawElementProviderHwndOverride {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRawElementProviderHwndOverride_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderHwndOverride_Impl, const OFFSET: isize>() -> IRawElementProviderHwndOverride_Vtbl {
@@ -1654,6 +1703,8 @@ pub trait IRawElementProviderSimple_Impl: Sized {
     fn GetPropertyValue(&self, propertyid: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn HostRawElementProvider(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRawElementProviderSimple {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRawElementProviderSimple_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderSimple_Impl, const OFFSET: isize>() -> IRawElementProviderSimple_Vtbl {
@@ -1718,6 +1769,8 @@ pub trait IRawElementProviderSimple2_Impl: Sized + IRawElementProviderSimple_Imp
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRawElementProviderSimple2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRawElementProviderSimple2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderSimple2_Impl, const OFFSET: isize>() -> IRawElementProviderSimple2_Vtbl {
         unsafe extern "system" fn ShowContextMenu<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderSimple2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1735,6 +1788,8 @@ impl IRawElementProviderSimple2_Vtbl {
 pub trait IRawElementProviderSimple3_Impl: Sized + IRawElementProviderSimple_Impl + IRawElementProviderSimple2_Impl {
     fn GetMetadataValue(&self, targetid: i32, metadataid: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRawElementProviderSimple3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRawElementProviderSimple3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderSimple3_Impl, const OFFSET: isize>() -> IRawElementProviderSimple3_Vtbl {
@@ -1760,6 +1815,8 @@ pub trait IRawElementProviderWindowlessSite_Impl: Sized {
     fn GetAdjacentFragment(&self, direction: NavigateDirection) -> ::windows::core::Result<IRawElementProviderFragment>;
     fn GetRuntimeIdPrefix(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IRawElementProviderWindowlessSite {}
 #[cfg(feature = "Win32_System_Com")]
 impl IRawElementProviderWindowlessSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRawElementProviderWindowlessSite_Impl, const OFFSET: isize>() -> IRawElementProviderWindowlessSite_Vtbl {
@@ -1799,6 +1856,7 @@ pub trait IRichEditUiaInformation_Impl: Sized {
     fn GetBoundaryRectangle(&self, puiarect: *mut UiaRect) -> ::windows::core::Result<()>;
     fn IsVisible(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRichEditUiaInformation {}
 impl IRichEditUiaInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRichEditUiaInformation_Impl, const OFFSET: isize>() -> IRichEditUiaInformation_Vtbl {
         unsafe extern "system" fn GetBoundaryRectangle<Identity: ::windows::core::IUnknownImpl, Impl: IRichEditUiaInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puiarect: *mut UiaRect) -> ::windows::core::HRESULT {
@@ -1824,6 +1882,7 @@ impl IRichEditUiaInformation_Vtbl {
 pub trait IRicheditWindowlessAccessibility_Impl: Sized {
     fn CreateProvider(&self, psite: &::core::option::Option<IRawElementProviderWindowlessSite>) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+impl ::windows::core::RuntimeName for IRicheditWindowlessAccessibility {}
 impl IRicheditWindowlessAccessibility_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRicheditWindowlessAccessibility_Impl, const OFFSET: isize>() -> IRicheditWindowlessAccessibility_Vtbl {
         unsafe extern "system" fn CreateProvider<Identity: ::windows::core::IUnknownImpl, Impl: IRicheditWindowlessAccessibility_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psite: ::windows::core::RawPtr, ppprovider: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1846,6 +1905,7 @@ impl IRicheditWindowlessAccessibility_Vtbl {
 pub trait IScrollItemProvider_Impl: Sized {
     fn ScrollIntoView(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IScrollItemProvider {}
 impl IScrollItemProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScrollItemProvider_Impl, const OFFSET: isize>() -> IScrollItemProvider_Vtbl {
         unsafe extern "system" fn ScrollIntoView<Identity: ::windows::core::IUnknownImpl, Impl: IScrollItemProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1870,6 +1930,8 @@ pub trait IScrollProvider_Impl: Sized {
     fn HorizontallyScrollable(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn VerticallyScrollable(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IScrollProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IScrollProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScrollProvider_Impl, const OFFSET: isize>() -> IScrollProvider_Vtbl {
@@ -1974,6 +2036,8 @@ pub trait ISelectionItemProvider_Impl: Sized {
     fn SelectionContainer(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISelectionItemProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISelectionItemProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISelectionItemProvider_Impl, const OFFSET: isize>() -> ISelectionItemProvider_Vtbl {
         unsafe extern "system" fn Select<Identity: ::windows::core::IUnknownImpl, Impl: ISelectionItemProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2033,6 +2097,8 @@ pub trait ISelectionProvider_Impl: Sized {
     fn IsSelectionRequired(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISelectionProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISelectionProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISelectionProvider_Impl, const OFFSET: isize>() -> ISelectionProvider_Vtbl {
         unsafe extern "system" fn GetSelection<Identity: ::windows::core::IUnknownImpl, Impl: ISelectionProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -2086,6 +2152,8 @@ pub trait ISelectionProvider2_Impl: Sized + ISelectionProvider_Impl {
     fn CurrentSelectedItem(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
     fn ItemCount(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISelectionProvider2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISelectionProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISelectionProvider2_Impl, const OFFSET: isize>() -> ISelectionProvider2_Vtbl {
@@ -2152,6 +2220,8 @@ pub trait ISpreadsheetItemProvider_Impl: Sized {
     fn GetAnnotationTypes(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ISpreadsheetItemProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ISpreadsheetItemProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpreadsheetItemProvider_Impl, const OFFSET: isize>() -> ISpreadsheetItemProvider_Vtbl {
         unsafe extern "system" fn Formula<Identity: ::windows::core::IUnknownImpl, Impl: ISpreadsheetItemProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2201,6 +2271,7 @@ impl ISpreadsheetItemProvider_Vtbl {
 pub trait ISpreadsheetProvider_Impl: Sized {
     fn GetItemByName(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
+impl ::windows::core::RuntimeName for ISpreadsheetProvider {}
 impl ISpreadsheetProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpreadsheetProvider_Impl, const OFFSET: isize>() -> ISpreadsheetProvider_Vtbl {
         unsafe extern "system" fn GetItemByName<Identity: ::windows::core::IUnknownImpl, Impl: ISpreadsheetProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2230,6 +2301,8 @@ pub trait IStylesProvider_Impl: Sized {
     fn FillPatternColor(&self) -> ::windows::core::Result<i32>;
     fn ExtendedProperties(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStylesProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IStylesProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStylesProvider_Impl, const OFFSET: isize>() -> IStylesProvider_Vtbl {
@@ -2329,6 +2402,7 @@ pub trait ISynchronizedInputProvider_Impl: Sized {
     fn StartListening(&self, inputtype: SynchronizedInputType) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISynchronizedInputProvider {}
 impl ISynchronizedInputProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizedInputProvider_Impl, const OFFSET: isize>() -> ISynchronizedInputProvider_Vtbl {
         unsafe extern "system" fn StartListening<Identity: ::windows::core::IUnknownImpl, Impl: ISynchronizedInputProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputtype: SynchronizedInputType) -> ::windows::core::HRESULT {
@@ -2356,6 +2430,8 @@ pub trait ITableItemProvider_Impl: Sized {
     fn GetRowHeaderItems(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetColumnHeaderItems(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITableItemProvider {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITableItemProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableItemProvider_Impl, const OFFSET: isize>() -> ITableItemProvider_Vtbl {
@@ -2397,6 +2473,8 @@ pub trait ITableProvider_Impl: Sized {
     fn GetColumnHeaders(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn RowOrColumnMajor(&self) -> ::windows::core::Result<RowOrColumnMajor>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITableProvider {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITableProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITableProvider_Impl, const OFFSET: isize>() -> ITableProvider_Vtbl {
@@ -2448,6 +2526,7 @@ pub trait ITextChildProvider_Impl: Sized {
     fn TextContainer(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
     fn TextRange(&self) -> ::windows::core::Result<ITextRangeProvider>;
 }
+impl ::windows::core::RuntimeName for ITextChildProvider {}
 impl ITextChildProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextChildProvider_Impl, const OFFSET: isize>() -> ITextChildProvider_Vtbl {
         unsafe extern "system" fn TextContainer<Identity: ::windows::core::IUnknownImpl, Impl: ITextChildProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2487,6 +2566,8 @@ pub trait ITextEditProvider_Impl: Sized + ITextProvider_Impl {
     fn GetActiveComposition(&self) -> ::windows::core::Result<ITextRangeProvider>;
     fn GetConversionTarget(&self) -> ::windows::core::Result<ITextRangeProvider>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITextEditProvider {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITextEditProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextEditProvider_Impl, const OFFSET: isize>() -> ITextEditProvider_Vtbl {
@@ -2531,6 +2612,8 @@ pub trait ITextProvider_Impl: Sized {
     fn DocumentRange(&self) -> ::windows::core::Result<ITextRangeProvider>;
     fn SupportedTextSelection(&self) -> ::windows::core::Result<SupportedTextSelection>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITextProvider {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITextProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextProvider_Impl, const OFFSET: isize>() -> ITextProvider_Vtbl {
@@ -2620,6 +2703,8 @@ pub trait ITextProvider2_Impl: Sized + ITextProvider_Impl {
     fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL, pretval: *mut ::core::option::Option<ITextRangeProvider>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITextProvider2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITextProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextProvider2_Impl, const OFFSET: isize>() -> ITextProvider2_Vtbl {
         unsafe extern "system" fn RangeFromAnnotation<Identity: ::windows::core::IUnknownImpl, Impl: ITextProvider2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, annotationelement: ::windows::core::RawPtr, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2669,6 +2754,8 @@ pub trait ITextRangeProvider_Impl: Sized {
     fn ScrollIntoView(&self, aligntotop: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetChildren(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextRangeProvider {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextRangeProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextRangeProvider_Impl, const OFFSET: isize>() -> ITextRangeProvider_Vtbl {
@@ -2865,6 +2952,8 @@ pub trait ITextRangeProvider2_Impl: Sized + ITextRangeProvider_Impl {
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextRangeProvider2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextRangeProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextRangeProvider2_Impl, const OFFSET: isize>() -> ITextRangeProvider2_Vtbl {
         unsafe extern "system" fn ShowContextMenu<Identity: ::windows::core::IUnknownImpl, Impl: ITextRangeProvider2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2882,6 +2971,7 @@ pub trait IToggleProvider_Impl: Sized {
     fn Toggle(&self) -> ::windows::core::Result<()>;
     fn ToggleState(&self) -> ::windows::core::Result<ToggleState>;
 }
+impl ::windows::core::RuntimeName for IToggleProvider {}
 impl IToggleProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IToggleProvider_Impl, const OFFSET: isize>() -> IToggleProvider_Vtbl {
         unsafe extern "system" fn Toggle<Identity: ::windows::core::IUnknownImpl, Impl: IToggleProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2919,6 +3009,8 @@ pub trait ITransformProvider_Impl: Sized {
     fn CanResize(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn CanRotate(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransformProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITransformProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransformProvider_Impl, const OFFSET: isize>() -> ITransformProvider_Vtbl {
@@ -2993,6 +3085,8 @@ pub trait ITransformProvider2_Impl: Sized + ITransformProvider_Impl {
     fn ZoomMaximum(&self) -> ::windows::core::Result<f64>;
     fn ZoomByUnit(&self, zoomunit: ZoomUnit) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITransformProvider2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITransformProvider2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransformProvider2_Impl, const OFFSET: isize>() -> ITransformProvider2_Vtbl {
@@ -3122,6 +3216,8 @@ pub trait IUIAutomation_Impl: Sized {
     fn ElementFromIAccessible(&self, accessible: &::core::option::Option<IAccessible>, childid: i32) -> ::windows::core::Result<IUIAutomationElement>;
     fn ElementFromIAccessibleBuildCache(&self, accessible: &::core::option::Option<IAccessible>, childid: i32, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>) -> ::windows::core::Result<IUIAutomationElement>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation_Impl, const OFFSET: isize>() -> IUIAutomation_Vtbl {
@@ -3719,6 +3815,8 @@ pub trait IUIAutomation2_Impl: Sized + IUIAutomation_Impl {
     fn SetTransactionTimeout(&self, timeout: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomation2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomation2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation2_Impl, const OFFSET: isize>() -> IUIAutomation2_Vtbl {
         unsafe extern "system" fn AutoSetFocus<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, autosetfocus: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3789,6 +3887,8 @@ pub trait IUIAutomation3_Impl: Sized + IUIAutomation_Impl + IUIAutomation2_Impl 
     fn RemoveTextEditTextChangedEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, handler: &::core::option::Option<IUIAutomationTextEditTextChangedEventHandler>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomation3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomation3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation3_Impl, const OFFSET: isize>() -> IUIAutomation3_Vtbl {
         unsafe extern "system" fn AddTextEditTextChangedEventHandler<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, element: ::windows::core::RawPtr, scope: TreeScope, texteditchangetype: TextEditChangeType, cacherequest: ::windows::core::RawPtr, handler: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3817,6 +3917,8 @@ pub trait IUIAutomation4_Impl: Sized + IUIAutomation_Impl + IUIAutomation2_Impl 
     fn RemoveChangesEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, handler: &::core::option::Option<IUIAutomationChangesEventHandler>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomation4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomation4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation4_Impl, const OFFSET: isize>() -> IUIAutomation4_Vtbl {
         unsafe extern "system" fn AddChangesEventHandler<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, element: ::windows::core::RawPtr, scope: TreeScope, changetypes: *const i32, changescount: i32, pcacherequest: ::windows::core::RawPtr, handler: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3844,6 +3946,8 @@ pub trait IUIAutomation5_Impl: Sized + IUIAutomation_Impl + IUIAutomation2_Impl 
     fn AddNotificationEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, scope: TreeScope, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationNotificationEventHandler>) -> ::windows::core::Result<()>;
     fn RemoveNotificationEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, handler: &::core::option::Option<IUIAutomationNotificationEventHandler>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomation5 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomation5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation5_Impl, const OFFSET: isize>() -> IUIAutomation5_Vtbl {
@@ -3879,6 +3983,8 @@ pub trait IUIAutomation6_Impl: Sized + IUIAutomation_Impl + IUIAutomation2_Impl 
     fn AddActiveTextPositionChangedEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, scope: TreeScope, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationActiveTextPositionChangedEventHandler>) -> ::windows::core::Result<()>;
     fn RemoveActiveTextPositionChangedEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, handler: &::core::option::Option<IUIAutomationActiveTextPositionChangedEventHandler>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomation6 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomation6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomation6_Impl, const OFFSET: isize>() -> IUIAutomation6_Vtbl {
@@ -3965,6 +4071,7 @@ impl IUIAutomation6_Vtbl {
 pub trait IUIAutomationActiveTextPositionChangedEventHandler_Impl: Sized {
     fn HandleActiveTextPositionChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, range: &::core::option::Option<IUIAutomationTextRange>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationActiveTextPositionChangedEventHandler {}
 impl IUIAutomationActiveTextPositionChangedEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationActiveTextPositionChangedEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationActiveTextPositionChangedEventHandler_Vtbl {
         unsafe extern "system" fn HandleActiveTextPositionChangedEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationActiveTextPositionChangedEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, range: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3987,6 +4094,8 @@ pub trait IUIAutomationAndCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn GetChildrenAsNativeArray(&self, childarray: *mut *mut ::core::option::Option<IUIAutomationCondition>, childarraycount: *mut i32) -> ::windows::core::Result<()>;
     fn GetChildren(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUIAutomationAndCondition {}
 #[cfg(feature = "Win32_System_Com")]
 impl IUIAutomationAndCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationAndCondition_Impl, const OFFSET: isize>() -> IUIAutomationAndCondition_Vtbl {
@@ -4041,6 +4150,8 @@ pub trait IUIAutomationAnnotationPattern_Impl: Sized {
     fn CachedDateTime(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn CachedTarget(&self) -> ::windows::core::Result<IUIAutomationElement>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationAnnotationPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationAnnotationPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationAnnotationPattern_Impl, const OFFSET: isize>() -> IUIAutomationAnnotationPattern_Vtbl {
@@ -4177,6 +4288,8 @@ pub trait IUIAutomationBoolCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn BooleanValue(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationBoolCondition {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationBoolCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationBoolCondition_Impl, const OFFSET: isize>() -> IUIAutomationBoolCondition_Vtbl {
         unsafe extern "system" fn BooleanValue<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationBoolCondition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, boolval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -4207,6 +4320,7 @@ pub trait IUIAutomationCacheRequest_Impl: Sized {
     fn AutomationElementMode(&self) -> ::windows::core::Result<AutomationElementMode>;
     fn SetAutomationElementMode(&self, mode: AutomationElementMode) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationCacheRequest {}
 impl IUIAutomationCacheRequest_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationCacheRequest_Impl, const OFFSET: isize>() -> IUIAutomationCacheRequest_Vtbl {
         unsafe extern "system" fn AddProperty<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationCacheRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertyid: i32) -> ::windows::core::HRESULT {
@@ -4300,6 +4414,8 @@ pub trait IUIAutomationChangesEventHandler_Impl: Sized {
     fn HandleChangesEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, uiachanges: *const UiaChangeInfo, changescount: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationChangesEventHandler {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationChangesEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationChangesEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationChangesEventHandler_Vtbl {
         unsafe extern "system" fn HandleChangesEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationChangesEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, uiachanges: *const UiaChangeInfo, changescount: i32) -> ::windows::core::HRESULT {
@@ -4314,6 +4430,7 @@ impl IUIAutomationChangesEventHandler_Vtbl {
     }
 }
 pub trait IUIAutomationCondition_Impl: Sized {}
+impl ::windows::core::RuntimeName for IUIAutomationCondition {}
 impl IUIAutomationCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationCondition_Impl, const OFFSET: isize>() -> IUIAutomationCondition_Vtbl {
         Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
@@ -4325,6 +4442,7 @@ impl IUIAutomationCondition_Vtbl {
 pub trait IUIAutomationCustomNavigationPattern_Impl: Sized {
     fn Navigate(&self, direction: NavigateDirection) -> ::windows::core::Result<IUIAutomationElement>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationCustomNavigationPattern {}
 impl IUIAutomationCustomNavigationPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationCustomNavigationPattern_Impl, const OFFSET: isize>() -> IUIAutomationCustomNavigationPattern_Vtbl {
         unsafe extern "system" fn Navigate<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationCustomNavigationPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, direction: NavigateDirection, pretval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4349,6 +4467,7 @@ pub trait IUIAutomationDockPattern_Impl: Sized {
     fn CurrentDockPosition(&self) -> ::windows::core::Result<DockPosition>;
     fn CachedDockPosition(&self) -> ::windows::core::Result<DockPosition>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationDockPattern {}
 impl IUIAutomationDockPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationDockPattern_Impl, const OFFSET: isize>() -> IUIAutomationDockPattern_Vtbl {
         unsafe extern "system" fn SetDockPosition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationDockPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dockpos: DockPosition) -> ::windows::core::HRESULT {
@@ -4400,6 +4519,8 @@ pub trait IUIAutomationDragPattern_Impl: Sized {
     fn GetCurrentGrabbedItems(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn GetCachedGrabbedItems(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUIAutomationDragPattern {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUIAutomationDragPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationDragPattern_Impl, const OFFSET: isize>() -> IUIAutomationDragPattern_Vtbl {
@@ -4514,6 +4635,8 @@ pub trait IUIAutomationDropTargetPattern_Impl: Sized {
     fn CurrentDropTargetEffects(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn CachedDropTargetEffects(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUIAutomationDropTargetPattern {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUIAutomationDropTargetPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationDropTargetPattern_Impl, const OFFSET: isize>() -> IUIAutomationDropTargetPattern_Vtbl {
@@ -4658,6 +4781,8 @@ pub trait IUIAutomationElement_Impl: Sized {
     fn CachedProviderDescription(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement_Impl, const OFFSET: isize>() -> IUIAutomationElement_Vtbl {
@@ -5639,6 +5764,8 @@ pub trait IUIAutomationElement2_Impl: Sized + IUIAutomationElement_Impl {
     fn CachedFlowsFrom(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement2_Impl, const OFFSET: isize>() -> IUIAutomationElement2_Vtbl {
         unsafe extern "system" fn CurrentOptimizeForVisualContent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5728,6 +5855,8 @@ pub trait IUIAutomationElement3_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn CachedIsPeripheral(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement3_Impl, const OFFSET: isize>() -> IUIAutomationElement3_Vtbl {
         unsafe extern "system" fn ShowContextMenu<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5781,6 +5910,8 @@ pub trait IUIAutomationElement4_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn CachedAnnotationTypes(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn CachedAnnotationObjects(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement4_Impl, const OFFSET: isize>() -> IUIAutomationElement4_Vtbl {
@@ -5920,6 +6051,8 @@ pub trait IUIAutomationElement5_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn CachedLocalizedLandmarkType(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement5_Impl, const OFFSET: isize>() -> IUIAutomationElement5_Vtbl {
         unsafe extern "system" fn CurrentLandmarkType<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -5984,6 +6117,8 @@ pub trait IUIAutomationElement6_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn CachedFullDescription(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement6 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement6_Impl, const OFFSET: isize>() -> IUIAutomationElement6_Vtbl {
         unsafe extern "system" fn CurrentFullDescription<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -6026,6 +6161,8 @@ pub trait IUIAutomationElement7_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn FindAllWithOptionsBuildCache(&self, scope: TreeScope, condition: &::core::option::Option<IUIAutomationCondition>, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, traversaloptions: TreeTraversalOptions, root: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn GetCurrentMetadataValue(&self, targetid: i32, metadataid: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement7 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement7_Impl, const OFFSET: isize>() -> IUIAutomationElement7_Vtbl {
@@ -6103,6 +6240,8 @@ pub trait IUIAutomationElement8_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn CachedHeadingLevel(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement8 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement8_Impl, const OFFSET: isize>() -> IUIAutomationElement8_Vtbl {
         unsafe extern "system" fn CurrentHeadingLevel<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT {
@@ -6143,6 +6282,8 @@ pub trait IUIAutomationElement9_Impl: Sized + IUIAutomationElement_Impl + IUIAut
     fn CachedIsDialog(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationElement9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationElement9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement9_Impl, const OFFSET: isize>() -> IUIAutomationElement9_Vtbl {
         unsafe extern "system" fn CurrentIsDialog<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElement9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -6181,6 +6322,7 @@ pub trait IUIAutomationElementArray_Impl: Sized {
     fn Length(&self) -> ::windows::core::Result<i32>;
     fn GetElement(&self, index: i32) -> ::windows::core::Result<IUIAutomationElement>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationElementArray {}
 impl IUIAutomationElementArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElementArray_Impl, const OFFSET: isize>() -> IUIAutomationElementArray_Vtbl {
         unsafe extern "system" fn Length<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationElementArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, length: *mut i32) -> ::windows::core::HRESULT {
@@ -6218,6 +6360,7 @@ impl IUIAutomationElementArray_Vtbl {
 pub trait IUIAutomationEventHandler_Impl: Sized {
     fn HandleAutomationEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, eventid: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationEventHandler {}
 impl IUIAutomationEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationEventHandler_Vtbl {
         unsafe extern "system" fn HandleAutomationEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, eventid: i32) -> ::windows::core::HRESULT {
@@ -6240,6 +6383,7 @@ pub trait IUIAutomationEventHandlerGroup_Impl: Sized {
     fn AddStructureChangedEventHandler(&self, scope: TreeScope, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationStructureChangedEventHandler>) -> ::windows::core::Result<()>;
     fn AddTextEditTextChangedEventHandler(&self, scope: TreeScope, texteditchangetype: TextEditChangeType, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationTextEditTextChangedEventHandler>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationEventHandlerGroup {}
 impl IUIAutomationEventHandlerGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationEventHandlerGroup_Impl, const OFFSET: isize>() -> IUIAutomationEventHandlerGroup_Vtbl {
         unsafe extern "system" fn AddActiveTextPositionChangedEventHandler<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationEventHandlerGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scope: TreeScope, cacherequest: ::windows::core::RawPtr, handler: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6298,6 +6442,7 @@ pub trait IUIAutomationExpandCollapsePattern_Impl: Sized {
     fn CurrentExpandCollapseState(&self) -> ::windows::core::Result<ExpandCollapseState>;
     fn CachedExpandCollapseState(&self) -> ::windows::core::Result<ExpandCollapseState>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationExpandCollapsePattern {}
 impl IUIAutomationExpandCollapsePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationExpandCollapsePattern_Impl, const OFFSET: isize>() -> IUIAutomationExpandCollapsePattern_Vtbl {
         unsafe extern "system" fn Expand<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationExpandCollapsePattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6347,6 +6492,7 @@ impl IUIAutomationExpandCollapsePattern_Vtbl {
 pub trait IUIAutomationFocusChangedEventHandler_Impl: Sized {
     fn HandleFocusChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationFocusChangedEventHandler {}
 impl IUIAutomationFocusChangedEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationFocusChangedEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationFocusChangedEventHandler_Vtbl {
         unsafe extern "system" fn HandleFocusChangedEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationFocusChangedEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6372,6 +6518,7 @@ pub trait IUIAutomationGridItemPattern_Impl: Sized {
     fn CachedRowSpan(&self) -> ::windows::core::Result<i32>;
     fn CachedColumnSpan(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationGridItemPattern {}
 impl IUIAutomationGridItemPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationGridItemPattern_Impl, const OFFSET: isize>() -> IUIAutomationGridItemPattern_Vtbl {
         unsafe extern "system" fn CurrentContainingGrid<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationGridItemPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6509,6 +6656,7 @@ pub trait IUIAutomationGridPattern_Impl: Sized {
     fn CachedRowCount(&self) -> ::windows::core::Result<i32>;
     fn CachedColumnCount(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationGridPattern {}
 impl IUIAutomationGridPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationGridPattern_Impl, const OFFSET: isize>() -> IUIAutomationGridPattern_Vtbl {
         unsafe extern "system" fn GetItem<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationGridPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, row: i32, column: i32, element: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6582,6 +6730,7 @@ impl IUIAutomationGridPattern_Vtbl {
 pub trait IUIAutomationInvokePattern_Impl: Sized {
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationInvokePattern {}
 impl IUIAutomationInvokePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationInvokePattern_Impl, const OFFSET: isize>() -> IUIAutomationInvokePattern_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationInvokePattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6599,6 +6748,8 @@ impl IUIAutomationInvokePattern_Vtbl {
 pub trait IUIAutomationItemContainerPattern_Impl: Sized {
     fn FindItemByProperty(&self, pstartafter: &::core::option::Option<IUIAutomationElement>, propertyid: i32, value: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IUIAutomationElement>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationItemContainerPattern {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationItemContainerPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationItemContainerPattern_Impl, const OFFSET: isize>() -> IUIAutomationItemContainerPattern_Vtbl {
@@ -6646,6 +6797,8 @@ pub trait IUIAutomationLegacyIAccessiblePattern_Impl: Sized {
     fn CachedDefaultAction(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetIAccessible(&self) -> ::windows::core::Result<IAccessible>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUIAutomationLegacyIAccessiblePattern {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationLegacyIAccessiblePattern_Impl, const OFFSET: isize>() -> IUIAutomationLegacyIAccessiblePattern_Vtbl {
@@ -6937,6 +7090,8 @@ pub trait IUIAutomationMultipleViewPattern_Impl: Sized {
     fn GetCachedSupportedViews(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUIAutomationMultipleViewPattern {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUIAutomationMultipleViewPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationMultipleViewPattern_Impl, const OFFSET: isize>() -> IUIAutomationMultipleViewPattern_Vtbl {
         unsafe extern "system" fn GetViewName<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationMultipleViewPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, view: i32, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -7016,6 +7171,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
 pub trait IUIAutomationNotCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn GetChild(&self) -> ::windows::core::Result<IUIAutomationCondition>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationNotCondition {}
 impl IUIAutomationNotCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationNotCondition_Impl, const OFFSET: isize>() -> IUIAutomationNotCondition_Vtbl {
         unsafe extern "system" fn GetChild<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationNotCondition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, condition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7040,6 +7196,8 @@ pub trait IUIAutomationNotificationEventHandler_Impl: Sized {
     fn HandleNotificationEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, notificationkind: NotificationKind, notificationprocessing: NotificationProcessing, displaystring: &super::super::Foundation::BSTR, activityid: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationNotificationEventHandler {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationNotificationEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationNotificationEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationNotificationEventHandler_Vtbl {
         unsafe extern "system" fn HandleNotificationEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationNotificationEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, notificationkind: NotificationKind, notificationprocessing: NotificationProcessing, displaystring: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, activityid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -7056,6 +7214,7 @@ impl IUIAutomationNotificationEventHandler_Vtbl {
 pub trait IUIAutomationObjectModelPattern_Impl: Sized {
     fn GetUnderlyingObjectModel(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationObjectModelPattern {}
 impl IUIAutomationObjectModelPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationObjectModelPattern_Impl, const OFFSET: isize>() -> IUIAutomationObjectModelPattern_Vtbl {
         unsafe extern "system" fn GetUnderlyingObjectModel<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationObjectModelPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7081,6 +7240,8 @@ pub trait IUIAutomationOrCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn GetChildrenAsNativeArray(&self, childarray: *mut *mut ::core::option::Option<IUIAutomationCondition>, childarraycount: *mut i32) -> ::windows::core::Result<()>;
     fn GetChildren(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUIAutomationOrCondition {}
 #[cfg(feature = "Win32_System_Com")]
 impl IUIAutomationOrCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationOrCondition_Impl, const OFFSET: isize>() -> IUIAutomationOrCondition_Vtbl {
@@ -7126,6 +7287,7 @@ pub trait IUIAutomationPatternHandler_Impl: Sized {
     fn CreateClientWrapper(&self, ppatterninstance: &::core::option::Option<IUIAutomationPatternInstance>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Dispatch(&self, ptarget: &::core::option::Option<::windows::core::IUnknown>, index: u32, pparams: *const UIAutomationParameter, cparams: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationPatternHandler {}
 impl IUIAutomationPatternHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPatternHandler_Impl, const OFFSET: isize>() -> IUIAutomationPatternHandler_Vtbl {
         unsafe extern "system" fn CreateClientWrapper<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPatternHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppatterninstance: ::windows::core::RawPtr, pclientwrapper: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7160,6 +7322,8 @@ pub trait IUIAutomationPatternInstance_Impl: Sized {
     fn CallMethod(&self, index: u32, pparams: *const UIAutomationParameter, cparams: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationPatternInstance {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationPatternInstance_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPatternInstance_Impl, const OFFSET: isize>() -> IUIAutomationPatternInstance_Vtbl {
         unsafe extern "system" fn GetProperty<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPatternInstance_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, cached: super::super::Foundation::BOOL, r#type: UIAutomationType, pptr: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7187,6 +7351,8 @@ pub trait IUIAutomationPropertyChangedEventHandler_Impl: Sized {
     fn HandlePropertyChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, propertyid: i32, newvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationPropertyChangedEventHandler {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationPropertyChangedEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPropertyChangedEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationPropertyChangedEventHandler_Vtbl {
         unsafe extern "system" fn HandlePropertyChangedEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPropertyChangedEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, propertyid: i32, newvalue: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -7209,6 +7375,8 @@ pub trait IUIAutomationPropertyCondition_Impl: Sized + IUIAutomationCondition_Im
     fn PropertyValue(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn PropertyConditionFlags(&self) -> ::windows::core::Result<PropertyConditionFlags>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationPropertyCondition {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationPropertyCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationPropertyCondition_Impl, const OFFSET: isize>() -> IUIAutomationPropertyCondition_Vtbl {
@@ -7262,6 +7430,8 @@ pub trait IUIAutomationProxyFactory_Impl: Sized {
     fn ProxyFactoryId(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationProxyFactory {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationProxyFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationProxyFactory_Impl, const OFFSET: isize>() -> IUIAutomationProxyFactory_Vtbl {
         unsafe extern "system" fn CreateProvider<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationProxyFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, provider: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7312,6 +7482,8 @@ pub trait IUIAutomationProxyFactoryEntry_Impl: Sized {
     fn SetWinEventsForAutomationEvent(&self, eventid: i32, propertyid: i32, winevents: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
     fn GetWinEventsForAutomationEvent(&self, eventid: i32, propertyid: i32) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUIAutomationProxyFactoryEntry {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUIAutomationProxyFactoryEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationProxyFactoryEntry_Impl, const OFFSET: isize>() -> IUIAutomationProxyFactoryEntry_Vtbl {
@@ -7456,6 +7628,8 @@ pub trait IUIAutomationProxyFactoryMapping_Impl: Sized {
     fn RestoreDefaultTable(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUIAutomationProxyFactoryMapping {}
+#[cfg(feature = "Win32_System_Com")]
 impl IUIAutomationProxyFactoryMapping_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationProxyFactoryMapping_Impl, const OFFSET: isize>() -> IUIAutomationProxyFactoryMapping_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationProxyFactoryMapping_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -7554,6 +7728,8 @@ pub trait IUIAutomationRangeValuePattern_Impl: Sized {
     fn CachedLargeChange(&self) -> ::windows::core::Result<f64>;
     fn CachedSmallChange(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationRangeValuePattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationRangeValuePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationRangeValuePattern_Impl, const OFFSET: isize>() -> IUIAutomationRangeValuePattern_Vtbl {
@@ -7722,6 +7898,8 @@ pub trait IUIAutomationRegistrar_Impl: Sized {
     fn RegisterPattern(&self, pattern: *const UIAutomationPatternInfo, ppatternid: *mut i32, ppatternavailablepropertyid: *mut i32, propertyidcount: u32, ppropertyids: *mut i32, eventidcount: u32, peventids: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationRegistrar {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationRegistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationRegistrar_Impl, const OFFSET: isize>() -> IUIAutomationRegistrar_Vtbl {
         unsafe extern "system" fn RegisterProperty<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationRegistrar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, property: *const UIAutomationPropertyInfo, propertyid: *mut i32) -> ::windows::core::HRESULT {
@@ -7765,6 +7943,7 @@ impl IUIAutomationRegistrar_Vtbl {
 pub trait IUIAutomationScrollItemPattern_Impl: Sized {
     fn ScrollIntoView(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationScrollItemPattern {}
 impl IUIAutomationScrollItemPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationScrollItemPattern_Impl, const OFFSET: isize>() -> IUIAutomationScrollItemPattern_Vtbl {
         unsafe extern "system" fn ScrollIntoView<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationScrollItemPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7795,6 +7974,8 @@ pub trait IUIAutomationScrollPattern_Impl: Sized {
     fn CachedHorizontallyScrollable(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn CachedVerticallyScrollable(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationScrollPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationScrollPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationScrollPattern_Impl, const OFFSET: isize>() -> IUIAutomationScrollPattern_Vtbl {
@@ -7973,6 +8154,8 @@ pub trait IUIAutomationSelectionItemPattern_Impl: Sized {
     fn CachedSelectionContainer(&self) -> ::windows::core::Result<IUIAutomationElement>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationSelectionItemPattern {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationSelectionItemPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSelectionItemPattern_Impl, const OFFSET: isize>() -> IUIAutomationSelectionItemPattern_Vtbl {
         unsafe extern "system" fn Select<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSelectionItemPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8058,6 +8241,8 @@ pub trait IUIAutomationSelectionPattern_Impl: Sized {
     fn CachedCanSelectMultiple(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn CachedIsSelectionRequired(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationSelectionPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationSelectionPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSelectionPattern_Impl, const OFFSET: isize>() -> IUIAutomationSelectionPattern_Vtbl {
@@ -8152,6 +8337,8 @@ pub trait IUIAutomationSelectionPattern2_Impl: Sized + IUIAutomationSelectionPat
     fn CachedCurrentSelectedItem(&self) -> ::windows::core::Result<IUIAutomationElement>;
     fn CachedItemCount(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationSelectionPattern2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationSelectionPattern2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSelectionPattern2_Impl, const OFFSET: isize>() -> IUIAutomationSelectionPattern2_Vtbl {
@@ -8269,6 +8456,8 @@ pub trait IUIAutomationSpreadsheetItemPattern_Impl: Sized {
     fn GetCachedAnnotationTypes(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IUIAutomationSpreadsheetItemPattern {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IUIAutomationSpreadsheetItemPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSpreadsheetItemPattern_Impl, const OFFSET: isize>() -> IUIAutomationSpreadsheetItemPattern_Vtbl {
         unsafe extern "system" fn CurrentFormula<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSpreadsheetItemPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -8356,6 +8545,8 @@ pub trait IUIAutomationSpreadsheetPattern_Impl: Sized {
     fn GetItemByName(&self, name: &super::super::Foundation::BSTR) -> ::windows::core::Result<IUIAutomationElement>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationSpreadsheetPattern {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationSpreadsheetPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSpreadsheetPattern_Impl, const OFFSET: isize>() -> IUIAutomationSpreadsheetPattern_Vtbl {
         unsafe extern "system" fn GetItemByName<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSpreadsheetPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, element: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8379,6 +8570,8 @@ impl IUIAutomationSpreadsheetPattern_Vtbl {
 pub trait IUIAutomationStructureChangedEventHandler_Impl: Sized {
     fn HandleStructureChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, changetype: StructureChangeType, runtimeid: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUIAutomationStructureChangedEventHandler {}
 #[cfg(feature = "Win32_System_Com")]
 impl IUIAutomationStructureChangedEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationStructureChangedEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationStructureChangedEventHandler_Vtbl {
@@ -8415,6 +8608,8 @@ pub trait IUIAutomationStylesPattern_Impl: Sized {
     fn CachedExtendedProperties(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetCachedExtendedPropertiesAsArray(&self, propertyarray: *mut *mut ExtendedProperty, propertycount: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationStylesPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationStylesPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationStylesPattern_Impl, const OFFSET: isize>() -> IUIAutomationStylesPattern_Vtbl {
@@ -8610,6 +8805,7 @@ pub trait IUIAutomationSynchronizedInputPattern_Impl: Sized {
     fn StartListening(&self, inputtype: SynchronizedInputType) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationSynchronizedInputPattern {}
 impl IUIAutomationSynchronizedInputPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSynchronizedInputPattern_Impl, const OFFSET: isize>() -> IUIAutomationSynchronizedInputPattern_Vtbl {
         unsafe extern "system" fn StartListening<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationSynchronizedInputPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, inputtype: SynchronizedInputType) -> ::windows::core::HRESULT {
@@ -8638,6 +8834,7 @@ pub trait IUIAutomationTableItemPattern_Impl: Sized {
     fn GetCachedRowHeaderItems(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn GetCachedColumnHeaderItems(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationTableItemPattern {}
 impl IUIAutomationTableItemPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTableItemPattern_Impl, const OFFSET: isize>() -> IUIAutomationTableItemPattern_Vtbl {
         unsafe extern "system" fn GetCurrentRowHeaderItems<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTableItemPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8704,6 +8901,7 @@ pub trait IUIAutomationTablePattern_Impl: Sized {
     fn GetCachedColumnHeaders(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn CachedRowOrColumnMajor(&self) -> ::windows::core::Result<RowOrColumnMajor>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationTablePattern {}
 impl IUIAutomationTablePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTablePattern_Impl, const OFFSET: isize>() -> IUIAutomationTablePattern_Vtbl {
         unsafe extern "system" fn GetCurrentRowHeaders<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTablePattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, retval: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8790,6 +8988,7 @@ pub trait IUIAutomationTextChildPattern_Impl: Sized {
     fn TextContainer(&self) -> ::windows::core::Result<IUIAutomationElement>;
     fn TextRange(&self) -> ::windows::core::Result<IUIAutomationTextRange>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationTextChildPattern {}
 impl IUIAutomationTextChildPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextChildPattern_Impl, const OFFSET: isize>() -> IUIAutomationTextChildPattern_Vtbl {
         unsafe extern "system" fn TextContainer<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextChildPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, container: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8830,6 +9029,8 @@ pub trait IUIAutomationTextEditPattern_Impl: Sized + IUIAutomationTextPattern_Im
     fn GetConversionTarget(&self) -> ::windows::core::Result<IUIAutomationTextRange>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationTextEditPattern {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationTextEditPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextEditPattern_Impl, const OFFSET: isize>() -> IUIAutomationTextEditPattern_Vtbl {
         unsafe extern "system" fn GetActiveComposition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextEditPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, range: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8869,6 +9070,8 @@ pub trait IUIAutomationTextEditTextChangedEventHandler_Impl: Sized {
     fn HandleTextEditTextChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, texteditchangetype: TextEditChangeType, eventstrings: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUIAutomationTextEditTextChangedEventHandler {}
+#[cfg(feature = "Win32_System_Com")]
 impl IUIAutomationTextEditTextChangedEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextEditTextChangedEventHandler_Impl, const OFFSET: isize>() -> IUIAutomationTextEditTextChangedEventHandler_Vtbl {
         unsafe extern "system" fn HandleTextEditTextChangedEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextEditTextChangedEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, texteditchangetype: TextEditChangeType, eventstrings: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -8894,6 +9097,8 @@ pub trait IUIAutomationTextPattern_Impl: Sized {
     fn DocumentRange(&self) -> ::windows::core::Result<IUIAutomationTextRange>;
     fn SupportedTextSelection(&self) -> ::windows::core::Result<SupportedTextSelection>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationTextPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationTextPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextPattern_Impl, const OFFSET: isize>() -> IUIAutomationTextPattern_Vtbl {
@@ -8983,6 +9188,8 @@ pub trait IUIAutomationTextPattern2_Impl: Sized + IUIAutomationTextPattern_Impl 
     fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL, range: *mut ::core::option::Option<IUIAutomationTextRange>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationTextPattern2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationTextPattern2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextPattern2_Impl, const OFFSET: isize>() -> IUIAutomationTextPattern2_Vtbl {
         unsafe extern "system" fn RangeFromAnnotation<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextPattern2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, annotation: ::windows::core::RawPtr, range: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9032,6 +9239,8 @@ pub trait IUIAutomationTextRange_Impl: Sized {
     fn ScrollIntoView(&self, aligntotop: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetChildren(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationTextRange {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationTextRange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextRange_Impl, const OFFSET: isize>() -> IUIAutomationTextRange_Vtbl {
@@ -9228,6 +9437,8 @@ pub trait IUIAutomationTextRange2_Impl: Sized + IUIAutomationTextRange_Impl {
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationTextRange2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationTextRange2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextRange2_Impl, const OFFSET: isize>() -> IUIAutomationTextRange2_Vtbl {
         unsafe extern "system" fn ShowContextMenu<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextRange2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9247,6 +9458,8 @@ pub trait IUIAutomationTextRange3_Impl: Sized + IUIAutomationTextRange_Impl + IU
     fn GetChildrenBuildCache(&self, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn GetAttributeValues(&self, attributeids: *const i32, attributeidcount: i32) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IUIAutomationTextRange3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IUIAutomationTextRange3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextRange3_Impl, const OFFSET: isize>() -> IUIAutomationTextRange3_Vtbl {
@@ -9298,6 +9511,7 @@ pub trait IUIAutomationTextRangeArray_Impl: Sized {
     fn Length(&self) -> ::windows::core::Result<i32>;
     fn GetElement(&self, index: i32) -> ::windows::core::Result<IUIAutomationTextRange>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationTextRangeArray {}
 impl IUIAutomationTextRangeArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextRangeArray_Impl, const OFFSET: isize>() -> IUIAutomationTextRangeArray_Vtbl {
         unsafe extern "system" fn Length<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTextRangeArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, length: *mut i32) -> ::windows::core::HRESULT {
@@ -9337,6 +9551,7 @@ pub trait IUIAutomationTogglePattern_Impl: Sized {
     fn CurrentToggleState(&self) -> ::windows::core::Result<ToggleState>;
     fn CachedToggleState(&self) -> ::windows::core::Result<ToggleState>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationTogglePattern {}
 impl IUIAutomationTogglePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTogglePattern_Impl, const OFFSET: isize>() -> IUIAutomationTogglePattern_Vtbl {
         unsafe extern "system" fn Toggle<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTogglePattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9389,6 +9604,8 @@ pub trait IUIAutomationTransformPattern_Impl: Sized {
     fn CachedCanResize(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn CachedCanRotate(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationTransformPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationTransformPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTransformPattern_Impl, const OFFSET: isize>() -> IUIAutomationTransformPattern_Vtbl {
@@ -9503,6 +9720,8 @@ pub trait IUIAutomationTransformPattern2_Impl: Sized + IUIAutomationTransformPat
     fn CurrentZoomMaximum(&self) -> ::windows::core::Result<f64>;
     fn CachedZoomMaximum(&self) -> ::windows::core::Result<f64>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationTransformPattern2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationTransformPattern2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTransformPattern2_Impl, const OFFSET: isize>() -> IUIAutomationTransformPattern2_Vtbl {
@@ -9637,6 +9856,7 @@ pub trait IUIAutomationTreeWalker_Impl: Sized {
     fn NormalizeElementBuildCache(&self, element: &::core::option::Option<IUIAutomationElement>, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>) -> ::windows::core::Result<IUIAutomationElement>;
     fn Condition(&self) -> ::windows::core::Result<IUIAutomationCondition>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationTreeWalker {}
 impl IUIAutomationTreeWalker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTreeWalker_Impl, const OFFSET: isize>() -> IUIAutomationTreeWalker_Vtbl {
         unsafe extern "system" fn GetParentElement<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationTreeWalker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, element: ::windows::core::RawPtr, parent: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9812,6 +10032,8 @@ pub trait IUIAutomationValuePattern_Impl: Sized {
     fn CachedIsReadOnly(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationValuePattern {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationValuePattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationValuePattern_Impl, const OFFSET: isize>() -> IUIAutomationValuePattern_Vtbl {
         unsafe extern "system" fn SetValue<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationValuePattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, val: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -9879,6 +10101,7 @@ impl IUIAutomationValuePattern_Vtbl {
 pub trait IUIAutomationVirtualizedItemPattern_Impl: Sized {
     fn Realize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAutomationVirtualizedItemPattern {}
 impl IUIAutomationVirtualizedItemPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationVirtualizedItemPattern_Impl, const OFFSET: isize>() -> IUIAutomationVirtualizedItemPattern_Vtbl {
         unsafe extern "system" fn Realize<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationVirtualizedItemPattern_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9910,6 +10133,8 @@ pub trait IUIAutomationWindowPattern_Impl: Sized {
     fn CachedWindowVisualState(&self) -> ::windows::core::Result<WindowVisualState>;
     fn CachedWindowInteractionState(&self) -> ::windows::core::Result<WindowInteractionState>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAutomationWindowPattern {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAutomationWindowPattern_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAutomationWindowPattern_Impl, const OFFSET: isize>() -> IUIAutomationWindowPattern_Vtbl {
@@ -10096,6 +10321,8 @@ pub trait IValueProvider_Impl: Sized {
     fn IsReadOnly(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IValueProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl IValueProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IValueProvider_Impl, const OFFSET: isize>() -> IValueProvider_Vtbl {
         unsafe extern "system" fn SetValue<Identity: ::windows::core::IUnknownImpl, Impl: IValueProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, val: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -10139,6 +10366,7 @@ impl IValueProvider_Vtbl {
 pub trait IVirtualizedItemProvider_Impl: Sized {
     fn Realize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IVirtualizedItemProvider {}
 impl IVirtualizedItemProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVirtualizedItemProvider_Impl, const OFFSET: isize>() -> IVirtualizedItemProvider_Vtbl {
         unsafe extern "system" fn Realize<Identity: ::windows::core::IUnknownImpl, Impl: IVirtualizedItemProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10164,6 +10392,8 @@ pub trait IWindowProvider_Impl: Sized {
     fn WindowInteractionState(&self) -> ::windows::core::Result<WindowInteractionState>;
     fn IsTopmost(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IWindowProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl IWindowProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWindowProvider_Impl, const OFFSET: isize>() -> IWindowProvider_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
@@ -7,6 +7,7 @@ pub trait IUIAnimationInterpolator_Impl: Sized {
     fn InterpolateVelocity(&self, offset: f64) -> ::windows::core::Result<f64>;
     fn GetDependencies(&self, initialvaluedependencies: *mut UI_ANIMATION_DEPENDENCIES, initialvelocitydependencies: *mut UI_ANIMATION_DEPENDENCIES, durationdependencies: *mut UI_ANIMATION_DEPENDENCIES) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationInterpolator {}
 impl IUIAnimationInterpolator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationInterpolator_Impl, const OFFSET: isize>() -> IUIAnimationInterpolator_Vtbl {
         unsafe extern "system" fn SetInitialValueAndVelocity<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationInterpolator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, initialvalue: f64, initialvelocity: f64) -> ::windows::core::HRESULT {
@@ -94,6 +95,7 @@ pub trait IUIAnimationInterpolator2_Impl: Sized {
     fn GetPrimitiveInterpolation(&self, interpolation: &::core::option::Option<IUIAnimationPrimitiveInterpolation>, cdimension: u32) -> ::windows::core::Result<()>;
     fn GetDependencies(&self, initialvaluedependencies: *mut UI_ANIMATION_DEPENDENCIES, initialvelocitydependencies: *mut UI_ANIMATION_DEPENDENCIES, durationdependencies: *mut UI_ANIMATION_DEPENDENCIES) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationInterpolator2 {}
 impl IUIAnimationInterpolator2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationInterpolator2_Impl, const OFFSET: isize>() -> IUIAnimationInterpolator2_Vtbl {
         unsafe extern "system" fn GetDimension<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationInterpolator2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dimension: *mut u32) -> ::windows::core::HRESULT {
@@ -173,6 +175,7 @@ impl IUIAnimationInterpolator2_Vtbl {
 pub trait IUIAnimationLoopIterationChangeHandler2_Impl: Sized {
     fn OnLoopIterationChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, id: usize, newiterationcount: u32, olditerationcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationLoopIterationChangeHandler2 {}
 impl IUIAnimationLoopIterationChangeHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationLoopIterationChangeHandler2_Impl, const OFFSET: isize>() -> IUIAnimationLoopIterationChangeHandler2_Vtbl {
         unsafe extern "system" fn OnLoopIterationChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationLoopIterationChangeHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, id: usize, newiterationcount: u32, olditerationcount: u32) -> ::windows::core::HRESULT {
@@ -207,6 +210,7 @@ pub trait IUIAnimationManager_Impl: Sized {
     fn SetDefaultLongestAcceptableDelay(&self, delay: f64) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationManager {}
 impl IUIAnimationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManager_Impl, const OFFSET: isize>() -> IUIAnimationManager_Vtbl {
         unsafe extern "system" fn CreateAnimationVariable<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, initialvalue: f64, variable: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -391,6 +395,8 @@ pub trait IUIAnimationManager2_Impl: Sized {
     fn SetDefaultLongestAcceptableDelay(&self, delay: f64) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAnimationManager2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIAnimationManager2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManager2_Impl, const OFFSET: isize>() -> IUIAnimationManager2_Vtbl {
@@ -579,6 +585,7 @@ impl IUIAnimationManager2_Vtbl {
 pub trait IUIAnimationManagerEventHandler_Impl: Sized {
     fn OnManagerStatusChanged(&self, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationManagerEventHandler {}
 impl IUIAnimationManagerEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManagerEventHandler_Impl, const OFFSET: isize>() -> IUIAnimationManagerEventHandler_Vtbl {
         unsafe extern "system" fn OnManagerStatusChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManagerEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::HRESULT {
@@ -595,6 +602,7 @@ impl IUIAnimationManagerEventHandler_Vtbl {
 pub trait IUIAnimationManagerEventHandler2_Impl: Sized {
     fn OnManagerStatusChanged(&self, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationManagerEventHandler2 {}
 impl IUIAnimationManagerEventHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManagerEventHandler2_Impl, const OFFSET: isize>() -> IUIAnimationManagerEventHandler2_Vtbl {
         unsafe extern "system" fn OnManagerStatusChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationManagerEventHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::HRESULT {
@@ -612,6 +620,7 @@ pub trait IUIAnimationPrimitiveInterpolation_Impl: Sized {
     fn AddCubic(&self, dimension: u32, beginoffset: f64, constantcoefficient: f32, linearcoefficient: f32, quadraticcoefficient: f32, cubiccoefficient: f32) -> ::windows::core::Result<()>;
     fn AddSinusoidal(&self, dimension: u32, beginoffset: f64, bias: f32, amplitude: f32, frequency: f32, phase: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationPrimitiveInterpolation {}
 impl IUIAnimationPrimitiveInterpolation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationPrimitiveInterpolation_Impl, const OFFSET: isize>() -> IUIAnimationPrimitiveInterpolation_Vtbl {
         unsafe extern "system" fn AddCubic<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationPrimitiveInterpolation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dimension: u32, beginoffset: f64, constantcoefficient: f32, linearcoefficient: f32, quadraticcoefficient: f32, cubiccoefficient: f32) -> ::windows::core::HRESULT {
@@ -637,6 +646,7 @@ impl IUIAnimationPrimitiveInterpolation_Vtbl {
 pub trait IUIAnimationPriorityComparison_Impl: Sized {
     fn HasPriority(&self, scheduledstoryboard: &::core::option::Option<IUIAnimationStoryboard>, newstoryboard: &::core::option::Option<IUIAnimationStoryboard>, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationPriorityComparison {}
 impl IUIAnimationPriorityComparison_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationPriorityComparison_Impl, const OFFSET: isize>() -> IUIAnimationPriorityComparison_Vtbl {
         unsafe extern "system" fn HasPriority<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationPriorityComparison_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scheduledstoryboard: ::windows::core::RawPtr, newstoryboard: ::windows::core::RawPtr, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::HRESULT {
@@ -653,6 +663,7 @@ impl IUIAnimationPriorityComparison_Vtbl {
 pub trait IUIAnimationPriorityComparison2_Impl: Sized {
     fn HasPriority(&self, scheduledstoryboard: &::core::option::Option<IUIAnimationStoryboard2>, newstoryboard: &::core::option::Option<IUIAnimationStoryboard2>, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationPriorityComparison2 {}
 impl IUIAnimationPriorityComparison2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationPriorityComparison2_Impl, const OFFSET: isize>() -> IUIAnimationPriorityComparison2_Vtbl {
         unsafe extern "system" fn HasPriority<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationPriorityComparison2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, scheduledstoryboard: ::windows::core::RawPtr, newstoryboard: ::windows::core::RawPtr, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::HRESULT {
@@ -685,6 +696,7 @@ pub trait IUIAnimationStoryboard_Impl: Sized {
     fn GetElapsedTime(&self) -> ::windows::core::Result<f64>;
     fn SetStoryboardEventHandler(&self, handler: &::core::option::Option<IUIAnimationStoryboardEventHandler>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationStoryboard {}
 impl IUIAnimationStoryboard_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboard_Impl, const OFFSET: isize>() -> IUIAnimationStoryboard_Vtbl {
         unsafe extern "system" fn AddTransition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboard_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, variable: ::windows::core::RawPtr, transition: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -849,6 +861,8 @@ pub trait IUIAnimationStoryboard2_Impl: Sized {
     fn SetStoryboardEventHandler(&self, handler: &::core::option::Option<IUIAnimationStoryboardEventHandler2>, fregisterstatuschangefornextanimationevent: super::super::Foundation::BOOL, fregisterupdatefornextanimationevent: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIAnimationStoryboard2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUIAnimationStoryboard2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboard2_Impl, const OFFSET: isize>() -> IUIAnimationStoryboard2_Vtbl {
         unsafe extern "system" fn AddTransition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboard2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, variable: ::windows::core::RawPtr, transition: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1001,6 +1015,7 @@ pub trait IUIAnimationStoryboardEventHandler_Impl: Sized {
     fn OnStoryboardStatusChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::Result<()>;
     fn OnStoryboardUpdated(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationStoryboardEventHandler {}
 impl IUIAnimationStoryboardEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboardEventHandler_Impl, const OFFSET: isize>() -> IUIAnimationStoryboardEventHandler_Vtbl {
         unsafe extern "system" fn OnStoryboardStatusChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboardEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::HRESULT {
@@ -1027,6 +1042,7 @@ pub trait IUIAnimationStoryboardEventHandler2_Impl: Sized {
     fn OnStoryboardStatusChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::Result<()>;
     fn OnStoryboardUpdated(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationStoryboardEventHandler2 {}
 impl IUIAnimationStoryboardEventHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboardEventHandler2_Impl, const OFFSET: isize>() -> IUIAnimationStoryboardEventHandler2_Vtbl {
         unsafe extern "system" fn OnStoryboardStatusChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationStoryboardEventHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::HRESULT {
@@ -1058,6 +1074,7 @@ pub trait IUIAnimationTimer_Impl: Sized {
     fn GetTime(&self) -> ::windows::core::Result<f64>;
     fn SetFrameRateThreshold(&self, framespersecond: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTimer {}
 impl IUIAnimationTimer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimer_Impl, const OFFSET: isize>() -> IUIAnimationTimer_Vtbl {
         unsafe extern "system" fn SetTimerUpdateHandler<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, updatehandler: ::windows::core::RawPtr, idlebehavior: UI_ANIMATION_IDLE_BEHAVIOR) -> ::windows::core::HRESULT {
@@ -1119,6 +1136,7 @@ impl IUIAnimationTimer_Vtbl {
 pub trait IUIAnimationTimerClientEventHandler_Impl: Sized {
     fn OnTimerClientStatusChanged(&self, newstatus: UI_ANIMATION_TIMER_CLIENT_STATUS, previousstatus: UI_ANIMATION_TIMER_CLIENT_STATUS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTimerClientEventHandler {}
 impl IUIAnimationTimerClientEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimerClientEventHandler_Impl, const OFFSET: isize>() -> IUIAnimationTimerClientEventHandler_Vtbl {
         unsafe extern "system" fn OnTimerClientStatusChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimerClientEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_TIMER_CLIENT_STATUS, previousstatus: UI_ANIMATION_TIMER_CLIENT_STATUS) -> ::windows::core::HRESULT {
@@ -1140,6 +1158,7 @@ pub trait IUIAnimationTimerEventHandler_Impl: Sized {
     fn OnPostUpdate(&self) -> ::windows::core::Result<()>;
     fn OnRenderingTooSlow(&self, framespersecond: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTimerEventHandler {}
 impl IUIAnimationTimerEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimerEventHandler_Impl, const OFFSET: isize>() -> IUIAnimationTimerEventHandler_Vtbl {
         unsafe extern "system" fn OnPreUpdate<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimerEventHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1173,6 +1192,7 @@ pub trait IUIAnimationTimerUpdateHandler_Impl: Sized {
     fn SetTimerClientEventHandler(&self, handler: &::core::option::Option<IUIAnimationTimerClientEventHandler>) -> ::windows::core::Result<()>;
     fn ClearTimerClientEventHandler(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTimerUpdateHandler {}
 impl IUIAnimationTimerUpdateHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimerUpdateHandler_Impl, const OFFSET: isize>() -> IUIAnimationTimerUpdateHandler_Vtbl {
         unsafe extern "system" fn OnUpdate<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTimerUpdateHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timenow: f64, result: *mut UI_ANIMATION_UPDATE_RESULT) -> ::windows::core::HRESULT {
@@ -1213,6 +1233,7 @@ pub trait IUIAnimationTransition_Impl: Sized {
     fn IsDurationKnown(&self) -> ::windows::core::Result<()>;
     fn GetDuration(&self) -> ::windows::core::Result<f64>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTransition {}
 impl IUIAnimationTransition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransition_Impl, const OFFSET: isize>() -> IUIAnimationTransition_Vtbl {
         unsafe extern "system" fn SetInitialValue<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: f64) -> ::windows::core::HRESULT {
@@ -1262,6 +1283,7 @@ pub trait IUIAnimationTransition2_Impl: Sized {
     fn IsDurationKnown(&self) -> ::windows::core::Result<()>;
     fn GetDuration(&self) -> ::windows::core::Result<f64>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTransition2 {}
 impl IUIAnimationTransition2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransition2_Impl, const OFFSET: isize>() -> IUIAnimationTransition2_Vtbl {
         unsafe extern "system" fn GetDimension<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransition2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dimension: *mut u32) -> ::windows::core::HRESULT {
@@ -1329,6 +1351,7 @@ impl IUIAnimationTransition2_Vtbl {
 pub trait IUIAnimationTransitionFactory_Impl: Sized {
     fn CreateTransition(&self, interpolator: &::core::option::Option<IUIAnimationInterpolator>) -> ::windows::core::Result<IUIAnimationTransition>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTransitionFactory {}
 impl IUIAnimationTransitionFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionFactory_Impl, const OFFSET: isize>() -> IUIAnimationTransitionFactory_Vtbl {
         unsafe extern "system" fn CreateTransition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interpolator: ::windows::core::RawPtr, transition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1351,6 +1374,7 @@ impl IUIAnimationTransitionFactory_Vtbl {
 pub trait IUIAnimationTransitionFactory2_Impl: Sized {
     fn CreateTransition(&self, interpolator: &::core::option::Option<IUIAnimationInterpolator2>) -> ::windows::core::Result<IUIAnimationTransition2>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTransitionFactory2 {}
 impl IUIAnimationTransitionFactory2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionFactory2_Impl, const OFFSET: isize>() -> IUIAnimationTransitionFactory2_Vtbl {
         unsafe extern "system" fn CreateTransition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionFactory2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, interpolator: ::windows::core::RawPtr, transition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1384,6 +1408,7 @@ pub trait IUIAnimationTransitionLibrary_Impl: Sized {
     fn CreateSmoothStopTransition(&self, maximumduration: f64, finalvalue: f64) -> ::windows::core::Result<IUIAnimationTransition>;
     fn CreateParabolicTransitionFromAcceleration(&self, finalvalue: f64, finalvelocity: f64, acceleration: f64) -> ::windows::core::Result<IUIAnimationTransition>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTransitionLibrary {}
 impl IUIAnimationTransitionLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionLibrary_Impl, const OFFSET: isize>() -> IUIAnimationTransitionLibrary_Vtbl {
         unsafe extern "system" fn CreateInstantaneousTransition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionLibrary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, finalvalue: f64, transition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1559,6 +1584,7 @@ pub trait IUIAnimationTransitionLibrary2_Impl: Sized {
     fn CreateCubicBezierLinearTransition(&self, duration: f64, finalvalue: f64, x1: f64, y1: f64, x2: f64, y2: f64) -> ::windows::core::Result<IUIAnimationTransition2>;
     fn CreateCubicBezierLinearVectorTransition(&self, duration: f64, finalvalue: *const f64, cdimension: u32, x1: f64, y1: f64, x2: f64, y2: f64) -> ::windows::core::Result<IUIAnimationTransition2>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationTransitionLibrary2 {}
 impl IUIAnimationTransitionLibrary2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionLibrary2_Impl, const OFFSET: isize>() -> IUIAnimationTransitionLibrary2_Vtbl {
         unsafe extern "system" fn CreateInstantaneousTransition<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationTransitionLibrary2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, finalvalue: f64, transition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1813,6 +1839,7 @@ pub trait IUIAnimationVariable_Impl: Sized {
     fn SetVariableChangeHandler(&self, handler: &::core::option::Option<IUIAnimationVariableChangeHandler>) -> ::windows::core::Result<()>;
     fn SetVariableIntegerChangeHandler(&self, handler: &::core::option::Option<IUIAnimationVariableIntegerChangeHandler>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationVariable {}
 impl IUIAnimationVariable_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariable_Impl, const OFFSET: isize>() -> IUIAnimationVariable_Vtbl {
         unsafe extern "system" fn GetValue<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut f64) -> ::windows::core::HRESULT {
@@ -1978,6 +2005,8 @@ pub trait IUIAnimationVariable2_Impl: Sized {
     fn SetVariableIntegerChangeHandler(&self, handler: &::core::option::Option<IUIAnimationVariableIntegerChangeHandler2>, fregisterfornextanimationevent: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SetVariableCurveChangeHandler(&self, handler: &::core::option::Option<IUIAnimationVariableCurveChangeHandler2>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectComposition"))]
+impl ::windows::core::RuntimeName for IUIAnimationVariable2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectComposition"))]
 impl IUIAnimationVariable2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariable2_Impl, const OFFSET: isize>() -> IUIAnimationVariable2_Vtbl {
@@ -2196,6 +2225,7 @@ impl IUIAnimationVariable2_Vtbl {
 pub trait IUIAnimationVariableChangeHandler_Impl: Sized {
     fn OnValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>, variable: &::core::option::Option<IUIAnimationVariable>, newvalue: f64, previousvalue: f64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationVariableChangeHandler {}
 impl IUIAnimationVariableChangeHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableChangeHandler_Impl, const OFFSET: isize>() -> IUIAnimationVariableChangeHandler_Vtbl {
         unsafe extern "system" fn OnValueChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableChangeHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, variable: ::windows::core::RawPtr, newvalue: f64, previousvalue: f64) -> ::windows::core::HRESULT {
@@ -2212,6 +2242,7 @@ impl IUIAnimationVariableChangeHandler_Vtbl {
 pub trait IUIAnimationVariableChangeHandler2_Impl: Sized {
     fn OnValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, variable: &::core::option::Option<IUIAnimationVariable2>, newvalue: *const f64, previousvalue: *const f64, cdimension: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationVariableChangeHandler2 {}
 impl IUIAnimationVariableChangeHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableChangeHandler2_Impl, const OFFSET: isize>() -> IUIAnimationVariableChangeHandler2_Vtbl {
         unsafe extern "system" fn OnValueChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableChangeHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, variable: ::windows::core::RawPtr, newvalue: *const f64, previousvalue: *const f64, cdimension: u32) -> ::windows::core::HRESULT {
@@ -2228,6 +2259,7 @@ impl IUIAnimationVariableChangeHandler2_Vtbl {
 pub trait IUIAnimationVariableCurveChangeHandler2_Impl: Sized {
     fn OnCurveChanged(&self, variable: &::core::option::Option<IUIAnimationVariable2>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationVariableCurveChangeHandler2 {}
 impl IUIAnimationVariableCurveChangeHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableCurveChangeHandler2_Impl, const OFFSET: isize>() -> IUIAnimationVariableCurveChangeHandler2_Vtbl {
         unsafe extern "system" fn OnCurveChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableCurveChangeHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, variable: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2244,6 +2276,7 @@ impl IUIAnimationVariableCurveChangeHandler2_Vtbl {
 pub trait IUIAnimationVariableIntegerChangeHandler_Impl: Sized {
     fn OnIntegerValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>, variable: &::core::option::Option<IUIAnimationVariable>, newvalue: i32, previousvalue: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationVariableIntegerChangeHandler {}
 impl IUIAnimationVariableIntegerChangeHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableIntegerChangeHandler_Impl, const OFFSET: isize>() -> IUIAnimationVariableIntegerChangeHandler_Vtbl {
         unsafe extern "system" fn OnIntegerValueChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableIntegerChangeHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, variable: ::windows::core::RawPtr, newvalue: i32, previousvalue: i32) -> ::windows::core::HRESULT {
@@ -2260,6 +2293,7 @@ impl IUIAnimationVariableIntegerChangeHandler_Vtbl {
 pub trait IUIAnimationVariableIntegerChangeHandler2_Impl: Sized {
     fn OnIntegerValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, variable: &::core::option::Option<IUIAnimationVariable2>, newvalue: *const i32, previousvalue: *const i32, cdimension: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIAnimationVariableIntegerChangeHandler2 {}
 impl IUIAnimationVariableIntegerChangeHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableIntegerChangeHandler2_Impl, const OFFSET: isize>() -> IUIAnimationVariableIntegerChangeHandler2_Vtbl {
         unsafe extern "system" fn OnIntegerValueChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIAnimationVariableIntegerChangeHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, storyboard: ::windows::core::RawPtr, variable: ::windows::core::RawPtr, newvalue: *const i32, previousvalue: *const i32, cdimension: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
@@ -13,6 +13,8 @@ pub trait IDeviceModelPlugIn_Impl: Sized {
     fn GetNeutralAxis(&self, ccolors: u32, pxyzcolors: *mut XYZColorF) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDeviceModelPlugIn {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDeviceModelPlugIn_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceModelPlugIn_Impl, const OFFSET: isize>() -> IDeviceModelPlugIn_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDeviceModelPlugIn_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrxml: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, cnummodels: u32, imodelposition: u32) -> ::windows::core::HRESULT {
@@ -124,6 +126,8 @@ pub trait IGamutMapModelPlugIn_Impl: Sized {
     fn Initialize(&self, bstrxml: &super::super::Foundation::BSTR, psrcplugin: &::core::option::Option<IDeviceModelPlugIn>, pdestplugin: &::core::option::Option<IDeviceModelPlugIn>, psrcgbd: *const GamutBoundaryDescription, pdestgbd: *const GamutBoundaryDescription) -> ::windows::core::Result<()>;
     fn SourceToDestinationAppearanceColors(&self, ccolors: u32, pinputcolors: *const JChColorF, poutputcolors: *mut JChColorF) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGamutMapModelPlugIn {}
 #[cfg(feature = "Win32_Foundation")]
 impl IGamutMapModelPlugIn_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGamutMapModelPlugIn_Impl, const OFFSET: isize>() -> IGamutMapModelPlugIn_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/impl.rs
@@ -5,6 +5,8 @@ pub trait IPrintDialogCallback_Impl: Sized {
     fn HandleMessage(&self, hdlg: super::super::super::Foundation::HWND, umsg: u32, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM, presult: *mut super::super::super::Foundation::LRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPrintDialogCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPrintDialogCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDialogCallback_Impl, const OFFSET: isize>() -> IPrintDialogCallback_Vtbl {
         unsafe extern "system" fn InitDone<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDialogCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -39,6 +41,8 @@ pub trait IPrintDialogServices_Impl: Sized {
     fn GetCurrentPrinterName(&self, pprintername: ::windows::core::PWSTR, pcchsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetCurrentPortName(&self, pportname: ::windows::core::PWSTR, pcchsize: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IPrintDialogServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IPrintDialogServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPrintDialogServices_Impl, const OFFSET: isize>() -> IPrintDialogServices_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
@@ -18,6 +18,8 @@ pub trait IRichEditOle_Impl: Sized {
     fn ImportDataObject(&self, lpdataobj: &::core::option::Option<super::super::super::System::Com::IDataObject>, cf: u16, hmetapict: isize) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRichEditOle {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 impl IRichEditOle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRichEditOle_Impl, const OFFSET: isize>() -> IRichEditOle_Vtbl {
         unsafe extern "system" fn GetClientSite<Identity: ::windows::core::IUnknownImpl, Impl: IRichEditOle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lplpolesite: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -144,6 +146,8 @@ pub trait IRichEditOleCallback_Impl: Sized {
     fn GetContextMenu(&self, seltype: RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE, lpoleobj: &::core::option::Option<super::super::super::System::Ole::IOleObject>, lpchrg: *mut CHARRANGE, lphmenu: *mut super::super::WindowsAndMessaging::HMENU) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IRichEditOleCallback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IRichEditOleCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRichEditOleCallback_Impl, const OFFSET: isize>() -> IRichEditOleCallback_Vtbl {
         unsafe extern "system" fn GetNewStorage<Identity: ::windows::core::IUnknownImpl, Impl: IRichEditOleCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lplpstg: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -225,6 +229,8 @@ pub trait IRicheditUiaOverrides_Impl: Sized {
     fn GetPropertyOverrideValue(&self, propertyid: i32, pretvalue: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IRicheditUiaOverrides {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IRicheditUiaOverrides_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRicheditUiaOverrides_Impl, const OFFSET: isize>() -> IRicheditUiaOverrides_Vtbl {
         unsafe extern "system" fn GetPropertyOverrideValue<Identity: ::windows::core::IUnknownImpl, Impl: IRicheditUiaOverrides_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertyid: i32, pretvalue: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -240,6 +246,8 @@ impl IRicheditUiaOverrides_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextDisplays_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextDisplays {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextDisplays_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextDisplays_Impl, const OFFSET: isize>() -> ITextDisplays_Vtbl {
@@ -271,6 +279,8 @@ pub trait ITextDocument_Impl: Sized + super::super::super::System::Com::IDispatc
     fn Range(&self, cpactive: i32, cpanchor: i32) -> ::windows::core::Result<ITextRange>;
     fn RangeFromPoint(&self, x: i32, y: i32) -> ::windows::core::Result<ITextRange>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextDocument {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextDocument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextDocument_Impl, const OFFSET: isize>() -> ITextDocument_Vtbl {
@@ -515,6 +525,8 @@ pub trait ITextDocument2_Impl: Sized + super::super::super::System::Com::IDispat
     fn GetNewStory(&self) -> ::windows::core::Result<ITextStory>;
     fn GetStory(&self, index: i32) -> ::windows::core::Result<ITextStory>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextDocument2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextDocument2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextDocument2_Impl, const OFFSET: isize>() -> ITextDocument2_Vtbl {
@@ -962,6 +974,8 @@ pub trait ITextDocument2Old_Impl: Sized + super::super::super::System::Com::IDis
     fn ReleaseCallManager(&self, pvoid: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextDocument2Old {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextDocument2Old_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextDocument2Old_Impl, const OFFSET: isize>() -> ITextDocument2Old_Vtbl {
         unsafe extern "system" fn AttachMsgFilter<Identity: ::windows::core::IUnknownImpl, Impl: ITextDocument2Old_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1234,6 +1248,8 @@ pub trait ITextFont_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn GetWeight(&self) -> ::windows::core::Result<i32>;
     fn SetWeight(&self, value: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextFont {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextFont_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextFont_Impl, const OFFSET: isize>() -> ITextFont_Vtbl {
@@ -1793,6 +1809,8 @@ pub trait ITextFont2_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn SetProperty(&self, r#type: i32, value: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextFont2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextFont2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextFont2_Impl, const OFFSET: isize>() -> ITextFont2_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: ITextFont2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut i32) -> ::windows::core::HRESULT {
@@ -2254,6 +2272,8 @@ pub trait ITextHost_Impl: Sized {
     fn TxGetSelectionBarWidth(&self, lselbarwidth: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITextHost {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITextHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextHost_Impl, const OFFSET: isize>() -> ITextHost_Vtbl {
         unsafe extern "system" fn TxGetDC<Identity: ::windows::core::IUnknownImpl, Impl: ITextHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::super::Graphics::Gdi::HDC {
@@ -2520,6 +2540,8 @@ pub trait ITextHost2_Impl: Sized + ITextHost_Impl {
     fn TxGetHorzExtent(&self, plhorzextent: *mut i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITextHost2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITextHost2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextHost2_Impl, const OFFSET: isize>() -> ITextHost2_Vtbl {
         unsafe extern "system" fn TxIsDoubleClickPending<Identity: ::windows::core::IUnknownImpl, Impl: ITextHost2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::super::Foundation::BOOL {
@@ -2653,6 +2675,8 @@ pub trait ITextPara_Impl: Sized + super::super::super::System::Com::IDispatch_Im
     fn DeleteTab(&self, tbpos: f32) -> ::windows::core::Result<()>;
     fn GetTab(&self, itab: i32, ptbpos: *mut f32, ptbalign: *mut i32, ptbleader: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextPara {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextPara_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextPara_Impl, const OFFSET: isize>() -> ITextPara_Vtbl {
@@ -3116,6 +3140,8 @@ pub trait ITextPara2_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn SetProperty(&self, r#type: i32, value: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextPara2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextPara2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextPara2_Impl, const OFFSET: isize>() -> ITextPara2_Vtbl {
         unsafe extern "system" fn GetBorders<Identity: ::windows::core::IUnknownImpl, Impl: ITextPara2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppborders: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3324,6 +3350,8 @@ pub trait ITextRange_Impl: Sized + super::super::super::System::Com::IDispatch_I
     fn ScrollIntoView(&self, value: i32) -> ::windows::core::Result<()>;
     fn GetEmbeddedObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextRange {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextRange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextRange_Impl, const OFFSET: isize>() -> ITextRange_Vtbl {
@@ -3895,6 +3923,8 @@ pub trait ITextRange2_Impl: Sized + super::super::super::System::Com::IDispatch_
     fn InsertImage(&self, width: i32, height: i32, ascent: i32, r#type: super::super::super::Graphics::Gdi::TEXT_ALIGN_OPTIONS, bstralttext: &super::super::super::Foundation::BSTR, pstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextRange2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextRange2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextRange2_Impl, const OFFSET: isize>() -> ITextRange2_Vtbl {
         unsafe extern "system" fn GetCch<Identity: ::windows::core::IUnknownImpl, Impl: ITextRange2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcch: *mut i32) -> ::windows::core::HRESULT {
@@ -4296,6 +4326,8 @@ pub trait ITextRow_Impl: Sized + super::super::super::System::Com::IDispatch_Imp
     fn Reset(&self, value: i32) -> ::windows::core::Result<()>;
     fn SetProperty(&self, r#type: i32, value: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextRow {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextRow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextRow_Impl, const OFFSET: isize>() -> ITextRow_Vtbl {
@@ -4723,6 +4755,8 @@ pub trait ITextSelection_Impl: Sized + super::super::super::System::Com::IDispat
     fn TypeText(&self, bstr: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextSelection {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextSelection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextSelection_Impl, const OFFSET: isize>() -> ITextSelection_Vtbl {
         unsafe extern "system" fn GetFlags<Identity: ::windows::core::IUnknownImpl, Impl: ITextSelection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pflags: *mut i32) -> ::windows::core::HRESULT {
@@ -4844,6 +4878,8 @@ impl ITextSelection_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextSelection2_Impl: Sized + super::super::super::System::Com::IDispatch_Impl + ITextRange_Impl + ITextSelection_Impl + ITextRange2_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextSelection2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextSelection2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextSelection2_Impl, const OFFSET: isize>() -> ITextSelection2_Vtbl {
         Self { base__: ITextRange2_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -4873,6 +4909,8 @@ pub trait ITextServices_Impl: Sized {
     fn OnTxPropertyBitsChange(&self, dwmask: u32, dwbits: u32) -> ::windows::core::Result<()>;
     fn TxGetCachedSize(&self, pdwwidth: *mut u32, pdwheight: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextServices {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextServices_Impl, const OFFSET: isize>() -> ITextServices_Vtbl {
@@ -5019,6 +5057,8 @@ pub trait ITextServices2_Impl: Sized + ITextServices_Impl {
     fn TxDrawD2D(&self, prendertarget: &::core::option::Option<super::super::super::Graphics::Direct2D::ID2D1RenderTarget>, lprcbounds: *mut super::super::super::Foundation::RECTL, lprcupdate: *mut super::super::super::Foundation::RECT, lviewid: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextServices2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextServices2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextServices2_Impl, const OFFSET: isize>() -> ITextServices2_Vtbl {
         unsafe extern "system" fn TxGetNaturalSize2<Identity: ::windows::core::IUnknownImpl, Impl: ITextServices2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwaspect: u32, hdcdraw: super::super::super::Graphics::Gdi::HDC, hictargetdev: super::super::super::Graphics::Gdi::HDC, ptd: *mut super::super::super::System::Com::DVTARGETDEVICE, dwmode: u32, psizelextent: *const super::super::super::Foundation::SIZE, pwidth: *mut i32, pheight: *mut i32, pascent: *mut i32) -> ::windows::core::HRESULT {
@@ -5056,6 +5096,8 @@ pub trait ITextStory_Impl: Sized {
     fn SetProperty(&self, r#type: i32, value: i32) -> ::windows::core::Result<()>;
     fn SetText(&self, flags: i32, bstr: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITextStory {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITextStory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStory_Impl, const OFFSET: isize>() -> ITextStory_Vtbl {
@@ -5188,6 +5230,8 @@ pub trait ITextStoryRanges_Impl: Sized + super::super::super::System::Com::IDisp
     fn GetCount(&self) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextStoryRanges {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextStoryRanges_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoryRanges_Impl, const OFFSET: isize>() -> ITextStoryRanges_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoryRanges_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppunkenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5239,6 +5283,8 @@ pub trait ITextStoryRanges2_Impl: Sized + super::super::super::System::Com::IDis
     fn Item2(&self, index: i32) -> ::windows::core::Result<ITextRange2>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextStoryRanges2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextStoryRanges2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoryRanges2_Impl, const OFFSET: isize>() -> ITextStoryRanges2_Vtbl {
         unsafe extern "system" fn Item2<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoryRanges2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: i32, pprange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5278,6 +5324,8 @@ pub trait ITextStrings_Impl: Sized + super::super::super::System::Com::IDispatch
     fn SuffixTop(&self, bstr: &super::super::super::Foundation::BSTR, prange: &::core::option::Option<ITextRange2>) -> ::windows::core::Result<()>;
     fn Swap(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextStrings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextStrings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStrings_Impl, const OFFSET: isize>() -> ITextStrings_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
@@ -31,6 +31,8 @@ pub trait IImageList_Impl: Sized {
     fn GetOverlayImage(&self, ioverlay: i32) -> ::windows::core::Result<i32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IImageList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IImageList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImageList_Impl, const OFFSET: isize>() -> IImageList_Vtbl {
         unsafe extern "system" fn Add<Identity: ::windows::core::IUnknownImpl, Impl: IImageList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hbmimage: super::super::Graphics::Gdi::HBITMAP, hbmmask: super::super::Graphics::Gdi::HBITMAP, pi: *mut i32) -> ::windows::core::HRESULT {
@@ -296,6 +298,8 @@ pub trait IImageList2_Impl: Sized + IImageList_Impl {
     fn Replace2(&self, i: i32, hbmimage: super::super::Graphics::Gdi::HBITMAP, hbmmask: super::super::Graphics::Gdi::HBITMAP, punk: &::core::option::Option<::windows::core::IUnknown>, dwflags: u32) -> ::windows::core::Result<()>;
     fn ReplaceFromImageList(&self, i: i32, pil: &::core::option::Option<IImageList>, isrc: i32, punk: &::core::option::Option<::windows::core::IUnknown>, dwflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IImageList2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IImageList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImageList2_Impl, const OFFSET: isize>() -> IImageList2_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
@@ -19,6 +19,8 @@ pub trait IActiveIME_Impl: Sized {
     fn GetLangId(&self) -> ::windows::core::Result<u16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_UI_TextServices"))]
+impl ::windows::core::RuntimeName for IActiveIME {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_UI_TextServices"))]
 impl IActiveIME_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIME_Impl, const OFFSET: isize>() -> IActiveIME_Vtbl {
         unsafe extern "system" fn Inquire<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIME_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwsysteminfoflags: u32, pimeinfo: *mut IMEINFO, szwndclass: ::windows::core::PWSTR, pdwprivate: *mut u32) -> ::windows::core::HRESULT {
@@ -155,6 +157,8 @@ pub trait IActiveIME2_Impl: Sized + IActiveIME_Impl {
     fn Unsleep(&self, fdead: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_UI_TextServices"))]
+impl ::windows::core::RuntimeName for IActiveIME2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_UI_TextServices"))]
 impl IActiveIME2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIME2_Impl, const OFFSET: isize>() -> IActiveIME2_Vtbl {
         unsafe extern "system" fn Sleep<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIME2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -244,6 +248,8 @@ pub trait IActiveIMMApp_Impl: Sized {
     fn GetImeMenuItemsW(&self, himc: super::super::super::Globalization::HIMC, dwflags: u32, dwtype: u32, pimeparentmenu: *const IMEMENUITEMINFOW, pimemenu: *mut IMEMENUITEMINFOW, dwsize: u32, pdwresult: *mut u32) -> ::windows::core::Result<()>;
     fn EnumInputContext(&self, idthread: u32) -> ::windows::core::Result<IEnumInputContext>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_TextServices"))]
+impl ::windows::core::RuntimeName for IActiveIMMApp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_TextServices"))]
 impl IActiveIMMApp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIMMApp_Impl, const OFFSET: isize>() -> IActiveIMMApp_Vtbl {
@@ -868,6 +874,8 @@ pub trait IActiveIMMIME_Impl: Sized {
     fn SendIMCW(&self, hwnd: super::super::super::Foundation::HWND, umsg: u32, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::super::Foundation::LRESULT>;
     fn IsSleeping(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_TextServices"))]
+impl ::windows::core::RuntimeName for IActiveIMMIME {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_TextServices"))]
 impl IActiveIMMIME_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIMMIME_Impl, const OFFSET: isize>() -> IActiveIMMIME_Vtbl {
@@ -1590,6 +1598,8 @@ pub trait IActiveIMMMessagePumpOwner_Impl: Sized {
     fn Resume(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IActiveIMMMessagePumpOwner {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IActiveIMMMessagePumpOwner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIMMMessagePumpOwner_Impl, const OFFSET: isize>() -> IActiveIMMMessagePumpOwner_Vtbl {
         unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIMMMessagePumpOwner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1640,6 +1650,7 @@ pub trait IActiveIMMRegistrar_Impl: Sized {
     fn RegisterIME(&self, rclsid: *const ::windows::core::GUID, lgid: u16, psziconfile: &::windows::core::PCWSTR, pszdesc: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn UnregisterIME(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveIMMRegistrar {}
 impl IActiveIMMRegistrar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIMMRegistrar_Impl, const OFFSET: isize>() -> IActiveIMMRegistrar_Vtbl {
         unsafe extern "system" fn RegisterIME<Identity: ::windows::core::IUnknownImpl, Impl: IActiveIMMRegistrar_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, lgid: u16, psziconfile: ::windows::core::PCWSTR, pszdesc: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1669,6 +1680,8 @@ pub trait IEnumInputContext_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Globalization")]
+impl ::windows::core::RuntimeName for IEnumInputContext {}
 #[cfg(feature = "Win32_Globalization")]
 impl IEnumInputContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumInputContext_Impl, const OFFSET: isize>() -> IEnumInputContext_Vtbl {
@@ -1716,6 +1729,7 @@ pub trait IEnumRegisterWordA_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumRegisterWordA {}
 impl IEnumRegisterWordA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRegisterWordA_Impl, const OFFSET: isize>() -> IEnumRegisterWordA_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRegisterWordA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1762,6 +1776,7 @@ pub trait IEnumRegisterWordW_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumRegisterWordW {}
 impl IEnumRegisterWordW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRegisterWordW_Impl, const OFFSET: isize>() -> IEnumRegisterWordW_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumRegisterWordW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1805,6 +1820,8 @@ impl IEnumRegisterWordW_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFEClassFactory_Impl: Sized + super::super::super::System::Com::IClassFactory_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFEClassFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFEClassFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFEClassFactory_Impl, const OFFSET: isize>() -> IFEClassFactory_Vtbl {
         Self { base__: super::super::super::System::Com::IClassFactory_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -1820,6 +1837,8 @@ pub trait IFECommon_Impl: Sized {
     fn InvokeWordRegDialog(&self, pimedlg: *mut IMEDLG) -> ::windows::core::Result<()>;
     fn InvokeDictToolDialog(&self, pimedlg: *mut IMEDLG) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFECommon {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFECommon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFECommon_Impl, const OFFSET: isize>() -> IFECommon_Vtbl {
@@ -1875,6 +1894,8 @@ pub trait IFEDictionary_Impl: Sized {
     fn ConvertFromOldMSIME(&self, pchdic: &::windows::core::PCSTR, pfnlog: &PFNLOG, reg: IMEREG) -> ::windows::core::Result<()>;
     fn ConvertFromUserToSys(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFEDictionary {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFEDictionary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFEDictionary_Impl, const OFFSET: isize>() -> IFEDictionary_Vtbl {
@@ -1998,6 +2019,8 @@ pub trait IFELanguage_Impl: Sized {
     fn GetConversion(&self, string: &super::super::super::Foundation::BSTR, start: i32, length: i32, result: *mut super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFELanguage {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFELanguage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFELanguage_Impl, const OFFSET: isize>() -> IFELanguage_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IFELanguage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2049,6 +2072,8 @@ pub trait IImePad_Impl: Sized {
     fn Request(&self, piimepadapplet: &::core::option::Option<IImePadApplet>, reqid: IME_PAD_REQUEST_FLAGS, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IImePad {}
+#[cfg(feature = "Win32_Foundation")]
 impl IImePad_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImePad_Impl, const OFFSET: isize>() -> IImePad_Vtbl {
         unsafe extern "system" fn Request<Identity: ::windows::core::IUnknownImpl, Impl: IImePad_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piimepadapplet: ::windows::core::RawPtr, reqid: IME_PAD_REQUEST_FLAGS, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -2070,6 +2095,8 @@ pub trait IImePadApplet_Impl: Sized {
     fn CreateUI(&self, hwndparent: super::super::super::Foundation::HWND, lpimeappletui: *mut IMEAPPLETUI) -> ::windows::core::Result<()>;
     fn Notify(&self, lpimepad: &::core::option::Option<::windows::core::IUnknown>, notify: i32, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IImePadApplet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IImePadApplet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImePadApplet_Impl, const OFFSET: isize>() -> IImePadApplet_Vtbl {
@@ -2117,6 +2144,8 @@ pub trait IImePlugInDictDictionaryList_Impl: Sized {
     fn DeleteDictionary(&self, bstrdictionaryguid: &super::super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IImePlugInDictDictionaryList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IImePlugInDictDictionaryList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImePlugInDictDictionaryList_Impl, const OFFSET: isize>() -> IImePlugInDictDictionaryList_Vtbl {
         unsafe extern "system" fn GetDictionariesInUse<Identity: ::windows::core::IUnknownImpl, Impl: IImePlugInDictDictionaryList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prgdictionaryguid: *mut *mut super::super::super::System::Com::SAFEARRAY, prgdatecreated: *mut *mut super::super::super::System::Com::SAFEARRAY, prgfencrypted: *mut *mut super::super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT {
@@ -2142,6 +2171,7 @@ impl IImePlugInDictDictionaryList_Vtbl {
 pub trait IImeSpecifyApplets_Impl: Sized {
     fn GetAppletIIDList(&self, refiid: *const ::windows::core::GUID, lpiidlist: *mut APPLETIDLIST) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IImeSpecifyApplets {}
 impl IImeSpecifyApplets_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImeSpecifyApplets_Impl, const OFFSET: isize>() -> IImeSpecifyApplets_Vtbl {
         unsafe extern "system" fn GetAppletIIDList<Identity: ::windows::core::IUnknownImpl, Impl: IImeSpecifyApplets_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, refiid: *const ::windows::core::GUID, lpiidlist: *mut APPLETIDLIST) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/impl.rs
@@ -1,6 +1,7 @@
 pub trait IInkCommitRequestHandler_Impl: Sized {
     fn OnCommitRequested(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInkCommitRequestHandler {}
 impl IInkCommitRequestHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCommitRequestHandler_Impl, const OFFSET: isize>() -> IInkCommitRequestHandler_Vtbl {
         unsafe extern "system" fn OnCommitRequested<Identity: ::windows::core::IUnknownImpl, Impl: IInkCommitRequestHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -19,6 +20,8 @@ pub trait IInkD2DRenderer_Impl: Sized {
     fn Draw(&self, pd2d1devicecontext: &::core::option::Option<::windows::core::IUnknown>, pinkstrokeiterable: &::core::option::Option<::windows::core::IUnknown>, fhighcontrast: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInkD2DRenderer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IInkD2DRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkD2DRenderer_Impl, const OFFSET: isize>() -> IInkD2DRenderer_Vtbl {
         unsafe extern "system" fn Draw<Identity: ::windows::core::IUnknownImpl, Impl: IInkD2DRenderer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pd2d1devicecontext: *mut ::core::ffi::c_void, pinkstrokeiterable: *mut ::core::ffi::c_void, fhighcontrast: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -35,6 +38,7 @@ impl IInkD2DRenderer_Vtbl {
 pub trait IInkD2DRenderer2_Impl: Sized {
     fn Draw(&self, pd2d1devicecontext: &::core::option::Option<::windows::core::IUnknown>, pinkstrokeiterable: &::core::option::Option<::windows::core::IUnknown>, highcontrastadjustment: INK_HIGH_CONTRAST_ADJUSTMENT) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInkD2DRenderer2 {}
 impl IInkD2DRenderer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkD2DRenderer2_Impl, const OFFSET: isize>() -> IInkD2DRenderer2_Vtbl {
         unsafe extern "system" fn Draw<Identity: ::windows::core::IUnknownImpl, Impl: IInkD2DRenderer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pd2d1devicecontext: *mut ::core::ffi::c_void, pinkstrokeiterable: *mut ::core::ffi::c_void, highcontrastadjustment: INK_HIGH_CONTRAST_ADJUSTMENT) -> ::windows::core::HRESULT {
@@ -53,6 +57,7 @@ pub trait IInkDesktopHost_Impl: Sized {
     fn CreateInkPresenter(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateAndInitializeInkPresenter(&self, rootvisual: &::core::option::Option<::windows::core::IUnknown>, width: f32, height: f32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInkDesktopHost {}
 impl IInkDesktopHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDesktopHost_Impl, const OFFSET: isize>() -> IInkDesktopHost_Vtbl {
         unsafe extern "system" fn QueueWorkItem<Identity: ::windows::core::IUnknownImpl, Impl: IInkDesktopHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, workitem: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -84,6 +89,7 @@ impl IInkDesktopHost_Vtbl {
 pub trait IInkHostWorkItem_Impl: Sized {
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInkHostWorkItem {}
 impl IInkHostWorkItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkHostWorkItem_Impl, const OFFSET: isize>() -> IInkHostWorkItem_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: IInkHostWorkItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -104,6 +110,7 @@ pub trait IInkPresenterDesktop_Impl: Sized {
     fn SetSize(&self, width: f32, height: f32) -> ::windows::core::Result<()>;
     fn OnHighContrastChanged(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInkPresenterDesktop {}
 impl IInkPresenterDesktop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkPresenterDesktop_Impl, const OFFSET: isize>() -> IInkPresenterDesktop_Vtbl {
         unsafe extern "system" fn SetRootVisual<Identity: ::windows::core::IUnknownImpl, Impl: IInkPresenterDesktop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rootvisual: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Radial/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Radial/impl.rs
@@ -3,9 +3,7 @@ pub trait IRadialControllerConfigurationInterop_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IRadialControllerConfigurationInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IRadialControllerConfigurationInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRadialControllerConfigurationInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRadialControllerConfigurationInterop_Impl, const OFFSET: isize>() -> IRadialControllerConfigurationInterop_Vtbl {
@@ -28,9 +26,7 @@ pub trait IRadialControllerIndependentInputSourceInterop_Impl: Sized {
     fn CreateForWindow(&self, hwnd: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IRadialControllerIndependentInputSourceInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IRadialControllerIndependentInputSourceInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRadialControllerIndependentInputSourceInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRadialControllerIndependentInputSourceInterop_Impl, const OFFSET: isize>() -> IRadialControllerIndependentInputSourceInterop_Vtbl {
@@ -53,9 +49,7 @@ pub trait IRadialControllerInterop_Impl: Sized {
     fn CreateForWindow(&self, hwnd: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IRadialControllerInterop {
-    const NAME: &'static str = "";
-}
+impl ::windows::core::RuntimeName for IRadialControllerInterop {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRadialControllerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRadialControllerInterop_Impl, const OFFSET: isize>() -> IRadialControllerInterop_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
@@ -51,6 +51,8 @@ pub trait IInertiaProcessor_Impl: Sized {
     fn CompleteTime(&self, timestamp: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInertiaProcessor {}
+#[cfg(feature = "Win32_Foundation")]
 impl IInertiaProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInertiaProcessor_Impl, const OFFSET: isize>() -> IInertiaProcessor_Vtbl {
         unsafe extern "system" fn InitialOriginX<Identity: ::windows::core::IUnknownImpl, Impl: IInertiaProcessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, x: *mut f32) -> ::windows::core::HRESULT {
@@ -522,6 +524,7 @@ pub trait IManipulationProcessor_Impl: Sized {
     fn MinimumScaleRotateRadius(&self) -> ::windows::core::Result<f32>;
     fn SetMinimumScaleRotateRadius(&self, minradius: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IManipulationProcessor {}
 impl IManipulationProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IManipulationProcessor_Impl, const OFFSET: isize>() -> IManipulationProcessor_Vtbl {
         unsafe extern "system" fn SupportedManipulations<Identity: ::windows::core::IUnknownImpl, Impl: IManipulationProcessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, manipulations: *mut MANIPULATION_PROCESSOR_MANIPULATIONS) -> ::windows::core::HRESULT {
@@ -717,6 +720,7 @@ pub trait _IManipulationEvents_Impl: Sized {
     fn ManipulationDelta(&self, x: f32, y: f32, translationdeltax: f32, translationdeltay: f32, scaledelta: f32, expansiondelta: f32, rotationdelta: f32, cumulativetranslationx: f32, cumulativetranslationy: f32, cumulativescale: f32, cumulativeexpansion: f32, cumulativerotation: f32) -> ::windows::core::Result<()>;
     fn ManipulationCompleted(&self, x: f32, y: f32, cumulativetranslationx: f32, cumulativetranslationy: f32, cumulativescale: f32, cumulativeexpansion: f32, cumulativerotation: f32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for _IManipulationEvents {}
 impl _IManipulationEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IManipulationEvents_Impl, const OFFSET: isize>() -> _IManipulationEvents_Vtbl {
         unsafe extern "system" fn ManipulationStarted<Identity: ::windows::core::IUnknownImpl, Impl: _IManipulationEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, x: f32, y: f32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
@@ -6,6 +6,8 @@ pub trait IADesktopP2_Impl: Sized {
     fn MakeDynamicChanges(&self, poleobj: &::core::option::Option<super::super::System::Ole::IOleObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Ole")]
+impl ::windows::core::RuntimeName for IADesktopP2 {}
+#[cfg(feature = "Win32_System_Ole")]
 impl IADesktopP2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IADesktopP2_Impl, const OFFSET: isize>() -> IADesktopP2_Vtbl {
         unsafe extern "system" fn ReReadWallpaper<Identity: ::windows::core::IUnknownImpl, Impl: IADesktopP2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -46,6 +48,7 @@ pub trait IActiveDesktopP_Impl: Sized {
     fn SetScheme(&self, pwszschemename: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetScheme(&self, pwszschemename: ::windows::core::PWSTR, pdwcchbuffer: *mut u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActiveDesktopP {}
 impl IActiveDesktopP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActiveDesktopP_Impl, const OFFSET: isize>() -> IActiveDesktopP_Vtbl {
         unsafe extern "system" fn SetSafeMode<Identity: ::windows::core::IUnknownImpl, Impl: IActiveDesktopP_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -85,6 +88,8 @@ pub trait IBriefcaseInitiator_Impl: Sized {
     fn IsMonikerInBriefcase(&self, pmk: &::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IBriefcaseInitiator {}
+#[cfg(feature = "Win32_System_Com")]
 impl IBriefcaseInitiator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBriefcaseInitiator_Impl, const OFFSET: isize>() -> IBriefcaseInitiator_Vtbl {
         unsafe extern "system" fn IsMonikerInBriefcase<Identity: ::windows::core::IUnknownImpl, Impl: IBriefcaseInitiator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmk: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -106,6 +111,8 @@ pub trait IEmptyVolumeCache_Impl: Sized {
     fn ShowProperties(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn Deactivate(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IEmptyVolumeCache {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IEmptyVolumeCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEmptyVolumeCache_Impl, const OFFSET: isize>() -> IEmptyVolumeCache_Vtbl {
@@ -158,6 +165,8 @@ pub trait IEmptyVolumeCache2_Impl: Sized + IEmptyVolumeCache_Impl {
     fn InitializeEx(&self, hkregkey: super::super::System::Registry::HKEY, pcwszvolume: &::windows::core::PCWSTR, pcwszkeyname: &::windows::core::PCWSTR, ppwszdisplayname: *mut ::windows::core::PWSTR, ppwszdescription: *mut ::windows::core::PWSTR, ppwszbtntext: *mut ::windows::core::PWSTR, pdwflags: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IEmptyVolumeCache2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IEmptyVolumeCache2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEmptyVolumeCache2_Impl, const OFFSET: isize>() -> IEmptyVolumeCache2_Vtbl {
         unsafe extern "system" fn InitializeEx<Identity: ::windows::core::IUnknownImpl, Impl: IEmptyVolumeCache2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hkregkey: super::super::System::Registry::HKEY, pcwszvolume: ::windows::core::PCWSTR, pcwszkeyname: ::windows::core::PCWSTR, ppwszdisplayname: *mut ::windows::core::PWSTR, ppwszdescription: *mut ::windows::core::PWSTR, ppwszbtntext: *mut ::windows::core::PWSTR, pdwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -175,6 +184,7 @@ pub trait IEmptyVolumeCacheCallBack_Impl: Sized {
     fn ScanProgress(&self, dwlspaceused: u64, dwflags: u32, pcwszstatus: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn PurgeProgress(&self, dwlspacefreed: u64, dwlspacetofree: u64, dwflags: u32, pcwszstatus: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEmptyVolumeCacheCallBack {}
 impl IEmptyVolumeCacheCallBack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEmptyVolumeCacheCallBack_Impl, const OFFSET: isize>() -> IEmptyVolumeCacheCallBack_Vtbl {
         unsafe extern "system" fn ScanProgress<Identity: ::windows::core::IUnknownImpl, Impl: IEmptyVolumeCacheCallBack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwlspaceused: u64, dwflags: u32, pcwszstatus: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -202,6 +212,8 @@ pub trait IReconcilableObject_Impl: Sized {
     fn Reconcile(&self, pinitiator: &::core::option::Option<IReconcileInitiator>, dwflags: u32, hwndowner: super::super::Foundation::HWND, hwndprogressfeedback: super::super::Foundation::HWND, ulcinput: u32, rgpmkotherinput: *mut ::core::option::Option<super::super::System::Com::IMoniker>, ploutindex: *mut i32, pstgnewresidues: &::core::option::Option<super::super::System::Com::StructuredStorage::IStorage>, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetProgressFeedbackMaxEstimate(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IReconcilableObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IReconcilableObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReconcilableObject_Impl, const OFFSET: isize>() -> IReconcilableObject_Vtbl {
@@ -235,6 +247,7 @@ pub trait IReconcileInitiator_Impl: Sized {
     fn SetAbortCallback(&self, punkforabort: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetProgressFeedback(&self, ulprogress: u32, ulprogressmax: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IReconcileInitiator {}
 impl IReconcileInitiator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IReconcileInitiator_Impl, const OFFSET: isize>() -> IReconcileInitiator_Vtbl {
         unsafe extern "system" fn SetAbortCallback<Identity: ::windows::core::IUnknownImpl, Impl: IReconcileInitiator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkforabort: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/impl.rs
@@ -1,6 +1,7 @@
 pub trait INotificationActivationCallback_Impl: Sized {
     fn Activate(&self, appusermodelid: &::windows::core::PCWSTR, invokedargs: &::windows::core::PCWSTR, data: *const NOTIFICATION_USER_INPUT_DATA, count: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for INotificationActivationCallback {}
 impl INotificationActivationCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INotificationActivationCallback_Impl, const OFFSET: isize>() -> INotificationActivationCallback_Vtbl {
         unsafe extern "system" fn Activate<Identity: ::windows::core::IUnknownImpl, Impl: INotificationActivationCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, invokedargs: ::windows::core::PCWSTR, data: *const NOTIFICATION_USER_INPUT_DATA, count: u32) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
@@ -3,6 +3,7 @@ pub trait IUIApplication_Impl: Sized {
     fn OnCreateUICommand(&self, commandid: u32, typeid: UI_COMMANDTYPE) -> ::windows::core::Result<IUICommandHandler>;
     fn OnDestroyUICommand(&self, commandid: u32, typeid: UI_COMMANDTYPE, commandhandler: &::core::option::Option<IUICommandHandler>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIApplication {}
 impl IUIApplication_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIApplication_Impl, const OFFSET: isize>() -> IUIApplication_Vtbl {
         unsafe extern "system" fn OnViewChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUIApplication_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, viewid: u32, typeid: UI_VIEWTYPE, view: *mut ::core::ffi::c_void, verb: UI_VIEWVERB, ureasoncode: i32) -> ::windows::core::HRESULT {
@@ -46,6 +47,7 @@ pub trait IUICollection_Impl: Sized {
     fn Replace(&self, indexreplaced: u32, itemreplacewith: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUICollection {}
 impl IUICollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUICollection_Impl, const OFFSET: isize>() -> IUICollection_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IUICollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT {
@@ -113,6 +115,7 @@ impl IUICollection_Vtbl {
 pub trait IUICollectionChangedEvent_Impl: Sized {
     fn OnChanged(&self, action: UI_COLLECTIONCHANGE, oldindex: u32, olditem: &::core::option::Option<::windows::core::IUnknown>, newindex: u32, newitem: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUICollectionChangedEvent {}
 impl IUICollectionChangedEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUICollectionChangedEvent_Impl, const OFFSET: isize>() -> IUICollectionChangedEvent_Vtbl {
         unsafe extern "system" fn OnChanged<Identity: ::windows::core::IUnknownImpl, Impl: IUICollectionChangedEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, action: UI_COLLECTIONCHANGE, oldindex: u32, olditem: *mut ::core::ffi::c_void, newindex: u32, newitem: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -131,6 +134,8 @@ pub trait IUICommandHandler_Impl: Sized {
     fn Execute(&self, commandid: u32, verb: UI_EXECUTIONVERB, key: *const super::Shell::PropertiesSystem::PROPERTYKEY, currentvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT, commandexecutionproperties: &::core::option::Option<IUISimplePropertySet>) -> ::windows::core::Result<()>;
     fn UpdateProperty(&self, commandid: u32, key: *const super::Shell::PropertiesSystem::PROPERTYKEY, currentvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IUICommandHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IUICommandHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUICommandHandler_Impl, const OFFSET: isize>() -> IUICommandHandler_Vtbl {
@@ -163,6 +168,7 @@ impl IUICommandHandler_Vtbl {
 pub trait IUIContextualUI_Impl: Sized {
     fn ShowAtLocation(&self, x: i32, y: i32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIContextualUI {}
 impl IUIContextualUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIContextualUI_Impl, const OFFSET: isize>() -> IUIContextualUI_Vtbl {
         unsafe extern "system" fn ShowAtLocation<Identity: ::windows::core::IUnknownImpl, Impl: IUIContextualUI_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, x: i32, y: i32) -> ::windows::core::HRESULT {
@@ -179,6 +185,7 @@ impl IUIContextualUI_Vtbl {
 pub trait IUIEventLogger_Impl: Sized {
     fn OnUIEvent(&self, peventparams: *const UI_EVENTPARAMS);
 }
+impl ::windows::core::RuntimeName for IUIEventLogger {}
 impl IUIEventLogger_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIEventLogger_Impl, const OFFSET: isize>() -> IUIEventLogger_Vtbl {
         unsafe extern "system" fn OnUIEvent<Identity: ::windows::core::IUnknownImpl, Impl: IUIEventLogger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peventparams: *const UI_EVENTPARAMS) {
@@ -195,6 +202,7 @@ impl IUIEventLogger_Vtbl {
 pub trait IUIEventingManager_Impl: Sized {
     fn SetEventLogger(&self, eventlogger: &::core::option::Option<IUIEventLogger>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUIEventingManager {}
 impl IUIEventingManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIEventingManager_Impl, const OFFSET: isize>() -> IUIEventingManager_Vtbl {
         unsafe extern "system" fn SetEventLogger<Identity: ::windows::core::IUnknownImpl, Impl: IUIEventingManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventlogger: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -220,6 +228,8 @@ pub trait IUIFramework_Impl: Sized {
     fn FlushPendingInvalidations(&self) -> ::windows::core::Result<()>;
     fn SetModes(&self, imodes: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IUIFramework {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IUIFramework_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIFramework_Impl, const OFFSET: isize>() -> IUIFramework_Vtbl {
@@ -296,6 +306,8 @@ pub trait IUIImage_Impl: Sized {
     fn GetBitmap(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IUIImage {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IUIImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIImage_Impl, const OFFSET: isize>() -> IUIImage_Vtbl {
         unsafe extern "system" fn GetBitmap<Identity: ::windows::core::IUnknownImpl, Impl: IUIImage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bitmap: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT {
@@ -319,6 +331,8 @@ impl IUIImage_Vtbl {
 pub trait IUIImageFromBitmap_Impl: Sized {
     fn CreateImage(&self, bitmap: super::super::Graphics::Gdi::HBITMAP, options: UI_OWNERSHIP) -> ::windows::core::Result<IUIImage>;
 }
+#[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IUIImageFromBitmap {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl IUIImageFromBitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIImageFromBitmap_Impl, const OFFSET: isize>() -> IUIImageFromBitmap_Vtbl {
@@ -345,6 +359,8 @@ pub trait IUIRibbon_Impl: Sized {
     fn LoadSettingsFromStream(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
     fn SaveSettingsToStream(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IUIRibbon {}
 #[cfg(feature = "Win32_System_Com")]
 impl IUIRibbon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIRibbon_Impl, const OFFSET: isize>() -> IUIRibbon_Vtbl {
@@ -384,6 +400,8 @@ impl IUIRibbon_Vtbl {
 pub trait IUISimplePropertySet_Impl: Sized {
     fn GetValue(&self, key: *const super::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IUISimplePropertySet {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IUISimplePropertySet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUISimplePropertySet_Impl, const OFFSET: isize>() -> IUISimplePropertySet_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
@@ -2,6 +2,7 @@ pub trait IObjectArray_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, uiindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectArray {}
 impl IObjectArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectArray_Impl, const OFFSET: isize>() -> IObjectArray_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IObjectArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcobjects: *mut u32) -> ::windows::core::HRESULT {
@@ -36,6 +37,7 @@ pub trait IObjectCollection_Impl: Sized + IObjectArray_Impl {
     fn RemoveObjectAt(&self, uiindex: u32) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectCollection {}
 impl IObjectCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectCollection_Impl, const OFFSET: isize>() -> IObjectCollection_Vtbl {
         unsafe extern "system" fn AddObject<Identity: ::windows::core::IUnknownImpl, Impl: IObjectCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
@@ -1,6 +1,7 @@
 pub trait ICreateObject_Impl: Sized {
     fn CreateObject(&self, clsid: *const ::windows::core::GUID, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICreateObject {}
 impl ICreateObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateObject_Impl, const OFFSET: isize>() -> ICreateObject_Vtbl {
         unsafe extern "system" fn CreateObject<Identity: ::windows::core::IUnknownImpl, Impl: ICreateObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -17,6 +18,7 @@ impl ICreateObject_Vtbl {
 pub trait IDelayedPropertyStoreFactory_Impl: Sized + IPropertyStoreFactory_Impl {
     fn GetDelayedPropertyStore(&self, flags: GETPROPERTYSTOREFLAGS, dwstoreid: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDelayedPropertyStoreFactory {}
 impl IDelayedPropertyStoreFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDelayedPropertyStoreFactory_Impl, const OFFSET: isize>() -> IDelayedPropertyStoreFactory_Vtbl {
         unsafe extern "system" fn GetDelayedPropertyStore<Identity: ::windows::core::IUnknownImpl, Impl: IDelayedPropertyStoreFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: GETPROPERTYSTOREFLAGS, dwstoreid: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -33,6 +35,7 @@ impl IDelayedPropertyStoreFactory_Vtbl {
 pub trait IInitializeWithFile_Impl: Sized {
     fn Initialize(&self, pszfilepath: &::windows::core::PCWSTR, grfmode: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInitializeWithFile {}
 impl IInitializeWithFile_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithFile_Impl, const OFFSET: isize>() -> IInitializeWithFile_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithFile_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfilepath: ::windows::core::PCWSTR, grfmode: u32) -> ::windows::core::HRESULT {
@@ -50,6 +53,8 @@ impl IInitializeWithFile_Vtbl {
 pub trait IInitializeWithStream_Impl: Sized {
     fn Initialize(&self, pstream: &::core::option::Option<super::super::super::System::Com::IStream>, grfmode: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IInitializeWithStream {}
 #[cfg(feature = "Win32_System_Com")]
 impl IInitializeWithStream_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithStream_Impl, const OFFSET: isize>() -> IInitializeWithStream_Vtbl {
@@ -71,6 +76,8 @@ pub trait INamedPropertyStore_Impl: Sized {
     fn GetNameCount(&self) -> ::windows::core::Result<u32>;
     fn GetNameAt(&self, iprop: u32) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for INamedPropertyStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl INamedPropertyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamedPropertyStore_Impl, const OFFSET: isize>() -> INamedPropertyStore_Vtbl {
@@ -128,6 +135,7 @@ pub trait IObjectWithPropertyKey_Impl: Sized {
     fn SetPropertyKey(&self, key: *const PROPERTYKEY) -> ::windows::core::Result<()>;
     fn GetPropertyKey(&self) -> ::windows::core::Result<PROPERTYKEY>;
 }
+impl ::windows::core::RuntimeName for IObjectWithPropertyKey {}
 impl IObjectWithPropertyKey_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithPropertyKey_Impl, const OFFSET: isize>() -> IObjectWithPropertyKey_Vtbl {
         unsafe extern "system" fn SetPropertyKey<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithPropertyKey_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: *const PROPERTYKEY) -> ::windows::core::HRESULT {
@@ -161,6 +169,7 @@ pub trait IPersistSerializedPropStorage_Impl: Sized {
     fn SetPropertyStorage(&self, psps: *const SERIALIZEDPROPSTORAGE, cb: u32) -> ::windows::core::Result<()>;
     fn GetPropertyStorage(&self, ppsps: *mut *mut SERIALIZEDPROPSTORAGE, pcb: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPersistSerializedPropStorage {}
 impl IPersistSerializedPropStorage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistSerializedPropStorage_Impl, const OFFSET: isize>() -> IPersistSerializedPropStorage_Vtbl {
         unsafe extern "system" fn SetFlags<Identity: ::windows::core::IUnknownImpl, Impl: IPersistSerializedPropStorage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: i32) -> ::windows::core::HRESULT {
@@ -193,6 +202,7 @@ pub trait IPersistSerializedPropStorage2_Impl: Sized + IPersistSerializedPropSto
     fn GetPropertyStorageSize(&self) -> ::windows::core::Result<u32>;
     fn GetPropertyStorageBuffer(&self, psps: *mut SERIALIZEDPROPSTORAGE, cb: u32, pcbwritten: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPersistSerializedPropStorage2 {}
 impl IPersistSerializedPropStorage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistSerializedPropStorage2_Impl, const OFFSET: isize>() -> IPersistSerializedPropStorage2_Vtbl {
         unsafe extern "system" fn GetPropertyStorageSize<Identity: ::windows::core::IUnknownImpl, Impl: IPersistSerializedPropStorage2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcb: *mut u32) -> ::windows::core::HRESULT {
@@ -226,6 +236,8 @@ pub trait IPropertyChange_Impl: Sized + IObjectWithPropertyKey_Impl {
     fn ApplyToPropVariant(&self, propvarin: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<super::super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyChange {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyChange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyChange_Impl, const OFFSET: isize>() -> IPropertyChange_Vtbl {
         unsafe extern "system" fn ApplyToPropVariant<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyChange_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propvarin: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT, ppropvarout: *mut super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT {
@@ -254,6 +266,7 @@ pub trait IPropertyChangeArray_Impl: Sized {
     fn RemoveAt(&self, iindex: u32) -> ::windows::core::Result<()>;
     fn IsKeyInArray(&self, key: *const PROPERTYKEY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPropertyChangeArray {}
 impl IPropertyChangeArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyChangeArray_Impl, const OFFSET: isize>() -> IPropertyChangeArray_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyChangeArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcoperations: *mut u32) -> ::windows::core::HRESULT {
@@ -336,6 +349,8 @@ pub trait IPropertyDescription_Impl: Sized {
     fn FormatForDisplay(&self, propvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT, pdfflags: PROPDESC_FORMAT_FLAGS) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn IsValueCanonical(&self, propvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IPropertyDescription {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IPropertyDescription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescription_Impl, const OFFSET: isize>() -> IPropertyDescription_Vtbl {
@@ -574,6 +589,8 @@ pub trait IPropertyDescription2_Impl: Sized + IPropertyDescription_Impl {
     fn GetImageReferenceForValue(&self, propvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IPropertyDescription2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IPropertyDescription2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescription2_Impl, const OFFSET: isize>() -> IPropertyDescription2_Vtbl {
         unsafe extern "system" fn GetImageReferenceForValue<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescription2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT, ppszimageres: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -602,6 +619,8 @@ pub trait IPropertyDescriptionAliasInfo_Impl: Sized + IPropertyDescription_Impl 
     fn GetAdditionalSortByAliases(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IPropertyDescriptionAliasInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IPropertyDescriptionAliasInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionAliasInfo_Impl, const OFFSET: isize>() -> IPropertyDescriptionAliasInfo_Vtbl {
         unsafe extern "system" fn GetSortByAlias<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionAliasInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -628,6 +647,7 @@ pub trait IPropertyDescriptionList_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, ielem: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPropertyDescriptionList {}
 impl IPropertyDescriptionList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionList_Impl, const OFFSET: isize>() -> IPropertyDescriptionList_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcelem: *mut u32) -> ::windows::core::HRESULT {
@@ -661,6 +681,8 @@ pub trait IPropertyDescriptionRelatedPropertyInfo_Impl: Sized + IPropertyDescrip
     fn GetRelatedProperty(&self, pszrelationshipname: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IPropertyDescriptionRelatedPropertyInfo {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IPropertyDescriptionRelatedPropertyInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionRelatedPropertyInfo_Impl, const OFFSET: isize>() -> IPropertyDescriptionRelatedPropertyInfo_Vtbl {
         unsafe extern "system" fn GetRelatedProperty<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionRelatedPropertyInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszrelationshipname: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -681,6 +703,8 @@ pub trait IPropertyDescriptionSearchInfo_Impl: Sized + IPropertyDescription_Impl
     fn GetProjectionString(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetMaxSize(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
+impl ::windows::core::RuntimeName for IPropertyDescriptionSearchInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 impl IPropertyDescriptionSearchInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyDescriptionSearchInfo_Impl, const OFFSET: isize>() -> IPropertyDescriptionSearchInfo_Vtbl {
@@ -748,6 +772,8 @@ pub trait IPropertyEnumType_Impl: Sized {
     fn GetRangeSetValue(&self) -> ::windows::core::Result<super::super::super::System::Com::StructuredStorage::PROPVARIANT>;
     fn GetDisplayText(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyEnumType {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyEnumType_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyEnumType_Impl, const OFFSET: isize>() -> IPropertyEnumType_Vtbl {
@@ -824,6 +850,8 @@ pub trait IPropertyEnumType2_Impl: Sized + IPropertyEnumType_Impl {
     fn GetImageReference(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyEnumType2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyEnumType2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyEnumType2_Impl, const OFFSET: isize>() -> IPropertyEnumType2_Vtbl {
         unsafe extern "system" fn GetImageReference<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyEnumType2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszimageres: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -850,6 +878,8 @@ pub trait IPropertyEnumTypeList_Impl: Sized {
     fn GetConditionAt(&self, nindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn FindMatchingIndex(&self, propvarcmp: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyEnumTypeList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyEnumTypeList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyEnumTypeList_Impl, const OFFSET: isize>() -> IPropertyEnumTypeList_Vtbl {
@@ -905,6 +935,8 @@ pub trait IPropertyStore_Impl: Sized {
     fn SetValue(&self, key: *const PROPERTYKEY, propvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
     fn Commit(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStore_Impl, const OFFSET: isize>() -> IPropertyStore_Vtbl {
@@ -972,6 +1004,8 @@ pub trait IPropertyStoreCache_Impl: Sized + IPropertyStore_Impl {
     fn SetValueAndState(&self, key: *const PROPERTYKEY, ppropvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT, state: PSC_STATE) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyStoreCache {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyStoreCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreCache_Impl, const OFFSET: isize>() -> IPropertyStoreCache_Vtbl {
         unsafe extern "system" fn GetState<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreCache_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: *const PROPERTYKEY, pstate: *mut PSC_STATE) -> ::windows::core::HRESULT {
@@ -1015,6 +1049,7 @@ impl IPropertyStoreCache_Vtbl {
 pub trait IPropertyStoreCapabilities_Impl: Sized {
     fn IsPropertyWritable(&self, key: *const PROPERTYKEY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPropertyStoreCapabilities {}
 impl IPropertyStoreCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreCapabilities_Impl, const OFFSET: isize>() -> IPropertyStoreCapabilities_Vtbl {
         unsafe extern "system" fn IsPropertyWritable<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: *const PROPERTYKEY) -> ::windows::core::HRESULT {
@@ -1032,6 +1067,7 @@ pub trait IPropertyStoreFactory_Impl: Sized {
     fn GetPropertyStore(&self, flags: GETPROPERTYSTOREFLAGS, punkfactory: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetPropertyStoreForKeys(&self, rgkeys: *const PROPERTYKEY, ckeys: u32, flags: GETPROPERTYSTOREFLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPropertyStoreFactory {}
 impl IPropertyStoreFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreFactory_Impl, const OFFSET: isize>() -> IPropertyStoreFactory_Vtbl {
         unsafe extern "system" fn GetPropertyStore<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyStoreFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: GETPROPERTYSTOREFLAGS, punkfactory: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1066,6 +1102,8 @@ pub trait IPropertySystem_Impl: Sized {
     fn UnregisterPropertySchema(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn RefreshPropertySchema(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertySystem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertySystem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySystem_Impl, const OFFSET: isize>() -> IPropertySystem_Vtbl {
@@ -1140,6 +1178,7 @@ impl IPropertySystem_Vtbl {
 pub trait IPropertySystemChangeNotify_Impl: Sized {
     fn SchemaRefreshed(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPropertySystemChangeNotify {}
 impl IPropertySystemChangeNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySystemChangeNotify_Impl, const OFFSET: isize>() -> IPropertySystemChangeNotify_Vtbl {
         unsafe extern "system" fn SchemaRefreshed<Identity: ::windows::core::IUnknownImpl, Impl: IPropertySystemChangeNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1164,6 +1203,8 @@ pub trait IPropertyUI_Impl: Sized {
     fn FormatForDisplay(&self, fmtid: *const ::windows::core::GUID, pid: u32, ppropvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT, puiff: PROPERTYUI_FORMAT_FLAGS, pwsztext: ::windows::core::PWSTR, cchtext: u32) -> ::windows::core::Result<()>;
     fn GetHelpInfo(&self, fmtid: *const ::windows::core::GUID, pid: u32, pwszhelpfile: ::windows::core::PWSTR, cch: u32, puhelpid: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IPropertyUI {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl IPropertyUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyUI_Impl, const OFFSET: isize>() -> IPropertyUI_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
@@ -4,6 +4,8 @@ pub trait CIE4ConnectionPoint_Impl: Sized + super::super::System::Com::IConnecti
     fn DoInvokePIDLIE4(&self, dispid: i32, pidl: *mut Common::ITEMIDLIST, fcancancel: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for CIE4ConnectionPoint {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl CIE4ConnectionPoint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: CIE4ConnectionPoint_Impl, const OFFSET: isize>() -> CIE4ConnectionPoint_Vtbl {
         unsafe extern "system" fn DoInvokeIE4<Identity: ::windows::core::IUnknownImpl, Impl: CIE4ConnectionPoint_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pf: *mut super::super::Foundation::BOOL, ppv: *mut *mut ::core::ffi::c_void, dispid: i32, pdispparams: *mut super::super::System::Com::DISPPARAMS) -> ::windows::core::HRESULT {
@@ -31,6 +33,8 @@ pub trait DFConstraint_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Value(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DFConstraint {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DFConstraint_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DFConstraint_Impl, const OFFSET: isize>() -> DFConstraint_Vtbl {
@@ -69,6 +73,8 @@ impl DFConstraint_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DShellFolderViewEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DShellFolderViewEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DShellFolderViewEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DShellFolderViewEvents_Impl, const OFFSET: isize>() -> DShellFolderViewEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -79,6 +85,8 @@ impl DShellFolderViewEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DShellNameSpaceEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DShellNameSpaceEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DShellNameSpaceEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DShellNameSpaceEvents_Impl, const OFFSET: isize>() -> DShellNameSpaceEvents_Vtbl {
@@ -91,6 +99,8 @@ impl DShellNameSpaceEvents_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DShellWindowsEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DShellWindowsEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DShellWindowsEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DShellWindowsEvents_Impl, const OFFSET: isize>() -> DShellWindowsEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -102,6 +112,8 @@ impl DShellWindowsEvents_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DWebBrowserEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DWebBrowserEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DWebBrowserEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DWebBrowserEvents_Impl, const OFFSET: isize>() -> DWebBrowserEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -112,6 +124,8 @@ impl DWebBrowserEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DWebBrowserEvents2_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for DWebBrowserEvents2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl DWebBrowserEvents2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: DWebBrowserEvents2_Impl, const OFFSET: isize>() -> DWebBrowserEvents2_Vtbl {
@@ -134,6 +148,8 @@ pub trait Folder_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CopyHere(&self, vitem: &super::super::System::Com::VARIANT, voptions: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn GetDetailsOf(&self, vitem: &super::super::System::Com::VARIANT, icolumn: i32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Folder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Folder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Folder_Impl, const OFFSET: isize>() -> Folder_Vtbl {
@@ -256,6 +272,8 @@ pub trait Folder2_Impl: Sized + super::super::System::Com::IDispatch_Impl + Fold
     fn DismissedWebViewBarricade(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Folder2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Folder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Folder2_Impl, const OFFSET: isize>() -> Folder2_Vtbl {
         unsafe extern "system" fn Self_<Identity: ::windows::core::IUnknownImpl, Impl: Folder2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppfi: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -320,6 +338,8 @@ pub trait Folder3_Impl: Sized + super::super::System::Com::IDispatch_Impl + Fold
     fn SetShowWebViewBarricade(&self, bshowwebviewbarricade: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for Folder3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl Folder3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: Folder3_Impl, const OFFSET: isize>() -> Folder3_Vtbl {
         unsafe extern "system" fn ShowWebViewBarricade<Identity: ::windows::core::IUnknownImpl, Impl: Folder3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbshowwebviewbarricade: *mut i16) -> ::windows::core::HRESULT {
@@ -368,6 +388,8 @@ pub trait FolderItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Verbs(&self) -> ::windows::core::Result<FolderItemVerbs>;
     fn InvokeVerb(&self, vverb: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItem {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItem_Impl, const OFFSET: isize>() -> FolderItem_Vtbl {
@@ -571,6 +593,8 @@ pub trait FolderItem2_Impl: Sized + super::super::System::Com::IDispatch_Impl + 
     fn ExtendedProperty(&self, bstrpropname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItem2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItem2_Impl, const OFFSET: isize>() -> FolderItem2_Vtbl {
         unsafe extern "system" fn InvokeVerbEx<Identity: ::windows::core::IUnknownImpl, Impl: FolderItem2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, vverb: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, vargs: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -606,6 +630,8 @@ pub trait FolderItemVerb_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Name(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn DoIt(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItemVerb {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItemVerb_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItemVerb_Impl, const OFFSET: isize>() -> FolderItemVerb_Vtbl {
@@ -667,6 +693,8 @@ pub trait FolderItemVerbs_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Item(&self, index: &super::super::System::Com::VARIANT) -> ::windows::core::Result<FolderItemVerb>;
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItemVerbs {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItemVerbs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItemVerbs_Impl, const OFFSET: isize>() -> FolderItemVerbs_Vtbl {
@@ -747,6 +775,8 @@ pub trait FolderItems_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItems {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItems_Impl, const OFFSET: isize>() -> FolderItems_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: FolderItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT {
@@ -822,6 +852,8 @@ pub trait FolderItems2_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn InvokeVerbEx(&self, vverb: &super::super::System::Com::VARIANT, vargs: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItems2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItems2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItems2_Impl, const OFFSET: isize>() -> FolderItems2_Vtbl {
         unsafe extern "system" fn InvokeVerbEx<Identity: ::windows::core::IUnknownImpl, Impl: FolderItems2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, vverb: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, vargs: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -840,6 +872,8 @@ pub trait FolderItems3_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn Filter(&self, grfflags: i32, bstrfilespec: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Verbs(&self) -> ::windows::core::Result<FolderItemVerbs>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for FolderItems3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl FolderItems3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: FolderItems3_Impl, const OFFSET: isize>() -> FolderItems3_Vtbl {
@@ -868,6 +902,7 @@ impl FolderItems3_Vtbl {
 pub trait IACList_Impl: Sized {
     fn Expand(&self, pszexpand: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IACList {}
 impl IACList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IACList_Impl, const OFFSET: isize>() -> IACList_Vtbl {
         unsafe extern "system" fn Expand<Identity: ::windows::core::IUnknownImpl, Impl: IACList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszexpand: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -885,6 +920,7 @@ pub trait IACList2_Impl: Sized + IACList_Impl {
     fn SetOptions(&self, dwflag: u32) -> ::windows::core::Result<()>;
     fn GetOptions(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IACList2 {}
 impl IACList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IACList2_Impl, const OFFSET: isize>() -> IACList2_Vtbl {
         unsafe extern "system" fn SetOptions<Identity: ::windows::core::IUnknownImpl, Impl: IACList2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflag: u32) -> ::windows::core::HRESULT {
@@ -920,6 +956,8 @@ pub trait IAccessibilityDockingService_Impl: Sized {
     fn UndockWindow(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IAccessibilityDockingService {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IAccessibilityDockingService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibilityDockingService_Impl, const OFFSET: isize>() -> IAccessibilityDockingService_Vtbl {
         unsafe extern "system" fn GetAvailableSize<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibilityDockingService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR, pcxfixed: *mut u32, pcymax: *mut u32) -> ::windows::core::HRESULT {
@@ -951,6 +989,7 @@ impl IAccessibilityDockingService_Vtbl {
 pub trait IAccessibilityDockingServiceCallback_Impl: Sized {
     fn Undocked(&self, undockreason: UNDOCK_REASON) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAccessibilityDockingServiceCallback {}
 impl IAccessibilityDockingServiceCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibilityDockingServiceCallback_Impl, const OFFSET: isize>() -> IAccessibilityDockingServiceCallback_Vtbl {
         unsafe extern "system" fn Undocked<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibilityDockingServiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, undockreason: UNDOCK_REASON) -> ::windows::core::HRESULT {
@@ -967,6 +1006,7 @@ impl IAccessibilityDockingServiceCallback_Vtbl {
 pub trait IAccessibleObject_Impl: Sized {
     fn SetAccessibleName(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAccessibleObject {}
 impl IAccessibleObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleObject_Impl, const OFFSET: isize>() -> IAccessibleObject_Vtbl {
         unsafe extern "system" fn SetAccessibleName<Identity: ::windows::core::IUnknownImpl, Impl: IAccessibleObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -989,6 +1029,8 @@ pub trait IActionProgress_Impl: Sized {
     fn ResetCancel(&self) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IActionProgress {}
 #[cfg(feature = "Win32_Foundation")]
 impl IActionProgress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActionProgress_Impl, const OFFSET: isize>() -> IActionProgress_Vtbl {
@@ -1046,6 +1088,7 @@ pub trait IActionProgressDialog_Impl: Sized {
     fn Initialize(&self, flags: u32, psztitle: &::windows::core::PCWSTR, pszcancel: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IActionProgressDialog {}
 impl IActionProgressDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IActionProgressDialog_Impl, const OFFSET: isize>() -> IActionProgressDialog_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IActionProgressDialog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, psztitle: ::windows::core::PCWSTR, pszcancel: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1076,6 +1119,8 @@ pub trait IAppActivationUIInfo_Impl: Sized {
     fn GetShowUI(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn GetKeyState(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IAppActivationUIInfo {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IAppActivationUIInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppActivationUIInfo_Impl, const OFFSET: isize>() -> IAppActivationUIInfo_Vtbl {
@@ -1153,6 +1198,7 @@ pub trait IAppPublisher_Impl: Sized {
     fn GetNumberOfApps(&self) -> ::windows::core::Result<u32>;
     fn EnumApps(&self, pappcategoryid: *const ::windows::core::GUID) -> ::windows::core::Result<IEnumPublishedApps>;
 }
+impl ::windows::core::RuntimeName for IAppPublisher {}
 impl IAppPublisher_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppPublisher_Impl, const OFFSET: isize>() -> IAppPublisher_Vtbl {
         unsafe extern "system" fn GetNumberOfCategories<Identity: ::windows::core::IUnknownImpl, Impl: IAppPublisher_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcat: *mut u32) -> ::windows::core::HRESULT {
@@ -1219,6 +1265,8 @@ pub trait IAppVisibility_Impl: Sized {
     fn Unadvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IAppVisibility {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IAppVisibility_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppVisibility_Impl, const OFFSET: isize>() -> IAppVisibility_Vtbl {
         unsafe extern "system" fn GetAppVisibilityOnMonitor<Identity: ::windows::core::IUnknownImpl, Impl: IAppVisibility_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR, pmode: *mut MONITOR_APP_VISIBILITY) -> ::windows::core::HRESULT {
@@ -1277,6 +1325,8 @@ pub trait IAppVisibilityEvents_Impl: Sized {
     fn LauncherVisibilityChange(&self, currentvisiblestate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IAppVisibilityEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IAppVisibilityEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAppVisibilityEvents_Impl, const OFFSET: isize>() -> IAppVisibilityEvents_Vtbl {
         unsafe extern "system" fn AppVisibilityOnMonitorChanged<Identity: ::windows::core::IUnknownImpl, Impl: IAppVisibilityEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR, previousmode: MONITOR_APP_VISIBILITY, currentmode: MONITOR_APP_VISIBILITY) -> ::windows::core::HRESULT {
@@ -1304,6 +1354,7 @@ pub trait IApplicationActivationManager_Impl: Sized {
     fn ActivateForFile(&self, appusermodelid: &::windows::core::PCWSTR, itemarray: &::core::option::Option<IShellItemArray>, verb: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
     fn ActivateForProtocol(&self, appusermodelid: &::windows::core::PCWSTR, itemarray: &::core::option::Option<IShellItemArray>) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IApplicationActivationManager {}
 impl IApplicationActivationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationActivationManager_Impl, const OFFSET: isize>() -> IApplicationActivationManager_Vtbl {
         unsafe extern "system" fn ActivateApplication<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationActivationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, options: ACTIVATEOPTIONS, processid: *mut u32) -> ::windows::core::HRESULT {
@@ -1359,6 +1410,8 @@ pub trait IApplicationAssociationRegistration_Impl: Sized {
     fn SetAppAsDefaultAll(&self, pszappregistryname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ClearUserAssociations(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IApplicationAssociationRegistration {}
 #[cfg(feature = "Win32_Foundation")]
 impl IApplicationAssociationRegistration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationAssociationRegistration_Impl, const OFFSET: isize>() -> IApplicationAssociationRegistration_Vtbl {
@@ -1427,6 +1480,7 @@ impl IApplicationAssociationRegistration_Vtbl {
 pub trait IApplicationAssociationRegistrationUI_Impl: Sized {
     fn LaunchAdvancedAssociationUI(&self, pszappregistryname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IApplicationAssociationRegistrationUI {}
 impl IApplicationAssociationRegistrationUI_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationAssociationRegistrationUI_Impl, const OFFSET: isize>() -> IApplicationAssociationRegistrationUI_Vtbl {
         unsafe extern "system" fn LaunchAdvancedAssociationUI<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationAssociationRegistrationUI_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszappregistryname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1452,6 +1506,8 @@ pub trait IApplicationDesignModeSettings_Impl: Sized {
     fn IsApplicationViewStateSupported(&self, viewstate: APPLICATION_VIEW_STATE, nativedisplaysizepixels: &super::super::Foundation::SIZE, scalefactor: Common::DEVICE_SCALE_FACTOR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn TriggerEdgeGesture(&self, edgegesturekind: EDGE_GESTURE_KIND) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IApplicationDesignModeSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IApplicationDesignModeSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDesignModeSettings_Impl, const OFFSET: isize>() -> IApplicationDesignModeSettings_Vtbl {
@@ -1522,6 +1578,8 @@ pub trait IApplicationDesignModeSettings2_Impl: Sized + IApplicationDesignModeSe
     fn GetApplicationViewOrientation(&self, applicationsizepixels: &super::super::Foundation::SIZE) -> ::windows::core::Result<APPLICATION_VIEW_ORIENTATION>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IApplicationDesignModeSettings2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IApplicationDesignModeSettings2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDesignModeSettings2_Impl, const OFFSET: isize>() -> IApplicationDesignModeSettings2_Vtbl {
         unsafe extern "system" fn SetNativeDisplayOrientation<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDesignModeSettings2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nativedisplayorientation: NATIVE_DISPLAY_ORIENTATION) -> ::windows::core::HRESULT {
@@ -1585,6 +1643,7 @@ pub trait IApplicationDestinations_Impl: Sized {
     fn RemoveDestination(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn RemoveAllDestinations(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IApplicationDestinations {}
 impl IApplicationDestinations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDestinations_Impl, const OFFSET: isize>() -> IApplicationDestinations_Vtbl {
         unsafe extern "system" fn SetAppID<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDestinations_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1617,6 +1676,7 @@ pub trait IApplicationDocumentLists_Impl: Sized {
     fn SetAppID(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetList(&self, listtype: APPDOCLISTTYPE, citemsdesired: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IApplicationDocumentLists {}
 impl IApplicationDocumentLists_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDocumentLists_Impl, const OFFSET: isize>() -> IApplicationDocumentLists_Vtbl {
         unsafe extern "system" fn SetAppID<Identity: ::windows::core::IUnknownImpl, Impl: IApplicationDocumentLists_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1649,6 +1709,8 @@ pub trait IAssocHandler_Impl: Sized {
     fn Invoke(&self, pdo: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
     fn CreateInvoker(&self, pdo: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<IAssocHandlerInvoker>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IAssocHandler {}
 #[cfg(feature = "Win32_System_Com")]
 impl IAssocHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssocHandler_Impl, const OFFSET: isize>() -> IAssocHandler_Vtbl {
@@ -1724,6 +1786,7 @@ pub trait IAssocHandlerInvoker_Impl: Sized {
     fn SupportsSelection(&self) -> ::windows::core::Result<()>;
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAssocHandlerInvoker {}
 impl IAssocHandlerInvoker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAssocHandlerInvoker_Impl, const OFFSET: isize>() -> IAssocHandlerInvoker_Vtbl {
         unsafe extern "system" fn SupportsSelection<Identity: ::windows::core::IUnknownImpl, Impl: IAssocHandlerInvoker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1761,6 +1824,8 @@ pub trait IAttachmentExecute_Impl: Sized {
     fn SaveWithUI(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn ClearClientState(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAttachmentExecute {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAttachmentExecute_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAttachmentExecute_Impl, const OFFSET: isize>() -> IAttachmentExecute_Vtbl {
@@ -1862,6 +1927,8 @@ pub trait IAutoComplete_Impl: Sized {
     fn Enable(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAutoComplete {}
+#[cfg(feature = "Win32_Foundation")]
 impl IAutoComplete_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutoComplete_Impl, const OFFSET: isize>() -> IAutoComplete_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: IAutoComplete_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndedit: super::super::Foundation::HWND, punkacl: *mut ::core::ffi::c_void, pwszregkeypath: ::windows::core::PCWSTR, pwszquickcomplete: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -1885,6 +1952,8 @@ pub trait IAutoComplete2_Impl: Sized + IAutoComplete_Impl {
     fn SetOptions(&self, dwflag: u32) -> ::windows::core::Result<()>;
     fn GetOptions(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAutoComplete2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAutoComplete2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutoComplete2_Impl, const OFFSET: isize>() -> IAutoComplete2_Vtbl {
@@ -1918,6 +1987,7 @@ pub trait IAutoCompleteDropDown_Impl: Sized {
     fn GetDropDownStatus(&self, pdwflags: *mut u32, ppwszstring: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn ResetEnumerator(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAutoCompleteDropDown {}
 impl IAutoCompleteDropDown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAutoCompleteDropDown_Impl, const OFFSET: isize>() -> IAutoCompleteDropDown_Vtbl {
         unsafe extern "system" fn GetDropDownStatus<Identity: ::windows::core::IUnknownImpl, Impl: IAutoCompleteDropDown_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwflags: *mut u32, ppwszstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -1946,6 +2016,8 @@ pub trait IBandHost_Impl: Sized {
     fn SetBandAvailability(&self, rclsidband: *const ::windows::core::GUID, favailable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn DestroyBand(&self, rclsidband: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IBandHost {}
 #[cfg(feature = "Win32_Foundation")]
 impl IBandHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBandHost_Impl, const OFFSET: isize>() -> IBandHost_Vtbl {
@@ -1986,6 +2058,8 @@ pub trait IBandSite_Impl: Sized {
     fn SetBandSiteInfo(&self, pbsinfo: *const BANDSITEINFO) -> ::windows::core::Result<()>;
     fn GetBandSiteInfo(&self, pbsinfo: *mut BANDSITEINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Ole")]
+impl ::windows::core::RuntimeName for IBandSite {}
 #[cfg(feature = "Win32_System_Ole")]
 impl IBandSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBandSite_Impl, const OFFSET: isize>() -> IBandSite_Vtbl {
@@ -2054,6 +2128,7 @@ impl IBandSite_Vtbl {
 pub trait IBannerNotificationHandler_Impl: Sized {
     fn OnBannerEvent(&self, notification: *const BANNER_NOTIFICATION) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IBannerNotificationHandler {}
 impl IBannerNotificationHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBannerNotificationHandler_Impl, const OFFSET: isize>() -> IBannerNotificationHandler_Vtbl {
         unsafe extern "system" fn OnBannerEvent<Identity: ::windows::core::IUnknownImpl, Impl: IBannerNotificationHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, notification: *const BANNER_NOTIFICATION) -> ::windows::core::HRESULT {
@@ -2074,6 +2149,8 @@ pub trait IBanneredBar_Impl: Sized {
     fn SetBitmap(&self, hbitmap: super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::Result<()>;
     fn GetBitmap(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
+#[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IBanneredBar {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl IBanneredBar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBanneredBar_Impl, const OFFSET: isize>() -> IBanneredBar_Vtbl {
@@ -2124,6 +2201,7 @@ impl IBanneredBar_Vtbl {
 pub trait IBrowserFrameOptions_Impl: Sized {
     fn GetFrameOptions(&self, dwmask: u32) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IBrowserFrameOptions {}
 impl IBrowserFrameOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserFrameOptions_Impl, const OFFSET: isize>() -> IBrowserFrameOptions_Vtbl {
         unsafe extern "system" fn GetFrameOptions<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserFrameOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwmask: u32, pdwoptions: *mut u32) -> ::windows::core::HRESULT {
@@ -2176,6 +2254,8 @@ pub trait IBrowserService_Impl: Sized {
     fn GetPalette(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HPALETTE>;
     fn RegisterWindow(&self, fforceregister: super::super::Foundation::BOOL, swc: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IBrowserService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl IBrowserService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserService_Impl, const OFFSET: isize>() -> IBrowserService_Vtbl {
@@ -2510,6 +2590,8 @@ pub trait IBrowserService2_Impl: Sized + IBrowserService_Impl {
     fn _GetBorderDWHelper(&self, punksrc: &::core::option::Option<::windows::core::IUnknown>, lprectborder: *mut super::super::Foundation::RECT, busehmonitor: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn v_CheckZoneCrossing(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IBrowserService2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IBrowserService2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserService2_Impl, const OFFSET: isize>() -> IBrowserService2_Vtbl {
@@ -2923,6 +3005,8 @@ pub trait IBrowserService3_Impl: Sized + IBrowserService_Impl + IBrowserService2
     fn IEParseDisplayNameEx(&self, uicp: u32, pwszpath: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IBrowserService3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IBrowserService3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserService3_Impl, const OFFSET: isize>() -> IBrowserService3_Vtbl {
         unsafe extern "system" fn _PositionViewWindow<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserService3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -2958,6 +3042,8 @@ pub trait IBrowserService4_Impl: Sized + IBrowserService_Impl + IBrowserService2
     fn _ResizeAllBorders(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IBrowserService4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IBrowserService4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserService4_Impl, const OFFSET: isize>() -> IBrowserService4_Vtbl {
         unsafe extern "system" fn ActivateView<Identity: ::windows::core::IUnknownImpl, Impl: IBrowserService4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fpendingview: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -2992,6 +3078,8 @@ pub trait ICDBurn_Impl: Sized {
     fn Burn(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn HasRecordableDrive(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICDBurn {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICDBurn_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICDBurn_Impl, const OFFSET: isize>() -> ICDBurn_Vtbl {
@@ -3030,6 +3118,7 @@ impl ICDBurn_Vtbl {
 pub trait ICDBurnExt_Impl: Sized {
     fn GetSupportedActionTypes(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for ICDBurnExt {}
 impl ICDBurnExt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICDBurnExt_Impl, const OFFSET: isize>() -> ICDBurnExt_Vtbl {
         unsafe extern "system" fn GetSupportedActionTypes<Identity: ::windows::core::IUnknownImpl, Impl: ICDBurnExt_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwactions: *mut u32) -> ::windows::core::HRESULT {
@@ -3056,6 +3145,8 @@ pub trait ICategorizer_Impl: Sized {
     fn GetCategoryInfo(&self, dwcategoryid: u32) -> ::windows::core::Result<CATEGORY_INFO>;
     fn CompareCategory(&self, csfflags: CATSORT_FLAGS, dwcategoryid1: u32, dwcategoryid2: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for ICategorizer {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl ICategorizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICategorizer_Impl, const OFFSET: isize>() -> ICategorizer_Vtbl {
@@ -3106,6 +3197,8 @@ pub trait ICategoryProvider_Impl: Sized {
     fn GetCategoryName(&self, pguid: *const ::windows::core::GUID, pszname: ::windows::core::PWSTR, cch: u32) -> ::windows::core::Result<()>;
     fn CreateCategory(&self, pguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ICategoryProvider {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ICategoryProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICategoryProvider_Impl, const OFFSET: isize>() -> ICategoryProvider_Vtbl {
@@ -3174,6 +3267,8 @@ pub trait IColumnManager_Impl: Sized {
     fn SetColumns(&self, rgkeyorder: *const PropertiesSystem::PROPERTYKEY, cvisible: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IColumnManager {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IColumnManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnManager_Impl, const OFFSET: isize>() -> IColumnManager_Vtbl {
         unsafe extern "system" fn SetColumnInfo<Identity: ::windows::core::IUnknownImpl, Impl: IColumnManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propkey: *const PropertiesSystem::PROPERTYKEY, pcmci: *const CM_COLUMNINFO) -> ::windows::core::HRESULT {
@@ -3227,6 +3322,8 @@ pub trait IColumnProvider_Impl: Sized {
     fn GetItemData(&self, pscid: *const PropertiesSystem::PROPERTYKEY, pscd: *const SHCOLUMNDATA) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IColumnProvider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IColumnProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IColumnProvider_Impl, const OFFSET: isize>() -> IColumnProvider_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IColumnProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psci: *const SHCOLUMNINIT) -> ::windows::core::HRESULT {
@@ -3274,6 +3371,8 @@ pub trait ICommDlgBrowser_Impl: Sized {
     fn IncludeObject(&self, ppshv: &::core::option::Option<IShellView>, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for ICommDlgBrowser {}
+#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl ICommDlgBrowser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommDlgBrowser_Impl, const OFFSET: isize>() -> ICommDlgBrowser_Vtbl {
         unsafe extern "system" fn OnDefaultCommand<Identity: ::windows::core::IUnknownImpl, Impl: ICommDlgBrowser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppshv: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3308,6 +3407,8 @@ pub trait ICommDlgBrowser2_Impl: Sized + ICommDlgBrowser_Impl {
     fn GetDefaultMenuText(&self, ppshv: &::core::option::Option<IShellView>, psztext: ::windows::core::PWSTR, cchmax: i32) -> ::windows::core::Result<()>;
     fn GetViewFlags(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for ICommDlgBrowser2 {}
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl ICommDlgBrowser2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommDlgBrowser2_Impl, const OFFSET: isize>() -> ICommDlgBrowser2_Vtbl {
@@ -3350,6 +3451,8 @@ pub trait ICommDlgBrowser3_Impl: Sized + ICommDlgBrowser_Impl + ICommDlgBrowser2
     fn OnPreViewCreated(&self, ppshv: &::core::option::Option<IShellView>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for ICommDlgBrowser3 {}
+#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl ICommDlgBrowser3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICommDlgBrowser3_Impl, const OFFSET: isize>() -> ICommDlgBrowser3_Vtbl {
         unsafe extern "system" fn OnColumnClicked<Identity: ::windows::core::IUnknownImpl, Impl: ICommDlgBrowser3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppshv: ::windows::core::RawPtr, icolumn: i32) -> ::windows::core::HRESULT {
@@ -3381,6 +3484,7 @@ impl ICommDlgBrowser3_Vtbl {
 pub trait IComputerInfoChangeNotify_Impl: Sized {
     fn ComputerInfoChanged(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IComputerInfoChangeNotify {}
 impl IComputerInfoChangeNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IComputerInfoChangeNotify_Impl, const OFFSET: isize>() -> IComputerInfoChangeNotify_Vtbl {
         unsafe extern "system" fn ComputerInfoChanged<Identity: ::windows::core::IUnknownImpl, Impl: IComputerInfoChangeNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3399,6 +3503,8 @@ pub trait IConnectableCredentialProviderCredential_Impl: Sized + ICredentialProv
     fn Connect(&self, pqcws: &::core::option::Option<IQueryContinueWithStatus>) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IConnectableCredentialProviderCredential {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IConnectableCredentialProviderCredential_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IConnectableCredentialProviderCredential_Impl, const OFFSET: isize>() -> IConnectableCredentialProviderCredential_Vtbl {
@@ -3427,6 +3533,8 @@ pub trait IContactManagerInterop_Impl: Sized {
     fn ShowContactCardForWindow(&self, appwindow: super::super::Foundation::HWND, contact: &::core::option::Option<::windows::core::IUnknown>, selection: *const super::super::Foundation::RECT, preferredplacement: FLYOUT_PLACEMENT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContactManagerInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl IContactManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContactManagerInterop_Impl, const OFFSET: isize>() -> IContactManagerInterop_Vtbl {
         unsafe extern "system" fn ShowContactCardForWindow<Identity: ::windows::core::IUnknownImpl, Impl: IContactManagerInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, appwindow: super::super::Foundation::HWND, contact: *mut ::core::ffi::c_void, selection: *const super::super::Foundation::RECT, preferredplacement: FLYOUT_PLACEMENT) -> ::windows::core::HRESULT {
@@ -3446,6 +3554,8 @@ pub trait IContextMenu_Impl: Sized {
     fn InvokeCommand(&self, pici: *const CMINVOKECOMMANDINFO) -> ::windows::core::Result<()>;
     fn GetCommandString(&self, idcmd: usize, utype: u32, preserved: *mut u32, pszname: ::windows::core::PSTR, cchmax: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IContextMenu {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IContextMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenu_Impl, const OFFSET: isize>() -> IContextMenu_Vtbl {
@@ -3480,6 +3590,8 @@ pub trait IContextMenu2_Impl: Sized + IContextMenu_Impl {
     fn HandleMenuMsg(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IContextMenu2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IContextMenu2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenu2_Impl, const OFFSET: isize>() -> IContextMenu2_Vtbl {
         unsafe extern "system" fn HandleMenuMsg<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenu2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -3497,6 +3609,8 @@ impl IContextMenu2_Vtbl {
 pub trait IContextMenu3_Impl: Sized + IContextMenu_Impl + IContextMenu2_Impl {
     fn HandleMenuMsg2(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IContextMenu3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IContextMenu3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenu3_Impl, const OFFSET: isize>() -> IContextMenu3_Vtbl {
@@ -3522,6 +3636,8 @@ pub trait IContextMenuCB_Impl: Sized {
     fn CallBack(&self, psf: &::core::option::Option<IShellFolder>, hwndowner: super::super::Foundation::HWND, pdtobj: &::core::option::Option<super::super::System::Com::IDataObject>, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IContextMenuCB {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IContextMenuCB_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuCB_Impl, const OFFSET: isize>() -> IContextMenuCB_Vtbl {
         unsafe extern "system" fn CallBack<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuCB_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psf: ::windows::core::RawPtr, hwndowner: super::super::Foundation::HWND, pdtobj: ::windows::core::RawPtr, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -3539,6 +3655,8 @@ impl IContextMenuCB_Vtbl {
 pub trait IContextMenuSite_Impl: Sized {
     fn DoContextMenuPopup(&self, punkcontextmenu: &::core::option::Option<::windows::core::IUnknown>, fflags: u32, pt: &super::super::Foundation::POINT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IContextMenuSite {}
 #[cfg(feature = "Win32_Foundation")]
 impl IContextMenuSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IContextMenuSite_Impl, const OFFSET: isize>() -> IContextMenuSite_Vtbl {
@@ -3558,6 +3676,8 @@ pub trait ICopyHookA_Impl: Sized {
     fn CopyCallback(&self, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: &::windows::core::PCSTR, dwsrcattribs: u32, pszdestfile: &::windows::core::PCSTR, dwdestattribs: u32) -> u32;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICopyHookA {}
+#[cfg(feature = "Win32_Foundation")]
 impl ICopyHookA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICopyHookA_Impl, const OFFSET: isize>() -> ICopyHookA_Vtbl {
         unsafe extern "system" fn CopyCallback<Identity: ::windows::core::IUnknownImpl, Impl: ICopyHookA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: ::windows::core::PCSTR, dwsrcattribs: u32, pszdestfile: ::windows::core::PCSTR, dwdestattribs: u32) -> u32 {
@@ -3575,6 +3695,8 @@ impl ICopyHookA_Vtbl {
 pub trait ICopyHookW_Impl: Sized {
     fn CopyCallback(&self, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: &::windows::core::PCWSTR, dwsrcattribs: u32, pszdestfile: &::windows::core::PCWSTR, dwdestattribs: u32) -> u32;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICopyHookW {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICopyHookW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICopyHookW_Impl, const OFFSET: isize>() -> ICopyHookW_Vtbl {
@@ -3598,6 +3720,7 @@ pub trait ICreateProcessInputs_Impl: Sized {
     fn SetTitle(&self, psztitle: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetEnvironmentVariable(&self, pszname: &::windows::core::PCWSTR, pszvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICreateProcessInputs {}
 impl ICreateProcessInputs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreateProcessInputs_Impl, const OFFSET: isize>() -> ICreateProcessInputs_Vtbl {
         unsafe extern "system" fn GetCreateFlags<Identity: ::windows::core::IUnknownImpl, Impl: ICreateProcessInputs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwcreationflags: *mut u32) -> ::windows::core::HRESULT {
@@ -3659,6 +3782,7 @@ impl ICreateProcessInputs_Vtbl {
 pub trait ICreatingProcess_Impl: Sized {
     fn OnCreating(&self, pcpi: &::core::option::Option<ICreateProcessInputs>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICreatingProcess {}
 impl ICreatingProcess_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICreatingProcess_Impl, const OFFSET: isize>() -> ICreatingProcess_Vtbl {
         unsafe extern "system" fn OnCreating<Identity: ::windows::core::IUnknownImpl, Impl: ICreatingProcess_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcpi: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3683,6 +3807,8 @@ pub trait ICredentialProvider_Impl: Sized {
     fn GetCredentialCount(&self, pdwcount: *mut u32, pdwdefault: *mut u32, pbautologonwithdefault: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetCredentialAt(&self, dwindex: u32) -> ::windows::core::Result<ICredentialProviderCredential>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICredentialProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICredentialProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProvider_Impl, const OFFSET: isize>() -> ICredentialProvider_Vtbl {
@@ -3780,6 +3906,8 @@ pub trait ICredentialProviderCredential_Impl: Sized {
     fn GetSerialization(&self, pcpgsr: *mut CREDENTIAL_PROVIDER_GET_SERIALIZATION_RESPONSE, pcpcs: *mut CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION, ppszoptionalstatustext: *mut ::windows::core::PWSTR, pcpsioptionalstatusicon: *mut CREDENTIAL_PROVIDER_STATUS_ICON) -> ::windows::core::Result<()>;
     fn ReportResult(&self, ntsstatus: super::super::Foundation::NTSTATUS, ntssubstatus: super::super::Foundation::NTSTATUS, ppszoptionalstatustext: *mut ::windows::core::PWSTR, pcpsioptionalstatusicon: *mut CREDENTIAL_PROVIDER_STATUS_ICON) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ICredentialProviderCredential {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ICredentialProviderCredential_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredential_Impl, const OFFSET: isize>() -> ICredentialProviderCredential_Vtbl {
@@ -3928,6 +4056,8 @@ pub trait ICredentialProviderCredential2_Impl: Sized + ICredentialProviderCreden
     fn GetUserSid(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ICredentialProviderCredential2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ICredentialProviderCredential2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredential2_Impl, const OFFSET: isize>() -> ICredentialProviderCredential2_Vtbl {
         unsafe extern "system" fn GetUserSid<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredential2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -3960,6 +4090,8 @@ pub trait ICredentialProviderCredentialEvents_Impl: Sized {
     fn SetFieldSubmitButton(&self, pcpc: &::core::option::Option<ICredentialProviderCredential>, dwfieldid: u32, dwadjacentto: u32) -> ::windows::core::Result<()>;
     fn OnCreatingWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ICredentialProviderCredentialEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ICredentialProviderCredentialEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredentialEvents_Impl, const OFFSET: isize>() -> ICredentialProviderCredentialEvents_Vtbl {
@@ -4044,6 +4176,8 @@ pub trait ICredentialProviderCredentialEvents2_Impl: Sized + ICredentialProvider
     fn SetFieldOptions(&self, credential: &::core::option::Option<ICredentialProviderCredential>, fieldid: u32, options: CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ICredentialProviderCredentialEvents2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ICredentialProviderCredentialEvents2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredentialEvents2_Impl, const OFFSET: isize>() -> ICredentialProviderCredentialEvents2_Vtbl {
         unsafe extern "system" fn BeginFieldUpdates<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredentialEvents2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4075,6 +4209,7 @@ impl ICredentialProviderCredentialEvents2_Vtbl {
 pub trait ICredentialProviderCredentialWithFieldOptions_Impl: Sized {
     fn GetFieldOptions(&self, fieldid: u32) -> ::windows::core::Result<CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS>;
 }
+impl ::windows::core::RuntimeName for ICredentialProviderCredentialWithFieldOptions {}
 impl ICredentialProviderCredentialWithFieldOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredentialWithFieldOptions_Impl, const OFFSET: isize>() -> ICredentialProviderCredentialWithFieldOptions_Vtbl {
         unsafe extern "system" fn GetFieldOptions<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderCredentialWithFieldOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fieldid: u32, options: *mut CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS) -> ::windows::core::HRESULT {
@@ -4097,6 +4232,7 @@ impl ICredentialProviderCredentialWithFieldOptions_Vtbl {
 pub trait ICredentialProviderEvents_Impl: Sized {
     fn CredentialsChanged(&self, upadvisecontext: usize) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICredentialProviderEvents {}
 impl ICredentialProviderEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderEvents_Impl, const OFFSET: isize>() -> ICredentialProviderEvents_Vtbl {
         unsafe extern "system" fn CredentialsChanged<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, upadvisecontext: usize) -> ::windows::core::HRESULT {
@@ -4115,6 +4251,8 @@ pub trait ICredentialProviderFilter_Impl: Sized {
     fn Filter(&self, cpus: CREDENTIAL_PROVIDER_USAGE_SCENARIO, dwflags: u32, rgclsidproviders: *const ::windows::core::GUID, rgballow: *mut super::super::Foundation::BOOL, cproviders: u32) -> ::windows::core::Result<()>;
     fn UpdateRemoteCredential(&self, pcpcsin: *const CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION) -> ::windows::core::Result<CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ICredentialProviderFilter {}
 #[cfg(feature = "Win32_Foundation")]
 impl ICredentialProviderFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderFilter_Impl, const OFFSET: isize>() -> ICredentialProviderFilter_Vtbl {
@@ -4147,6 +4285,7 @@ impl ICredentialProviderFilter_Vtbl {
 pub trait ICredentialProviderSetUserArray_Impl: Sized {
     fn SetUserArray(&self, users: &::core::option::Option<ICredentialProviderUserArray>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICredentialProviderSetUserArray {}
 impl ICredentialProviderSetUserArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderSetUserArray_Impl, const OFFSET: isize>() -> ICredentialProviderSetUserArray_Vtbl {
         unsafe extern "system" fn SetUserArray<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderSetUserArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, users: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4167,6 +4306,8 @@ pub trait ICredentialProviderUser_Impl: Sized {
     fn GetStringValue(&self, key: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetValue(&self, key: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ICredentialProviderUser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ICredentialProviderUser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderUser_Impl, const OFFSET: isize>() -> ICredentialProviderUser_Vtbl {
@@ -4232,6 +4373,7 @@ pub trait ICredentialProviderUserArray_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, userindex: u32) -> ::windows::core::Result<ICredentialProviderUser>;
 }
+impl ::windows::core::RuntimeName for ICredentialProviderUserArray {}
 impl ICredentialProviderUserArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderUserArray_Impl, const OFFSET: isize>() -> ICredentialProviderUserArray_Vtbl {
         unsafe extern "system" fn SetProviderFilter<Identity: ::windows::core::IUnknownImpl, Impl: ICredentialProviderUserArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidprovidertofilterto: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -4287,6 +4429,8 @@ impl ICredentialProviderUserArray_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ICurrentItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for ICurrentItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl ICurrentItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICurrentItem_Impl, const OFFSET: isize>() -> ICurrentItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -4299,6 +4443,7 @@ pub trait ICurrentWorkingDirectory_Impl: Sized {
     fn GetDirectory(&self, pwzpath: ::windows::core::PWSTR, cchsize: u32) -> ::windows::core::Result<()>;
     fn SetDirectory(&self, pwzpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ICurrentWorkingDirectory {}
 impl ICurrentWorkingDirectory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICurrentWorkingDirectory_Impl, const OFFSET: isize>() -> ICurrentWorkingDirectory_Vtbl {
         unsafe extern "system" fn GetDirectory<Identity: ::windows::core::IUnknownImpl, Impl: ICurrentWorkingDirectory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwzpath: ::windows::core::PWSTR, cchsize: u32) -> ::windows::core::HRESULT {
@@ -4333,6 +4478,8 @@ pub trait ICustomDestinationList_Impl: Sized {
     fn DeleteList(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn AbortList(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for ICustomDestinationList {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl ICustomDestinationList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICustomDestinationList_Impl, const OFFSET: isize>() -> ICustomDestinationList_Vtbl {
@@ -4407,6 +4554,8 @@ pub trait IDataObjectAsyncCapability_Impl: Sized {
     fn EndOperation(&self, hresult: ::windows::core::HRESULT, pbcreserved: &::core::option::Option<super::super::System::Com::IBindCtx>, dweffects: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDataObjectAsyncCapability {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDataObjectAsyncCapability_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataObjectAsyncCapability_Impl, const OFFSET: isize>() -> IDataObjectAsyncCapability_Vtbl {
         unsafe extern "system" fn SetAsyncMode<Identity: ::windows::core::IUnknownImpl, Impl: IDataObjectAsyncCapability_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fdoopasync: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -4465,6 +4614,8 @@ pub trait IDataObjectProvider_Impl: Sized {
     fn SetDataObject(&self, dataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDataObjectProvider {}
+#[cfg(feature = "Win32_System_Com")]
 impl IDataObjectProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataObjectProvider_Impl, const OFFSET: isize>() -> IDataObjectProvider_Vtbl {
         unsafe extern "system" fn GetDataObject<Identity: ::windows::core::IUnknownImpl, Impl: IDataObjectProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dataobject: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4499,6 +4650,8 @@ pub trait IDataTransferManagerInterop_Impl: Sized {
     fn ShowShareUIForWindow(&self, appwindow: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDataTransferManagerInterop {}
+#[cfg(feature = "Win32_Foundation")]
 impl IDataTransferManagerInterop_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDataTransferManagerInterop_Impl, const OFFSET: isize>() -> IDataTransferManagerInterop_Vtbl {
         unsafe extern "system" fn GetForWindow<Identity: ::windows::core::IUnknownImpl, Impl: IDataTransferManagerInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, datatransfermanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4530,6 +4683,8 @@ pub trait IDefaultExtractIconInit_Impl: Sized {
     fn SetShortcutIcon(&self, pszfile: &::windows::core::PCWSTR, iicon: i32) -> ::windows::core::Result<()>;
     fn SetDefaultIcon(&self, pszfile: &::windows::core::PCWSTR, iicon: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Registry")]
+impl ::windows::core::RuntimeName for IDefaultExtractIconInit {}
 #[cfg(feature = "Win32_System_Registry")]
 impl IDefaultExtractIconInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultExtractIconInit_Impl, const OFFSET: isize>() -> IDefaultExtractIconInit_Vtbl {
@@ -4585,6 +4740,8 @@ pub trait IDefaultFolderMenuInitialize_Impl: Sized {
     fn SetHandlerClsid(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IDefaultFolderMenuInitialize {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
 impl IDefaultFolderMenuInitialize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultFolderMenuInitialize_Impl, const OFFSET: isize>() -> IDefaultFolderMenuInitialize_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IDefaultFolderMenuInitialize_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pcmcb: ::windows::core::RawPtr, pidlfolder: *const Common::ITEMIDLIST, psf: ::windows::core::RawPtr, cidl: u32, apidl: *const *const Common::ITEMIDLIST, punkassociation: *mut ::core::ffi::c_void, ckeys: u32, akeys: *const super::super::System::Registry::HKEY) -> ::windows::core::HRESULT {
@@ -4630,6 +4787,8 @@ pub trait IDelegateFolder_Impl: Sized {
     fn SetItemAlloc(&self, pmalloc: &::core::option::Option<super::super::System::Com::IMalloc>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDelegateFolder {}
+#[cfg(feature = "Win32_System_Com")]
 impl IDelegateFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDelegateFolder_Impl, const OFFSET: isize>() -> IDelegateFolder_Vtbl {
         unsafe extern "system" fn SetItemAlloc<Identity: ::windows::core::IUnknownImpl, Impl: IDelegateFolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmalloc: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4646,6 +4805,8 @@ impl IDelegateFolder_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IDelegateItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IDelegateItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IDelegateItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDelegateItem_Impl, const OFFSET: isize>() -> IDelegateItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -4658,6 +4819,8 @@ impl IDelegateItem_Vtbl {
 pub trait IDeskBand_Impl: Sized + super::super::System::Ole::IOleWindow_Impl + IDockingWindow_Impl {
     fn GetBandInfo(&self, dwbandid: u32, dwviewmode: u32, pdbi: *mut DESKBANDINFO) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDeskBand {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDeskBand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeskBand_Impl, const OFFSET: isize>() -> IDeskBand_Vtbl {
@@ -4678,6 +4841,8 @@ pub trait IDeskBand2_Impl: Sized + super::super::System::Ole::IOleWindow_Impl + 
     fn SetCompositionState(&self, fcompositionenabled: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetCompositionState(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDeskBand2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDeskBand2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeskBand2_Impl, const OFFSET: isize>() -> IDeskBand2_Vtbl {
@@ -4722,6 +4887,7 @@ impl IDeskBand2_Vtbl {
 pub trait IDeskBandInfo_Impl: Sized {
     fn GetDefaultBandWidth(&self, dwbandid: u32, dwviewmode: u32) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IDeskBandInfo {}
 impl IDeskBandInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeskBandInfo_Impl, const OFFSET: isize>() -> IDeskBandInfo_Vtbl {
         unsafe extern "system" fn GetDefaultBandWidth<Identity: ::windows::core::IUnknownImpl, Impl: IDeskBandInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwbandid: u32, dwviewmode: u32, pnwidth: *mut i32) -> ::windows::core::HRESULT {
@@ -4747,6 +4913,8 @@ pub trait IDeskBar_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn GetClient(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn OnPosRectChangeDB(&self, prc: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDeskBar {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDeskBar_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeskBar_Impl, const OFFSET: isize>() -> IDeskBar_Vtbl {
@@ -4789,6 +4957,8 @@ pub trait IDeskBarClient_Impl: Sized + super::super::System::Ole::IOleWindow_Imp
     fn UIActivateDBC(&self, dwstate: u32) -> ::windows::core::Result<()>;
     fn GetSize(&self, dwwhich: u32) -> ::windows::core::Result<super::super::Foundation::RECT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDeskBarClient {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDeskBarClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDeskBarClient_Impl, const OFFSET: isize>() -> IDeskBarClient_Vtbl {
@@ -4833,6 +5003,7 @@ impl IDeskBarClient_Vtbl {
 pub trait IDesktopGadget_Impl: Sized {
     fn RunGadget(&self, gadgetpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IDesktopGadget {}
 impl IDesktopGadget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopGadget_Impl, const OFFSET: isize>() -> IDesktopGadget_Vtbl {
         unsafe extern "system" fn RunGadget<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopGadget_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gadgetpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -4865,6 +5036,8 @@ pub trait IDesktopWallpaper_Impl: Sized {
     fn GetStatus(&self) -> ::windows::core::Result<DESKTOP_SLIDESHOW_STATE>;
     fn Enable(&self, enable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IDesktopWallpaper {}
 #[cfg(feature = "Win32_Foundation")]
 impl IDesktopWallpaper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDesktopWallpaper_Impl, const OFFSET: isize>() -> IDesktopWallpaper_Vtbl {
@@ -5025,6 +5198,8 @@ pub trait IDestinationStreamFactory_Impl: Sized {
     fn GetDestinationStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IDestinationStreamFactory {}
+#[cfg(feature = "Win32_System_Com")]
 impl IDestinationStreamFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDestinationStreamFactory_Impl, const OFFSET: isize>() -> IDestinationStreamFactory_Vtbl {
         unsafe extern "system" fn GetDestinationStream<Identity: ::windows::core::IUnknownImpl, Impl: IDestinationStreamFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppstm: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5047,6 +5222,8 @@ impl IDestinationStreamFactory_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IDisplayItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IDisplayItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IDisplayItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayItem_Impl, const OFFSET: isize>() -> IDisplayItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -5059,6 +5236,8 @@ impl IDisplayItem_Vtbl {
 pub trait IDocViewSite_Impl: Sized {
     fn OnSetTitle(&self, pvtitle: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDocViewSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IDocViewSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDocViewSite_Impl, const OFFSET: isize>() -> IDocViewSite_Vtbl {
@@ -5079,6 +5258,8 @@ pub trait IDockingWindow_Impl: Sized + super::super::System::Ole::IOleWindow_Imp
     fn CloseDW(&self, dwreserved: u32) -> ::windows::core::Result<()>;
     fn ResizeBorderDW(&self, prcborder: *const super::super::Foundation::RECT, punktoolbarsite: &::core::option::Option<::windows::core::IUnknown>, freserved: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDockingWindow {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDockingWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDockingWindow_Impl, const OFFSET: isize>() -> IDockingWindow_Vtbl {
@@ -5115,6 +5296,8 @@ pub trait IDockingWindowFrame_Impl: Sized + super::super::System::Ole::IOleWindo
     fn FindToolbar(&self, pwszitem: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDockingWindowFrame {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDockingWindowFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDockingWindowFrame_Impl, const OFFSET: isize>() -> IDockingWindowFrame_Vtbl {
         unsafe extern "system" fn AddToolbar<Identity: ::windows::core::IUnknownImpl, Impl: IDockingWindowFrame_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punksrc: *mut ::core::ffi::c_void, pwszitem: ::windows::core::PCWSTR, dwaddflags: u32) -> ::windows::core::HRESULT {
@@ -5149,6 +5332,8 @@ pub trait IDockingWindowSite_Impl: Sized + super::super::System::Ole::IOleWindow
     fn RequestBorderSpaceDW(&self, punkobj: &::core::option::Option<::windows::core::IUnknown>, pbw: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
     fn SetBorderSpaceDW(&self, punkobj: &::core::option::Option<::windows::core::IUnknown>, pbw: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IDockingWindowSite {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IDockingWindowSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDockingWindowSite_Impl, const OFFSET: isize>() -> IDockingWindowSite_Vtbl {
@@ -5190,6 +5375,8 @@ pub trait IDragSourceHelper_Impl: Sized {
     fn InitializeFromWindow(&self, hwnd: super::super::Foundation::HWND, ppt: *const super::super::Foundation::POINT, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDragSourceHelper {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IDragSourceHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDragSourceHelper_Impl, const OFFSET: isize>() -> IDragSourceHelper_Vtbl {
         unsafe extern "system" fn InitializeFromBitmap<Identity: ::windows::core::IUnknownImpl, Impl: IDragSourceHelper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshdi: *const SHDRAGIMAGE, pdataobject: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5217,6 +5404,8 @@ pub trait IDragSourceHelper2_Impl: Sized + IDragSourceHelper_Impl {
     fn SetFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDragSourceHelper2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 impl IDragSourceHelper2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDragSourceHelper2_Impl, const OFFSET: isize>() -> IDragSourceHelper2_Vtbl {
         unsafe extern "system" fn SetFlags<Identity: ::windows::core::IUnknownImpl, Impl: IDragSourceHelper2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -5238,6 +5427,8 @@ pub trait IDropTargetHelper_Impl: Sized {
     fn Drop(&self, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>, ppt: *const super::super::Foundation::POINT, dweffect: u32) -> ::windows::core::Result<()>;
     fn Show(&self, fshow: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDropTargetHelper {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDropTargetHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDropTargetHelper_Impl, const OFFSET: isize>() -> IDropTargetHelper_Vtbl {
@@ -5282,6 +5473,7 @@ impl IDropTargetHelper_Vtbl {
 pub trait IDynamicHWHandler_Impl: Sized {
     fn GetDynamicInfo(&self, pszdeviceid: &::windows::core::PCWSTR, dwcontenttype: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IDynamicHWHandler {}
 impl IDynamicHWHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicHWHandler_Impl, const OFFSET: isize>() -> IDynamicHWHandler_Vtbl {
         unsafe extern "system" fn GetDynamicInfo<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicHWHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdeviceid: ::windows::core::PCWSTR, dwcontenttype: u32, ppszaction: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -5307,6 +5499,8 @@ pub trait IEnumACString_Impl: Sized + super::super::System::Com::IEnumString_Imp
     fn SetEnumOptions(&self, dwoptions: u32) -> ::windows::core::Result<()>;
     fn GetEnumOptions(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IEnumACString {}
 #[cfg(feature = "Win32_System_Com")]
 impl IEnumACString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumACString_Impl, const OFFSET: isize>() -> IEnumACString_Vtbl {
@@ -5345,6 +5539,7 @@ impl IEnumACString_Vtbl {
 pub trait IEnumAssocHandlers_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IAssocHandler>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumAssocHandlers {}
 impl IEnumAssocHandlers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAssocHandlers_Impl, const OFFSET: isize>() -> IEnumAssocHandlers_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumAssocHandlers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5364,6 +5559,7 @@ pub trait IEnumExplorerCommand_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumExplorerCommand>;
 }
+impl ::windows::core::RuntimeName for IEnumExplorerCommand {}
 impl IEnumExplorerCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumExplorerCommand_Impl, const OFFSET: isize>() -> IEnumExplorerCommand_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumExplorerCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, puicommand: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5410,6 +5606,7 @@ pub trait IEnumExtraSearch_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumExtraSearch>;
 }
+impl ::windows::core::RuntimeName for IEnumExtraSearch {}
 impl IEnumExtraSearch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumExtraSearch_Impl, const OFFSET: isize>() -> IEnumExtraSearch_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumExtraSearch_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut EXTRASEARCH, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5458,6 +5655,8 @@ pub trait IEnumFullIDList_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumFullIDList>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IEnumFullIDList {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IEnumFullIDList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFullIDList_Impl, const OFFSET: isize>() -> IEnumFullIDList_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumFullIDList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut Common::ITEMIDLIST, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5504,6 +5703,7 @@ pub trait IEnumHLITEM_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumHLITEM>;
 }
+impl ::windows::core::RuntimeName for IEnumHLITEM {}
 impl IEnumHLITEM_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumHLITEM_Impl, const OFFSET: isize>() -> IEnumHLITEM_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumHLITEM_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut HLITEM, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5552,6 +5752,8 @@ pub trait IEnumIDList_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumIDList>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IEnumIDList {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IEnumIDList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumIDList_Impl, const OFFSET: isize>() -> IEnumIDList_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumIDList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut Common::ITEMIDLIST, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5598,6 +5800,7 @@ pub trait IEnumObjects_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumObjects>;
 }
+impl ::windows::core::RuntimeName for IEnumObjects {}
 impl IEnumObjects_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumObjects_Impl, const OFFSET: isize>() -> IEnumObjects_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumObjects_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, riid: *const ::windows::core::GUID, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5642,6 +5845,7 @@ pub trait IEnumPublishedApps_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPublishedApp>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumPublishedApps {}
 impl IEnumPublishedApps_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPublishedApps_Impl, const OFFSET: isize>() -> IEnumPublishedApps_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumPublishedApps_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pia: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5669,6 +5873,7 @@ impl IEnumPublishedApps_Vtbl {
 pub trait IEnumReadyCallback_Impl: Sized {
     fn EnumReady(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumReadyCallback {}
 impl IEnumReadyCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumReadyCallback_Impl, const OFFSET: isize>() -> IEnumReadyCallback_Vtbl {
         unsafe extern "system" fn EnumReady<Identity: ::windows::core::IUnknownImpl, Impl: IEnumReadyCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5688,6 +5893,7 @@ pub trait IEnumResources_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumResources>;
 }
+impl ::windows::core::RuntimeName for IEnumResources {}
 impl IEnumResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumResources_Impl, const OFFSET: isize>() -> IEnumResources_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumResources_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, psir: *mut SHELL_ITEM_RESOURCE, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5734,6 +5940,7 @@ pub trait IEnumShellItems_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumShellItems>;
 }
+impl ::windows::core::RuntimeName for IEnumShellItems {}
 impl IEnumShellItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumShellItems_Impl, const OFFSET: isize>() -> IEnumShellItems_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumShellItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5780,6 +5987,7 @@ pub trait IEnumSyncMgrConflict_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncMgrConflict>;
 }
+impl ::windows::core::RuntimeName for IEnumSyncMgrConflict {}
 impl IEnumSyncMgrConflict_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncMgrConflict_Impl, const OFFSET: isize>() -> IEnumSyncMgrConflict_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncMgrConflict_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5826,6 +6034,7 @@ pub trait IEnumSyncMgrEvents_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncMgrEvents>;
 }
+impl ::windows::core::RuntimeName for IEnumSyncMgrEvents {}
 impl IEnumSyncMgrEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncMgrEvents_Impl, const OFFSET: isize>() -> IEnumSyncMgrEvents_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncMgrEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5872,6 +6081,7 @@ pub trait IEnumSyncMgrSyncItems_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumSyncMgrSyncItems>;
 }
+impl ::windows::core::RuntimeName for IEnumSyncMgrSyncItems {}
 impl IEnumSyncMgrSyncItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncMgrSyncItems_Impl, const OFFSET: isize>() -> IEnumSyncMgrSyncItems_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSyncMgrSyncItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5918,6 +6128,7 @@ pub trait IEnumTravelLogEntry_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IEnumTravelLogEntry>;
 }
+impl ::windows::core::RuntimeName for IEnumTravelLogEntry {}
 impl IEnumTravelLogEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTravelLogEntry_Impl, const OFFSET: isize>() -> IEnumTravelLogEntry_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTravelLogEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::RawPtr, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -5964,6 +6175,8 @@ pub trait IEnumerableView_Impl: Sized {
     fn CreateEnumIDListFromContents(&self, pidlfolder: *const Common::ITEMIDLIST, dwenumflags: u32) -> ::windows::core::Result<IEnumIDList>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IEnumerableView {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IEnumerableView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumerableView_Impl, const OFFSET: isize>() -> IEnumerableView_Vtbl {
         unsafe extern "system" fn SetEnumReadyCallback<Identity: ::windows::core::IUnknownImpl, Impl: IEnumerableView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, percb: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6002,6 +6215,8 @@ pub trait IExecuteCommand_Impl: Sized {
     fn SetDirectory(&self, pszdirectory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Execute(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IExecuteCommand {}
 #[cfg(feature = "Win32_Foundation")]
 impl IExecuteCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExecuteCommand_Impl, const OFFSET: isize>() -> IExecuteCommand_Vtbl {
@@ -6058,6 +6273,7 @@ impl IExecuteCommand_Vtbl {
 pub trait IExecuteCommandApplicationHostEnvironment_Impl: Sized {
     fn GetValue(&self) -> ::windows::core::Result<AHE_TYPE>;
 }
+impl ::windows::core::RuntimeName for IExecuteCommandApplicationHostEnvironment {}
 impl IExecuteCommandApplicationHostEnvironment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExecuteCommandApplicationHostEnvironment_Impl, const OFFSET: isize>() -> IExecuteCommandApplicationHostEnvironment_Vtbl {
         unsafe extern "system" fn GetValue<Identity: ::windows::core::IUnknownImpl, Impl: IExecuteCommandApplicationHostEnvironment_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pahe: *mut AHE_TYPE) -> ::windows::core::HRESULT {
@@ -6080,6 +6296,7 @@ impl IExecuteCommandApplicationHostEnvironment_Vtbl {
 pub trait IExecuteCommandHost_Impl: Sized {
     fn GetUIMode(&self) -> ::windows::core::Result<EC_HOST_UI_MODE>;
 }
+impl ::windows::core::RuntimeName for IExecuteCommandHost {}
 impl IExecuteCommandHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExecuteCommandHost_Impl, const OFFSET: isize>() -> IExecuteCommandHost_Vtbl {
         unsafe extern "system" fn GetUIMode<Identity: ::windows::core::IUnknownImpl, Impl: IExecuteCommandHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puimode: *mut EC_HOST_UI_MODE) -> ::windows::core::HRESULT {
@@ -6105,6 +6322,8 @@ pub trait IExpDispSupport_Impl: Sized {
     fn OnTranslateAccelerator(&self, pmsg: *const super::WindowsAndMessaging::MSG, grfmodifiers: u32) -> ::windows::core::Result<()>;
     fn OnInvoke(&self, dispidmember: i32, iid: *const ::windows::core::GUID, lcid: u32, wflags: u16, pdispparams: *const super::super::System::Com::DISPPARAMS, pvarresult: *mut super::super::System::Com::VARIANT, pexcepinfo: *mut super::super::System::Com::EXCEPINFO, puargerr: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IExpDispSupport {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IExpDispSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExpDispSupport_Impl, const OFFSET: isize>() -> IExpDispSupport_Vtbl {
@@ -6146,6 +6365,8 @@ pub trait IExpDispSupportXP_Impl: Sized {
     fn OnTranslateAccelerator(&self, pmsg: *const super::WindowsAndMessaging::MSG, grfmodifiers: u32) -> ::windows::core::Result<()>;
     fn OnInvoke(&self, dispidmember: i32, iid: *const ::windows::core::GUID, lcid: u32, wflags: u16, pdispparams: *const super::super::System::Com::DISPPARAMS, pvarresult: *mut super::super::System::Com::VARIANT, pexcepinfo: *mut super::super::System::Com::EXCEPINFO, puargerr: *mut u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IExpDispSupportXP {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IExpDispSupportXP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExpDispSupportXP_Impl, const OFFSET: isize>() -> IExpDispSupportXP_Vtbl {
@@ -6199,6 +6420,8 @@ pub trait IExplorerBrowser_Impl: Sized {
     fn RemoveAll(&self) -> ::windows::core::Result<()>;
     fn GetCurrentView(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IExplorerBrowser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IExplorerBrowser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerBrowser_Impl, const OFFSET: isize>() -> IExplorerBrowser_Vtbl {
@@ -6320,6 +6543,8 @@ pub trait IExplorerBrowserEvents_Impl: Sized {
     fn OnNavigationFailed(&self, pidlfolder: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IExplorerBrowserEvents {}
+#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl IExplorerBrowserEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerBrowserEvents_Impl, const OFFSET: isize>() -> IExplorerBrowserEvents_Vtbl {
         unsafe extern "system" fn OnNavigationPending<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerBrowserEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidlfolder: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -6365,6 +6590,8 @@ pub trait IExplorerCommand_Impl: Sized {
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
     fn EnumSubCommands(&self) -> ::windows::core::Result<IEnumExplorerCommand>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IExplorerCommand {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IExplorerCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerCommand_Impl, const OFFSET: isize>() -> IExplorerCommand_Vtbl {
@@ -6470,6 +6697,7 @@ pub trait IExplorerCommandProvider_Impl: Sized {
     fn GetCommands(&self, punksite: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetCommand(&self, rguidcommandid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IExplorerCommandProvider {}
 impl IExplorerCommandProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerCommandProvider_Impl, const OFFSET: isize>() -> IExplorerCommandProvider_Vtbl {
         unsafe extern "system" fn GetCommands<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerCommandProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punksite: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6497,6 +6725,8 @@ pub trait IExplorerCommandState_Impl: Sized {
     fn GetState(&self, psiitemarray: &::core::option::Option<IShellItemArray>, foktobeslow: super::super::Foundation::BOOL) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IExplorerCommandState {}
+#[cfg(feature = "Win32_Foundation")]
 impl IExplorerCommandState_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerCommandState_Impl, const OFFSET: isize>() -> IExplorerCommandState_Vtbl {
         unsafe extern "system" fn GetState<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerCommandState_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psiitemarray: ::windows::core::RawPtr, foktobeslow: super::super::Foundation::BOOL, pcmdstate: *mut u32) -> ::windows::core::HRESULT {
@@ -6519,6 +6749,7 @@ impl IExplorerCommandState_Vtbl {
 pub trait IExplorerPaneVisibility_Impl: Sized {
     fn GetPaneState(&self, ep: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IExplorerPaneVisibility {}
 impl IExplorerPaneVisibility_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerPaneVisibility_Impl, const OFFSET: isize>() -> IExplorerPaneVisibility_Vtbl {
         unsafe extern "system" fn GetPaneState<Identity: ::windows::core::IUnknownImpl, Impl: IExplorerPaneVisibility_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ep: *const ::windows::core::GUID, peps: *mut u32) -> ::windows::core::HRESULT {
@@ -6543,6 +6774,8 @@ pub trait IExtensionServices_Impl: Sized {
     fn SetAdditionalHeaders(&self, pwzadditionalheaders: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetAuthenticateData(&self, phwnd: super::super::Foundation::HWND, pwzusername: &::windows::core::PCWSTR, pwzpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IExtensionServices {}
 #[cfg(feature = "Win32_Foundation")]
 impl IExtensionServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtensionServices_Impl, const OFFSET: isize>() -> IExtensionServices_Vtbl {
@@ -6572,6 +6805,8 @@ pub trait IExtractIconA_Impl: Sized {
     fn Extract(&self, pszfile: &::windows::core::PCSTR, niconindex: u32, phiconlarge: *mut super::WindowsAndMessaging::HICON, phiconsmall: *mut super::WindowsAndMessaging::HICON, niconsize: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
+impl ::windows::core::RuntimeName for IExtractIconA {}
+#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl IExtractIconA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtractIconA_Impl, const OFFSET: isize>() -> IExtractIconA_Vtbl {
         unsafe extern "system" fn GetIconLocation<Identity: ::windows::core::IUnknownImpl, Impl: IExtractIconA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uflags: u32, psziconfile: ::windows::core::PSTR, cchmax: u32, piindex: *mut i32, pwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -6600,6 +6835,8 @@ pub trait IExtractIconW_Impl: Sized {
     fn Extract(&self, pszfile: &::windows::core::PCWSTR, niconindex: u32, phiconlarge: *mut super::WindowsAndMessaging::HICON, phiconsmall: *mut super::WindowsAndMessaging::HICON, niconsize: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
+impl ::windows::core::RuntimeName for IExtractIconW {}
+#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl IExtractIconW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtractIconW_Impl, const OFFSET: isize>() -> IExtractIconW_Vtbl {
         unsafe extern "system" fn GetIconLocation<Identity: ::windows::core::IUnknownImpl, Impl: IExtractIconW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uflags: u32, psziconfile: ::windows::core::PWSTR, cchmax: u32, piindex: *mut i32, pwflags: *mut u32) -> ::windows::core::HRESULT {
@@ -6627,6 +6864,8 @@ pub trait IExtractImage_Impl: Sized {
     fn GetLocation(&self, pszpathbuffer: ::windows::core::PWSTR, cch: u32, pdwpriority: *mut u32, prgsize: *const super::super::Foundation::SIZE, dwrecclrdepth: u32, pdwflags: *mut u32) -> ::windows::core::Result<()>;
     fn Extract(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IExtractImage {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IExtractImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtractImage_Impl, const OFFSET: isize>() -> IExtractImage_Vtbl {
@@ -6660,6 +6899,8 @@ impl IExtractImage_Vtbl {
 pub trait IExtractImage2_Impl: Sized + IExtractImage_Impl {
     fn GetDateStamp(&self) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IExtractImage2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IExtractImage2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IExtractImage2_Impl, const OFFSET: isize>() -> IExtractImage2_Vtbl {
@@ -6706,6 +6947,8 @@ pub trait IFileDialog_Impl: Sized + IModalWindow_Impl {
     fn ClearClientData(&self) -> ::windows::core::Result<()>;
     fn SetFilter(&self, pfilter: &::core::option::Option<IShellItemFilter>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IFileDialog {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IFileDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialog_Impl, const OFFSET: isize>() -> IFileDialog_Vtbl {
@@ -6903,6 +7146,8 @@ pub trait IFileDialog2_Impl: Sized + IModalWindow_Impl + IFileDialog_Impl {
     fn SetNavigationRoot(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IFileDialog2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IFileDialog2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialog2_Impl, const OFFSET: isize>() -> IFileDialog2_Vtbl {
         unsafe extern "system" fn SetCancelButtonLabel<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialog2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszlabel: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -6932,6 +7177,8 @@ pub trait IFileDialogControlEvents_Impl: Sized {
     fn OnCheckButtonToggled(&self, pfdc: &::core::option::Option<IFileDialogCustomize>, dwidctl: u32, bchecked: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn OnControlActivating(&self, pfdc: &::core::option::Option<IFileDialogCustomize>, dwidctl: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileDialogControlEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFileDialogControlEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialogControlEvents_Impl, const OFFSET: isize>() -> IFileDialogControlEvents_Vtbl {
@@ -6997,6 +7244,8 @@ pub trait IFileDialogCustomize_Impl: Sized {
     fn MakeProminent(&self, dwidctl: u32) -> ::windows::core::Result<()>;
     fn SetControlItemText(&self, dwidctl: u32, dwiditem: u32, pszlabel: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileDialogCustomize {}
 #[cfg(feature = "Win32_Foundation")]
 impl IFileDialogCustomize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialogCustomize_Impl, const OFFSET: isize>() -> IFileDialogCustomize_Vtbl {
@@ -7209,6 +7458,7 @@ pub trait IFileDialogEvents_Impl: Sized {
     fn OnTypeChange(&self, pfd: &::core::option::Option<IFileDialog>) -> ::windows::core::Result<()>;
     fn OnOverwrite(&self, pfd: &::core::option::Option<IFileDialog>, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<FDE_OVERWRITE_RESPONSE>;
 }
+impl ::windows::core::RuntimeName for IFileDialogEvents {}
 impl IFileDialogEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialogEvents_Impl, const OFFSET: isize>() -> IFileDialogEvents_Vtbl {
         unsafe extern "system" fn OnFileOk<Identity: ::windows::core::IUnknownImpl, Impl: IFileDialogEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfd: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7282,6 +7532,8 @@ pub trait IFileIsInUse_Impl: Sized {
     fn CloseFile(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFileIsInUse {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFileIsInUse_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileIsInUse_Impl, const OFFSET: isize>() -> IFileIsInUse_Vtbl {
         unsafe extern "system" fn GetAppName<Identity: ::windows::core::IUnknownImpl, Impl: IFileIsInUse_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -7352,6 +7604,8 @@ pub trait IFileOpenDialog_Impl: Sized + IModalWindow_Impl + IFileDialog_Impl {
     fn GetSelectedItems(&self) -> ::windows::core::Result<IShellItemArray>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IFileOpenDialog {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IFileOpenDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileOpenDialog_Impl, const OFFSET: isize>() -> IFileOpenDialog_Vtbl {
         unsafe extern "system" fn GetResults<Identity: ::windows::core::IUnknownImpl, Impl: IFileOpenDialog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7409,6 +7663,8 @@ pub trait IFileOperation_Impl: Sized {
     fn PerformOperations(&self) -> ::windows::core::Result<()>;
     fn GetAnyOperationsAborted(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFileOperation {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFileOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileOperation_Impl, const OFFSET: isize>() -> IFileOperation_Vtbl {
@@ -7557,6 +7813,8 @@ pub trait IFileOperation2_Impl: Sized + IFileOperation_Impl {
     fn SetOperationFlags2(&self, operationflags2: FILE_OPERATION_FLAGS2) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFileOperation2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFileOperation2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileOperation2_Impl, const OFFSET: isize>() -> IFileOperation2_Vtbl {
         unsafe extern "system" fn SetOperationFlags2<Identity: ::windows::core::IUnknownImpl, Impl: IFileOperation2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, operationflags2: FILE_OPERATION_FLAGS2) -> ::windows::core::HRESULT {
@@ -7588,6 +7846,7 @@ pub trait IFileOperationProgressSink_Impl: Sized {
     fn PauseTimer(&self) -> ::windows::core::Result<()>;
     fn ResumeTimer(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFileOperationProgressSink {}
 impl IFileOperationProgressSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileOperationProgressSink_Impl, const OFFSET: isize>() -> IFileOperationProgressSink_Vtbl {
         unsafe extern "system" fn StartOperations<Identity: ::windows::core::IUnknownImpl, Impl: IFileOperationProgressSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7703,6 +7962,8 @@ pub trait IFileSaveDialog_Impl: Sized + IModalWindow_Impl + IFileDialog_Impl {
     fn ApplyProperties(&self, psi: &::core::option::Option<IShellItem>, pstore: &::core::option::Option<PropertiesSystem::IPropertyStore>, hwnd: super::super::Foundation::HWND, psink: &::core::option::Option<IFileOperationProgressSink>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFileSaveDialog {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFileSaveDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSaveDialog_Impl, const OFFSET: isize>() -> IFileSaveDialog_Vtbl {
         unsafe extern "system" fn SetSaveAsItem<Identity: ::windows::core::IUnknownImpl, Impl: IFileSaveDialog_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psi: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7757,6 +8018,8 @@ pub trait IFileSearchBand_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Scope(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn QueryFile(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFileSearchBand {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFileSearchBand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSearchBand_Impl, const OFFSET: isize>() -> IFileSearchBand_Vtbl {
@@ -7822,6 +8085,8 @@ pub trait IFileSyncMergeHandler_Impl: Sized {
     fn ShowResolveConflictUIAsync(&self, localfilepath: &::windows::core::PCWSTR, monitortodisplayon: super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IFileSyncMergeHandler {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IFileSyncMergeHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSyncMergeHandler_Impl, const OFFSET: isize>() -> IFileSyncMergeHandler_Vtbl {
         unsafe extern "system" fn Merge<Identity: ::windows::core::IUnknownImpl, Impl: IFileSyncMergeHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, localfilepath: ::windows::core::PCWSTR, serverfilepath: ::windows::core::PCWSTR, updatestatus: *mut MERGE_UPDATE_STATUS) -> ::windows::core::HRESULT {
@@ -7855,6 +8120,8 @@ pub trait IFileSystemBindData_Impl: Sized {
     fn SetFindData(&self, pfd: *const super::super::Storage::FileSystem::WIN32_FIND_DATAW) -> ::windows::core::Result<()>;
     fn GetFindData(&self) -> ::windows::core::Result<super::super::Storage::FileSystem::WIN32_FIND_DATAW>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
+impl ::windows::core::RuntimeName for IFileSystemBindData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl IFileSystemBindData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemBindData_Impl, const OFFSET: isize>() -> IFileSystemBindData_Vtbl {
@@ -7891,6 +8158,8 @@ pub trait IFileSystemBindData2_Impl: Sized + IFileSystemBindData_Impl {
     fn SetJunctionCLSID(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetJunctionCLSID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
+impl ::windows::core::RuntimeName for IFileSystemBindData2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 impl IFileSystemBindData2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFileSystemBindData2_Impl, const OFFSET: isize>() -> IFileSystemBindData2_Vtbl {
@@ -7946,6 +8215,8 @@ pub trait IFolderBandPriv_Impl: Sized {
     fn SetNoText(&self, fnotext: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFolderBandPriv {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFolderBandPriv_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderBandPriv_Impl, const OFFSET: isize>() -> IFolderBandPriv_Vtbl {
         unsafe extern "system" fn SetCascade<Identity: ::windows::core::IUnknownImpl, Impl: IFolderBandPriv_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fcascade: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -7986,6 +8257,8 @@ pub trait IFolderFilter_Impl: Sized {
     fn GetEnumFlags(&self, psf: &::core::option::Option<IShellFolder>, pidlfolder: *const Common::ITEMIDLIST, phwnd: *mut super::super::Foundation::HWND, pgrfflags: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IFolderFilter {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IFolderFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderFilter_Impl, const OFFSET: isize>() -> IFolderFilter_Vtbl {
         unsafe extern "system" fn ShouldShow<Identity: ::windows::core::IUnknownImpl, Impl: IFolderFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psf: ::windows::core::RawPtr, pidlfolder: *const Common::ITEMIDLIST, pidlitem: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -8011,6 +8284,7 @@ impl IFolderFilter_Vtbl {
 pub trait IFolderFilterSite_Impl: Sized {
     fn SetFilter(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IFolderFilterSite {}
 impl IFolderFilterSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderFilterSite_Impl, const OFFSET: isize>() -> IFolderFilterSite_Vtbl {
         unsafe extern "system" fn SetFilter<Identity: ::windows::core::IUnknownImpl, Impl: IFolderFilterSite_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8041,6 +8315,8 @@ pub trait IFolderView_Impl: Sized {
     fn SelectItem(&self, iitem: i32, dwflags: u32) -> ::windows::core::Result<()>;
     fn SelectAndPositionItems(&self, cidl: u32, apidl: *const *const Common::ITEMIDLIST, apt: *const super::super::Foundation::POINT, dwflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IFolderView {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IFolderView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderView_Impl, const OFFSET: isize>() -> IFolderView_Vtbl {
@@ -8206,6 +8482,8 @@ pub trait IFolderView2_Impl: Sized + IFolderView_Impl {
     fn IsMoveInSameFolder(&self) -> ::windows::core::Result<()>;
     fn DoRename(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFolderView2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFolderView2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderView2_Impl, const OFFSET: isize>() -> IFolderView2_Vtbl {
@@ -8420,6 +8698,8 @@ pub trait IFolderViewHost_Impl: Sized {
     fn Initialize(&self, hwndparent: super::super::Foundation::HWND, pdo: &::core::option::Option<super::super::System::Com::IDataObject>, prc: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IFolderViewHost {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IFolderViewHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewHost_Impl, const OFFSET: isize>() -> IFolderViewHost_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, pdo: ::windows::core::RawPtr, prc: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -8438,6 +8718,8 @@ pub trait IFolderViewOC_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn SetFolderView(&self, pdisp: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IFolderViewOC {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IFolderViewOC_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewOC_Impl, const OFFSET: isize>() -> IFolderViewOC_Vtbl {
         unsafe extern "system" fn SetFolderView<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewOC_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdisp: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8455,6 +8737,7 @@ pub trait IFolderViewOptions_Impl: Sized {
     fn SetFolderViewOptions(&self, fvomask: FOLDERVIEWOPTIONS, fvoflags: FOLDERVIEWOPTIONS) -> ::windows::core::Result<()>;
     fn GetFolderViewOptions(&self) -> ::windows::core::Result<FOLDERVIEWOPTIONS>;
 }
+impl ::windows::core::RuntimeName for IFolderViewOptions {}
 impl IFolderViewOptions_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewOptions_Impl, const OFFSET: isize>() -> IFolderViewOptions_Vtbl {
         unsafe extern "system" fn SetFolderViewOptions<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewOptions_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, fvomask: FOLDERVIEWOPTIONS, fvoflags: FOLDERVIEWOPTIONS) -> ::windows::core::HRESULT {
@@ -8493,6 +8776,8 @@ pub trait IFolderViewSettings_Impl: Sized {
     fn GetSortColumns(&self, rgsortcolumns: *mut SORTCOLUMN, ccolumnsin: u32, pccolumnsout: *mut u32) -> ::windows::core::Result<()>;
     fn GetGroupSubsetCount(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IFolderViewSettings {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IFolderViewSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFolderViewSettings_Impl, const OFFSET: isize>() -> IFolderViewSettings_Vtbl {
@@ -8572,6 +8857,8 @@ pub trait IFrameworkInputPane_Impl: Sized {
     fn Location(&self) -> ::windows::core::Result<super::super::Foundation::RECT>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFrameworkInputPane {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFrameworkInputPane_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFrameworkInputPane_Impl, const OFFSET: isize>() -> IFrameworkInputPane_Vtbl {
         unsafe extern "system" fn Advise<Identity: ::windows::core::IUnknownImpl, Impl: IFrameworkInputPane_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwindow: *mut ::core::ffi::c_void, phandler: ::windows::core::RawPtr, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -8630,6 +8917,8 @@ pub trait IFrameworkInputPaneHandler_Impl: Sized {
     fn Hiding(&self, fensurefocusedelementinview: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IFrameworkInputPaneHandler {}
+#[cfg(feature = "Win32_Foundation")]
 impl IFrameworkInputPaneHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IFrameworkInputPaneHandler_Impl, const OFFSET: isize>() -> IFrameworkInputPaneHandler_Vtbl {
         unsafe extern "system" fn Showing<Identity: ::windows::core::IUnknownImpl, Impl: IFrameworkInputPaneHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prcinputpanescreenlocation: *const super::super::Foundation::RECT, fensurefocusedelementinview: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -8655,6 +8944,7 @@ impl IFrameworkInputPaneHandler_Vtbl {
 pub trait IGetServiceIds_Impl: Sized {
     fn GetServiceIds(&self, serviceidcount: *mut u32, serviceids: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IGetServiceIds {}
 impl IGetServiceIds_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGetServiceIds_Impl, const OFFSET: isize>() -> IGetServiceIds_Vtbl {
         unsafe extern "system" fn GetServiceIds<Identity: ::windows::core::IUnknownImpl, Impl: IGetServiceIds_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, serviceidcount: *mut u32, serviceids: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -8674,6 +8964,8 @@ pub trait IHWEventHandler_Impl: Sized {
     fn HandleEvent(&self, pszdeviceid: &::windows::core::PCWSTR, pszaltdeviceid: &::windows::core::PCWSTR, pszeventtype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn HandleEventWithContent(&self, pszdeviceid: &::windows::core::PCWSTR, pszaltdeviceid: &::windows::core::PCWSTR, pszeventtype: &::windows::core::PCWSTR, pszcontenttypehandler: &::windows::core::PCWSTR, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IHWEventHandler {}
 #[cfg(feature = "Win32_System_Com")]
 impl IHWEventHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHWEventHandler_Impl, const OFFSET: isize>() -> IHWEventHandler_Vtbl {
@@ -8708,6 +9000,8 @@ pub trait IHWEventHandler2_Impl: Sized + IHWEventHandler_Impl {
     fn HandleEventWithHWND(&self, pszdeviceid: &::windows::core::PCWSTR, pszaltdeviceid: &::windows::core::PCWSTR, pszeventtype: &::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IHWEventHandler2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IHWEventHandler2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHWEventHandler2_Impl, const OFFSET: isize>() -> IHWEventHandler2_Vtbl {
         unsafe extern "system" fn HandleEventWithHWND<Identity: ::windows::core::IUnknownImpl, Impl: IHWEventHandler2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszdeviceid: ::windows::core::PCWSTR, pszaltdeviceid: ::windows::core::PCWSTR, pszeventtype: ::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -8725,6 +9019,7 @@ pub trait IHandlerActivationHost_Impl: Sized {
     fn BeforeCoCreateInstance(&self, clsidhandler: *const ::windows::core::GUID, itemsbeingactivated: &::core::option::Option<IShellItemArray>, handlerinfo: &::core::option::Option<IHandlerInfo>) -> ::windows::core::Result<()>;
     fn BeforeCreateProcess(&self, applicationpath: &::windows::core::PCWSTR, commandline: &::windows::core::PCWSTR, handlerinfo: &::core::option::Option<IHandlerInfo>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IHandlerActivationHost {}
 impl IHandlerActivationHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHandlerActivationHost_Impl, const OFFSET: isize>() -> IHandlerActivationHost_Vtbl {
         unsafe extern "system" fn BeforeCoCreateInstance<Identity: ::windows::core::IUnknownImpl, Impl: IHandlerActivationHost_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsidhandler: *const ::windows::core::GUID, itemsbeingactivated: ::windows::core::RawPtr, handlerinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -8752,6 +9047,7 @@ pub trait IHandlerInfo_Impl: Sized {
     fn GetApplicationPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetApplicationIconReference(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IHandlerInfo {}
 impl IHandlerInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHandlerInfo_Impl, const OFFSET: isize>() -> IHandlerInfo_Vtbl {
         unsafe extern "system" fn GetApplicationDisplayName<Identity: ::windows::core::IUnknownImpl, Impl: IHandlerInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -8801,6 +9097,7 @@ impl IHandlerInfo_Vtbl {
 pub trait IHandlerInfo2_Impl: Sized + IHandlerInfo_Impl {
     fn GetApplicationId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IHandlerInfo2 {}
 impl IHandlerInfo2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHandlerInfo2_Impl, const OFFSET: isize>() -> IHandlerInfo2_Vtbl {
         unsafe extern "system" fn GetApplicationId<Identity: ::windows::core::IUnknownImpl, Impl: IHandlerInfo2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -8837,6 +9134,8 @@ pub trait IHlink_Impl: Sized {
     fn SetAdditionalParams(&self, pwzadditionalparams: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetAdditionalParams(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IHlink {}
 #[cfg(feature = "Win32_System_Com")]
 impl IHlink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHlink_Impl, const OFFSET: isize>() -> IHlink_Vtbl {
@@ -8973,6 +9272,8 @@ pub trait IHlinkBrowseContext_Impl: Sized {
     fn Clone(&self, piunkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Close(&self, reserved: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IHlinkBrowseContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IHlinkBrowseContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHlinkBrowseContext_Impl, const OFFSET: isize>() -> IHlinkBrowseContext_Vtbl {
@@ -9119,6 +9420,8 @@ pub trait IHlinkFrame_Impl: Sized {
     fn UpdateHlink(&self, uhlid: u32, pimktarget: &::core::option::Option<super::super::System::Com::IMoniker>, pwzlocation: &::windows::core::PCWSTR, pwzfriendlyname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IHlinkFrame {}
+#[cfg(feature = "Win32_System_Com")]
 impl IHlinkFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHlinkFrame_Impl, const OFFSET: isize>() -> IHlinkFrame_Vtbl {
         unsafe extern "system" fn SetBrowseContext<Identity: ::windows::core::IUnknownImpl, Impl: IHlinkFrame_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pihlbc: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9172,6 +9475,8 @@ pub trait IHlinkSite_Impl: Sized {
     fn ReadyToNavigate(&self, dwsitedata: u32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn OnNavigationComplete(&self, dwsitedata: u32, dwreserved: u32, hrerror: ::windows::core::HRESULT, pwzerror: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IHlinkSite {}
 #[cfg(feature = "Win32_System_Com")]
 impl IHlinkSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHlinkSite_Impl, const OFFSET: isize>() -> IHlinkSite_Vtbl {
@@ -9227,6 +9532,8 @@ pub trait IHlinkTarget_Impl: Sized {
     fn GetMoniker(&self, pwzlocation: &::windows::core::PCWSTR, dwassign: u32) -> ::windows::core::Result<super::super::System::Com::IMoniker>;
     fn GetFriendlyName(&self, pwzlocation: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IHlinkTarget {}
 #[cfg(feature = "Win32_System_Com")]
 impl IHlinkTarget_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHlinkTarget_Impl, const OFFSET: isize>() -> IHlinkTarget_Vtbl {
@@ -9292,6 +9599,8 @@ pub trait IHomeGroup_Impl: Sized {
     fn ShowSharingWizard(&self, owner: super::super::Foundation::HWND) -> ::windows::core::Result<HOMEGROUPSHARINGCHOICES>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IHomeGroup {}
+#[cfg(feature = "Win32_Foundation")]
 impl IHomeGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHomeGroup_Impl, const OFFSET: isize>() -> IHomeGroup_Vtbl {
         unsafe extern "system" fn IsMember<Identity: ::windows::core::IUnknownImpl, Impl: IHomeGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, member: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -9330,6 +9639,7 @@ pub trait IIOCancelInformation_Impl: Sized {
     fn SetCancelInformation(&self, dwthreadid: u32, umsgcancel: u32) -> ::windows::core::Result<()>;
     fn GetCancelInformation(&self, pdwthreadid: *mut u32, pumsgcancel: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IIOCancelInformation {}
 impl IIOCancelInformation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIOCancelInformation_Impl, const OFFSET: isize>() -> IIOCancelInformation_Vtbl {
         unsafe extern "system" fn SetCancelInformation<Identity: ::windows::core::IUnknownImpl, Impl: IIOCancelInformation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwthreadid: u32, umsgcancel: u32) -> ::windows::core::HRESULT {
@@ -9355,6 +9665,8 @@ impl IIOCancelInformation_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IIdentityName_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IIdentityName {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IIdentityName_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IIdentityName_Impl, const OFFSET: isize>() -> IIdentityName_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -9367,6 +9679,8 @@ impl IIdentityName_Vtbl {
 pub trait IImageRecompress_Impl: Sized {
     fn RecompressImage(&self, psi: &::core::option::Option<IShellItem>, cx: i32, cy: i32, iquality: i32, pstg: &::core::option::Option<super::super::System::Com::StructuredStorage::IStorage>) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IImageRecompress {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IImageRecompress_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IImageRecompress_Impl, const OFFSET: isize>() -> IImageRecompress_Vtbl {
@@ -9392,6 +9706,8 @@ pub trait IInitializeCommand_Impl: Sized {
     fn Initialize(&self, pszcommandname: &::windows::core::PCWSTR, ppb: &::core::option::Option<super::super::System::Com::StructuredStorage::IPropertyBag>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
+impl ::windows::core::RuntimeName for IInitializeCommand {}
+#[cfg(feature = "Win32_System_Com_StructuredStorage")]
 impl IInitializeCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeCommand_Impl, const OFFSET: isize>() -> IInitializeCommand_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcommandname: ::windows::core::PCWSTR, ppb: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9410,6 +9726,8 @@ pub trait IInitializeNetworkFolder_Impl: Sized {
     fn Initialize(&self, pidl: *const Common::ITEMIDLIST, pidltarget: *const Common::ITEMIDLIST, udisplaytype: u32, pszresname: &::windows::core::PCWSTR, pszprovider: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IInitializeNetworkFolder {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IInitializeNetworkFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeNetworkFolder_Impl, const OFFSET: isize>() -> IInitializeNetworkFolder_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeNetworkFolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, pidltarget: *const Common::ITEMIDLIST, udisplaytype: u32, pszresname: ::windows::core::PCWSTR, pszprovider: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -9426,6 +9744,7 @@ impl IInitializeNetworkFolder_Vtbl {
 pub trait IInitializeObject_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInitializeObject {}
 impl IInitializeObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeObject_Impl, const OFFSET: isize>() -> IInitializeObject_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeObject_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9444,6 +9763,8 @@ pub trait IInitializeWithBindCtx_Impl: Sized {
     fn Initialize(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IInitializeWithBindCtx {}
+#[cfg(feature = "Win32_System_Com")]
 impl IInitializeWithBindCtx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithBindCtx_Impl, const OFFSET: isize>() -> IInitializeWithBindCtx_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithBindCtx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbc: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9460,6 +9781,7 @@ impl IInitializeWithBindCtx_Vtbl {
 pub trait IInitializeWithItem_Impl: Sized {
     fn Initialize(&self, psi: &::core::option::Option<IShellItem>, grfmode: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInitializeWithItem {}
 impl IInitializeWithItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithItem_Impl, const OFFSET: isize>() -> IInitializeWithItem_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psi: ::windows::core::RawPtr, grfmode: u32) -> ::windows::core::HRESULT {
@@ -9478,6 +9800,8 @@ pub trait IInitializeWithPropertyStore_Impl: Sized {
     fn Initialize(&self, pps: &::core::option::Option<PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IInitializeWithPropertyStore {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IInitializeWithPropertyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithPropertyStore_Impl, const OFFSET: isize>() -> IInitializeWithPropertyStore_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithPropertyStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pps: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9495,6 +9819,8 @@ impl IInitializeWithPropertyStore_Vtbl {
 pub trait IInitializeWithWindow_Impl: Sized {
     fn Initialize(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInitializeWithWindow {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInitializeWithWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInitializeWithWindow_Impl, const OFFSET: isize>() -> IInitializeWithWindow_Vtbl {
@@ -9515,6 +9841,8 @@ pub trait IInputObject_Impl: Sized {
     fn HasFocusIO(&self) -> ::windows::core::Result<()>;
     fn TranslateAcceleratorIO(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IInputObject {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IInputObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputObject_Impl, const OFFSET: isize>() -> IInputObject_Vtbl {
@@ -9549,6 +9877,8 @@ pub trait IInputObject2_Impl: Sized + IInputObject_Impl {
     fn TranslateAcceleratorGlobal(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IInputObject2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IInputObject2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputObject2_Impl, const OFFSET: isize>() -> IInputObject2_Vtbl {
         unsafe extern "system" fn TranslateAcceleratorGlobal<Identity: ::windows::core::IUnknownImpl, Impl: IInputObject2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::HRESULT {
@@ -9566,6 +9896,8 @@ impl IInputObject2_Vtbl {
 pub trait IInputObjectSite_Impl: Sized {
     fn OnFocusChangeIS(&self, punkobj: &::core::option::Option<::windows::core::IUnknown>, fsetfocus: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IInputObjectSite {}
 #[cfg(feature = "Win32_Foundation")]
 impl IInputObjectSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputObjectSite_Impl, const OFFSET: isize>() -> IInputObjectSite_Vtbl {
@@ -9585,6 +9917,8 @@ pub trait IInputPaneAnimationCoordinator_Impl: Sized {
     fn AddAnimation(&self, device: &::core::option::Option<::windows::core::IUnknown>, animation: &::core::option::Option<super::super::Graphics::DirectComposition::IDCompositionAnimation>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_DirectComposition")]
+impl ::windows::core::RuntimeName for IInputPaneAnimationCoordinator {}
+#[cfg(feature = "Win32_Graphics_DirectComposition")]
 impl IInputPaneAnimationCoordinator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputPaneAnimationCoordinator_Impl, const OFFSET: isize>() -> IInputPaneAnimationCoordinator_Vtbl {
         unsafe extern "system" fn AddAnimation<Identity: ::windows::core::IUnknownImpl, Impl: IInputPaneAnimationCoordinator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void, animation: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -9601,6 +9935,7 @@ impl IInputPaneAnimationCoordinator_Vtbl {
 pub trait IInputPanelConfiguration_Impl: Sized {
     fn EnableFocusTracking(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInputPanelConfiguration {}
 impl IInputPanelConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputPanelConfiguration_Impl, const OFFSET: isize>() -> IInputPanelConfiguration_Vtbl {
         unsafe extern "system" fn EnableFocusTracking<Identity: ::windows::core::IUnknownImpl, Impl: IInputPanelConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9617,6 +9952,7 @@ impl IInputPanelConfiguration_Vtbl {
 pub trait IInputPanelInvocationConfiguration_Impl: Sized {
     fn RequireTouchInEditControl(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInputPanelInvocationConfiguration {}
 impl IInputPanelInvocationConfiguration_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputPanelInvocationConfiguration_Impl, const OFFSET: isize>() -> IInputPanelInvocationConfiguration_Vtbl {
         unsafe extern "system" fn RequireTouchInEditControl<Identity: ::windows::core::IUnknownImpl, Impl: IInputPanelInvocationConfiguration_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9635,6 +9971,8 @@ pub trait IInsertItem_Impl: Sized {
     fn InsertItem(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IInsertItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IInsertItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInsertItem_Impl, const OFFSET: isize>() -> IInsertItem_Vtbl {
         unsafe extern "system" fn InsertItem<Identity: ::windows::core::IUnknownImpl, Impl: IInsertItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -9652,6 +9990,7 @@ pub trait IItemNameLimits_Impl: Sized {
     fn GetValidCharacters(&self, ppwszvalidchars: *mut ::windows::core::PWSTR, ppwszinvalidchars: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn GetMaxLength(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IItemNameLimits {}
 impl IItemNameLimits_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IItemNameLimits_Impl, const OFFSET: isize>() -> IItemNameLimits_Vtbl {
         unsafe extern "system" fn GetValidCharacters<Identity: ::windows::core::IUnknownImpl, Impl: IItemNameLimits_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppwszvalidchars: *mut ::windows::core::PWSTR, ppwszinvalidchars: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -9692,6 +10031,8 @@ pub trait IKnownFolder_Impl: Sized {
     fn GetRedirectionCapabilities(&self) -> ::windows::core::Result<u32>;
     fn GetFolderDefinition(&self) -> ::windows::core::Result<KNOWNFOLDER_DEFINITION>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IKnownFolder {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl IKnownFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKnownFolder_Impl, const OFFSET: isize>() -> IKnownFolder_Vtbl {
@@ -9813,6 +10154,8 @@ pub trait IKnownFolderManager_Impl: Sized {
     fn Redirect(&self, rfid: *const ::windows::core::GUID, hwnd: super::super::Foundation::HWND, flags: u32, psztargetpath: &::windows::core::PCWSTR, cfolders: u32, pexclusion: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IKnownFolderManager {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl IKnownFolderManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IKnownFolderManager_Impl, const OFFSET: isize>() -> IKnownFolderManager_Vtbl {
         unsafe extern "system" fn FolderIdFromCsidl<Identity: ::windows::core::IUnknownImpl, Impl: IKnownFolderManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ncsidl: i32, pfid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -9928,6 +10271,7 @@ impl IKnownFolderManager_Vtbl {
 pub trait ILaunchSourceAppUserModelId_Impl: Sized {
     fn GetAppUserModelId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ILaunchSourceAppUserModelId {}
 impl ILaunchSourceAppUserModelId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchSourceAppUserModelId_Impl, const OFFSET: isize>() -> ILaunchSourceAppUserModelId_Vtbl {
         unsafe extern "system" fn GetAppUserModelId<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchSourceAppUserModelId_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, launchingapp: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -9952,6 +10296,8 @@ pub trait ILaunchSourceViewSizePreference_Impl: Sized {
     fn GetSourceViewToPosition(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
     fn GetSourceViewSizePreference(&self) -> ::windows::core::Result<APPLICATION_VIEW_SIZE_PREFERENCE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ILaunchSourceViewSizePreference {}
 #[cfg(feature = "Win32_Foundation")]
 impl ILaunchSourceViewSizePreference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchSourceViewSizePreference_Impl, const OFFSET: isize>() -> ILaunchSourceViewSizePreference_Vtbl {
@@ -9992,6 +10338,8 @@ pub trait ILaunchTargetMonitor_Impl: Sized {
     fn GetMonitor(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HMONITOR>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for ILaunchTargetMonitor {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl ILaunchTargetMonitor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchTargetMonitor_Impl, const OFFSET: isize>() -> ILaunchTargetMonitor_Vtbl {
         unsafe extern "system" fn GetMonitor<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchTargetMonitor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, monitor: *mut super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::HRESULT {
@@ -10014,6 +10362,7 @@ impl ILaunchTargetMonitor_Vtbl {
 pub trait ILaunchTargetViewSizePreference_Impl: Sized {
     fn GetTargetViewSizePreference(&self) -> ::windows::core::Result<APPLICATION_VIEW_SIZE_PREFERENCE>;
 }
+impl ::windows::core::RuntimeName for ILaunchTargetViewSizePreference {}
 impl ILaunchTargetViewSizePreference_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchTargetViewSizePreference_Impl, const OFFSET: isize>() -> ILaunchTargetViewSizePreference_Vtbl {
         unsafe extern "system" fn GetTargetViewSizePreference<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchTargetViewSizePreference_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, targetsizeonlaunch: *mut APPLICATION_VIEW_SIZE_PREFERENCE) -> ::windows::core::HRESULT {
@@ -10042,6 +10391,8 @@ pub trait ILaunchUIContext_Impl: Sized {
     fn SetTabGroupingPreference(&self, value: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ILaunchUIContext {}
+#[cfg(feature = "Win32_Foundation")]
 impl ILaunchUIContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchUIContext_Impl, const OFFSET: isize>() -> ILaunchUIContext_Vtbl {
         unsafe extern "system" fn SetAssociatedWindow<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchUIContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -10067,6 +10418,7 @@ impl ILaunchUIContext_Vtbl {
 pub trait ILaunchUIContextProvider_Impl: Sized {
     fn UpdateContext(&self, context: &::core::option::Option<ILaunchUIContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ILaunchUIContextProvider {}
 impl ILaunchUIContextProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchUIContextProvider_Impl, const OFFSET: isize>() -> ILaunchUIContextProvider_Vtbl {
         unsafe extern "system" fn UpdateContext<Identity: ::windows::core::IUnknownImpl, Impl: ILaunchUIContextProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, context: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -10085,6 +10437,8 @@ pub trait IMenuBand_Impl: Sized {
     fn IsMenuMessage(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
     fn TranslateMenuMessage(&self, pmsg: *mut super::WindowsAndMessaging::MSG, plret: *mut super::super::Foundation::LRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IMenuBand {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IMenuBand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMenuBand_Impl, const OFFSET: isize>() -> IMenuBand_Vtbl {
@@ -10114,6 +10468,8 @@ pub trait IMenuPopup_Impl: Sized + super::super::System::Ole::IOleWindow_Impl + 
     fn OnSelect(&self, dwselecttype: u32) -> ::windows::core::Result<()>;
     fn SetSubMenu(&self, pmp: &::core::option::Option<IMenuPopup>, fset: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMenuPopup {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 impl IMenuPopup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMenuPopup_Impl, const OFFSET: isize>() -> IMenuPopup_Vtbl {
@@ -10148,6 +10504,8 @@ pub trait IModalWindow_Impl: Sized {
     fn Show(&self, hwndowner: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IModalWindow {}
+#[cfg(feature = "Win32_Foundation")]
 impl IModalWindow_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IModalWindow_Impl, const OFFSET: isize>() -> IModalWindow_Vtbl {
         unsafe extern "system" fn Show<Identity: ::windows::core::IUnknownImpl, Impl: IModalWindow_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -10167,6 +10525,8 @@ pub trait INameSpaceTreeAccessible_Impl: Sized {
     fn OnDoDefaultAccessibilityAction(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn OnGetAccessibilityRole(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INameSpaceTreeAccessible {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INameSpaceTreeAccessible_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeAccessible_Impl, const OFFSET: isize>() -> INameSpaceTreeAccessible_Vtbl {
@@ -10230,6 +10590,8 @@ pub trait INameSpaceTreeControl_Impl: Sized {
     fn GetItemRect(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<super::super::Foundation::RECT>;
     fn CollapseAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INameSpaceTreeControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl INameSpaceTreeControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControl_Impl, const OFFSET: isize>() -> INameSpaceTreeControl_Vtbl {
@@ -10411,6 +10773,8 @@ pub trait INameSpaceTreeControl2_Impl: Sized + INameSpaceTreeControl_Impl {
     fn GetControlStyle2(&self, nstcsmask: NSTCSTYLE2) -> ::windows::core::Result<NSTCSTYLE2>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INameSpaceTreeControl2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl INameSpaceTreeControl2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControl2_Impl, const OFFSET: isize>() -> INameSpaceTreeControl2_Vtbl {
         unsafe extern "system" fn SetControlStyle<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControl2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nstcsmask: u32, nstcsstyle: u32) -> ::windows::core::HRESULT {
@@ -10465,6 +10829,8 @@ pub trait INameSpaceTreeControlCustomDraw_Impl: Sized {
     fn ItemPostPaint(&self, hdc: super::super::Graphics::Gdi::HDC, prc: *const super::super::Foundation::RECT, pnstccditem: *const NSTCCUSTOMDRAW) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls"))]
+impl ::windows::core::RuntimeName for INameSpaceTreeControlCustomDraw {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls"))]
 impl INameSpaceTreeControlCustomDraw_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControlCustomDraw_Impl, const OFFSET: isize>() -> INameSpaceTreeControlCustomDraw_Vtbl {
         unsafe extern "system" fn PrePaint<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControlCustomDraw_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hdc: super::super::Graphics::Gdi::HDC, prc: *const super::super::Foundation::RECT, plres: *mut super::super::Foundation::LRESULT) -> ::windows::core::HRESULT {
@@ -10514,6 +10880,8 @@ pub trait INameSpaceTreeControlDropHandler_Impl: Sized {
     fn OnDropPosition(&self, psiover: &::core::option::Option<IShellItem>, psiadata: &::core::option::Option<IShellItemArray>, inewposition: i32, ioldposition: i32) -> ::windows::core::Result<()>;
     fn OnDragLeave(&self, psiover: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INameSpaceTreeControlDropHandler {}
 #[cfg(feature = "Win32_Foundation")]
 impl INameSpaceTreeControlDropHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControlDropHandler_Impl, const OFFSET: isize>() -> INameSpaceTreeControlDropHandler_Vtbl {
@@ -10582,6 +10950,8 @@ pub trait INameSpaceTreeControlEvents_Impl: Sized {
     fn OnBeforeStateImageChange(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn OnGetDefaultIconIndex(&self, psi: &::core::option::Option<IShellItem>, pidefaulticon: *mut i32, piopenicon: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INameSpaceTreeControlEvents {}
 #[cfg(feature = "Win32_Foundation")]
 impl INameSpaceTreeControlEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControlEvents_Impl, const OFFSET: isize>() -> INameSpaceTreeControlEvents_Vtbl {
@@ -10704,6 +11074,7 @@ impl INameSpaceTreeControlEvents_Vtbl {
 pub trait INameSpaceTreeControlFolderCapabilities_Impl: Sized {
     fn GetFolderCapabilities(&self, nfcmask: NSTCFOLDERCAPABILITIES) -> ::windows::core::Result<NSTCFOLDERCAPABILITIES>;
 }
+impl ::windows::core::RuntimeName for INameSpaceTreeControlFolderCapabilities {}
 impl INameSpaceTreeControlFolderCapabilities_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControlFolderCapabilities_Impl, const OFFSET: isize>() -> INameSpaceTreeControlFolderCapabilities_Vtbl {
         unsafe extern "system" fn GetFolderCapabilities<Identity: ::windows::core::IUnknownImpl, Impl: INameSpaceTreeControlFolderCapabilities_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nfcmask: NSTCFOLDERCAPABILITIES, pnfcvalue: *mut NSTCFOLDERCAPABILITIES) -> ::windows::core::HRESULT {
@@ -10729,6 +11100,8 @@ pub trait INamedPropertyBag_Impl: Sized {
     fn WritePropertyNPB(&self, pszbagname: &::windows::core::PCWSTR, pszpropname: &::windows::core::PCWSTR, pvar: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
     fn RemovePropertyNPB(&self, pszbagname: &::windows::core::PCWSTR, pszpropname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for INamedPropertyBag {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 impl INamedPropertyBag_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamedPropertyBag_Impl, const OFFSET: isize>() -> INamedPropertyBag_Vtbl {
@@ -10764,6 +11137,8 @@ pub trait INamespaceWalk_Impl: Sized {
     fn GetIDArrayResult(&self, pcitems: *mut u32, prgpidl: *mut *mut *mut Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for INamespaceWalk {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl INamespaceWalk_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamespaceWalk_Impl, const OFFSET: isize>() -> INamespaceWalk_Vtbl {
         unsafe extern "system" fn Walk<Identity: ::windows::core::IUnknownImpl, Impl: INamespaceWalk_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punktowalk: *mut ::core::ffi::c_void, dwflags: u32, cdepth: i32, pnswcb: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -10793,6 +11168,8 @@ pub trait INamespaceWalkCB_Impl: Sized {
     fn LeaveFolder(&self, psf: &::core::option::Option<IShellFolder>, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
     fn InitializeProgressDialog(&self, ppsztitle: *mut ::windows::core::PWSTR, ppszcancel: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for INamespaceWalkCB {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl INamespaceWalkCB_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamespaceWalkCB_Impl, const OFFSET: isize>() -> INamespaceWalkCB_Vtbl {
@@ -10833,6 +11210,8 @@ pub trait INamespaceWalkCB2_Impl: Sized + INamespaceWalkCB_Impl {
     fn WalkComplete(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for INamespaceWalkCB2 {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl INamespaceWalkCB2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INamespaceWalkCB2_Impl, const OFFSET: isize>() -> INamespaceWalkCB2_Vtbl {
         unsafe extern "system" fn WalkComplete<Identity: ::windows::core::IUnknownImpl, Impl: INamespaceWalkCB2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -10852,6 +11231,8 @@ pub trait INetworkFolderInternal_Impl: Sized {
     fn GetIDList(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
     fn GetProvider(&self, itemidcount: u32, itemids: *const *const Common::ITEMIDLIST, providermaxlength: u32, provider: ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for INetworkFolderInternal {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl INetworkFolderInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INetworkFolderInternal_Impl, const OFFSET: isize>() -> INetworkFolderInternal_Vtbl {
@@ -10899,6 +11280,8 @@ pub trait INewMenuClient_Impl: Sized {
     fn SelectAndEditItem(&self, pidlitem: *const Common::ITEMIDLIST, flags: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for INewMenuClient {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl INewMenuClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INewMenuClient_Impl, const OFFSET: isize>() -> INewMenuClient_Vtbl {
         unsafe extern "system" fn IncludeItems<Identity: ::windows::core::IUnknownImpl, Impl: INewMenuClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pflags: *mut i32) -> ::windows::core::HRESULT {
@@ -10936,6 +11319,8 @@ pub trait INewShortcutHookA_Impl: Sized {
     fn GetName(&self, pszname: ::windows::core::PSTR, cchname: i32) -> ::windows::core::Result<()>;
     fn GetExtension(&self, pszextension: ::windows::core::PSTR, cchextension: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INewShortcutHookA {}
 #[cfg(feature = "Win32_Foundation")]
 impl INewShortcutHookA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INewShortcutHookA_Impl, const OFFSET: isize>() -> INewShortcutHookA_Vtbl {
@@ -10993,6 +11378,8 @@ pub trait INewShortcutHookW_Impl: Sized {
     fn GetExtension(&self, pszextension: ::windows::core::PWSTR, cchextension: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INewShortcutHookW {}
+#[cfg(feature = "Win32_Foundation")]
 impl INewShortcutHookW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INewShortcutHookW_Impl, const OFFSET: isize>() -> INewShortcutHookW_Vtbl {
         unsafe extern "system" fn SetReferent<Identity: ::windows::core::IUnknownImpl, Impl: INewShortcutHookW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcszreferent: ::windows::core::PCWSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -11044,6 +11431,8 @@ pub trait INewWDEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn PassportAuthenticate(&self, bstrsigninurl: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for INewWDEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl INewWDEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INewWDEvents_Impl, const OFFSET: isize>() -> INewWDEvents_Vtbl {
         unsafe extern "system" fn PassportAuthenticate<Identity: ::windows::core::IUnknownImpl, Impl: INewWDEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrsigninurl: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pvfauthenitcated: *mut i16) -> ::windows::core::HRESULT {
@@ -11068,6 +11457,8 @@ pub trait INewWindowManager_Impl: Sized {
     fn EvaluateNewWindow(&self, pszurl: &::windows::core::PCWSTR, pszname: &::windows::core::PCWSTR, pszurlcontext: &::windows::core::PCWSTR, pszfeatures: &::windows::core::PCWSTR, freplace: super::super::Foundation::BOOL, dwflags: u32, dwuseractiontime: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for INewWindowManager {}
+#[cfg(feature = "Win32_Foundation")]
 impl INewWindowManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INewWindowManager_Impl, const OFFSET: isize>() -> INewWindowManager_Vtbl {
         unsafe extern "system" fn EvaluateNewWindow<Identity: ::windows::core::IUnknownImpl, Impl: INewWindowManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pszname: ::windows::core::PCWSTR, pszurlcontext: ::windows::core::PCWSTR, pszfeatures: ::windows::core::PCWSTR, freplace: super::super::Foundation::BOOL, dwflags: u32, dwuseractiontime: u32) -> ::windows::core::HRESULT {
@@ -11086,6 +11477,8 @@ pub trait INotifyReplica_Impl: Sized {
     fn YouAreAReplica(&self, ulcotherreplicas: u32, rgpmkotherreplicas: *mut ::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for INotifyReplica {}
+#[cfg(feature = "Win32_System_Com")]
 impl INotifyReplica_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: INotifyReplica_Impl, const OFFSET: isize>() -> INotifyReplica_Vtbl {
         unsafe extern "system" fn YouAreAReplica<Identity: ::windows::core::IUnknownImpl, Impl: INotifyReplica_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ulcotherreplicas: u32, rgpmkotherreplicas: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11103,6 +11496,7 @@ pub trait IObjMgr_Impl: Sized {
     fn Append(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Remove(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjMgr {}
 impl IObjMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjMgr_Impl, const OFFSET: isize>() -> IObjMgr_Vtbl {
         unsafe extern "system" fn Append<Identity: ::windows::core::IUnknownImpl, Impl: IObjMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11128,6 +11522,7 @@ impl IObjMgr_Vtbl {
 pub trait IObjectProvider_Impl: Sized {
     fn QueryObject(&self, guidobject: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectProvider {}
 impl IObjectProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectProvider_Impl, const OFFSET: isize>() -> IObjectProvider_Vtbl {
         unsafe extern "system" fn QueryObject<Identity: ::windows::core::IUnknownImpl, Impl: IObjectProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidobject: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11145,6 +11540,7 @@ pub trait IObjectWithAppUserModelID_Impl: Sized {
     fn SetAppID(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetAppID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IObjectWithAppUserModelID {}
 impl IObjectWithAppUserModelID_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithAppUserModelID_Impl, const OFFSET: isize>() -> IObjectWithAppUserModelID_Vtbl {
         unsafe extern "system" fn SetAppID<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithAppUserModelID_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -11176,6 +11572,7 @@ impl IObjectWithAppUserModelID_Vtbl {
 pub trait IObjectWithBackReferences_Impl: Sized {
     fn RemoveBackReferences(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectWithBackReferences {}
 impl IObjectWithBackReferences_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithBackReferences_Impl, const OFFSET: isize>() -> IObjectWithBackReferences_Vtbl {
         unsafe extern "system" fn RemoveBackReferences<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithBackReferences_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11193,6 +11590,8 @@ impl IObjectWithBackReferences_Vtbl {
 pub trait IObjectWithCancelEvent_Impl: Sized {
     fn GetCancelEvent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IObjectWithCancelEvent {}
 #[cfg(feature = "Win32_Foundation")]
 impl IObjectWithCancelEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithCancelEvent_Impl, const OFFSET: isize>() -> IObjectWithCancelEvent_Vtbl {
@@ -11217,6 +11616,7 @@ pub trait IObjectWithFolderEnumMode_Impl: Sized {
     fn SetMode(&self, femode: FOLDER_ENUM_MODE) -> ::windows::core::Result<()>;
     fn GetMode(&self) -> ::windows::core::Result<FOLDER_ENUM_MODE>;
 }
+impl ::windows::core::RuntimeName for IObjectWithFolderEnumMode {}
 impl IObjectWithFolderEnumMode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithFolderEnumMode_Impl, const OFFSET: isize>() -> IObjectWithFolderEnumMode_Vtbl {
         unsafe extern "system" fn SetMode<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithFolderEnumMode_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, femode: FOLDER_ENUM_MODE) -> ::windows::core::HRESULT {
@@ -11249,6 +11649,7 @@ pub trait IObjectWithProgID_Impl: Sized {
     fn SetProgID(&self, pszprogid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetProgID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IObjectWithProgID {}
 impl IObjectWithProgID_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithProgID_Impl, const OFFSET: isize>() -> IObjectWithProgID_Vtbl {
         unsafe extern "system" fn SetProgID<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithProgID_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszprogid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -11281,6 +11682,7 @@ pub trait IObjectWithSelection_Impl: Sized {
     fn SetSelection(&self, psia: &::core::option::Option<IShellItemArray>) -> ::windows::core::Result<()>;
     fn GetSelection(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IObjectWithSelection {}
 impl IObjectWithSelection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithSelection_Impl, const OFFSET: isize>() -> IObjectWithSelection_Vtbl {
         unsafe extern "system" fn SetSelection<Identity: ::windows::core::IUnknownImpl, Impl: IObjectWithSelection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psia: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11308,6 +11710,7 @@ pub trait IOpenControlPanel_Impl: Sized {
     fn GetPath(&self, pszname: &::windows::core::PCWSTR, pszpath: ::windows::core::PWSTR, cchpath: u32) -> ::windows::core::Result<()>;
     fn GetCurrentView(&self) -> ::windows::core::Result<CPVIEW>;
 }
+impl ::windows::core::RuntimeName for IOpenControlPanel {}
 impl IOpenControlPanel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpenControlPanel_Impl, const OFFSET: isize>() -> IOpenControlPanel_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl, Impl: IOpenControlPanel_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pszpage: ::windows::core::PCWSTR, punksite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11347,6 +11750,8 @@ pub trait IOpenSearchSource_Impl: Sized {
     fn GetResults(&self, hwnd: super::super::Foundation::HWND, pszquery: &::windows::core::PCWSTR, dwstartindex: u32, dwcount: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IOpenSearchSource {}
+#[cfg(feature = "Win32_Foundation")]
 impl IOpenSearchSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOpenSearchSource_Impl, const OFFSET: isize>() -> IOpenSearchSource_Vtbl {
         unsafe extern "system" fn GetResults<Identity: ::windows::core::IUnknownImpl, Impl: IOpenSearchSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pszquery: ::windows::core::PCWSTR, dwstartindex: u32, dwcount: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -11374,6 +11779,8 @@ pub trait IOperationsProgressDialog_Impl: Sized {
     fn GetMilliseconds(&self, pullelapsed: *mut u64, pullremaining: *mut u64) -> ::windows::core::Result<()>;
     fn GetOperationStatus(&self) -> ::windows::core::Result<PropertiesSystem::PDOPSTATUS>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IOperationsProgressDialog {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IOperationsProgressDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IOperationsProgressDialog_Impl, const OFFSET: isize>() -> IOperationsProgressDialog_Vtbl {
@@ -11474,6 +11881,7 @@ pub trait IPackageDebugSettings_Impl: Sized {
     fn RegisterForPackageStateChanges(&self, packagefullname: &::windows::core::PCWSTR, ppackageexecutionstatechangenotification: &::core::option::Option<IPackageExecutionStateChangeNotification>) -> ::windows::core::Result<u32>;
     fn UnregisterForPackageStateChanges(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPackageDebugSettings {}
 impl IPackageDebugSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPackageDebugSettings_Impl, const OFFSET: isize>() -> IPackageDebugSettings_Vtbl {
         unsafe extern "system" fn EnableDebugging<Identity: ::windows::core::IUnknownImpl, Impl: IPackageDebugSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagefullname: ::windows::core::PCWSTR, debuggercommandline: ::windows::core::PCWSTR, environment: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -11589,6 +11997,7 @@ impl IPackageDebugSettings_Vtbl {
 pub trait IPackageDebugSettings2_Impl: Sized + IPackageDebugSettings_Impl {
     fn EnumerateApps(&self, packagefullname: &::windows::core::PCWSTR, appcount: *mut u32, appusermodelids: *mut *mut ::windows::core::PWSTR, appdisplaynames: *mut *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPackageDebugSettings2 {}
 impl IPackageDebugSettings2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPackageDebugSettings2_Impl, const OFFSET: isize>() -> IPackageDebugSettings2_Vtbl {
         unsafe extern "system" fn EnumerateApps<Identity: ::windows::core::IUnknownImpl, Impl: IPackageDebugSettings2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, packagefullname: ::windows::core::PCWSTR, appcount: *mut u32, appusermodelids: *mut *mut ::windows::core::PWSTR, appdisplaynames: *mut *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -11605,6 +12014,7 @@ impl IPackageDebugSettings2_Vtbl {
 pub trait IPackageExecutionStateChangeNotification_Impl: Sized {
     fn OnStateChanged(&self, pszpackagefullname: &::windows::core::PCWSTR, pesnewstate: PACKAGE_EXECUTION_STATE) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IPackageExecutionStateChangeNotification {}
 impl IPackageExecutionStateChangeNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPackageExecutionStateChangeNotification_Impl, const OFFSET: isize>() -> IPackageExecutionStateChangeNotification_Vtbl {
         unsafe extern "system" fn OnStateChanged<Identity: ::windows::core::IUnknownImpl, Impl: IPackageExecutionStateChangeNotification_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpackagefullname: ::windows::core::PCWSTR, pesnewstate: PACKAGE_EXECUTION_STATE) -> ::windows::core::HRESULT {
@@ -11623,6 +12033,8 @@ pub trait IParentAndItem_Impl: Sized {
     fn SetParentAndItem(&self, pidlparent: *const Common::ITEMIDLIST, psf: &::core::option::Option<IShellFolder>, pidlchild: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
     fn GetParentAndItem(&self, ppidlparent: *mut *mut Common::ITEMIDLIST, ppsf: *mut ::core::option::Option<IShellFolder>, ppidlchild: *mut *mut Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IParentAndItem {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl IParentAndItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IParentAndItem_Impl, const OFFSET: isize>() -> IParentAndItem_Vtbl {
@@ -11650,6 +12062,7 @@ pub trait IParseAndCreateItem_Impl: Sized {
     fn SetItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn GetItem(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IParseAndCreateItem {}
 impl IParseAndCreateItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IParseAndCreateItem_Impl, const OFFSET: isize>() -> IParseAndCreateItem_Vtbl {
         unsafe extern "system" fn SetItem<Identity: ::windows::core::IUnknownImpl, Impl: IParseAndCreateItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psi: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -11677,6 +12090,8 @@ pub trait IPersistFolder_Impl: Sized + super::super::System::Com::IPersist_Impl 
     fn Initialize(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IPersistFolder {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IPersistFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistFolder_Impl, const OFFSET: isize>() -> IPersistFolder_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IPersistFolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -11694,6 +12109,8 @@ impl IPersistFolder_Vtbl {
 pub trait IPersistFolder2_Impl: Sized + super::super::System::Com::IPersist_Impl + IPersistFolder_Impl {
     fn GetCurFolder(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IPersistFolder2 {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IPersistFolder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistFolder2_Impl, const OFFSET: isize>() -> IPersistFolder2_Vtbl {
@@ -11719,6 +12136,8 @@ pub trait IPersistFolder3_Impl: Sized + super::super::System::Com::IPersist_Impl
     fn InitializeEx(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, pidlroot: *const Common::ITEMIDLIST, ppfti: *const PERSIST_FOLDER_TARGET_INFO) -> ::windows::core::Result<()>;
     fn GetFolderTargetInfo(&self) -> ::windows::core::Result<PERSIST_FOLDER_TARGET_INFO>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IPersistFolder3 {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IPersistFolder3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistFolder3_Impl, const OFFSET: isize>() -> IPersistFolder3_Vtbl {
@@ -11753,6 +12172,8 @@ pub trait IPersistIDList_Impl: Sized + super::super::System::Com::IPersist_Impl 
     fn SetIDList(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
     fn GetIDList(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IPersistIDList {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IPersistIDList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPersistIDList_Impl, const OFFSET: isize>() -> IPersistIDList_Vtbl {
@@ -11792,6 +12213,8 @@ pub trait IPreviewHandler_Impl: Sized {
     fn QueryFocus(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
     fn TranslateAccelerator(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPreviewHandler {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPreviewHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPreviewHandler_Impl, const OFFSET: isize>() -> IPreviewHandler_Vtbl {
@@ -11857,6 +12280,8 @@ pub trait IPreviewHandlerFrame_Impl: Sized {
     fn TranslateAccelerator(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IPreviewHandlerFrame {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IPreviewHandlerFrame_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPreviewHandlerFrame_Impl, const OFFSET: isize>() -> IPreviewHandlerFrame_Vtbl {
         unsafe extern "system" fn GetWindowContext<Identity: ::windows::core::IUnknownImpl, Impl: IPreviewHandlerFrame_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *mut PREVIEWHANDLERFRAMEINFO) -> ::windows::core::HRESULT {
@@ -11892,6 +12317,8 @@ pub trait IPreviewHandlerVisuals_Impl: Sized {
     fn SetTextColor(&self, color: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IPreviewHandlerVisuals {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IPreviewHandlerVisuals_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPreviewHandlerVisuals_Impl, const OFFSET: isize>() -> IPreviewHandlerVisuals_Vtbl {
         unsafe extern "system" fn SetBackgroundColor<Identity: ::windows::core::IUnknownImpl, Impl: IPreviewHandlerVisuals_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, color: u32) -> ::windows::core::HRESULT {
@@ -11923,6 +12350,8 @@ impl IPreviewHandlerVisuals_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IPreviewItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IPreviewItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IPreviewItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPreviewItem_Impl, const OFFSET: isize>() -> IPreviewItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -11935,6 +12364,8 @@ impl IPreviewItem_Vtbl {
 pub trait IPreviousVersionsInfo_Impl: Sized {
     fn AreSnapshotsAvailable(&self, pszpath: &::windows::core::PCWSTR, foktobeslow: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPreviousVersionsInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IPreviousVersionsInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPreviousVersionsInfo_Impl, const OFFSET: isize>() -> IPreviousVersionsInfo_Vtbl {
@@ -11960,6 +12391,8 @@ pub trait IProfferService_Impl: Sized {
     fn ProfferService(&self, serviceid: *const ::windows::core::GUID, serviceprovider: &::core::option::Option<super::super::System::Com::IServiceProvider>) -> ::windows::core::Result<u32>;
     fn RevokeService(&self, cookie: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IProfferService {}
 #[cfg(feature = "Win32_System_Com")]
 impl IProfferService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProfferService_Impl, const OFFSET: isize>() -> IProfferService_Vtbl {
@@ -12002,6 +12435,8 @@ pub trait IProgressDialog_Impl: Sized {
     fn SetCancelMsg(&self, pwzcancelmsg: &::windows::core::PCWSTR, pvresevered: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Timer(&self, dwtimeraction: u32, pvresevered: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IProgressDialog {}
 #[cfg(feature = "Win32_Foundation")]
 impl IProgressDialog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IProgressDialog_Impl, const OFFSET: isize>() -> IProgressDialog_Vtbl {
@@ -12083,6 +12518,8 @@ pub trait IPropertyKeyStore_Impl: Sized {
     fn RemoveKey(&self, key: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IPropertyKeyStore {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IPropertyKeyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyKeyStore_Impl, const OFFSET: isize>() -> IPropertyKeyStore_Vtbl {
         unsafe extern "system" fn GetKeyCount<Identity: ::windows::core::IUnknownImpl, Impl: IPropertyKeyStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keycount: *mut i32) -> ::windows::core::HRESULT {
@@ -12148,6 +12585,8 @@ pub trait IPublishedApp_Impl: Sized + IShellApp_Impl {
     fn Unschedule(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPublishedApp {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPublishedApp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPublishedApp_Impl, const OFFSET: isize>() -> IPublishedApp_Vtbl {
         unsafe extern "system" fn Install<Identity: ::windows::core::IUnknownImpl, Impl: IPublishedApp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstinstall: *const super::super::Foundation::SYSTEMTIME) -> ::windows::core::HRESULT {
@@ -12181,6 +12620,8 @@ pub trait IPublishedApp2_Impl: Sized + IShellApp_Impl + IPublishedApp_Impl {
     fn Install2(&self, pstinstall: *const super::super::Foundation::SYSTEMTIME, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IPublishedApp2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IPublishedApp2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPublishedApp2_Impl, const OFFSET: isize>() -> IPublishedApp2_Vtbl {
         unsafe extern "system" fn Install2<Identity: ::windows::core::IUnknownImpl, Impl: IPublishedApp2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstinstall: *const super::super::Foundation::SYSTEMTIME, hwndparent: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -12199,6 +12640,8 @@ pub trait IPublishingWizard_Impl: Sized + IWizardExtension_Impl {
     fn Initialize(&self, pdo: &::core::option::Option<super::super::System::Com::IDataObject>, dwoptions: u32, pszservicescope: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetTransferManifest(&self, phrfromtransfer: *mut ::windows::core::HRESULT, pdocmanifest: *mut ::core::option::Option<super::super::Data::Xml::MsXml::IXMLDOMDocument>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
+impl ::windows::core::RuntimeName for IPublishingWizard {}
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
 impl IPublishingWizard_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPublishingWizard_Impl, const OFFSET: isize>() -> IPublishingWizard_Vtbl {
@@ -12230,6 +12673,8 @@ pub trait IQueryAssociations_Impl: Sized {
     fn GetData(&self, flags: u32, data: ASSOCDATA, pszextra: &::windows::core::PCWSTR, pvout: *mut ::core::ffi::c_void, pcbout: *mut u32) -> ::windows::core::Result<()>;
     fn GetEnum(&self, flags: u32, assocenum: ASSOCENUM, pszextra: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
+impl ::windows::core::RuntimeName for IQueryAssociations {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 impl IQueryAssociations_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryAssociations_Impl, const OFFSET: isize>() -> IQueryAssociations_Vtbl {
@@ -12280,6 +12725,7 @@ impl IQueryAssociations_Vtbl {
 pub trait IQueryCancelAutoPlay_Impl: Sized {
     fn AllowAutoPlay(&self, pszpath: &::windows::core::PCWSTR, dwcontenttype: u32, pszlabel: &::windows::core::PCWSTR, dwserialnumber: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IQueryCancelAutoPlay {}
 impl IQueryCancelAutoPlay_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryCancelAutoPlay_Impl, const OFFSET: isize>() -> IQueryCancelAutoPlay_Vtbl {
         unsafe extern "system" fn AllowAutoPlay<Identity: ::windows::core::IUnknownImpl, Impl: IQueryCancelAutoPlay_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, dwcontenttype: u32, pszlabel: ::windows::core::PCWSTR, dwserialnumber: u32) -> ::windows::core::HRESULT {
@@ -12297,6 +12743,7 @@ pub trait IQueryCodePage_Impl: Sized {
     fn GetCodePage(&self) -> ::windows::core::Result<u32>;
     fn SetCodePage(&self, uicodepage: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IQueryCodePage {}
 impl IQueryCodePage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryCodePage_Impl, const OFFSET: isize>() -> IQueryCodePage_Vtbl {
         unsafe extern "system" fn GetCodePage<Identity: ::windows::core::IUnknownImpl, Impl: IQueryCodePage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puicodepage: *mut u32) -> ::windows::core::HRESULT {
@@ -12328,6 +12775,7 @@ impl IQueryCodePage_Vtbl {
 pub trait IQueryContinue_Impl: Sized {
     fn QueryContinue(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IQueryContinue {}
 impl IQueryContinue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryContinue_Impl, const OFFSET: isize>() -> IQueryContinue_Vtbl {
         unsafe extern "system" fn QueryContinue<Identity: ::windows::core::IUnknownImpl, Impl: IQueryContinue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12344,6 +12792,7 @@ impl IQueryContinue_Vtbl {
 pub trait IQueryContinueWithStatus_Impl: Sized + IQueryContinue_Impl {
     fn SetStatusMessage(&self, psz: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IQueryContinueWithStatus {}
 impl IQueryContinueWithStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryContinueWithStatus_Impl, const OFFSET: isize>() -> IQueryContinueWithStatus_Vtbl {
         unsafe extern "system" fn SetStatusMessage<Identity: ::windows::core::IUnknownImpl, Impl: IQueryContinueWithStatus_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psz: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -12361,6 +12810,7 @@ pub trait IQueryInfo_Impl: Sized {
     fn GetInfoTip(&self, dwflags: QITIPF_FLAGS) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetInfoFlags(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IQueryInfo {}
 impl IQueryInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IQueryInfo_Impl, const OFFSET: isize>() -> IQueryInfo_Vtbl {
         unsafe extern "system" fn GetInfoTip<Identity: ::windows::core::IUnknownImpl, Impl: IQueryInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: QITIPF_FLAGS, ppwsztip: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -12401,6 +12851,8 @@ pub trait IRegTreeItem_Impl: Sized {
     fn SetCheckState(&self, bcheck: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRegTreeItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRegTreeItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRegTreeItem_Impl, const OFFSET: isize>() -> IRegTreeItem_Vtbl {
         unsafe extern "system" fn GetCheckState<Identity: ::windows::core::IUnknownImpl, Impl: IRegTreeItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbcheck: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -12434,6 +12886,8 @@ pub trait IRelatedItem_Impl: Sized {
     fn GetItemIDList(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
     fn GetItem(&self) -> ::windows::core::Result<IShellItem>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IRelatedItem {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl IRelatedItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRelatedItem_Impl, const OFFSET: isize>() -> IRelatedItem_Vtbl {
@@ -12474,6 +12928,8 @@ pub trait IRemoteComputer_Impl: Sized {
     fn Initialize(&self, pszmachine: &::windows::core::PCWSTR, benumerating: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRemoteComputer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRemoteComputer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteComputer_Impl, const OFFSET: isize>() -> IRemoteComputer_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IRemoteComputer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszmachine: ::windows::core::PCWSTR, benumerating: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -12491,6 +12947,8 @@ impl IRemoteComputer_Vtbl {
 pub trait IResolveShellLink_Impl: Sized {
     fn ResolveShellLink(&self, punklink: &::core::option::Option<::windows::core::IUnknown>, hwnd: super::super::Foundation::HWND, fflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IResolveShellLink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IResolveShellLink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResolveShellLink_Impl, const OFFSET: isize>() -> IResolveShellLink_Vtbl {
@@ -12513,6 +12971,8 @@ pub trait IResultsFolder_Impl: Sized {
     fn RemoveIDList(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
     fn RemoveAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IResultsFolder {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl IResultsFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IResultsFolder_Impl, const OFFSET: isize>() -> IResultsFolder_Vtbl {
@@ -12568,6 +13028,8 @@ pub trait IRunnableTask_Impl: Sized {
     fn Resume(&self) -> ::windows::core::Result<()>;
     fn IsRunning(&self) -> u32;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRunnableTask {}
 #[cfg(feature = "Win32_Foundation")]
 impl IRunnableTask_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRunnableTask_Impl, const OFFSET: isize>() -> IRunnableTask_Vtbl {
@@ -12626,6 +13088,8 @@ pub trait IScriptErrorList_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn getPerErrorDisplay(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn setPerErrorDisplay(&self, fpererrordisplay: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IScriptErrorList {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IScriptErrorList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IScriptErrorList_Impl, const OFFSET: isize>() -> IScriptErrorList_Vtbl {
@@ -12785,6 +13249,7 @@ pub trait ISearchBoxInfo_Impl: Sized {
     fn GetCondition(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetText(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ISearchBoxInfo {}
 impl ISearchBoxInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchBoxInfo_Impl, const OFFSET: isize>() -> ISearchBoxInfo_Vtbl {
         unsafe extern "system" fn GetCondition<Identity: ::windows::core::IUnknownImpl, Impl: ISearchBoxInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -12819,6 +13284,8 @@ pub trait ISearchContext_Impl: Sized {
     fn GetSearchText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetSearchStyle(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISearchContext {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISearchContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchContext_Impl, const OFFSET: isize>() -> ISearchContext_Vtbl {
@@ -12881,6 +13348,8 @@ pub trait ISearchFolderItemFactory_Impl: Sized {
     fn GetShellItem(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetIDList(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISearchFolderItemFactory {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISearchFolderItemFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISearchFolderItemFactory_Impl, const OFFSET: isize>() -> ISearchFolderItemFactory_Vtbl {
@@ -12979,6 +13448,8 @@ pub trait ISharedBitmap_Impl: Sized {
     fn Detach(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ISharedBitmap {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ISharedBitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISharedBitmap_Impl, const OFFSET: isize>() -> ISharedBitmap_Vtbl {
         unsafe extern "system" fn GetSharedBitmap<Identity: ::windows::core::IUnknownImpl, Impl: ISharedBitmap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phbm: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT {
@@ -13052,6 +13523,7 @@ pub trait ISharingConfigurationManager_Impl: Sized {
     fn StopSharingPrinters(&self) -> ::windows::core::Result<()>;
     fn ArePrintersShared(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISharingConfigurationManager {}
 impl ISharingConfigurationManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISharingConfigurationManager_Impl, const OFFSET: isize>() -> ISharingConfigurationManager_Vtbl {
         unsafe extern "system" fn CreateShare<Identity: ::windows::core::IUnknownImpl, Impl: ISharingConfigurationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dsid: DEF_SHARE_ID, role: SHARE_ROLE) -> ::windows::core::HRESULT {
@@ -13118,6 +13590,8 @@ pub trait IShellApp_Impl: Sized {
     fn GetCachedSlowAppInfo(&self) -> ::windows::core::Result<SLOWAPPINFO>;
     fn IsInstalled(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShellApp {}
 #[cfg(feature = "Win32_Foundation")]
 impl IShellApp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellApp_Impl, const OFFSET: isize>() -> IShellApp_Vtbl {
@@ -13193,6 +13667,8 @@ pub trait IShellBrowser_Impl: Sized + super::super::System::Ole::IOleWindow_Impl
     fn OnViewWindowActive(&self, pshv: &::core::option::Option<IShellView>) -> ::windows::core::Result<()>;
     fn SetToolbarItems(&self, lpbuttons: *const super::Controls::TBBUTTON, nbuttons: u32, uflags: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IShellBrowser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IShellBrowser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellBrowser_Impl, const OFFSET: isize>() -> IShellBrowser_Vtbl {
@@ -13311,6 +13787,8 @@ pub trait IShellChangeNotify_Impl: Sized {
     fn OnChange(&self, levent: i32, pidl1: *const Common::ITEMIDLIST, pidl2: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IShellChangeNotify {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IShellChangeNotify_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellChangeNotify_Impl, const OFFSET: isize>() -> IShellChangeNotify_Vtbl {
         unsafe extern "system" fn OnChange<Identity: ::windows::core::IUnknownImpl, Impl: IShellChangeNotify_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, levent: i32, pidl1: *const Common::ITEMIDLIST, pidl2: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -13329,6 +13807,8 @@ pub trait IShellDetails_Impl: Sized {
     fn GetDetailsOf(&self, pidl: *const Common::ITEMIDLIST, icolumn: u32) -> ::windows::core::Result<Common::SHELLDETAILS>;
     fn ColumnClick(&self, icolumn: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IShellDetails {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl IShellDetails_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDetails_Impl, const OFFSET: isize>() -> IShellDetails_Vtbl {
@@ -13384,6 +13864,8 @@ pub trait IShellDispatch_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn RefreshMenu(&self) -> ::windows::core::Result<()>;
     fn ControlPanelItem(&self, bstrdir: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellDispatch {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellDispatch_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch_Impl, const OFFSET: isize>() -> IShellDispatch_Vtbl {
@@ -13576,6 +14058,8 @@ pub trait IShellDispatch2_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn ShowBrowserBar(&self, bstrclsid: &super::super::Foundation::BSTR, bshow: &super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellDispatch2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellDispatch2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch2_Impl, const OFFSET: isize>() -> IShellDispatch2_Vtbl {
         unsafe extern "system" fn IsRestricted<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, group: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, restriction: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, plrestrictvalue: *mut i32) -> ::windows::core::HRESULT {
@@ -13687,6 +14171,8 @@ pub trait IShellDispatch3_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn AddToRecent(&self, varfile: &super::super::System::Com::VARIANT, bstrcategory: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellDispatch3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellDispatch3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch3_Impl, const OFFSET: isize>() -> IShellDispatch3_Vtbl {
         unsafe extern "system" fn AddToRecent<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, varfile: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, bstrcategory: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -13707,6 +14193,8 @@ pub trait IShellDispatch4_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn ExplorerPolicy(&self, bstrpolicyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn GetSetting(&self, lsetting: i32) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellDispatch4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellDispatch4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch4_Impl, const OFFSET: isize>() -> IShellDispatch4_Vtbl {
@@ -13759,6 +14247,8 @@ pub trait IShellDispatch5_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn WindowSwitcher(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellDispatch5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellDispatch5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch5_Impl, const OFFSET: isize>() -> IShellDispatch5_Vtbl {
         unsafe extern "system" fn WindowSwitcher<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13777,6 +14267,8 @@ pub trait IShellDispatch6_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn SearchCommand(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellDispatch6 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellDispatch6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch6_Impl, const OFFSET: isize>() -> IShellDispatch6_Vtbl {
         unsafe extern "system" fn SearchCommand<Identity: ::windows::core::IUnknownImpl, Impl: IShellDispatch6_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13794,6 +14286,8 @@ impl IShellDispatch6_Vtbl {
 pub trait IShellExtInit_Impl: Sized {
     fn Initialize(&self, pidlfolder: *const Common::ITEMIDLIST, pdtobj: &::core::option::Option<super::super::System::Com::IDataObject>, hkeyprogid: super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IShellExtInit {}
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
 impl IShellExtInit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellExtInit_Impl, const OFFSET: isize>() -> IShellExtInit_Vtbl {
@@ -13824,6 +14318,8 @@ pub trait IShellFavoritesNameSpace_Impl: Sized + super::super::System::Com::IDis
     fn DeleteSubscriptionForSelection(&self) -> ::windows::core::Result<i16>;
     fn SetRoot(&self, bstrfullpath: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellFavoritesNameSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellFavoritesNameSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFavoritesNameSpace_Impl, const OFFSET: isize>() -> IShellFavoritesNameSpace_Vtbl {
@@ -13945,6 +14441,8 @@ pub trait IShellFolder_Impl: Sized {
     fn SetNameOf(&self, hwnd: super::super::Foundation::HWND, pidl: *const Common::ITEMIDLIST, pszname: &::windows::core::PCWSTR, uflags: u32) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IShellFolder {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IShellFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolder_Impl, const OFFSET: isize>() -> IShellFolder_Vtbl {
         unsafe extern "system" fn ParseDisplayName<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pbc: ::windows::core::RawPtr, pszdisplayname: ::windows::core::PCWSTR, pcheaten: *mut u32, ppidl: *mut *mut Common::ITEMIDLIST, pdwattributes: *mut u32) -> ::windows::core::HRESULT {
@@ -14037,6 +14535,8 @@ pub trait IShellFolder2_Impl: Sized + IShellFolder_Impl {
     fn GetDetailsOf(&self, pidl: *const Common::ITEMIDLIST, icolumn: u32) -> ::windows::core::Result<Common::SHELLDETAILS>;
     fn MapColumnToSCID(&self, icolumn: u32) -> ::windows::core::Result<PropertiesSystem::PROPERTYKEY>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IShellFolder2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IShellFolder2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolder2_Impl, const OFFSET: isize>() -> IShellFolder2_Vtbl {
@@ -14133,6 +14633,8 @@ pub trait IShellFolderBand_Impl: Sized {
     fn GetBandInfoSFB(&self, pbi: *mut BANDINFOSFB) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IShellFolderBand {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IShellFolderBand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderBand_Impl, const OFFSET: isize>() -> IShellFolderBand_Vtbl {
         unsafe extern "system" fn InitializeSFB<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderBand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psf: ::windows::core::RawPtr, pidl: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -14192,6 +14694,8 @@ pub trait IShellFolderView_Impl: Sized {
     fn QuerySupport(&self, pdwsupport: *mut u32) -> ::windows::core::Result<()>;
     fn SetAutomationObject(&self, pdisp: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IShellFolderView {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 impl IShellFolderView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderView_Impl, const OFFSET: isize>() -> IShellFolderView_Vtbl {
@@ -14442,6 +14946,8 @@ pub trait IShellFolderViewCB_Impl: Sized {
     fn MessageSFVCB(&self, umsg: SFVM_MESSAGE_ID, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShellFolderViewCB {}
+#[cfg(feature = "Win32_Foundation")]
 impl IShellFolderViewCB_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderViewCB_Impl, const OFFSET: isize>() -> IShellFolderViewCB_Vtbl {
         unsafe extern "system" fn MessageSFVCB<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderViewCB_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, umsg: SFVM_MESSAGE_ID, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -14467,6 +14973,8 @@ pub trait IShellFolderViewDual_Impl: Sized + super::super::System::Com::IDispatc
     fn Script(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
     fn ViewOptions(&self) -> ::windows::core::Result<i32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellFolderViewDual {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellFolderViewDual_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderViewDual_Impl, const OFFSET: isize>() -> IShellFolderViewDual_Vtbl {
@@ -14587,6 +15095,8 @@ pub trait IShellFolderViewDual2_Impl: Sized + super::super::System::Com::IDispat
     fn SelectItemRelative(&self, irelative: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellFolderViewDual2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellFolderViewDual2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderViewDual2_Impl, const OFFSET: isize>() -> IShellFolderViewDual2_Vtbl {
         unsafe extern "system" fn CurrentViewMode<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderViewDual2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pviewmode: *mut u32) -> ::windows::core::HRESULT {
@@ -14633,6 +15143,8 @@ pub trait IShellFolderViewDual3_Impl: Sized + super::super::System::Com::IDispat
     fn IconSize(&self) -> ::windows::core::Result<i32>;
     fn FilterView(&self, bstrfiltertext: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellFolderViewDual3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellFolderViewDual3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellFolderViewDual3_Impl, const OFFSET: isize>() -> IShellFolderViewDual3_Vtbl {
@@ -14727,6 +15239,8 @@ pub trait IShellIcon_Impl: Sized {
     fn GetIconOf(&self, pidl: *const Common::ITEMIDLIST, flags: u32) -> ::windows::core::Result<i32>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IShellIcon {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IShellIcon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellIcon_Impl, const OFFSET: isize>() -> IShellIcon_Vtbl {
         unsafe extern "system" fn GetIconOf<Identity: ::windows::core::IUnknownImpl, Impl: IShellIcon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, flags: u32, piconindex: *mut i32) -> ::windows::core::HRESULT {
@@ -14751,6 +15265,8 @@ pub trait IShellIconOverlay_Impl: Sized {
     fn GetOverlayIndex(&self, pidl: *const Common::ITEMIDLIST, pindex: *mut i32) -> ::windows::core::Result<()>;
     fn GetOverlayIconIndex(&self, pidl: *const Common::ITEMIDLIST, piconindex: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IShellIconOverlay {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
 impl IShellIconOverlay_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellIconOverlay_Impl, const OFFSET: isize>() -> IShellIconOverlay_Vtbl {
@@ -14779,6 +15295,7 @@ pub trait IShellIconOverlayIdentifier_Impl: Sized {
     fn GetOverlayInfo(&self, pwsziconfile: ::windows::core::PWSTR, cchmax: i32, pindex: *mut i32, pdwflags: *mut u32) -> ::windows::core::Result<()>;
     fn GetPriority(&self) -> ::windows::core::Result<i32>;
 }
+impl ::windows::core::RuntimeName for IShellIconOverlayIdentifier {}
 impl IShellIconOverlayIdentifier_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellIconOverlayIdentifier_Impl, const OFFSET: isize>() -> IShellIconOverlayIdentifier_Vtbl {
         unsafe extern "system" fn IsMemberOf<Identity: ::windows::core::IUnknownImpl, Impl: IShellIconOverlayIdentifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszpath: ::windows::core::PCWSTR, dwattrib: u32) -> ::windows::core::HRESULT {
@@ -14821,6 +15338,8 @@ pub trait IShellIconOverlayManager_Impl: Sized {
     fn LoadNonloadedOverlayIdentifiers(&self) -> ::windows::core::Result<()>;
     fn OverlayIndexFromImageIndex(&self, iimage: i32, piindex: *mut i32, fadd: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShellIconOverlayManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IShellIconOverlayManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellIconOverlayManager_Impl, const OFFSET: isize>() -> IShellIconOverlayManager_Vtbl {
@@ -14895,6 +15414,8 @@ pub trait IShellImageData_Impl: Sized {
     fn CloneFrame(&self, ppimg: *mut *mut u8) -> ::windows::core::Result<()>;
     fn ReplaceFrame(&self, pimg: *mut u8) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
+impl ::windows::core::RuntimeName for IShellImageData {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 impl IShellImageData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellImageData_Impl, const OFFSET: isize>() -> IShellImageData_Vtbl {
@@ -15101,6 +15622,7 @@ impl IShellImageData_Vtbl {
 pub trait IShellImageDataAbort_Impl: Sized {
     fn QueryAbort(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IShellImageDataAbort {}
 impl IShellImageDataAbort_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellImageDataAbort_Impl, const OFFSET: isize>() -> IShellImageDataAbort_Vtbl {
         unsafe extern "system" fn QueryAbort<Identity: ::windows::core::IUnknownImpl, Impl: IShellImageDataAbort_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -15121,6 +15643,8 @@ pub trait IShellImageDataFactory_Impl: Sized {
     fn CreateImageFromStream(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<IShellImageData>;
     fn GetDataFormatFromPath(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::GUID>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IShellImageDataFactory {}
 #[cfg(feature = "Win32_System_Com")]
 impl IShellImageDataFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellImageDataFactory_Impl, const OFFSET: isize>() -> IShellImageDataFactory_Vtbl {
@@ -15188,6 +15712,8 @@ pub trait IShellItem_Impl: Sized {
     fn GetAttributes(&self, sfgaomask: u32) -> ::windows::core::Result<u32>;
     fn Compare(&self, psi: &::core::option::Option<IShellItem>, hint: u32) -> ::windows::core::Result<i32>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for IShellItem {}
 #[cfg(feature = "Win32_System_Com")]
 impl IShellItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellItem_Impl, const OFFSET: isize>() -> IShellItem_Vtbl {
@@ -15269,6 +15795,8 @@ pub trait IShellItem2_Impl: Sized + IShellItem_Impl {
     fn GetUInt64(&self, key: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<u64>;
     fn GetBool(&self, key: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IShellItem2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IShellItem2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellItem2_Impl, const OFFSET: isize>() -> IShellItem2_Vtbl {
@@ -15417,6 +15945,8 @@ pub trait IShellItemArray_Impl: Sized {
     fn EnumItems(&self) -> ::windows::core::Result<IEnumShellItems>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for IShellItemArray {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl IShellItemArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemArray_Impl, const OFFSET: isize>() -> IShellItemArray_Vtbl {
         unsafe extern "system" fn BindToHandler<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbc: ::windows::core::RawPtr, bhid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -15497,6 +16027,7 @@ pub trait IShellItemFilter_Impl: Sized {
     fn IncludeItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn GetEnumFlagsForItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IShellItemFilter {}
 impl IShellItemFilter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemFilter_Impl, const OFFSET: isize>() -> IShellItemFilter_Vtbl {
         unsafe extern "system" fn IncludeItem<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemFilter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psi: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -15530,6 +16061,8 @@ pub trait IShellItemImageFactory_Impl: Sized {
     fn GetImage(&self, size: &super::super::Foundation::SIZE, flags: SIIGBF) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IShellItemImageFactory {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IShellItemImageFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemImageFactory_Impl, const OFFSET: isize>() -> IShellItemImageFactory_Vtbl {
         unsafe extern "system" fn GetImage<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemImageFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, size: super::super::Foundation::SIZE, flags: SIIGBF, phbm: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT {
@@ -15562,6 +16095,8 @@ pub trait IShellItemResources_Impl: Sized {
     fn CreateResource(&self, pcsir: *const SHELL_ITEM_RESOURCE, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn MarkForDelete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShellItemResources {}
 #[cfg(feature = "Win32_Foundation")]
 impl IShellItemResources_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellItemResources_Impl, const OFFSET: isize>() -> IShellItemResources_Vtbl {
@@ -15676,6 +16211,7 @@ pub trait IShellLibrary_Impl: Sized {
     fn Save(&self, psifoldertosavein: &::core::option::Option<IShellItem>, pszlibraryname: &::windows::core::PCWSTR, lsf: LIBRARYSAVEFLAGS) -> ::windows::core::Result<IShellItem>;
     fn SaveInKnownFolder(&self, kfidtosavein: *const ::windows::core::GUID, pszlibraryname: &::windows::core::PCWSTR, lsf: LIBRARYSAVEFLAGS) -> ::windows::core::Result<IShellItem>;
 }
+impl ::windows::core::RuntimeName for IShellLibrary {}
 impl IShellLibrary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellLibrary_Impl, const OFFSET: isize>() -> IShellLibrary_Vtbl {
         unsafe extern "system" fn LoadLibraryFromItem<Identity: ::windows::core::IUnknownImpl, Impl: IShellLibrary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psilibrary: ::windows::core::RawPtr, grfmode: u32) -> ::windows::core::HRESULT {
@@ -15840,6 +16376,8 @@ pub trait IShellLinkA_Impl: Sized {
     fn SetPath(&self, pszfile: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IShellLinkA {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_UI_Shell_Common"))]
 impl IShellLinkA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkA_Impl, const OFFSET: isize>() -> IShellLinkA_Vtbl {
         unsafe extern "system" fn GetPath<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkA_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PSTR, cch: i32, pfd: *mut super::super::Storage::FileSystem::WIN32_FIND_DATAA, fflags: u32) -> ::windows::core::HRESULT {
@@ -15983,6 +16521,7 @@ pub trait IShellLinkDataList_Impl: Sized {
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
     fn SetFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IShellLinkDataList {}
 impl IShellLinkDataList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkDataList_Impl, const OFFSET: isize>() -> IShellLinkDataList_Vtbl {
         unsafe extern "system" fn AddDataBlock<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkDataList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdatablock: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -16048,6 +16587,8 @@ pub trait IShellLinkDual_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SetIconLocation(&self, bs: &super::super::Foundation::BSTR, iicon: i32) -> ::windows::core::Result<()>;
     fn Save(&self, vwhere: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellLinkDual {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellLinkDual_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkDual_Impl, const OFFSET: isize>() -> IShellLinkDual_Vtbl {
@@ -16196,6 +16737,8 @@ pub trait IShellLinkDual2_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Target(&self) -> ::windows::core::Result<FolderItem>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellLinkDual2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellLinkDual2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkDual2_Impl, const OFFSET: isize>() -> IShellLinkDual2_Vtbl {
         unsafe extern "system" fn Target<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkDual2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppfi: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -16236,6 +16779,8 @@ pub trait IShellLinkW_Impl: Sized {
     fn Resolve(&self, hwnd: super::super::Foundation::HWND, fflags: u32) -> ::windows::core::Result<()>;
     fn SetPath(&self, pszfile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IShellLinkW {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_UI_Shell_Common"))]
 impl IShellLinkW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellLinkW_Impl, const OFFSET: isize>() -> IShellLinkW_Vtbl {
@@ -16386,6 +16931,8 @@ pub trait IShellMenu_Impl: Sized {
     fn SetMenuToolbar(&self, punk: &::core::option::Option<::windows::core::IUnknown>, dwflags: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IShellMenu {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IShellMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellMenu_Impl, const OFFSET: isize>() -> IShellMenu_Vtbl {
         unsafe extern "system" fn Initialize<Identity: ::windows::core::IUnknownImpl, Impl: IShellMenu_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psmc: ::windows::core::RawPtr, uid: u32, uidancestor: u32, dwflags: u32) -> ::windows::core::HRESULT {
@@ -16461,6 +17008,8 @@ pub trait IShellMenuCallback_Impl: Sized {
     fn CallbackSM(&self, psmd: *mut SMDATA, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IShellMenuCallback {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IShellMenuCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellMenuCallback_Impl, const OFFSET: isize>() -> IShellMenuCallback_Vtbl {
         unsafe extern "system" fn CallbackSM<Identity: ::windows::core::IUnknownImpl, Impl: IShellMenuCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psmd: *mut SMDATA, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -16498,6 +17047,8 @@ pub trait IShellNameSpace_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Expand(&self, var: &super::super::System::Com::VARIANT, idepth: i32) -> ::windows::core::Result<()>;
     fn UnselectAll(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellNameSpace {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellNameSpace_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellNameSpace_Impl, const OFFSET: isize>() -> IShellNameSpace_Vtbl {
@@ -16701,6 +17252,8 @@ pub trait IShellPropSheetExt_Impl: Sized {
     fn ReplacePage(&self, upageid: u32, pfnreplacewith: &super::Controls::LPFNSVADDPROPSHEETPAGE, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
+impl ::windows::core::RuntimeName for IShellPropSheetExt {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 impl IShellPropSheetExt_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellPropSheetExt_Impl, const OFFSET: isize>() -> IShellPropSheetExt_Vtbl {
         unsafe extern "system" fn AddPages<Identity: ::windows::core::IUnknownImpl, Impl: IShellPropSheetExt_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfnaddpage: ::windows::core::RawPtr, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -16726,6 +17279,7 @@ impl IShellPropSheetExt_Vtbl {
 pub trait IShellRunDll_Impl: Sized {
     fn Run(&self, pszargs: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IShellRunDll {}
 impl IShellRunDll_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellRunDll_Impl, const OFFSET: isize>() -> IShellRunDll_Vtbl {
         unsafe extern "system" fn Run<Identity: ::windows::core::IUnknownImpl, Impl: IShellRunDll_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszargs: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -16742,6 +17296,7 @@ impl IShellRunDll_Vtbl {
 pub trait IShellService_Impl: Sized {
     fn SetOwner(&self, punkowner: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IShellService {}
 impl IShellService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellService_Impl, const OFFSET: isize>() -> IShellService_Vtbl {
         unsafe extern "system" fn SetOwner<Identity: ::windows::core::IUnknownImpl, Impl: IShellService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punkowner: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -16762,6 +17317,8 @@ pub trait IShellTaskScheduler_Impl: Sized {
     fn CountTasks(&self, rtoid: *const ::windows::core::GUID) -> u32;
     fn Status(&self, dwreleasestatus: u32, dwthreadtimeout: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IShellTaskScheduler {}
 #[cfg(feature = "Win32_Foundation")]
 impl IShellTaskScheduler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellTaskScheduler_Impl, const OFFSET: isize>() -> IShellTaskScheduler_Vtbl {
@@ -16813,6 +17370,8 @@ pub trait IShellUIHelper_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn AutoCompleteAttach(&self, reserved: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn ShowBrowserUI(&self, bstrname: &super::super::Foundation::BSTR, pvarin: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper_Impl, const OFFSET: isize>() -> IShellUIHelper_Vtbl {
@@ -16933,6 +17492,8 @@ pub trait IShellUIHelper2_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn RunOnceHasShown(&self) -> ::windows::core::Result<i16>;
     fn SearchGuideUrl(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper2 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper2_Impl, const OFFSET: isize>() -> IShellUIHelper2_Vtbl {
@@ -17105,6 +17666,8 @@ pub trait IShellUIHelper3_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn ShowInPrivateHelp(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper3_Impl, const OFFSET: isize>() -> IShellUIHelper3_Vtbl {
         unsafe extern "system" fn AddService<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, url: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -17232,6 +17795,8 @@ pub trait IShellUIHelper4_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn msTrackingProtectionEnabled(&self) -> ::windows::core::Result<i16>;
     fn msActiveXFilteringEnabled(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper4 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper4_Impl, const OFFSET: isize>() -> IShellUIHelper4_Vtbl {
@@ -17398,6 +17963,8 @@ pub trait IShellUIHelper5_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn msChangeDefaultBrowser(&self, fchange: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper5 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper5_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper5_Impl, const OFFSET: isize>() -> IShellUIHelper5_Vtbl {
         unsafe extern "system" fn msProvisionNetworks<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper5_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrprovisioningxml: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, puiresult: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -17473,6 +18040,8 @@ pub trait IShellUIHelper6_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn msStopPeriodicBadgeUpdate(&self) -> ::windows::core::Result<()>;
     fn msLaunchInternetOptions(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper6 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper6_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper6_Impl, const OFFSET: isize>() -> IShellUIHelper6_Vtbl {
@@ -17587,6 +18156,8 @@ pub trait IShellUIHelper7_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn LaunchIE(&self, bstrurl: &super::super::Foundation::BSTR, automated: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper7 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper7_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper7_Impl, const OFFSET: isize>() -> IShellUIHelper7_Vtbl {
         unsafe extern "system" fn SetExperimentalFlag<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper7_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrflagstring: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, vfflag: i16) -> ::windows::core::HRESULT {
@@ -17686,6 +18257,8 @@ pub trait IShellUIHelper8_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn LaunchInHVSI(&self, bstrurl: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper8 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper8_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper8_Impl, const OFFSET: isize>() -> IShellUIHelper8_Vtbl {
         unsafe extern "system" fn GetCVListData<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper8_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrresult: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -17767,6 +18340,8 @@ pub trait IShellUIHelper9_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn GetOSSku(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellUIHelper9 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellUIHelper9_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper9_Impl, const OFFSET: isize>() -> IShellUIHelper9_Vtbl {
         unsafe extern "system" fn GetOSSku<Identity: ::windows::core::IUnknownImpl, Impl: IShellUIHelper9_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwresult: *mut u32) -> ::windows::core::HRESULT {
@@ -17800,6 +18375,8 @@ pub trait IShellView_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn SelectItem(&self, pidlitem: *const Common::ITEMIDLIST, uflags: u32) -> ::windows::core::Result<()>;
     fn GetItemObject(&self, uitem: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IShellView {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IShellView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellView_Impl, const OFFSET: isize>() -> IShellView_Vtbl {
@@ -17897,6 +18474,8 @@ pub trait IShellView2_Impl: Sized + super::super::System::Ole::IOleWindow_Impl +
     fn SelectAndPositionItem(&self, pidlitem: *const Common::ITEMIDLIST, uflags: u32, ppt: *const super::super::Foundation::POINT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IShellView2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IShellView2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellView2_Impl, const OFFSET: isize>() -> IShellView2_Vtbl {
         unsafe extern "system" fn GetView<Identity: ::windows::core::IUnknownImpl, Impl: IShellView2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvid: *mut ::windows::core::GUID, uview: u32) -> ::windows::core::HRESULT {
@@ -17936,6 +18515,8 @@ pub trait IShellView3_Impl: Sized + super::super::System::Ole::IOleWindow_Impl +
     fn CreateViewWindow3(&self, psbowner: &::core::option::Option<IShellBrowser>, psvprev: &::core::option::Option<IShellView>, dwviewflags: u32, dwmask: FOLDERFLAGS, dwflags: FOLDERFLAGS, fvmode: FOLDERVIEWMODE, pvid: *const ::windows::core::GUID, prcview: *const super::super::Foundation::RECT) -> ::windows::core::Result<super::super::Foundation::HWND>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for IShellView3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl IShellView3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellView3_Impl, const OFFSET: isize>() -> IShellView3_Vtbl {
         unsafe extern "system" fn CreateViewWindow3<Identity: ::windows::core::IUnknownImpl, Impl: IShellView3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psbowner: ::windows::core::RawPtr, psvprev: ::windows::core::RawPtr, dwviewflags: u32, dwmask: FOLDERFLAGS, dwflags: FOLDERFLAGS, fvmode: FOLDERVIEWMODE, pvid: *const ::windows::core::GUID, prcview: *const super::super::Foundation::RECT, phwndview: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -17969,6 +18550,8 @@ pub trait IShellWindows_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn OnCreated(&self, lcookie: i32, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn ProcessAttachDetach(&self, fattach: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IShellWindows {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IShellWindows_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IShellWindows_Impl, const OFFSET: isize>() -> IShellWindows_Vtbl {
@@ -18083,6 +18666,8 @@ pub trait ISortColumnArray_Impl: Sized {
     fn GetSortType(&self) -> ::windows::core::Result<SORT_ORDER_TYPE>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for ISortColumnArray {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ISortColumnArray_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISortColumnArray_Impl, const OFFSET: isize>() -> ISortColumnArray_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: ISortColumnArray_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, columncount: *mut u32) -> ::windows::core::HRESULT {
@@ -18132,6 +18717,7 @@ impl ISortColumnArray_Vtbl {
 pub trait IStartMenuPinnedList_Impl: Sized {
     fn RemoveFromList(&self, pitem: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IStartMenuPinnedList {}
 impl IStartMenuPinnedList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStartMenuPinnedList_Impl, const OFFSET: isize>() -> IStartMenuPinnedList_Vtbl {
         unsafe extern "system" fn RemoveFromList<Identity: ::windows::core::IUnknownImpl, Impl: IStartMenuPinnedList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pitem: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18151,6 +18737,7 @@ pub trait IStorageProviderBanners_Impl: Sized {
     fn ClearAllBanners(&self, provideridentity: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetBanner(&self, provideridentity: &::windows::core::PCWSTR, subscriptionid: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for IStorageProviderBanners {}
 impl IStorageProviderBanners_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderBanners_Impl, const OFFSET: isize>() -> IStorageProviderBanners_Vtbl {
         unsafe extern "system" fn SetBanner<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderBanners_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, provideridentity: ::windows::core::PCWSTR, subscriptionid: ::windows::core::PCWSTR, contentid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -18196,6 +18783,8 @@ pub trait IStorageProviderCopyHook_Impl: Sized {
     fn CopyCallback(&self, hwnd: super::super::Foundation::HWND, operation: u32, flags: u32, srcfile: &::windows::core::PCWSTR, srcattribs: u32, destfile: &::windows::core::PCWSTR, destattribs: u32) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IStorageProviderCopyHook {}
+#[cfg(feature = "Win32_Foundation")]
 impl IStorageProviderCopyHook_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderCopyHook_Impl, const OFFSET: isize>() -> IStorageProviderCopyHook_Vtbl {
         unsafe extern "system" fn CopyCallback<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderCopyHook_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, operation: u32, flags: u32, srcfile: ::windows::core::PCWSTR, srcattribs: u32, destfile: ::windows::core::PCWSTR, destattribs: u32, result: *mut u32) -> ::windows::core::HRESULT {
@@ -18220,6 +18809,7 @@ pub trait IStorageProviderHandler_Impl: Sized {
     fn GetPropertyHandlerFromUri(&self, uri: &::windows::core::PCWSTR) -> ::windows::core::Result<IStorageProviderPropertyHandler>;
     fn GetPropertyHandlerFromFileId(&self, fileid: &::windows::core::PCWSTR) -> ::windows::core::Result<IStorageProviderPropertyHandler>;
 }
+impl ::windows::core::RuntimeName for IStorageProviderHandler {}
 impl IStorageProviderHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderHandler_Impl, const OFFSET: isize>() -> IStorageProviderHandler_Vtbl {
         unsafe extern "system" fn GetPropertyHandlerFromPath<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, propertyhandler: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18272,6 +18862,8 @@ pub trait IStorageProviderPropertyHandler_Impl: Sized {
     fn SaveProperties(&self, propertiestosave: &::core::option::Option<PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for IStorageProviderPropertyHandler {}
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl IStorageProviderPropertyHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderPropertyHandler_Impl, const OFFSET: isize>() -> IStorageProviderPropertyHandler_Vtbl {
         unsafe extern "system" fn RetrieveProperties<Identity: ::windows::core::IUnknownImpl, Impl: IStorageProviderPropertyHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, propertiestoretrieve: *const PropertiesSystem::PROPERTYKEY, propertiestoretrievecount: u32, retrievedproperties: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18307,6 +18899,8 @@ pub trait IStreamAsync_Impl: Sized + super::super::System::Com::ISequentialStrea
     fn OverlappedResult(&self, lpoverlapped: *const super::super::System::IO::OVERLAPPED, lpnumberofbytestransferred: *mut u32, bwait: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn CancelIo(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_IO"))]
+impl ::windows::core::RuntimeName for IStreamAsync {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_IO"))]
 impl IStreamAsync_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamAsync_Impl, const OFFSET: isize>() -> IStreamAsync_Vtbl {
@@ -18345,6 +18939,7 @@ impl IStreamAsync_Vtbl {
 pub trait IStreamUnbufferedInfo_Impl: Sized {
     fn GetSectorSize(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IStreamUnbufferedInfo {}
 impl IStreamUnbufferedInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStreamUnbufferedInfo_Impl, const OFFSET: isize>() -> IStreamUnbufferedInfo_Vtbl {
         unsafe extern "system" fn GetSectorSize<Identity: ::windows::core::IUnknownImpl, Impl: IStreamUnbufferedInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcbsectorsize: *mut u32) -> ::windows::core::HRESULT {
@@ -18370,6 +18965,8 @@ pub trait ISuspensionDependencyManager_Impl: Sized {
     fn GroupChildWithParent(&self, childprocesshandle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
     fn UngroupChildFromParent(&self, childprocesshandle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISuspensionDependencyManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISuspensionDependencyManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISuspensionDependencyManager_Impl, const OFFSET: isize>() -> ISuspensionDependencyManager_Vtbl {
@@ -18407,6 +19004,8 @@ pub trait ISyncMgrConflict_Impl: Sized {
     fn Resolve(&self, presolveinfo: &::core::option::Option<ISyncMgrConflictResolveInfo>) -> ::windows::core::Result<()>;
     fn GetResolutionHandler(&self, riid: *const ::windows::core::GUID, ppvresolutionhandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
+impl ::windows::core::RuntimeName for ISyncMgrConflict {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 impl ISyncMgrConflict_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflict_Impl, const OFFSET: isize>() -> ISyncMgrConflict_Vtbl {
@@ -18471,6 +19070,8 @@ pub trait ISyncMgrConflictFolder_Impl: Sized {
     fn GetConflictIDList(&self, pconflict: &::core::option::Option<ISyncMgrConflict>) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for ISyncMgrConflictFolder {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl ISyncMgrConflictFolder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictFolder_Impl, const OFFSET: isize>() -> ISyncMgrConflictFolder_Vtbl {
         unsafe extern "system" fn GetConflictIDList<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictFolder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconflict: ::windows::core::RawPtr, ppidlconflict: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -18494,6 +19095,7 @@ pub trait ISyncMgrConflictItems_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetItem(&self, iindex: u32) -> ::windows::core::Result<CONFIRM_CONFLICT_ITEM>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrConflictItems {}
 impl ISyncMgrConflictItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictItems_Impl, const OFFSET: isize>() -> ISyncMgrConflictItems_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT {
@@ -18531,6 +19133,7 @@ impl ISyncMgrConflictItems_Vtbl {
 pub trait ISyncMgrConflictPresenter_Impl: Sized {
     fn PresentConflict(&self, pconflict: &::core::option::Option<ISyncMgrConflict>, presolveinfo: &::core::option::Option<ISyncMgrConflictResolveInfo>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrConflictPresenter {}
 impl ISyncMgrConflictPresenter_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictPresenter_Impl, const OFFSET: isize>() -> ISyncMgrConflictPresenter_Vtbl {
         unsafe extern "system" fn PresentConflict<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictPresenter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconflict: ::windows::core::RawPtr, presolveinfo: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18548,6 +19151,7 @@ pub trait ISyncMgrConflictResolutionItems_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetItem(&self, iindex: u32) -> ::windows::core::Result<CONFIRM_CONFLICT_RESULT_INFO>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrConflictResolutionItems {}
 impl ISyncMgrConflictResolutionItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictResolutionItems_Impl, const OFFSET: isize>() -> ISyncMgrConflictResolutionItems_Vtbl {
         unsafe extern "system" fn GetCount<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictResolutionItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT {
@@ -18593,6 +19197,8 @@ pub trait ISyncMgrConflictResolveInfo_Impl: Sized {
     fn SetPresenterChoice(&self, npresenterchoice: SYNCMGR_PRESENTER_CHOICE, fapplytoall: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SetItemChoices(&self, prgiconflictitemindexes: *mut u32, cchoices: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrConflictResolveInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrConflictResolveInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictResolveInfo_Impl, const OFFSET: isize>() -> ISyncMgrConflictResolveInfo_Vtbl {
@@ -18678,6 +19284,8 @@ pub trait ISyncMgrConflictStore_Impl: Sized {
     fn GetCount(&self, pszhandlerid: &::windows::core::PCWSTR, pszitemid: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISyncMgrConflictStore {}
+#[cfg(feature = "Win32_System_Com")]
 impl ISyncMgrConflictStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictStore_Impl, const OFFSET: isize>() -> ISyncMgrConflictStore_Vtbl {
         unsafe extern "system" fn EnumConflicts<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrConflictStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszhandlerid: ::windows::core::PCWSTR, pszitemid: ::windows::core::PCWSTR, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -18742,6 +19350,8 @@ pub trait ISyncMgrControl_Impl: Sized {
     fn EnableHandler(&self, fenable: super::super::Foundation::BOOL, pszhandlerid: &::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND, ncontrolflags: SYNCMGR_CONTROL_FLAGS) -> ::windows::core::Result<()>;
     fn EnableItem(&self, fenable: super::super::Foundation::BOOL, pszhandlerid: &::windows::core::PCWSTR, pszitemid: &::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND, ncontrolflags: SYNCMGR_CONTROL_FLAGS) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrControl {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrControl_Impl, const OFFSET: isize>() -> ISyncMgrControl_Vtbl {
@@ -18851,6 +19461,8 @@ pub trait ISyncMgrEnumItems_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<ISyncMgrEnumItems>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ISyncMgrEnumItems {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ISyncMgrEnumItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEnumItems_Impl, const OFFSET: isize>() -> ISyncMgrEnumItems_Vtbl {
         unsafe extern "system" fn Next<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEnumItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut SYNCMGRITEM, pceltfetched: *mut u32) -> ::windows::core::HRESULT {
@@ -18905,6 +19517,8 @@ pub trait ISyncMgrEvent_Impl: Sized {
     fn GetLinkReference(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetContext(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrEvent {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrEvent_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEvent_Impl, const OFFSET: isize>() -> ISyncMgrEvent_Vtbl {
@@ -19053,6 +19667,8 @@ pub trait ISyncMgrEventLinkUIOperation_Impl: Sized + ISyncMgrUIOperation_Impl {
     fn Init(&self, rguideventid: *const ::windows::core::GUID, pevent: &::core::option::Option<ISyncMgrEvent>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrEventLinkUIOperation {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrEventLinkUIOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEventLinkUIOperation_Impl, const OFFSET: isize>() -> ISyncMgrEventLinkUIOperation_Vtbl {
         unsafe extern "system" fn Init<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEventLinkUIOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rguideventid: *const ::windows::core::GUID, pevent: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19072,6 +19688,7 @@ pub trait ISyncMgrEventStore_Impl: Sized {
     fn GetEvent(&self, rguideventid: *const ::windows::core::GUID) -> ::windows::core::Result<ISyncMgrEvent>;
     fn RemoveEvent(&self, pguideventids: *const ::windows::core::GUID, cevents: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrEventStore {}
 impl ISyncMgrEventStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEventStore_Impl, const OFFSET: isize>() -> ISyncMgrEventStore_Vtbl {
         unsafe extern "system" fn GetEventEnumerator<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrEventStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19135,6 +19752,8 @@ pub trait ISyncMgrHandler_Impl: Sized {
     fn Enable(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn Synchronize(&self, ppszitemids: *const ::windows::core::PWSTR, citems: u32, hwndowner: super::super::Foundation::HWND, psessioncreator: &::core::option::Option<ISyncMgrSessionCreator>, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrHandler {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrHandler_Impl, const OFFSET: isize>() -> ISyncMgrHandler_Vtbl {
@@ -19224,6 +19843,8 @@ pub trait ISyncMgrHandlerCollection_Impl: Sized {
     fn BindToHandler(&self, pszhandlerid: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISyncMgrHandlerCollection {}
+#[cfg(feature = "Win32_System_Com")]
 impl ISyncMgrHandlerCollection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrHandlerCollection_Impl, const OFFSET: isize>() -> ISyncMgrHandlerCollection_Vtbl {
         unsafe extern "system" fn GetHandlerEnumerator<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrHandlerCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19262,6 +19883,8 @@ pub trait ISyncMgrHandlerInfo_Impl: Sized {
     fn IsEnabled(&self) -> ::windows::core::Result<()>;
     fn IsConnected(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrHandlerInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrHandlerInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrHandlerInfo_Impl, const OFFSET: isize>() -> ISyncMgrHandlerInfo_Vtbl {
@@ -19344,6 +19967,7 @@ pub trait ISyncMgrRegister_Impl: Sized {
     fn UnregisterSyncMgrHandler(&self, clsidhandler: *const ::windows::core::GUID, dwreserved: u32) -> ::windows::core::Result<()>;
     fn GetHandlerRegistrationInfo(&self, clsidhandler: *const ::windows::core::GUID, pdwsyncmgrregisterflags: *mut u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrRegister {}
 impl ISyncMgrRegister_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrRegister_Impl, const OFFSET: isize>() -> ISyncMgrRegister_Vtbl {
         unsafe extern "system" fn RegisterSyncMgrHandler<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrRegister_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsidhandler: *const ::windows::core::GUID, pwszdescription: ::windows::core::PCWSTR, dwsyncmgrregisterflags: u32) -> ::windows::core::HRESULT {
@@ -19379,6 +20003,7 @@ pub trait ISyncMgrResolutionHandler_Impl: Sized {
     fn RemoveFromSyncSet(&self) -> ::windows::core::Result<SYNCMGR_RESOLUTION_FEEDBACK>;
     fn KeepItems(&self, parray: &::core::option::Option<ISyncMgrConflictResolutionItems>) -> ::windows::core::Result<SYNCMGR_RESOLUTION_FEEDBACK>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrResolutionHandler {}
 impl ISyncMgrResolutionHandler_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrResolutionHandler_Impl, const OFFSET: isize>() -> ISyncMgrResolutionHandler_Vtbl {
         unsafe extern "system" fn QueryAbilities<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrResolutionHandler_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdwabilities: *mut u32) -> ::windows::core::HRESULT {
@@ -19454,6 +20079,8 @@ pub trait ISyncMgrScheduleWizardUIOperation_Impl: Sized + ISyncMgrUIOperation_Im
     fn InitWizard(&self, pszhandlerid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrScheduleWizardUIOperation {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrScheduleWizardUIOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrScheduleWizardUIOperation_Impl, const OFFSET: isize>() -> ISyncMgrScheduleWizardUIOperation_Vtbl {
         unsafe extern "system" fn InitWizard<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrScheduleWizardUIOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszhandlerid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -19470,6 +20097,7 @@ impl ISyncMgrScheduleWizardUIOperation_Vtbl {
 pub trait ISyncMgrSessionCreator_Impl: Sized {
     fn CreateSession(&self, pszhandlerid: &::windows::core::PCWSTR, ppszitemids: *const ::windows::core::PWSTR, citems: u32) -> ::windows::core::Result<ISyncMgrSyncCallback>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrSessionCreator {}
 impl ISyncMgrSessionCreator_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSessionCreator_Impl, const OFFSET: isize>() -> ISyncMgrSessionCreator_Vtbl {
         unsafe extern "system" fn CreateSession<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSessionCreator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszhandlerid: ::windows::core::PCWSTR, ppszitemids: *const ::windows::core::PWSTR, citems: u32, ppcallback: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19502,6 +20130,8 @@ pub trait ISyncMgrSyncCallback_Impl: Sized {
     fn CommitItem(&self, pszitemid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ReportManualSync(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ISyncMgrSyncCallback {}
 #[cfg(feature = "Win32_System_Com")]
 impl ISyncMgrSyncCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncCallback_Impl, const OFFSET: isize>() -> ISyncMgrSyncCallback_Vtbl {
@@ -19590,6 +20220,8 @@ pub trait ISyncMgrSyncItem_Impl: Sized {
     fn Enable(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn Delete(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrSyncItem {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrSyncItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncItem_Impl, const OFFSET: isize>() -> ISyncMgrSyncItem_Vtbl {
@@ -19684,6 +20316,7 @@ pub trait ISyncMgrSyncItemContainer_Impl: Sized {
     fn GetSyncItemEnumerator(&self) -> ::windows::core::Result<IEnumSyncMgrSyncItems>;
     fn GetSyncItemCount(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrSyncItemContainer {}
 impl ISyncMgrSyncItemContainer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncItemContainer_Impl, const OFFSET: isize>() -> ISyncMgrSyncItemContainer_Vtbl {
         unsafe extern "system" fn GetSyncItem<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncItemContainer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszitemid: ::windows::core::PCWSTR, ppitem: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -19738,6 +20371,8 @@ pub trait ISyncMgrSyncItemInfo_Impl: Sized {
     fn IsEnabled(&self) -> ::windows::core::Result<()>;
     fn IsConnected(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrSyncItemInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrSyncItemInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncItemInfo_Impl, const OFFSET: isize>() -> ISyncMgrSyncItemInfo_Vtbl {
@@ -19800,6 +20435,7 @@ impl ISyncMgrSyncItemInfo_Vtbl {
 pub trait ISyncMgrSyncResult_Impl: Sized {
     fn Result(&self, nstatus: SYNCMGR_PROGRESS_STATUS, cerror: u32, cconflicts: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrSyncResult {}
 impl ISyncMgrSyncResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncResult_Impl, const OFFSET: isize>() -> ISyncMgrSyncResult_Vtbl {
         unsafe extern "system" fn Result<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSyncResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nstatus: SYNCMGR_PROGRESS_STATUS, cerror: u32, cconflicts: u32) -> ::windows::core::HRESULT {
@@ -19826,6 +20462,8 @@ pub trait ISyncMgrSynchronize_Impl: Sized {
     fn SetItemStatus(&self, pitemid: *const ::windows::core::GUID, dwsyncmgrstatus: u32) -> ::windows::core::Result<()>;
     fn ShowError(&self, hwndparent: super::super::Foundation::HWND, errorid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ISyncMgrSynchronize {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ISyncMgrSynchronize_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSynchronize_Impl, const OFFSET: isize>() -> ISyncMgrSynchronize_Vtbl {
@@ -19922,6 +20560,8 @@ pub trait ISyncMgrSynchronizeCallback_Impl: Sized {
     fn EstablishConnection(&self, pwszconnection: &::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrSynchronizeCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrSynchronizeCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSynchronizeCallback_Impl, const OFFSET: isize>() -> ISyncMgrSynchronizeCallback_Vtbl {
         unsafe extern "system" fn ShowPropertiesCompleted<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSynchronizeCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT {
@@ -19990,6 +20630,7 @@ pub trait ISyncMgrSynchronizeInvoke_Impl: Sized {
     fn UpdateItems(&self, dwinvokeflags: u32, clsid: *const ::windows::core::GUID, cbcookie: u32, pcookie: *const u8) -> ::windows::core::Result<()>;
     fn UpdateAll(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISyncMgrSynchronizeInvoke {}
 impl ISyncMgrSynchronizeInvoke_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSynchronizeInvoke_Impl, const OFFSET: isize>() -> ISyncMgrSynchronizeInvoke_Vtbl {
         unsafe extern "system" fn UpdateItems<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrSynchronizeInvoke_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwinvokeflags: u32, clsid: *const ::windows::core::GUID, cbcookie: u32, pcookie: *const u8) -> ::windows::core::HRESULT {
@@ -20017,6 +20658,8 @@ pub trait ISyncMgrUIOperation_Impl: Sized {
     fn Run(&self, hwndowner: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ISyncMgrUIOperation {}
+#[cfg(feature = "Win32_Foundation")]
 impl ISyncMgrUIOperation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrUIOperation_Impl, const OFFSET: isize>() -> ISyncMgrUIOperation_Vtbl {
         unsafe extern "system" fn Run<Identity: ::windows::core::IUnknownImpl, Impl: ISyncMgrUIOperation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -20038,6 +20681,8 @@ pub trait ITaskbarList_Impl: Sized {
     fn ActivateTab(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
     fn SetActiveAlt(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITaskbarList {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITaskbarList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskbarList_Impl, const OFFSET: isize>() -> ITaskbarList_Vtbl {
@@ -20084,6 +20729,8 @@ pub trait ITaskbarList2_Impl: Sized + ITaskbarList_Impl {
     fn MarkFullscreenWindow(&self, hwnd: super::super::Foundation::HWND, ffullscreen: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITaskbarList2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITaskbarList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskbarList2_Impl, const OFFSET: isize>() -> ITaskbarList2_Vtbl {
         unsafe extern "system" fn MarkFullscreenWindow<Identity: ::windows::core::IUnknownImpl, Impl: ITaskbarList2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, ffullscreen: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -20112,6 +20759,8 @@ pub trait ITaskbarList3_Impl: Sized + ITaskbarList_Impl + ITaskbarList2_Impl {
     fn SetThumbnailTooltip(&self, hwnd: super::super::Foundation::HWND, psztip: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetThumbnailClip(&self, hwnd: super::super::Foundation::HWND, prcclip: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITaskbarList3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITaskbarList3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskbarList3_Impl, const OFFSET: isize>() -> ITaskbarList3_Vtbl {
@@ -20200,6 +20849,8 @@ pub trait ITaskbarList4_Impl: Sized + ITaskbarList_Impl + ITaskbarList2_Impl + I
     fn SetTabProperties(&self, hwndtab: super::super::Foundation::HWND, stpflags: STPFLAG) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITaskbarList4 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITaskbarList4_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITaskbarList4_Impl, const OFFSET: isize>() -> ITaskbarList4_Vtbl {
         unsafe extern "system" fn SetTabProperties<Identity: ::windows::core::IUnknownImpl, Impl: ITaskbarList4_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndtab: super::super::Foundation::HWND, stpflags: STPFLAG) -> ::windows::core::HRESULT {
@@ -20217,6 +20868,7 @@ pub trait IThumbnailCache_Impl: Sized {
     fn GetThumbnail(&self, pshellitem: &::core::option::Option<IShellItem>, cxyrequestedthumbsize: u32, flags: WTS_FLAGS, ppvthumb: *mut ::core::option::Option<ISharedBitmap>, poutflags: *mut WTS_CACHEFLAGS, pthumbnailid: *mut WTS_THUMBNAILID) -> ::windows::core::Result<()>;
     fn GetThumbnailByID(&self, thumbnailid: &WTS_THUMBNAILID, cxyrequestedthumbsize: u32, ppvthumb: *mut ::core::option::Option<ISharedBitmap>, poutflags: *mut WTS_CACHEFLAGS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IThumbnailCache {}
 impl IThumbnailCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailCache_Impl, const OFFSET: isize>() -> IThumbnailCache_Vtbl {
         unsafe extern "system" fn GetThumbnail<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailCache_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshellitem: ::windows::core::RawPtr, cxyrequestedthumbsize: u32, flags: WTS_FLAGS, ppvthumb: *mut ::windows::core::RawPtr, poutflags: *mut WTS_CACHEFLAGS, pthumbnailid: *mut WTS_THUMBNAILID) -> ::windows::core::HRESULT {
@@ -20242,6 +20894,7 @@ impl IThumbnailCache_Vtbl {
 pub trait IThumbnailCachePrimer_Impl: Sized {
     fn PageInThumbnail(&self, psi: &::core::option::Option<IShellItem>, wtsflags: WTS_FLAGS, cxyrequestedthumbsize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IThumbnailCachePrimer {}
 impl IThumbnailCachePrimer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailCachePrimer_Impl, const OFFSET: isize>() -> IThumbnailCachePrimer_Vtbl {
         unsafe extern "system" fn PageInThumbnail<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailCachePrimer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psi: ::windows::core::RawPtr, wtsflags: WTS_FLAGS, cxyrequestedthumbsize: u32) -> ::windows::core::HRESULT {
@@ -20259,6 +20912,8 @@ impl IThumbnailCachePrimer_Vtbl {
 pub trait IThumbnailCapture_Impl: Sized {
     fn CaptureThumbnail(&self, pmaxsize: *const super::super::Foundation::SIZE, phtmldoc2: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IThumbnailCapture {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IThumbnailCapture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailCapture_Impl, const OFFSET: isize>() -> IThumbnailCapture_Vtbl {
@@ -20284,6 +20939,8 @@ pub trait IThumbnailHandlerFactory_Impl: Sized {
     fn GetThumbnailHandler(&self, pidlchild: *const Common::ITEMIDLIST, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IThumbnailHandlerFactory {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IThumbnailHandlerFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailHandlerFactory_Impl, const OFFSET: isize>() -> IThumbnailHandlerFactory_Vtbl {
         unsafe extern "system" fn GetThumbnailHandler<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailHandlerFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidlchild: *const Common::ITEMIDLIST, pbc: ::windows::core::RawPtr, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -20302,6 +20959,8 @@ pub trait IThumbnailProvider_Impl: Sized {
     fn GetThumbnail(&self, cx: u32, phbmp: *mut super::super::Graphics::Gdi::HBITMAP, pdwalpha: *mut WTS_ALPHATYPE) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for IThumbnailProvider {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl IThumbnailProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailProvider_Impl, const OFFSET: isize>() -> IThumbnailProvider_Vtbl {
         unsafe extern "system" fn GetThumbnail<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cx: u32, phbmp: *mut super::super::Graphics::Gdi::HBITMAP, pdwalpha: *mut WTS_ALPHATYPE) -> ::windows::core::HRESULT {
@@ -20318,6 +20977,7 @@ impl IThumbnailProvider_Vtbl {
 pub trait IThumbnailSettings_Impl: Sized {
     fn SetContext(&self, dwcontext: WTS_CONTEXTFLAGS) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IThumbnailSettings {}
 impl IThumbnailSettings_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailSettings_Impl, const OFFSET: isize>() -> IThumbnailSettings_Vtbl {
         unsafe extern "system" fn SetContext<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailSettings_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwcontext: WTS_CONTEXTFLAGS) -> ::windows::core::HRESULT {
@@ -20336,6 +20996,8 @@ pub trait IThumbnailStreamCache_Impl: Sized {
     fn GetThumbnailStream(&self, path: &::windows::core::PCWSTR, cacheid: u64, options: ThumbnailStreamCacheOptions, requestedthumbnailsize: u32, thumbnailsize: *mut super::super::Foundation::SIZE, thumbnailstream: *mut ::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
     fn SetThumbnailStream(&self, path: &::windows::core::PCWSTR, cacheid: u64, thumbnailsize: &super::super::Foundation::SIZE, thumbnailstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IThumbnailStreamCache {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IThumbnailStreamCache_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IThumbnailStreamCache_Impl, const OFFSET: isize>() -> IThumbnailStreamCache_Vtbl {
@@ -20365,6 +21027,8 @@ pub trait ITrackShellMenu_Impl: Sized + IShellMenu_Impl {
     fn Popup(&self, hwnd: super::super::Foundation::HWND, ppt: *mut super::super::Foundation::POINTL, prcexclude: *mut super::super::Foundation::RECTL, dwflags: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITrackShellMenu {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITrackShellMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITrackShellMenu_Impl, const OFFSET: isize>() -> ITrackShellMenu_Vtbl {
         unsafe extern "system" fn SetObscured<Identity: ::windows::core::IUnknownImpl, Impl: ITrackShellMenu_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndtb: super::super::Foundation::HWND, punkband: *mut ::core::ffi::c_void, dwsmsetflags: u32) -> ::windows::core::HRESULT {
@@ -20392,6 +21056,8 @@ pub trait ITranscodeImage_Impl: Sized {
     fn TranscodeImage(&self, pshellitem: &::core::option::Option<IShellItem>, uimaxwidth: u32, uimaxheight: u32, flags: u32, pvimage: &::core::option::Option<super::super::System::Com::IStream>, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITranscodeImage {}
+#[cfg(feature = "Win32_System_Com")]
 impl ITranscodeImage_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITranscodeImage_Impl, const OFFSET: isize>() -> ITranscodeImage_Vtbl {
         unsafe extern "system" fn TranscodeImage<Identity: ::windows::core::IUnknownImpl, Impl: ITranscodeImage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pshellitem: ::windows::core::RawPtr, uimaxwidth: u32, uimaxheight: u32, flags: u32, pvimage: ::windows::core::RawPtr, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT {
@@ -20415,6 +21081,8 @@ pub trait ITransferAdviseSink_Impl: Sized {
     fn SubStreamFailure(&self, psi: &::core::option::Option<IShellItem>, pszstreamname: &::windows::core::PCWSTR, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn PropertyFailure(&self, psi: &::core::option::Option<IShellItem>, pkey: *const PropertiesSystem::PROPERTYKEY, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for ITransferAdviseSink {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ITransferAdviseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransferAdviseSink_Impl, const OFFSET: isize>() -> ITransferAdviseSink_Vtbl {
@@ -20473,6 +21141,7 @@ pub trait ITransferDestination_Impl: Sized {
     fn Unadvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
     fn CreateItem(&self, pszname: &::windows::core::PCWSTR, dwattributes: u32, ullsize: u64, flags: u32, riiditem: *const ::windows::core::GUID, ppvitem: *mut *mut ::core::ffi::c_void, riidresources: *const ::windows::core::GUID, ppvresources: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITransferDestination {}
 impl ITransferDestination_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransferDestination_Impl, const OFFSET: isize>() -> ITransferDestination_Vtbl {
         unsafe extern "system" fn Advise<Identity: ::windows::core::IUnknownImpl, Impl: ITransferDestination_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psink: ::windows::core::RawPtr, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -20510,6 +21179,8 @@ impl ITransferDestination_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ITransferMediumItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for ITransferMediumItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl ITransferMediumItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransferMediumItem_Impl, const OFFSET: isize>() -> ITransferMediumItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -20534,6 +21205,8 @@ pub trait ITransferSource_Impl: Sized {
     fn EnterFolder(&self, psichildfolderdest: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn LeaveFolder(&self, psichildfolderdest: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
+impl ::windows::core::RuntimeName for ITransferSource {}
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 impl ITransferSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITransferSource_Impl, const OFFSET: isize>() -> ITransferSource_Vtbl {
@@ -20672,6 +21345,8 @@ pub trait ITravelEntry_Impl: Sized {
     fn GetPidl(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for ITravelEntry {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 impl ITravelEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITravelEntry_Impl, const OFFSET: isize>() -> ITravelEntry_Vtbl {
         unsafe extern "system" fn Invoke<Identity: ::windows::core::IUnknownImpl, Impl: ITravelEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -20720,6 +21395,8 @@ pub trait ITravelLog_Impl: Sized {
     fn CountEntries(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> u32;
     fn Revert(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITravelLog {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITravelLog_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITravelLog_Impl, const OFFSET: isize>() -> ITravelLog_Vtbl {
@@ -20822,6 +21499,8 @@ pub trait ITravelLogClient_Impl: Sized {
     fn LoadHistoryPosition(&self, pszurllocation: &::windows::core::PCWSTR, dwposition: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for ITravelLogClient {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl ITravelLogClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITravelLogClient_Impl, const OFFSET: isize>() -> ITravelLogClient_Vtbl {
         unsafe extern "system" fn FindWindowByIndex<Identity: ::windows::core::IUnknownImpl, Impl: ITravelLogClient_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwid: u32, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -20866,6 +21545,7 @@ pub trait ITravelLogEntry_Impl: Sized {
     fn GetTitle(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetURL(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
+impl ::windows::core::RuntimeName for ITravelLogEntry {}
 impl ITravelLogEntry_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITravelLogEntry_Impl, const OFFSET: isize>() -> ITravelLogEntry_Vtbl {
         unsafe extern "system" fn GetTitle<Identity: ::windows::core::IUnknownImpl, Impl: ITravelLogEntry_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppsztitle: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT {
@@ -20910,6 +21590,8 @@ pub trait ITravelLogStg_Impl: Sized {
     fn RemoveEntry(&self, ptle: &::core::option::Option<ITravelLogEntry>) -> ::windows::core::Result<()>;
     fn GetRelativeEntry(&self, ioffset: i32) -> ::windows::core::Result<ITravelLogEntry>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITravelLogStg {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITravelLogStg_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITravelLogStg_Impl, const OFFSET: isize>() -> ITravelLogStg_Vtbl {
@@ -20999,6 +21681,7 @@ pub trait ITrayDeskBand_Impl: Sized {
     fn IsDeskBandShown(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn DeskBandRegistrationChanged(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITrayDeskBand {}
 impl ITrayDeskBand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITrayDeskBand_Impl, const OFFSET: isize>() -> ITrayDeskBand_Vtbl {
         unsafe extern "system" fn ShowDeskBand<Identity: ::windows::core::IUnknownImpl, Impl: ITrayDeskBand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -21036,6 +21719,7 @@ impl ITrayDeskBand_Vtbl {
 pub trait IURLSearchHook_Impl: Sized {
     fn Translate(&self, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IURLSearchHook {}
 impl IURLSearchHook_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IURLSearchHook_Impl, const OFFSET: isize>() -> IURLSearchHook_Vtbl {
         unsafe extern "system" fn Translate<Identity: ::windows::core::IUnknownImpl, Impl: IURLSearchHook_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32) -> ::windows::core::HRESULT {
@@ -21052,6 +21736,7 @@ impl IURLSearchHook_Vtbl {
 pub trait IURLSearchHook2_Impl: Sized + IURLSearchHook_Impl {
     fn TranslateWithSearchContext(&self, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32, psearchcontext: &::core::option::Option<ISearchContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IURLSearchHook2 {}
 impl IURLSearchHook2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IURLSearchHook2_Impl, const OFFSET: isize>() -> IURLSearchHook2_Vtbl {
         unsafe extern "system" fn TranslateWithSearchContext<Identity: ::windows::core::IUnknownImpl, Impl: IURLSearchHook2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32, psearchcontext: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -21071,6 +21756,8 @@ pub trait IUniformResourceLocatorA_Impl: Sized {
     fn GetURL(&self) -> ::windows::core::Result<::windows::core::PSTR>;
     fn InvokeCommand(&self, purlici: *mut urlinvokecommandinfoA) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUniformResourceLocatorA {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUniformResourceLocatorA_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUniformResourceLocatorA_Impl, const OFFSET: isize>() -> IUniformResourceLocatorA_Vtbl {
@@ -21113,6 +21800,8 @@ pub trait IUniformResourceLocatorW_Impl: Sized {
     fn InvokeCommand(&self, purlici: *mut urlinvokecommandinfoW) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUniformResourceLocatorW {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUniformResourceLocatorW_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUniformResourceLocatorW_Impl, const OFFSET: isize>() -> IUniformResourceLocatorW_Vtbl {
         unsafe extern "system" fn SetURL<Identity: ::windows::core::IUnknownImpl, Impl: IUniformResourceLocatorW_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcszurl: ::windows::core::PCWSTR, dwinflags: u32) -> ::windows::core::HRESULT {
@@ -21152,6 +21841,8 @@ pub trait IUpdateIDList_Impl: Sized {
     fn Update(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, pidlin: *const Common::ITEMIDLIST) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
+impl ::windows::core::RuntimeName for IUpdateIDList {}
+#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 impl IUpdateIDList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateIDList_Impl, const OFFSET: isize>() -> IUpdateIDList_Vtbl {
         unsafe extern "system" fn Update<Identity: ::windows::core::IUnknownImpl, Impl: IUpdateIDList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbc: ::windows::core::RawPtr, pidlin: *const Common::ITEMIDLIST, ppidlout: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT {
@@ -21174,6 +21865,8 @@ impl IUpdateIDList_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IUseToBrowseItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IUseToBrowseItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IUseToBrowseItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUseToBrowseItem_Impl, const OFFSET: isize>() -> IUseToBrowseItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -21185,6 +21878,7 @@ impl IUseToBrowseItem_Vtbl {
 pub trait IUserAccountChangeCallback_Impl: Sized {
     fn OnPictureChange(&self, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IUserAccountChangeCallback {}
 impl IUserAccountChangeCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserAccountChangeCallback_Impl, const OFFSET: isize>() -> IUserAccountChangeCallback_Vtbl {
         unsafe extern "system" fn OnPictureChange<Identity: ::windows::core::IUnknownImpl, Impl: IUserAccountChangeCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszusername: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -21206,6 +21900,8 @@ pub trait IUserNotification_Impl: Sized {
     fn Show(&self, pqc: &::core::option::Option<IQueryContinue>, dwcontinuepollinterval: u32) -> ::windows::core::Result<()>;
     fn PlaySound(&self, pszsoundname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
+impl ::windows::core::RuntimeName for IUserNotification {}
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl IUserNotification_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserNotification_Impl, const OFFSET: isize>() -> IUserNotification_Vtbl {
@@ -21256,6 +21952,8 @@ pub trait IUserNotification2_Impl: Sized {
     fn PlaySound(&self, pszsoundname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
+impl ::windows::core::RuntimeName for IUserNotification2 {}
+#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl IUserNotification2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserNotification2_Impl, const OFFSET: isize>() -> IUserNotification2_Vtbl {
         unsafe extern "system" fn SetBalloonInfo<Identity: ::windows::core::IUnknownImpl, Impl: IUserNotification2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psztitle: ::windows::core::PCWSTR, psztext: ::windows::core::PCWSTR, dwinfoflags: u32) -> ::windows::core::HRESULT {
@@ -21303,6 +22001,8 @@ pub trait IUserNotificationCallback_Impl: Sized {
     fn OnContextMenu(&self, pt: *const super::super::Foundation::POINT) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUserNotificationCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IUserNotificationCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUserNotificationCallback_Impl, const OFFSET: isize>() -> IUserNotificationCallback_Vtbl {
         unsafe extern "system" fn OnBalloonUserClick<Identity: ::windows::core::IUnknownImpl, Impl: IUserNotificationCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pt: *const super::super::Foundation::POINT) -> ::windows::core::HRESULT {
@@ -21334,6 +22034,8 @@ impl IUserNotificationCallback_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IViewStateIdentityItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
+impl ::windows::core::RuntimeName for IViewStateIdentityItem {}
+#[cfg(feature = "Win32_UI_Shell_Common")]
 impl IViewStateIdentityItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IViewStateIdentityItem_Impl, const OFFSET: isize>() -> IViewStateIdentityItem_Vtbl {
         Self { base__: IRelatedItem_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -21348,6 +22050,8 @@ pub trait IVirtualDesktopManager_Impl: Sized {
     fn GetWindowDesktopId(&self, toplevelwindow: super::super::Foundation::HWND) -> ::windows::core::Result<::windows::core::GUID>;
     fn MoveWindowToDesktop(&self, toplevelwindow: super::super::Foundation::HWND, desktopid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVirtualDesktopManager {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVirtualDesktopManager_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVirtualDesktopManager_Impl, const OFFSET: isize>() -> IVirtualDesktopManager_Vtbl {
@@ -21400,6 +22104,8 @@ pub trait IVisualProperties_Impl: Sized {
     fn GetFont(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::LOGFONTW>;
     fn SetTheme(&self, pszsubappname: &::windows::core::PCWSTR, pszsubidlist: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for IVisualProperties {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl IVisualProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualProperties_Impl, const OFFSET: isize>() -> IVisualProperties_Vtbl {
@@ -21505,6 +22211,8 @@ pub trait IWebBrowser_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LocationURL(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn Busy(&self) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWebBrowser {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWebBrowser_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebBrowser_Impl, const OFFSET: isize>() -> IWebBrowser_Vtbl {
@@ -21767,6 +22475,8 @@ pub trait IWebBrowser2_Impl: Sized + super::super::System::Com::IDispatch_Impl +
     fn SetResizable(&self, value: i16) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWebBrowser2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWebBrowser2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebBrowser2_Impl, const OFFSET: isize>() -> IWebBrowser2_Vtbl {
         unsafe extern "system" fn Navigate2<Identity: ::windows::core::IUnknownImpl, Impl: IWebBrowser2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, url: *const super::super::System::Com::VARIANT, flags: *const super::super::System::Com::VARIANT, targetframename: *const super::super::System::Com::VARIANT, postdata: *const super::super::System::Com::VARIANT, headers: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -21968,6 +22678,8 @@ pub trait IWebBrowserApp_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn FullScreen(&self) -> ::windows::core::Result<i16>;
     fn SetFullScreen(&self, bfullscreen: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWebBrowserApp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWebBrowserApp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebBrowserApp_Impl, const OFFSET: isize>() -> IWebBrowserApp_Vtbl {
@@ -22171,6 +22883,8 @@ pub trait IWebWizardExtension_Impl: Sized + IWizardExtension_Impl {
     fn SetErrorURL(&self, pszerrorurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_Controls")]
+impl ::windows::core::RuntimeName for IWebWizardExtension {}
+#[cfg(feature = "Win32_UI_Controls")]
 impl IWebWizardExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebWizardExtension_Impl, const OFFSET: isize>() -> IWebWizardExtension_Vtbl {
         unsafe extern "system" fn SetInitialURL<Identity: ::windows::core::IUnknownImpl, Impl: IWebWizardExtension_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
@@ -22205,6 +22919,8 @@ pub trait IWebWizardHost_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn SetWizardButtons(&self, vfenableback: i16, vfenablenext: i16, vflastpage: i16) -> ::windows::core::Result<()>;
     fn SetHeaderText(&self, bstrheadertitle: &super::super::Foundation::BSTR, bstrheadersubtitle: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWebWizardHost {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWebWizardHost_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebWizardHost_Impl, const OFFSET: isize>() -> IWebWizardHost_Vtbl {
@@ -22287,6 +23003,8 @@ pub trait IWebWizardHost2_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn SignString(&self, value: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IWebWizardHost2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IWebWizardHost2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWebWizardHost2_Impl, const OFFSET: isize>() -> IWebWizardHost2_Vtbl {
         unsafe extern "system" fn SignString<Identity: ::windows::core::IUnknownImpl, Impl: IWebWizardHost2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, signedvalue: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -22312,6 +23030,8 @@ pub trait IWizardExtension_Impl: Sized {
     fn GetFirstPage(&self) -> ::windows::core::Result<super::Controls::HPROPSHEETPAGE>;
     fn GetLastPage(&self) -> ::windows::core::Result<super::Controls::HPROPSHEETPAGE>;
 }
+#[cfg(feature = "Win32_UI_Controls")]
+impl ::windows::core::RuntimeName for IWizardExtension {}
 #[cfg(feature = "Win32_UI_Controls")]
 impl IWizardExtension_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWizardExtension_Impl, const OFFSET: isize>() -> IWizardExtension_Vtbl {
@@ -22359,6 +23079,8 @@ pub trait IWizardSite_Impl: Sized {
     fn GetNextPage(&self) -> ::windows::core::Result<super::Controls::HPROPSHEETPAGE>;
     fn GetCancelledPage(&self) -> ::windows::core::Result<super::Controls::HPROPSHEETPAGE>;
 }
+#[cfg(feature = "Win32_UI_Controls")]
+impl ::windows::core::RuntimeName for IWizardSite {}
 #[cfg(feature = "Win32_UI_Controls")]
 impl IWizardSite_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IWizardSite_Impl, const OFFSET: isize>() -> IWizardSite_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
@@ -17,6 +17,8 @@ pub trait IDynamicRenderer_Impl: Sized {
     fn Draw(&self, hdc: super::super::Foundation::HANDLE_PTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IDynamicRenderer {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IDynamicRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicRenderer_Impl, const OFFSET: isize>() -> IDynamicRenderer_Vtbl {
         unsafe extern "system" fn Enabled<Identity: ::windows::core::IUnknownImpl, Impl: IDynamicRenderer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, benabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -163,6 +165,8 @@ pub trait IGestureRecognizer_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IGestureRecognizer {}
+#[cfg(feature = "Win32_Foundation")]
 impl IGestureRecognizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IGestureRecognizer_Impl, const OFFSET: isize>() -> IGestureRecognizer_Vtbl {
         unsafe extern "system" fn Enabled<Identity: ::windows::core::IUnknownImpl, Impl: IGestureRecognizer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -227,6 +231,8 @@ pub trait IHandwrittenTextInsertion_Impl: Sized {
     fn InsertInkRecognitionResult(&self, piinkrecoresult: &::core::option::Option<IInkRecognitionResult>, locale: u32, falternatecontainsautospacinginformation: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IHandwrittenTextInsertion {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IHandwrittenTextInsertion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IHandwrittenTextInsertion_Impl, const OFFSET: isize>() -> IHandwrittenTextInsertion_Vtbl {
         unsafe extern "system" fn InsertRecognitionResultsArray<Identity: ::windows::core::IUnknownImpl, Impl: IHandwrittenTextInsertion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psaalternates: *const super::super::System::Com::SAFEARRAY, locale: u32, falternatecontainsautospacinginformation: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -251,6 +257,8 @@ impl IHandwrittenTextInsertion_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInk_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInk {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInk_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInk_Impl, const OFFSET: isize>() -> IInk_Vtbl {
@@ -303,6 +311,8 @@ pub trait IInkCollector_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn GetEventInterest(&self, eventid: InkCollectorEventInterest) -> ::windows::core::Result<i16>;
     fn SetEventInterest(&self, eventid: InkCollectorEventInterest, listen: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkCollector {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkCollector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCollector_Impl, const OFFSET: isize>() -> IInkCollector_Vtbl {
@@ -679,6 +689,8 @@ pub trait IInkCursor_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Buttons(&self) -> ::windows::core::Result<IInkCursorButtons>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkCursor {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkCursor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursor_Impl, const OFFSET: isize>() -> IInkCursor_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -774,6 +786,8 @@ pub trait IInkCursorButton_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn State(&self) -> ::windows::core::Result<InkCursorButtonState>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkCursorButton {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkCursorButton_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursorButton_Impl, const OFFSET: isize>() -> IInkCursorButton_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursorButton_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -827,6 +841,8 @@ pub trait IInkCursorButtons_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Item(&self, identifier: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IInkCursorButton>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkCursorButtons {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkCursorButtons_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursorButtons_Impl, const OFFSET: isize>() -> IInkCursorButtons_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursorButtons_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -879,6 +895,8 @@ pub trait IInkCursors_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Item(&self, index: i32) -> ::windows::core::Result<IInkCursor>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkCursors {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkCursors_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCursors_Impl, const OFFSET: isize>() -> IInkCursors_Vtbl {
@@ -935,6 +953,8 @@ pub trait IInkCustomStrokes_Impl: Sized + super::super::System::Com::IDispatch_I
     fn Remove(&self, identifier: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Clear(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkCustomStrokes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkCustomStrokes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkCustomStrokes_Impl, const OFFSET: isize>() -> IInkCustomStrokes_Vtbl {
@@ -1028,6 +1048,8 @@ pub trait IInkDisp_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CanPaste(&self, dataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<i16>;
     fn ClipboardPaste(&self, x: i32, y: i32, dataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<IInkStrokes>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkDisp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkDisp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDisp_Impl, const OFFSET: isize>() -> IInkDisp_Vtbl {
@@ -1302,6 +1324,8 @@ pub trait IInkDivider_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Divide(&self) -> ::windows::core::Result<IInkDivisionResult>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkDivider {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkDivider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDivider_Impl, const OFFSET: isize>() -> IInkDivider_Vtbl {
         unsafe extern "system" fn Strokes<Identity: ::windows::core::IUnknownImpl, Impl: IInkDivider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strokes: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1384,6 +1408,8 @@ pub trait IInkDivisionResult_Impl: Sized + super::super::System::Com::IDispatch_
     fn ResultByType(&self, divisiontype: InkDivisionType) -> ::windows::core::Result<IInkDivisionUnits>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkDivisionResult {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkDivisionResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDivisionResult_Impl, const OFFSET: isize>() -> IInkDivisionResult_Vtbl {
         unsafe extern "system" fn Strokes<Identity: ::windows::core::IUnknownImpl, Impl: IInkDivisionResult_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strokes: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1425,6 +1451,8 @@ pub trait IInkDivisionUnit_Impl: Sized + super::super::System::Com::IDispatch_Im
     fn RecognizedString(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn RotationTransform(&self) -> ::windows::core::Result<IInkTransform>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkDivisionUnit {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkDivisionUnit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDivisionUnit_Impl, const OFFSET: isize>() -> IInkDivisionUnit_Vtbl {
@@ -1490,6 +1518,8 @@ pub trait IInkDivisionUnits_Impl: Sized + super::super::System::Com::IDispatch_I
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Item(&self, index: i32) -> ::windows::core::Result<IInkDivisionUnit>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkDivisionUnits {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkDivisionUnits_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDivisionUnits_Impl, const OFFSET: isize>() -> IInkDivisionUnits_Vtbl {
@@ -1560,6 +1590,8 @@ pub trait IInkDrawingAttributes_Impl: Sized + super::super::System::Com::IDispat
     fn ExtendedProperties(&self) -> ::windows::core::Result<IInkExtendedProperties>;
     fn Clone(&self) -> ::windows::core::Result<IInkDrawingAttributes>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkDrawingAttributes {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkDrawingAttributes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkDrawingAttributes_Impl, const OFFSET: isize>() -> IInkDrawingAttributes_Vtbl {
@@ -1837,6 +1869,8 @@ pub trait IInkEdit_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetSelRTF(&self, pbstrselrtf: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn Refresh(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkEdit {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkEdit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkEdit_Impl, const OFFSET: isize>() -> IInkEdit_Vtbl {
@@ -2549,6 +2583,8 @@ pub trait IInkExtendedProperties_Impl: Sized + super::super::System::Com::IDispa
     fn DoesPropertyExist(&self, guid: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkExtendedProperties {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkExtendedProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkExtendedProperties_Impl, const OFFSET: isize>() -> IInkExtendedProperties_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IInkExtendedProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -2638,6 +2674,8 @@ pub trait IInkExtendedProperty_Impl: Sized + super::super::System::Com::IDispatc
     fn SetData(&self, data: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkExtendedProperty {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkExtendedProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkExtendedProperty_Impl, const OFFSET: isize>() -> IInkExtendedProperty_Vtbl {
         unsafe extern "system" fn Guid<Identity: ::windows::core::IUnknownImpl, Impl: IInkExtendedProperty_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -2684,6 +2722,8 @@ pub trait IInkGesture_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<InkApplicationGesture>;
     fn GetHotPoint(&self, x: *mut i32, y: *mut i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkGesture {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkGesture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkGesture_Impl, const OFFSET: isize>() -> IInkGesture_Vtbl {
@@ -2733,6 +2773,7 @@ pub trait IInkLineInfo_Impl: Sized {
     fn SetCandidate(&self, ncandidatenum: u32, strrecogword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Recognize(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInkLineInfo {}
 impl IInkLineInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkLineInfo_Impl, const OFFSET: isize>() -> IInkLineInfo_Vtbl {
         unsafe extern "system" fn SetFormat<Identity: ::windows::core::IUnknownImpl, Impl: IInkLineInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pim: *const INKMETRIC) -> ::windows::core::HRESULT {
@@ -2836,6 +2877,8 @@ pub trait IInkOverlay_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetEventInterest(&self, eventid: InkCollectorEventInterest) -> ::windows::core::Result<i16>;
     fn SetEventInterest(&self, eventid: InkCollectorEventInterest, listen: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkOverlay {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkOverlay_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkOverlay_Impl, const OFFSET: isize>() -> IInkOverlay_Vtbl {
@@ -3389,6 +3432,8 @@ pub trait IInkPicture_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Enabled(&self) -> ::windows::core::Result<i16>;
     fn SetEnabled(&self, vbool: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkPicture {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkPicture_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkPicture_Impl, const OFFSET: isize>() -> IInkPicture_Vtbl {
@@ -3947,6 +3992,8 @@ pub trait IInkRecognitionAlternate_Impl: Sized + super::super::System::Com::IDis
     fn GetPropertyValue(&self, propertytype: &super::super::Foundation::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognitionAlternate {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognitionAlternate_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognitionAlternate_Impl, const OFFSET: isize>() -> IInkRecognitionAlternate_Vtbl {
         unsafe extern "system" fn String<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognitionAlternate_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, recostring: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4133,6 +4180,8 @@ pub trait IInkRecognitionAlternates_Impl: Sized + super::super::System::Com::IDi
     fn Item(&self, index: i32) -> ::windows::core::Result<IInkRecognitionAlternate>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognitionAlternates {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognitionAlternates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognitionAlternates_Impl, const OFFSET: isize>() -> IInkRecognitionAlternates_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognitionAlternates_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -4201,6 +4250,8 @@ pub trait IInkRecognitionResult_Impl: Sized + super::super::System::Com::IDispat
     fn ModifyTopAlternate(&self, alternate: &::core::option::Option<IInkRecognitionAlternate>) -> ::windows::core::Result<()>;
     fn SetResultOnStrokes(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognitionResult {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognitionResult_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognitionResult_Impl, const OFFSET: isize>() -> IInkRecognitionResult_Vtbl {
@@ -4294,6 +4345,8 @@ pub trait IInkRecognizer_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn PreferredPacketDescription(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn CreateRecognizerContext(&self) -> ::windows::core::Result<IInkRecognizerContext>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognizer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognizer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizer_Impl, const OFFSET: isize>() -> IInkRecognizer_Vtbl {
@@ -4395,6 +4448,8 @@ pub trait IInkRecognizer2_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn UnicodeRanges(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognizer2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognizer2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizer2_Impl, const OFFSET: isize>() -> IInkRecognizer2_Vtbl {
         unsafe extern "system" fn Id<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizer2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrid: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -4456,6 +4511,8 @@ pub trait IInkRecognizerContext_Impl: Sized + super::super::System::Com::IDispat
     fn Clone(&self) -> ::windows::core::Result<IInkRecognizerContext>;
     fn IsStringSupported(&self, string: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognizerContext {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognizerContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizerContext_Impl, const OFFSET: isize>() -> IInkRecognizerContext_Vtbl {
@@ -4683,6 +4740,8 @@ pub trait IInkRecognizerContext2_Impl: Sized + super::super::System::Com::IDispa
     fn SetEnabledUnicodeRanges(&self, unicoderanges: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognizerContext2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognizerContext2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizerContext2_Impl, const OFFSET: isize>() -> IInkRecognizerContext2_Vtbl {
         unsafe extern "system" fn EnabledUnicodeRanges<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizerContext2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, unicoderanges: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT {
@@ -4726,6 +4785,8 @@ pub trait IInkRecognizerGuide_Impl: Sized + super::super::System::Com::IDispatch
     fn GuideData(&self) -> ::windows::core::Result<InkRecoGuide>;
     fn SetGuideData(&self, recoguide: &InkRecoGuide) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognizerGuide {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognizerGuide_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizerGuide_Impl, const OFFSET: isize>() -> IInkRecognizerGuide_Vtbl {
@@ -4853,6 +4914,8 @@ pub trait IInkRecognizers_Impl: Sized + super::super::System::Com::IDispatch_Imp
     fn Item(&self, index: i32) -> ::windows::core::Result<IInkRecognizer>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRecognizers {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRecognizers_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizers_Impl, const OFFSET: isize>() -> IInkRecognizers_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IInkRecognizers_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -4926,6 +4989,8 @@ pub trait IInkRectangle_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn GetRectangle(&self, top: *mut i32, left: *mut i32, bottom: *mut i32, right: *mut i32) -> ::windows::core::Result<()>;
     fn SetRectangle(&self, top: i32, left: i32, bottom: i32, right: i32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRectangle {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRectangle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRectangle_Impl, const OFFSET: isize>() -> IInkRectangle_Vtbl {
@@ -5057,6 +5122,8 @@ pub trait IInkRenderer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Rotate(&self, degrees: f32, x: f32, y: f32) -> ::windows::core::Result<()>;
     fn ScaleTransform(&self, horizontalmultiplier: f32, verticalmultiplier: f32, applyonpenwidth: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkRenderer {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkRenderer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkRenderer_Impl, const OFFSET: isize>() -> IInkRenderer_Vtbl {
@@ -5206,6 +5273,8 @@ pub trait IInkStrokeDisp_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Shear(&self, horizontalmultiplier: f32, verticalmultiplier: f32) -> ::windows::core::Result<()>;
     fn ScaleTransform(&self, horizontalmultiplier: f32, verticalmultiplier: f32) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkStrokeDisp {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkStrokeDisp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkStrokeDisp_Impl, const OFFSET: isize>() -> IInkStrokeDisp_Vtbl {
@@ -5577,6 +5646,8 @@ pub trait IInkStrokes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RemoveRecognitionResult(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkStrokes {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkStrokes_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkStrokes_Impl, const OFFSET: isize>() -> IInkStrokes_Vtbl {
         unsafe extern "system" fn Count<Identity: ::windows::core::IUnknownImpl, Impl: IInkStrokes_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: *mut i32) -> ::windows::core::HRESULT {
@@ -5759,6 +5830,8 @@ pub trait IInkTablet_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetPropertyMetrics(&self, propertyname: &super::super::Foundation::BSTR, minimum: *mut i32, maximum: *mut i32, units: *mut TabletPropertyMetricUnit, resolution: *mut f32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkTablet {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkTablet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkTablet_Impl, const OFFSET: isize>() -> IInkTablet_Vtbl {
         unsafe extern "system" fn Name<Identity: ::windows::core::IUnknownImpl, Impl: IInkTablet_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -5840,6 +5913,8 @@ pub trait IInkTablet2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeviceKind(&self) -> ::windows::core::Result<TabletDeviceKind>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkTablet2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkTablet2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkTablet2_Impl, const OFFSET: isize>() -> IInkTablet2_Vtbl {
         unsafe extern "system" fn DeviceKind<Identity: ::windows::core::IUnknownImpl, Impl: IInkTablet2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, kind: *mut TabletDeviceKind) -> ::windows::core::HRESULT {
@@ -5864,6 +5939,8 @@ pub trait IInkTablet3_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsMultiTouch(&self) -> ::windows::core::Result<i16>;
     fn MaximumCursors(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkTablet3 {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkTablet3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkTablet3_Impl, const OFFSET: isize>() -> IInkTablet3_Vtbl {
@@ -5907,6 +5984,8 @@ pub trait IInkTablets_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Item(&self, index: i32) -> ::windows::core::Result<IInkTablet>;
     fn IsPacketPropertySupported(&self, packetpropertyname: &super::super::Foundation::BSTR) -> ::windows::core::Result<i16>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkTablets {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkTablets_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkTablets_Impl, const OFFSET: isize>() -> IInkTablets_Vtbl {
@@ -6003,6 +6082,8 @@ pub trait IInkTransform_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Data(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::XFORM>;
     fn SetData(&self, xform: &super::super::Graphics::Gdi::XFORM) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkTransform {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkTransform_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkTransform_Impl, const OFFSET: isize>() -> IInkTransform_Vtbl {
@@ -6195,6 +6276,8 @@ pub trait IInkWordList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Merge(&self, mergewordlist: &::core::option::Option<IInkWordList>) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkWordList {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkWordList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkWordList_Impl, const OFFSET: isize>() -> IInkWordList_Vtbl {
         unsafe extern "system" fn AddWord<Identity: ::windows::core::IUnknownImpl, Impl: IInkWordList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newword: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6228,6 +6311,8 @@ pub trait IInkWordList2_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn AddWords(&self, newwords: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IInkWordList2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IInkWordList2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInkWordList2_Impl, const OFFSET: isize>() -> IInkWordList2_Vtbl {
         unsafe extern "system" fn AddWords<Identity: ::windows::core::IUnknownImpl, Impl: IInkWordList2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newwords: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -6247,6 +6332,7 @@ pub trait IInputPanelWindowHandle_Impl: Sized {
     fn AttachedEditWindow64(&self) -> ::windows::core::Result<i64>;
     fn SetAttachedEditWindow64(&self, attachededitwindow: i64) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInputPanelWindowHandle {}
 impl IInputPanelWindowHandle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInputPanelWindowHandle_Impl, const OFFSET: isize>() -> IInputPanelWindowHandle_Vtbl {
         unsafe extern "system" fn AttachedEditWindow32<Identity: ::windows::core::IUnknownImpl, Impl: IInputPanelWindowHandle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, attachededitwindow: *mut i32) -> ::windows::core::HRESULT {
@@ -6313,6 +6399,8 @@ pub trait IMathInputControl_Impl: Sized + super::super::System::Com::IDispatch_I
     fn RemoveFunctionName(&self, functionname: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
     fn GetHoverIcon(&self) -> ::windows::core::Result<super::super::System::Ole::IPictureDisp>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IMathInputControl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IMathInputControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMathInputControl_Impl, const OFFSET: isize>() -> IMathInputControl_Vtbl {
@@ -6472,6 +6560,8 @@ pub trait IPenInputPanel_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn Refresh(&self) -> ::windows::core::Result<()>;
     fn EnableTsf(&self, enable: i16) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IPenInputPanel {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IPenInputPanel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IPenInputPanel_Impl, const OFFSET: isize>() -> IPenInputPanel_Vtbl {
@@ -6745,6 +6835,8 @@ pub trait IRealTimeStylus_Impl: Sized {
     fn GetDesiredPacketDescription(&self, pcproperties: *mut u32, pppropertyguids: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetPacketDescriptionData(&self, tcid: u32, pfinktodevicescalex: *mut f32, pfinktodevicescaley: *mut f32, pcpacketproperties: *mut u32, pppacketproperties: *mut *mut PACKET_PROPERTY) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IRealTimeStylus {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IRealTimeStylus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylus_Impl, const OFFSET: isize>() -> IRealTimeStylus_Vtbl {
@@ -7026,6 +7118,8 @@ pub trait IRealTimeStylus2_Impl: Sized {
     fn SetFlicksEnabled(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRealTimeStylus2 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRealTimeStylus2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylus2_Impl, const OFFSET: isize>() -> IRealTimeStylus2_Vtbl {
         unsafe extern "system" fn FlicksEnabled<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylus2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfenable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -7060,6 +7154,8 @@ pub trait IRealTimeStylus3_Impl: Sized {
     fn SetMultiTouchEnabled(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IRealTimeStylus3 {}
+#[cfg(feature = "Win32_Foundation")]
 impl IRealTimeStylus3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylus3_Impl, const OFFSET: isize>() -> IRealTimeStylus3_Vtbl {
         unsafe extern "system" fn MultiTouchEnabled<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylus3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfenable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -7092,6 +7188,7 @@ pub trait IRealTimeStylusSynchronization_Impl: Sized {
     fn AcquireLock(&self, lock: RealTimeStylusLockType) -> ::windows::core::Result<()>;
     fn ReleaseLock(&self, lock: RealTimeStylusLockType) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IRealTimeStylusSynchronization {}
 impl IRealTimeStylusSynchronization_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylusSynchronization_Impl, const OFFSET: isize>() -> IRealTimeStylusSynchronization_Vtbl {
         unsafe extern "system" fn AcquireLock<Identity: ::windows::core::IUnknownImpl, Impl: IRealTimeStylusSynchronization_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lock: RealTimeStylusLockType) -> ::windows::core::HRESULT {
@@ -7117,6 +7214,8 @@ impl IRealTimeStylusSynchronization_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISketchInk_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ISketchInk {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ISketchInk_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISketchInk_Impl, const OFFSET: isize>() -> ISketchInk_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7134,6 +7233,8 @@ pub trait IStrokeBuilder_Impl: Sized {
     fn Ink(&self) -> ::windows::core::Result<IInkDisp>;
     fn putref_Ink(&self, piinkobj: &::core::option::Option<IInkDisp>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IStrokeBuilder {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IStrokeBuilder_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStrokeBuilder_Impl, const OFFSET: isize>() -> IStrokeBuilder_Vtbl {
@@ -7190,6 +7291,8 @@ impl IStrokeBuilder_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStylusAsyncPlugin_Impl: Sized + IStylusPlugin_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IStylusAsyncPlugin {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IStylusAsyncPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStylusAsyncPlugin_Impl, const OFFSET: isize>() -> IStylusAsyncPlugin_Vtbl {
         Self { base__: IStylusPlugin_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7218,6 +7321,8 @@ pub trait IStylusPlugin_Impl: Sized {
     fn UpdateMapping(&self, pirtssrc: &::core::option::Option<IRealTimeStylus>) -> ::windows::core::Result<()>;
     fn DataInterest(&self) -> ::windows::core::Result<RealTimeStylusDataInterest>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IStylusPlugin {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IStylusPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStylusPlugin_Impl, const OFFSET: isize>() -> IStylusPlugin_Vtbl {
@@ -7340,6 +7445,8 @@ impl IStylusPlugin_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStylusSyncPlugin_Impl: Sized + IStylusPlugin_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IStylusSyncPlugin {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IStylusSyncPlugin_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IStylusSyncPlugin_Impl, const OFFSET: isize>() -> IStylusSyncPlugin_Vtbl {
         Self { base__: IStylusPlugin_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7376,6 +7483,8 @@ pub trait ITextInputPanel_Impl: Sized {
     fn Advise(&self, eventsink: &::core::option::Option<ITextInputPanelEventSink>, eventmask: u32) -> ::windows::core::Result<()>;
     fn Unadvise(&self, eventsink: &::core::option::Option<ITextInputPanelEventSink>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITextInputPanel {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITextInputPanel_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextInputPanel_Impl, const OFFSET: isize>() -> ITextInputPanel_Vtbl {
@@ -7631,6 +7740,8 @@ pub trait ITextInputPanelEventSink_Impl: Sized {
     fn TextInserted(&self, ink: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITextInputPanelEventSink {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITextInputPanelEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextInputPanelEventSink_Impl, const OFFSET: isize>() -> ITextInputPanelEventSink_Vtbl {
         unsafe extern "system" fn InPlaceStateChanging<Identity: ::windows::core::IUnknownImpl, Impl: ITextInputPanelEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, oldinplacestate: InPlaceState, newinplacestate: InPlaceState) -> ::windows::core::HRESULT {
@@ -7718,6 +7829,8 @@ pub trait ITextInputPanelRunInfo_Impl: Sized {
     fn IsTipRunning(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITextInputPanelRunInfo {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITextInputPanelRunInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextInputPanelRunInfo_Impl, const OFFSET: isize>() -> ITextInputPanelRunInfo_Vtbl {
         unsafe extern "system" fn IsTipRunning<Identity: ::windows::core::IUnknownImpl, Impl: ITextInputPanelRunInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfrunning: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -7745,6 +7858,8 @@ pub trait ITipAutoCompleteClient_Impl: Sized {
     fn PreferredRects(&self, prcaclist: *const super::super::Foundation::RECT, prcfield: *const super::super::Foundation::RECT, prcmodifiedaclist: *mut super::super::Foundation::RECT, pfshownabovetip: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn RequestShowUI(&self, hwndlist: super::super::Foundation::HWND) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITipAutoCompleteClient {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITipAutoCompleteClient_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITipAutoCompleteClient_Impl, const OFFSET: isize>() -> ITipAutoCompleteClient_Vtbl {
@@ -7798,6 +7913,8 @@ pub trait ITipAutoCompleteProvider_Impl: Sized {
     fn Show(&self, fshow: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITipAutoCompleteProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITipAutoCompleteProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITipAutoCompleteProvider_Impl, const OFFSET: isize>() -> ITipAutoCompleteProvider_Vtbl {
         unsafe extern "system" fn UpdatePendingText<Identity: ::windows::core::IUnknownImpl, Impl: ITipAutoCompleteProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrpendingtext: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -7823,6 +7940,8 @@ impl ITipAutoCompleteProvider_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkCollectorEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkCollectorEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkCollectorEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkCollectorEvents_Impl, const OFFSET: isize>() -> _IInkCollectorEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7833,6 +7952,8 @@ impl _IInkCollectorEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkEditEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkEditEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkEditEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkEditEvents_Impl, const OFFSET: isize>() -> _IInkEditEvents_Vtbl {
@@ -7845,6 +7966,8 @@ impl _IInkEditEvents_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkEvents_Impl, const OFFSET: isize>() -> _IInkEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7855,6 +7978,8 @@ impl _IInkEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkOverlayEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkOverlayEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkOverlayEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkOverlayEvents_Impl, const OFFSET: isize>() -> _IInkOverlayEvents_Vtbl {
@@ -7867,6 +7992,8 @@ impl _IInkOverlayEvents_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkPictureEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkPictureEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkPictureEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkPictureEvents_Impl, const OFFSET: isize>() -> _IInkPictureEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7877,6 +8004,8 @@ impl _IInkPictureEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkRecognitionEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkRecognitionEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkRecognitionEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkRecognitionEvents_Impl, const OFFSET: isize>() -> _IInkRecognitionEvents_Vtbl {
@@ -7889,6 +8018,8 @@ impl _IInkRecognitionEvents_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkStrokesEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IInkStrokesEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IInkStrokesEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IInkStrokesEvents_Impl, const OFFSET: isize>() -> _IInkStrokesEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7900,6 +8031,8 @@ impl _IInkStrokesEvents_Vtbl {
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IMathInputControlEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IMathInputControlEvents {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IMathInputControlEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IMathInputControlEvents_Impl, const OFFSET: isize>() -> _IMathInputControlEvents_Vtbl {
         Self { base__: super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>() }
@@ -7910,6 +8043,8 @@ impl _IMathInputControlEvents_Vtbl {
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IPenInputPanelEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for _IPenInputPanelEvents {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl _IPenInputPanelEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: _IPenInputPanelEvents_Impl, const OFFSET: isize>() -> _IPenInputPanelEvents_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
@@ -6,6 +6,8 @@ pub trait IAccClientDocMgr_Impl: Sized {
     fn GetFocused(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAccClientDocMgr {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAccClientDocMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccClientDocMgr_Impl, const OFFSET: isize>() -> IAccClientDocMgr_Vtbl {
         unsafe extern "system" fn GetDocuments<Identity: ::windows::core::IUnknownImpl, Impl: IAccClientDocMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumunknown: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -73,6 +75,8 @@ pub trait IAccDictionary_Impl: Sized {
     fn ConvertValueToString(&self, term: *const ::windows::core::GUID, lcid: u32, varvalue: &super::super::System::Com::VARIANT, pbstrresult: *mut super::super::Foundation::BSTR, plcid: *mut u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IAccDictionary {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IAccDictionary_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccDictionary_Impl, const OFFSET: isize>() -> IAccDictionary_Vtbl {
         unsafe extern "system" fn GetLocalizedString<Identity: ::windows::core::IUnknownImpl, Impl: IAccDictionary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, term: *const ::windows::core::GUID, lcid: u32, presult: *mut super::super::Foundation::BSTR, plcid: *mut u32) -> ::windows::core::HRESULT {
@@ -136,6 +140,7 @@ pub trait IAccServerDocMgr_Impl: Sized {
     fn RevokeDocument(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn OnDocumentFocus(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IAccServerDocMgr {}
 impl IAccServerDocMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccServerDocMgr_Impl, const OFFSET: isize>() -> IAccServerDocMgr_Vtbl {
         unsafe extern "system" fn NewDocument<Identity: ::windows::core::IUnknownImpl, Impl: IAccServerDocMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -174,6 +179,8 @@ pub trait IAccStore_Impl: Sized {
     fn OnDocumentFocus(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetFocused(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IAccStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IAccStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAccStore_Impl, const OFFSET: isize>() -> IAccStore_Vtbl {
@@ -265,6 +272,8 @@ pub trait IAnchor_Impl: Sized {
     fn ClearChangeHistory(&self) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IAnchor>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IAnchor {}
 #[cfg(feature = "Win32_Foundation")]
 impl IAnchor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IAnchor_Impl, const OFFSET: isize>() -> IAnchor_Vtbl {
@@ -381,6 +390,7 @@ impl IAnchor_Vtbl {
 pub trait IClonableWrapper_Impl: Sized {
     fn CloneNewWrapper(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IClonableWrapper {}
 impl IClonableWrapper_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IClonableWrapper_Impl, const OFFSET: isize>() -> IClonableWrapper_Vtbl {
         unsafe extern "system" fn CloneNewWrapper<Identity: ::windows::core::IUnknownImpl, Impl: IClonableWrapper_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -398,6 +408,8 @@ impl IClonableWrapper_Vtbl {
 pub trait ICoCreateLocally_Impl: Sized {
     fn CoCreateLocally(&self, rclsid: *const ::windows::core::GUID, dwclscontext: u32, riid: *const ::windows::core::GUID, punk: *mut ::core::option::Option<::windows::core::IUnknown>, riidparam: *const ::windows::core::GUID, punkparam: &::core::option::Option<::windows::core::IUnknown>, varparam: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICoCreateLocally {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICoCreateLocally_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoCreateLocally_Impl, const OFFSET: isize>() -> ICoCreateLocally_Vtbl {
@@ -417,6 +429,8 @@ pub trait ICoCreatedLocally_Impl: Sized {
     fn LocalInit(&self, punklocalobject: &::core::option::Option<::windows::core::IUnknown>, riidparam: *const ::windows::core::GUID, punkparam: &::core::option::Option<::windows::core::IUnknown>, varparam: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ICoCreatedLocally {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ICoCreatedLocally_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ICoCreatedLocally_Impl, const OFFSET: isize>() -> ICoCreatedLocally_Vtbl {
         unsafe extern "system" fn LocalInit<Identity: ::windows::core::IUnknownImpl, Impl: ICoCreatedLocally_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, punklocalobject: *mut ::core::ffi::c_void, riidparam: *const ::windows::core::GUID, punkparam: *mut ::core::ffi::c_void, varparam: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT {
@@ -434,6 +448,7 @@ pub trait IDocWrap_Impl: Sized {
     fn SetDoc(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetWrappedDoc(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+impl ::windows::core::RuntimeName for IDocWrap {}
 impl IDocWrap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IDocWrap_Impl, const OFFSET: isize>() -> IDocWrap_Vtbl {
         unsafe extern "system" fn SetDoc<Identity: ::windows::core::IUnknownImpl, Impl: IDocWrap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -468,6 +483,7 @@ pub trait IEnumITfCompositionView_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumITfCompositionView {}
 impl IEnumITfCompositionView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumITfCompositionView_Impl, const OFFSET: isize>() -> IEnumITfCompositionView_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumITfCompositionView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -514,6 +530,7 @@ pub trait IEnumSpeechCommands_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumSpeechCommands {}
 impl IEnumSpeechCommands_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSpeechCommands_Impl, const OFFSET: isize>() -> IEnumSpeechCommands_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumSpeechCommands_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -560,6 +577,7 @@ pub trait IEnumTfCandidates_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfCandidates {}
 impl IEnumTfCandidates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfCandidates_Impl, const OFFSET: isize>() -> IEnumTfCandidates_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfCandidates_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -606,6 +624,7 @@ pub trait IEnumTfContextViews_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfContextViews {}
 impl IEnumTfContextViews_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfContextViews_Impl, const OFFSET: isize>() -> IEnumTfContextViews_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfContextViews_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -652,6 +671,7 @@ pub trait IEnumTfContexts_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfContexts {}
 impl IEnumTfContexts_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfContexts_Impl, const OFFSET: isize>() -> IEnumTfContexts_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfContexts_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -698,6 +718,7 @@ pub trait IEnumTfDisplayAttributeInfo_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfDisplayAttributeInfo {}
 impl IEnumTfDisplayAttributeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfDisplayAttributeInfo_Impl, const OFFSET: isize>() -> IEnumTfDisplayAttributeInfo_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfDisplayAttributeInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -744,6 +765,7 @@ pub trait IEnumTfDocumentMgrs_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfDocumentMgrs {}
 impl IEnumTfDocumentMgrs_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfDocumentMgrs_Impl, const OFFSET: isize>() -> IEnumTfDocumentMgrs_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfDocumentMgrs_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -790,6 +812,7 @@ pub trait IEnumTfFunctionProviders_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfFunctionProviders {}
 impl IEnumTfFunctionProviders_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfFunctionProviders_Impl, const OFFSET: isize>() -> IEnumTfFunctionProviders_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfFunctionProviders_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -836,6 +859,7 @@ pub trait IEnumTfInputProcessorProfiles_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfInputProcessorProfiles {}
 impl IEnumTfInputProcessorProfiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfInputProcessorProfiles_Impl, const OFFSET: isize>() -> IEnumTfInputProcessorProfiles_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfInputProcessorProfiles_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -882,6 +906,7 @@ pub trait IEnumTfLangBarItems_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfLangBarItems {}
 impl IEnumTfLangBarItems_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfLangBarItems_Impl, const OFFSET: isize>() -> IEnumTfLangBarItems_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfLangBarItems_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -929,6 +954,8 @@ pub trait IEnumTfLanguageProfiles_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumTfLanguageProfiles {}
 #[cfg(feature = "Win32_Foundation")]
 impl IEnumTfLanguageProfiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfLanguageProfiles_Impl, const OFFSET: isize>() -> IEnumTfLanguageProfiles_Vtbl {
@@ -978,6 +1005,8 @@ pub trait IEnumTfLatticeElements_Impl: Sized {
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IEnumTfLatticeElements {}
+#[cfg(feature = "Win32_Foundation")]
 impl IEnumTfLatticeElements_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfLatticeElements_Impl, const OFFSET: isize>() -> IEnumTfLatticeElements_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfLatticeElements_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1024,6 +1053,7 @@ pub trait IEnumTfProperties_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfProperties {}
 impl IEnumTfProperties_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfProperties_Impl, const OFFSET: isize>() -> IEnumTfProperties_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfProperties_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1072,6 +1102,8 @@ pub trait IEnumTfPropertyValue_Impl: Sized {
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for IEnumTfPropertyValue {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl IEnumTfPropertyValue_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfPropertyValue_Impl, const OFFSET: isize>() -> IEnumTfPropertyValue_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfPropertyValue_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1118,6 +1150,7 @@ pub trait IEnumTfRanges_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfRanges {}
 impl IEnumTfRanges_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfRanges_Impl, const OFFSET: isize>() -> IEnumTfRanges_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfRanges_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1164,6 +1197,7 @@ pub trait IEnumTfUIElements_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Skip(&self, ulcount: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IEnumTfUIElements {}
 impl IEnumTfUIElements_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfUIElements_Impl, const OFFSET: isize>() -> IEnumTfUIElements_Vtbl {
         unsafe extern "system" fn Clone<Identity: ::windows::core::IUnknownImpl, Impl: IEnumTfUIElements_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1207,6 +1241,7 @@ impl IEnumTfUIElements_Vtbl {
 pub trait IInternalDocWrap_Impl: Sized {
     fn NotifyRevoke(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IInternalDocWrap {}
 impl IInternalDocWrap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IInternalDocWrap_Impl, const OFFSET: isize>() -> IInternalDocWrap_Vtbl {
         unsafe extern "system" fn NotifyRevoke<Identity: ::windows::core::IUnknownImpl, Impl: IInternalDocWrap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1224,6 +1259,7 @@ pub trait ISpeechCommandProvider_Impl: Sized {
     fn EnumSpeechCommands(&self, langid: u16) -> ::windows::core::Result<IEnumSpeechCommands>;
     fn ProcessCommand(&self, pszcommand: &::windows::core::PCWSTR, cch: u32, langid: u16) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ISpeechCommandProvider {}
 impl ISpeechCommandProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechCommandProvider_Impl, const OFFSET: isize>() -> ISpeechCommandProvider_Vtbl {
         unsafe extern "system" fn EnumSpeechCommands<Identity: ::windows::core::IUnknownImpl, Impl: ISpeechCommandProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, langid: u16, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -1281,6 +1317,8 @@ pub trait ITextStoreACP_Impl: Sized {
     fn GetScreenExt(&self, vcview: u32) -> ::windows::core::Result<super::super::Foundation::RECT>;
     fn GetWnd(&self, vcview: u32) -> ::windows::core::Result<super::super::Foundation::HWND>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextStoreACP {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextStoreACP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACP_Impl, const OFFSET: isize>() -> ITextStoreACP_Vtbl {
@@ -1549,6 +1587,8 @@ pub trait ITextStoreACP2_Impl: Sized {
     fn GetScreenExt(&self, vcview: u32) -> ::windows::core::Result<super::super::Foundation::RECT>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextStoreACP2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextStoreACP2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACP2_Impl, const OFFSET: isize>() -> ITextStoreACP2_Vtbl {
         unsafe extern "system" fn AdviseSink<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACP2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void, dwmask: u32) -> ::windows::core::HRESULT {
@@ -1780,6 +1820,8 @@ pub trait ITextStoreACPEx_Impl: Sized {
     fn ScrollToRect(&self, acpstart: i32, acpend: i32, rc: &super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITextStoreACPEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITextStoreACPEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPEx_Impl, const OFFSET: isize>() -> ITextStoreACPEx_Vtbl {
         unsafe extern "system" fn ScrollToRect<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, acpstart: i32, acpend: i32, rc: super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::HRESULT {
@@ -1800,6 +1842,8 @@ pub trait ITextStoreACPServices_Impl: Sized {
     fn ForceLoadProperty(&self, pprop: &::core::option::Option<ITfProperty>) -> ::windows::core::Result<()>;
     fn CreateRange(&self, acpstart: i32, acpend: i32) -> ::windows::core::Result<ITfRangeACP>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITextStoreACPServices {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITextStoreACPServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPServices_Impl, const OFFSET: isize>() -> ITextStoreACPServices_Vtbl {
@@ -1851,6 +1895,7 @@ pub trait ITextStoreACPSink_Impl: Sized {
     fn OnStartEditTransaction(&self) -> ::windows::core::Result<()>;
     fn OnEndEditTransaction(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITextStoreACPSink {}
 impl ITextStoreACPSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPSink_Impl, const OFFSET: isize>() -> ITextStoreACPSink_Vtbl {
         unsafe extern "system" fn OnTextChange<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: TEXT_STORE_TEXT_CHANGE_FLAGS, pchange: *const TS_TEXTCHANGE) -> ::windows::core::HRESULT {
@@ -1912,6 +1957,7 @@ impl ITextStoreACPSink_Vtbl {
 pub trait ITextStoreACPSinkEx_Impl: Sized + ITextStoreACPSink_Impl {
     fn OnDisconnect(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITextStoreACPSinkEx {}
 impl ITextStoreACPSinkEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPSinkEx_Impl, const OFFSET: isize>() -> ITextStoreACPSinkEx_Vtbl {
         unsafe extern "system" fn OnDisconnect<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreACPSinkEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1955,6 +2001,8 @@ pub trait ITextStoreAnchor_Impl: Sized {
     fn InsertTextAtSelection(&self, dwflags: u32, pchtext: &::windows::core::PCWSTR, cch: u32, ppastart: *mut ::core::option::Option<IAnchor>, ppaend: *mut ::core::option::Option<IAnchor>) -> ::windows::core::Result<()>;
     fn InsertEmbeddedAtSelection(&self, dwflags: u32, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>, ppastart: *mut ::core::option::Option<IAnchor>, ppaend: *mut ::core::option::Option<IAnchor>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITextStoreAnchor {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITextStoreAnchor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreAnchor_Impl, const OFFSET: isize>() -> ITextStoreAnchor_Vtbl {
@@ -2199,6 +2247,8 @@ pub trait ITextStoreAnchorEx_Impl: Sized {
     fn ScrollToRect(&self, pstart: &::core::option::Option<IAnchor>, pend: &::core::option::Option<IAnchor>, rc: &super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITextStoreAnchorEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITextStoreAnchorEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreAnchorEx_Impl, const OFFSET: isize>() -> ITextStoreAnchorEx_Vtbl {
         unsafe extern "system" fn ScrollToRect<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreAnchorEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstart: ::windows::core::RawPtr, pend: ::windows::core::RawPtr, rc: super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::HRESULT {
@@ -2222,6 +2272,7 @@ pub trait ITextStoreAnchorSink_Impl: Sized {
     fn OnStartEditTransaction(&self) -> ::windows::core::Result<()>;
     fn OnEndEditTransaction(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITextStoreAnchorSink {}
 impl ITextStoreAnchorSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreAnchorSink_Impl, const OFFSET: isize>() -> ITextStoreAnchorSink_Vtbl {
         unsafe extern "system" fn OnTextChange<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreAnchorSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: TEXT_STORE_CHANGE_FLAGS, pastart: ::windows::core::RawPtr, paend: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2283,6 +2334,7 @@ impl ITextStoreAnchorSink_Vtbl {
 pub trait ITextStoreSinkAnchorEx_Impl: Sized + ITextStoreAnchorSink_Impl {
     fn OnDisconnect(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITextStoreSinkAnchorEx {}
 impl ITextStoreSinkAnchorEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreSinkAnchorEx_Impl, const OFFSET: isize>() -> ITextStoreSinkAnchorEx_Vtbl {
         unsafe extern "system" fn OnDisconnect<Identity: ::windows::core::IUnknownImpl, Impl: ITextStoreSinkAnchorEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2300,6 +2352,8 @@ impl ITextStoreSinkAnchorEx_Vtbl {
 pub trait ITfActiveLanguageProfileNotifySink_Impl: Sized {
     fn OnActivated(&self, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, factivated: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfActiveLanguageProfileNotifySink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfActiveLanguageProfileNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfActiveLanguageProfileNotifySink_Impl, const OFFSET: isize>() -> ITfActiveLanguageProfileNotifySink_Vtbl {
@@ -2320,6 +2374,7 @@ pub trait ITfCandidateList_Impl: Sized {
     fn GetCandidateNum(&self) -> ::windows::core::Result<u32>;
     fn SetResult(&self, nindex: u32, imcr: TfCandidateResult) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfCandidateList {}
 impl ITfCandidateList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCandidateList_Impl, const OFFSET: isize>() -> ITfCandidateList_Vtbl {
         unsafe extern "system" fn EnumCandidates<Identity: ::windows::core::IUnknownImpl, Impl: ITfCandidateList_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2383,6 +2438,8 @@ pub trait ITfCandidateListUIElement_Impl: Sized + ITfUIElement_Impl {
     fn SetPageIndex(&self, pindex: *const u32, upagecnt: u32) -> ::windows::core::Result<()>;
     fn GetCurrentPage(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfCandidateListUIElement {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfCandidateListUIElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCandidateListUIElement_Impl, const OFFSET: isize>() -> ITfCandidateListUIElement_Vtbl {
@@ -2485,6 +2542,8 @@ pub trait ITfCandidateListUIElementBehavior_Impl: Sized + ITfUIElement_Impl + IT
     fn Abort(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfCandidateListUIElementBehavior {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfCandidateListUIElementBehavior_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCandidateListUIElementBehavior_Impl, const OFFSET: isize>() -> ITfCandidateListUIElementBehavior_Vtbl {
         unsafe extern "system" fn SetSelection<Identity: ::windows::core::IUnknownImpl, Impl: ITfCandidateListUIElementBehavior_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nindex: u32) -> ::windows::core::HRESULT {
@@ -2518,6 +2577,8 @@ pub trait ITfCandidateString_Impl: Sized {
     fn GetString(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetIndex(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfCandidateString {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfCandidateString_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCandidateString_Impl, const OFFSET: isize>() -> ITfCandidateString_Vtbl {
@@ -2570,6 +2631,8 @@ pub trait ITfCategoryMgr_Impl: Sized {
     fn GetGUID(&self, guidatom: u32) -> ::windows::core::Result<::windows::core::GUID>;
     fn IsEqualTfGuidAtom(&self, guidatom: u32, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfCategoryMgr {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfCategoryMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCategoryMgr_Impl, const OFFSET: isize>() -> ITfCategoryMgr_Vtbl {
@@ -2711,6 +2774,7 @@ pub trait ITfCleanupContextDurationSink_Impl: Sized {
     fn OnStartCleanupContext(&self) -> ::windows::core::Result<()>;
     fn OnEndCleanupContext(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfCleanupContextDurationSink {}
 impl ITfCleanupContextDurationSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCleanupContextDurationSink_Impl, const OFFSET: isize>() -> ITfCleanupContextDurationSink_Vtbl {
         unsafe extern "system" fn OnStartCleanupContext<Identity: ::windows::core::IUnknownImpl, Impl: ITfCleanupContextDurationSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2736,6 +2800,7 @@ impl ITfCleanupContextDurationSink_Vtbl {
 pub trait ITfCleanupContextSink_Impl: Sized {
     fn OnCleanupContext(&self, ecwrite: u32, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfCleanupContextSink {}
 impl ITfCleanupContextSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCleanupContextSink_Impl, const OFFSET: isize>() -> ITfCleanupContextSink_Vtbl {
         unsafe extern "system" fn OnCleanupContext<Identity: ::windows::core::IUnknownImpl, Impl: ITfCleanupContextSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ecwrite: u32, pic: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2752,6 +2817,7 @@ impl ITfCleanupContextSink_Vtbl {
 pub trait ITfClientId_Impl: Sized {
     fn GetClientId(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for ITfClientId {}
 impl ITfClientId_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfClientId_Impl, const OFFSET: isize>() -> ITfClientId_Vtbl {
         unsafe extern "system" fn GetClientId<Identity: ::windows::core::IUnknownImpl, Impl: ITfClientId_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, ptid: *mut u32) -> ::windows::core::HRESULT {
@@ -2776,6 +2842,8 @@ pub trait ITfCompartment_Impl: Sized {
     fn SetValue(&self, tid: u32, pvarvalue: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn GetValue(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITfCompartment {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITfCompartment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompartment_Impl, const OFFSET: isize>() -> ITfCompartment_Vtbl {
@@ -2808,6 +2876,7 @@ impl ITfCompartment_Vtbl {
 pub trait ITfCompartmentEventSink_Impl: Sized {
     fn OnChange(&self, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfCompartmentEventSink {}
 impl ITfCompartmentEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompartmentEventSink_Impl, const OFFSET: isize>() -> ITfCompartmentEventSink_Vtbl {
         unsafe extern "system" fn OnChange<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompartmentEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2827,6 +2896,8 @@ pub trait ITfCompartmentMgr_Impl: Sized {
     fn ClearCompartment(&self, tid: u32, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn EnumCompartments(&self) -> ::windows::core::Result<super::super::System::Com::IEnumGUID>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITfCompartmentMgr {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITfCompartmentMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompartmentMgr_Impl, const OFFSET: isize>() -> ITfCompartmentMgr_Vtbl {
@@ -2874,6 +2945,7 @@ pub trait ITfComposition_Impl: Sized {
     fn ShiftEnd(&self, ecwrite: u32, pnewend: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
     fn EndComposition(&self, ecwrite: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfComposition {}
 impl ITfComposition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfComposition_Impl, const OFFSET: isize>() -> ITfComposition_Vtbl {
         unsafe extern "system" fn GetRange<Identity: ::windows::core::IUnknownImpl, Impl: ITfComposition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2917,6 +2989,7 @@ impl ITfComposition_Vtbl {
 pub trait ITfCompositionSink_Impl: Sized {
     fn OnCompositionTerminated(&self, ecwrite: u32, pcomposition: &::core::option::Option<ITfComposition>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfCompositionSink {}
 impl ITfCompositionSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompositionSink_Impl, const OFFSET: isize>() -> ITfCompositionSink_Vtbl {
         unsafe extern "system" fn OnCompositionTerminated<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompositionSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ecwrite: u32, pcomposition: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -2934,6 +3007,7 @@ pub trait ITfCompositionView_Impl: Sized {
     fn GetOwnerClsid(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetRange(&self) -> ::windows::core::Result<ITfRange>;
 }
+impl ::windows::core::RuntimeName for ITfCompositionView {}
 impl ITfCompositionView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompositionView_Impl, const OFFSET: isize>() -> ITfCompositionView_Vtbl {
         unsafe extern "system" fn GetOwnerClsid<Identity: ::windows::core::IUnknownImpl, Impl: ITfCompositionView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -2972,6 +3046,7 @@ pub trait ITfConfigureSystemKeystrokeFeed_Impl: Sized {
     fn DisableSystemKeystrokeFeed(&self) -> ::windows::core::Result<()>;
     fn EnableSystemKeystrokeFeed(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfConfigureSystemKeystrokeFeed {}
 impl ITfConfigureSystemKeystrokeFeed_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfConfigureSystemKeystrokeFeed_Impl, const OFFSET: isize>() -> ITfConfigureSystemKeystrokeFeed_Vtbl {
         unsafe extern "system" fn DisableSystemKeystrokeFeed<Identity: ::windows::core::IUnknownImpl, Impl: ITfConfigureSystemKeystrokeFeed_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3012,6 +3087,8 @@ pub trait ITfContext_Impl: Sized {
     fn GetDocumentMgr(&self) -> ::windows::core::Result<ITfDocumentMgr>;
     fn CreateRangeBackup(&self, ec: u32, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<ITfRangeBackup>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfContext {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContext_Impl, const OFFSET: isize>() -> ITfContext_Vtbl {
@@ -3197,6 +3274,7 @@ pub trait ITfContextComposition_Impl: Sized {
     fn FindComposition(&self, ecread: u32, ptestrange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<IEnumITfCompositionView>;
     fn TakeOwnership(&self, ecwrite: u32, pcomposition: &::core::option::Option<ITfCompositionView>, psink: &::core::option::Option<ITfCompositionSink>) -> ::windows::core::Result<ITfComposition>;
 }
+impl ::windows::core::RuntimeName for ITfContextComposition {}
 impl ITfContextComposition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextComposition_Impl, const OFFSET: isize>() -> ITfContextComposition_Vtbl {
         unsafe extern "system" fn StartComposition<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextComposition_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ecwrite: u32, pcompositionrange: ::windows::core::RawPtr, psink: ::windows::core::RawPtr, ppcomposition: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3262,6 +3340,8 @@ pub trait ITfContextKeyEventSink_Impl: Sized {
     fn OnTestKeyDown(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn OnTestKeyUp(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfContextKeyEventSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfContextKeyEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextKeyEventSink_Impl, const OFFSET: isize>() -> ITfContextKeyEventSink_Vtbl {
@@ -3330,6 +3410,8 @@ pub trait ITfContextOwner_Impl: Sized {
     fn GetWnd(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
     fn GetAttribute(&self, rguidattribute: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITfContextOwner {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITfContextOwner_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextOwner_Impl, const OFFSET: isize>() -> ITfContextOwner_Vtbl {
@@ -3410,6 +3492,7 @@ impl ITfContextOwner_Vtbl {
 pub trait ITfContextOwnerCompositionServices_Impl: Sized + ITfContextComposition_Impl {
     fn TerminateComposition(&self, pcomposition: &::core::option::Option<ITfCompositionView>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfContextOwnerCompositionServices {}
 impl ITfContextOwnerCompositionServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextOwnerCompositionServices_Impl, const OFFSET: isize>() -> ITfContextOwnerCompositionServices_Vtbl {
         unsafe extern "system" fn TerminateComposition<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextOwnerCompositionServices_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcomposition: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3429,6 +3512,8 @@ pub trait ITfContextOwnerCompositionSink_Impl: Sized {
     fn OnUpdateComposition(&self, pcomposition: &::core::option::Option<ITfCompositionView>, prangenew: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
     fn OnEndComposition(&self, pcomposition: &::core::option::Option<ITfCompositionView>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfContextOwnerCompositionSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfContextOwnerCompositionSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextOwnerCompositionSink_Impl, const OFFSET: isize>() -> ITfContextOwnerCompositionSink_Vtbl {
@@ -3474,6 +3559,8 @@ pub trait ITfContextOwnerServices_Impl: Sized {
     fn ForceLoadProperty(&self, pprop: &::core::option::Option<ITfProperty>) -> ::windows::core::Result<()>;
     fn CreateRange(&self, acpstart: i32, acpend: i32) -> ::windows::core::Result<ITfRangeACP>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITfContextOwnerServices {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITfContextOwnerServices_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextOwnerServices_Impl, const OFFSET: isize>() -> ITfContextOwnerServices_Vtbl {
@@ -3541,6 +3628,8 @@ pub trait ITfContextView_Impl: Sized {
     fn GetWnd(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfContextView {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfContextView_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextView_Impl, const OFFSET: isize>() -> ITfContextView_Vtbl {
         unsafe extern "system" fn GetRangeFromPoint<Identity: ::windows::core::IUnknownImpl, Impl: ITfContextView_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ec: u32, ppt: *const super::super::Foundation::POINT, dwflags: u32, pprange: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3599,6 +3688,8 @@ pub trait ITfCreatePropertyStore_Impl: Sized {
     fn CreatePropertyStore(&self, guidprop: *const ::windows::core::GUID, prange: &::core::option::Option<ITfRange>, cb: u32, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<ITfPropertyStore>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfCreatePropertyStore {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfCreatePropertyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfCreatePropertyStore_Impl, const OFFSET: isize>() -> ITfCreatePropertyStore_Vtbl {
         unsafe extern "system" fn IsStoreSerializable<Identity: ::windows::core::IUnknownImpl, Impl: ITfCreatePropertyStore_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guidprop: *const ::windows::core::GUID, prange: ::windows::core::RawPtr, ppropstore: ::windows::core::RawPtr, pfserializable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3641,6 +3732,8 @@ pub trait ITfDisplayAttributeInfo_Impl: Sized {
     fn SetAttributeInfo(&self, pda: *const TF_DISPLAYATTRIBUTE) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfDisplayAttributeInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfDisplayAttributeInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeInfo_Impl, const OFFSET: isize>() -> ITfDisplayAttributeInfo_Vtbl {
@@ -3705,6 +3798,7 @@ pub trait ITfDisplayAttributeMgr_Impl: Sized {
     fn EnumDisplayAttributeInfo(&self) -> ::windows::core::Result<IEnumTfDisplayAttributeInfo>;
     fn GetDisplayAttributeInfo(&self, guid: *const ::windows::core::GUID, ppinfo: *mut ::core::option::Option<ITfDisplayAttributeInfo>, pclsidowner: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfDisplayAttributeMgr {}
 impl ITfDisplayAttributeMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeMgr_Impl, const OFFSET: isize>() -> ITfDisplayAttributeMgr_Vtbl {
         unsafe extern "system" fn OnUpdateInfo<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3742,6 +3836,7 @@ impl ITfDisplayAttributeMgr_Vtbl {
 pub trait ITfDisplayAttributeNotifySink_Impl: Sized {
     fn OnUpdateInfo(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfDisplayAttributeNotifySink {}
 impl ITfDisplayAttributeNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeNotifySink_Impl, const OFFSET: isize>() -> ITfDisplayAttributeNotifySink_Vtbl {
         unsafe extern "system" fn OnUpdateInfo<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3759,6 +3854,7 @@ pub trait ITfDisplayAttributeProvider_Impl: Sized {
     fn EnumDisplayAttributeInfo(&self) -> ::windows::core::Result<IEnumTfDisplayAttributeInfo>;
     fn GetDisplayAttributeInfo(&self, guid: *const ::windows::core::GUID) -> ::windows::core::Result<ITfDisplayAttributeInfo>;
 }
+impl ::windows::core::RuntimeName for ITfDisplayAttributeProvider {}
 impl ITfDisplayAttributeProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeProvider_Impl, const OFFSET: isize>() -> ITfDisplayAttributeProvider_Vtbl {
         unsafe extern "system" fn EnumDisplayAttributeInfo<Identity: ::windows::core::IUnknownImpl, Impl: ITfDisplayAttributeProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenum: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3801,6 +3897,7 @@ pub trait ITfDocumentMgr_Impl: Sized {
     fn GetBase(&self) -> ::windows::core::Result<ITfContext>;
     fn EnumContexts(&self) -> ::windows::core::Result<IEnumTfContexts>;
 }
+impl ::windows::core::RuntimeName for ITfDocumentMgr {}
 impl ITfDocumentMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfDocumentMgr_Impl, const OFFSET: isize>() -> ITfDocumentMgr_Vtbl {
         unsafe extern "system" fn CreateContext<Identity: ::windows::core::IUnknownImpl, Impl: ITfDocumentMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tidowner: u32, dwflags: u32, punk: *mut ::core::ffi::c_void, ppic: *mut ::windows::core::RawPtr, pectextstore: *mut u32) -> ::windows::core::HRESULT {
@@ -3871,6 +3968,8 @@ pub trait ITfEditRecord_Impl: Sized {
     fn GetTextAndPropertyUpdates(&self, dwflags: GET_TEXT_AND_PROPERTY_UPDATES_FLAGS, prgproperties: *const *const ::windows::core::GUID, cproperties: u32) -> ::windows::core::Result<IEnumTfRanges>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfEditRecord {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfEditRecord_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfEditRecord_Impl, const OFFSET: isize>() -> ITfEditRecord_Vtbl {
         unsafe extern "system" fn GetSelectionStatus<Identity: ::windows::core::IUnknownImpl, Impl: ITfEditRecord_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfchanged: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -3908,6 +4007,7 @@ impl ITfEditRecord_Vtbl {
 pub trait ITfEditSession_Impl: Sized {
     fn DoEditSession(&self, ec: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfEditSession {}
 impl ITfEditSession_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfEditSession_Impl, const OFFSET: isize>() -> ITfEditSession_Vtbl {
         unsafe extern "system" fn DoEditSession<Identity: ::windows::core::IUnknownImpl, Impl: ITfEditSession_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ec: u32) -> ::windows::core::HRESULT {
@@ -3925,6 +4025,7 @@ pub trait ITfEditTransactionSink_Impl: Sized {
     fn OnStartEditTransaction(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
     fn OnEndEditTransaction(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfEditTransactionSink {}
 impl ITfEditTransactionSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfEditTransactionSink_Impl, const OFFSET: isize>() -> ITfEditTransactionSink_Vtbl {
         unsafe extern "system" fn OnStartEditTransaction<Identity: ::windows::core::IUnknownImpl, Impl: ITfEditTransactionSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pic: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -3953,6 +4054,8 @@ pub trait ITfFnAdviseText_Impl: Sized + ITfFunction_Impl {
     fn OnLatticeUpdate(&self, prange: &::core::option::Option<ITfRange>, plattice: &::core::option::Option<ITfLMLattice>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnAdviseText {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnAdviseText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnAdviseText_Impl, const OFFSET: isize>() -> ITfFnAdviseText_Vtbl {
         unsafe extern "system" fn OnTextUpdate<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnAdviseText_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prange: ::windows::core::RawPtr, pchtext: ::windows::core::PCWSTR, cch: i32) -> ::windows::core::HRESULT {
@@ -3978,6 +4081,7 @@ impl ITfFnAdviseText_Vtbl {
 pub trait ITfFnBalloon_Impl: Sized {
     fn UpdateBalloon(&self, style: TfLBBalloonStyle, pch: &::windows::core::PCWSTR, cch: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfFnBalloon {}
 impl ITfFnBalloon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnBalloon_Impl, const OFFSET: isize>() -> ITfFnBalloon_Vtbl {
         unsafe extern "system" fn UpdateBalloon<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnBalloon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, style: TfLBBalloonStyle, pch: ::windows::core::PCWSTR, cch: u32) -> ::windows::core::HRESULT {
@@ -3995,6 +4099,8 @@ impl ITfFnBalloon_Vtbl {
 pub trait ITfFnConfigure_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnConfigure {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnConfigure_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnConfigure_Impl, const OFFSET: isize>() -> ITfFnConfigure_Vtbl {
@@ -4014,6 +4120,8 @@ pub trait ITfFnConfigureRegisterEudc_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID, bstrregistered: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnConfigureRegisterEudc {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnConfigureRegisterEudc_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnConfigureRegisterEudc_Impl, const OFFSET: isize>() -> ITfFnConfigureRegisterEudc_Vtbl {
         unsafe extern "system" fn Show<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnConfigureRegisterEudc_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID, bstrregistered: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -4031,6 +4139,8 @@ impl ITfFnConfigureRegisterEudc_Vtbl {
 pub trait ITfFnConfigureRegisterWord_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID, bstrregistered: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnConfigureRegisterWord {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnConfigureRegisterWord_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnConfigureRegisterWord_Impl, const OFFSET: isize>() -> ITfFnConfigureRegisterWord_Vtbl {
@@ -4050,6 +4160,8 @@ pub trait ITfFnCustomSpeechCommand_Impl: Sized + ITfFunction_Impl {
     fn SetSpeechCommandProvider(&self, pspcmdprovider: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnCustomSpeechCommand {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnCustomSpeechCommand_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnCustomSpeechCommand_Impl, const OFFSET: isize>() -> ITfFnCustomSpeechCommand_Vtbl {
         unsafe extern "system" fn SetSpeechCommandProvider<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnCustomSpeechCommand_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pspcmdprovider: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4067,6 +4179,8 @@ impl ITfFnCustomSpeechCommand_Vtbl {
 pub trait ITfFnGetLinguisticAlternates_Impl: Sized + ITfFunction_Impl {
     fn GetAlternates(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<ITfCandidateList>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnGetLinguisticAlternates {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnGetLinguisticAlternates_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnGetLinguisticAlternates_Impl, const OFFSET: isize>() -> ITfFnGetLinguisticAlternates_Vtbl {
@@ -4092,6 +4206,8 @@ pub trait ITfFnGetPreferredTouchKeyboardLayout_Impl: Sized + ITfFunction_Impl {
     fn GetLayout(&self, ptkblayouttype: *mut TKBLayoutType, pwpreferredlayoutid: *const u16) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnGetPreferredTouchKeyboardLayout {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnGetPreferredTouchKeyboardLayout_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnGetPreferredTouchKeyboardLayout_Impl, const OFFSET: isize>() -> ITfFnGetPreferredTouchKeyboardLayout_Vtbl {
         unsafe extern "system" fn GetLayout<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnGetPreferredTouchKeyboardLayout_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptkblayouttype: *mut TKBLayoutType, pwpreferredlayoutid: *const u16) -> ::windows::core::HRESULT {
@@ -4109,6 +4225,8 @@ impl ITfFnGetPreferredTouchKeyboardLayout_Vtbl {
 pub trait ITfFnGetSAPIObject_Impl: Sized + ITfFunction_Impl {
     fn Get(&self, sobj: TfSapiObject) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnGetSAPIObject {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnGetSAPIObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnGetSAPIObject_Impl, const OFFSET: isize>() -> ITfFnGetSAPIObject_Vtbl {
@@ -4134,6 +4252,8 @@ pub trait ITfFnLMInternal_Impl: Sized + ITfFunction_Impl + ITfFnLMProcessor_Impl
     fn ProcessLattice(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnLMInternal {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnLMInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnLMInternal_Impl, const OFFSET: isize>() -> ITfFnLMInternal_Vtbl {
         unsafe extern "system" fn ProcessLattice<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnLMInternal_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prange: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4157,6 +4277,8 @@ pub trait ITfFnLMProcessor_Impl: Sized + ITfFunction_Impl {
     fn InvokeKey(&self, fup: super::super::Foundation::BOOL, vkey: super::super::Foundation::WPARAM, lparamkeydata: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
     fn InvokeFunc(&self, pic: &::core::option::Option<ITfContext>, refguidfunc: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnLMProcessor {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnLMProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnLMProcessor_Impl, const OFFSET: isize>() -> ITfFnLMProcessor_Vtbl {
@@ -4234,6 +4356,8 @@ pub trait ITfFnLangProfileUtil_Impl: Sized + ITfFunction_Impl {
     fn IsProfileAvailableForLang(&self, langid: u16) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnLangProfileUtil {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnLangProfileUtil_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnLangProfileUtil_Impl, const OFFSET: isize>() -> ITfFnLangProfileUtil_Vtbl {
         unsafe extern "system" fn RegisterActiveProfiles<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnLangProfileUtil_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4268,6 +4392,8 @@ pub trait ITfFnPlayBack_Impl: Sized + ITfFunction_Impl {
     fn Play(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnPlayBack {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnPlayBack_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnPlayBack_Impl, const OFFSET: isize>() -> ITfFnPlayBack_Vtbl {
         unsafe extern "system" fn QueryRange<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnPlayBack_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, prange: ::windows::core::RawPtr, ppnewrange: *mut ::windows::core::RawPtr, pfplayable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -4295,6 +4421,8 @@ pub trait ITfFnPropertyUIStatus_Impl: Sized + ITfFunction_Impl {
     fn GetStatus(&self, refguidprop: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
     fn SetStatus(&self, refguidprop: *const ::windows::core::GUID, dw: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnPropertyUIStatus {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnPropertyUIStatus_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnPropertyUIStatus_Impl, const OFFSET: isize>() -> ITfFnPropertyUIStatus_Vtbl {
@@ -4330,6 +4458,8 @@ pub trait ITfFnReconversion_Impl: Sized + ITfFunction_Impl {
     fn GetReconversion(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<ITfCandidateList>;
     fn Reconvert(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnReconversion {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFnReconversion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnReconversion_Impl, const OFFSET: isize>() -> ITfFnReconversion_Vtbl {
@@ -4371,6 +4501,8 @@ pub trait ITfFnSearchCandidateProvider_Impl: Sized + ITfFunction_Impl {
     fn SetResult(&self, bstrquery: &super::super::Foundation::BSTR, bstrapplicationid: &super::super::Foundation::BSTR, bstrresult: &super::super::Foundation::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnSearchCandidateProvider {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnSearchCandidateProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnSearchCandidateProvider_Impl, const OFFSET: isize>() -> ITfFnSearchCandidateProvider_Vtbl {
         unsafe extern "system" fn GetSearchCandidates<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnSearchCandidateProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrquery: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, bstrapplicationid: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>, pplist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4404,6 +4536,8 @@ pub trait ITfFnShowHelp_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFnShowHelp {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfFnShowHelp_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnShowHelp_Impl, const OFFSET: isize>() -> ITfFnShowHelp_Vtbl {
         unsafe extern "system" fn Show<Identity: ::windows::core::IUnknownImpl, Impl: ITfFnShowHelp_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
@@ -4421,6 +4555,8 @@ impl ITfFnShowHelp_Vtbl {
 pub trait ITfFunction_Impl: Sized {
     fn GetDisplayName(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFunction {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFunction_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFunction_Impl, const OFFSET: isize>() -> ITfFunction_Vtbl {
@@ -4447,6 +4583,8 @@ pub trait ITfFunctionProvider_Impl: Sized {
     fn GetDescription(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetFunction(&self, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfFunctionProvider {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfFunctionProvider_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfFunctionProvider_Impl, const OFFSET: isize>() -> ITfFunctionProvider_Vtbl {
@@ -4497,6 +4635,7 @@ impl ITfFunctionProvider_Vtbl {
 pub trait ITfInputProcessorProfileActivationSink_Impl: Sized {
     fn OnActivated(&self, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, catid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfInputProcessorProfileActivationSink {}
 impl ITfInputProcessorProfileActivationSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfileActivationSink_Impl, const OFFSET: isize>() -> ITfInputProcessorProfileActivationSink_Vtbl {
         unsafe extern "system" fn OnActivated<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfileActivationSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, catid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::HRESULT {
@@ -4521,6 +4660,8 @@ pub trait ITfInputProcessorProfileMgr_Impl: Sized {
     fn UnregisterProfile(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetActiveProfile(&self, catid: *const ::windows::core::GUID) -> ::windows::core::Result<TF_INPUTPROCESSORPROFILE>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfInputProcessorProfileMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfInputProcessorProfileMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfileMgr_Impl, const OFFSET: isize>() -> ITfInputProcessorProfileMgr_Vtbl {
@@ -4616,6 +4757,7 @@ impl ITfInputProcessorProfileMgr_Vtbl {
 pub trait ITfInputProcessorProfileSubstituteLayout_Impl: Sized {
     fn GetSubstituteKeyboardLayout(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID) -> ::windows::core::Result<HKL>;
 }
+impl ::windows::core::RuntimeName for ITfInputProcessorProfileSubstituteLayout {}
 impl ITfInputProcessorProfileSubstituteLayout_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfileSubstituteLayout_Impl, const OFFSET: isize>() -> ITfInputProcessorProfileSubstituteLayout_Vtbl {
         unsafe extern "system" fn GetSubstituteKeyboardLayout<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfileSubstituteLayout_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, phkl: *mut HKL) -> ::windows::core::HRESULT {
@@ -4659,6 +4801,8 @@ pub trait ITfInputProcessorProfiles_Impl: Sized {
     fn EnableLanguageProfileByDefault(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn SubstituteKeyboardLayout(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, hkl: HKL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfInputProcessorProfiles {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfInputProcessorProfiles_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfiles_Impl, const OFFSET: isize>() -> ITfInputProcessorProfiles_Vtbl {
@@ -4813,6 +4957,8 @@ pub trait ITfInputProcessorProfilesEx_Impl: Sized + ITfInputProcessorProfiles_Im
     fn SetLanguageProfileDisplayName(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, pchfile: &::windows::core::PCWSTR, cchfile: u32, uresid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfInputProcessorProfilesEx {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfInputProcessorProfilesEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfilesEx_Impl, const OFFSET: isize>() -> ITfInputProcessorProfilesEx_Vtbl {
         unsafe extern "system" fn SetLanguageProfileDisplayName<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputProcessorProfilesEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, pchfile: ::windows::core::PCWSTR, cchfile: u32, uresid: u32) -> ::windows::core::HRESULT {
@@ -4837,6 +4983,8 @@ pub trait ITfInputScope_Impl: Sized {
     fn GetSRGS(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetXML(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfInputScope {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfInputScope_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputScope_Impl, const OFFSET: isize>() -> ITfInputScope_Vtbl {
@@ -4901,6 +5049,8 @@ pub trait ITfInputScope2_Impl: Sized + ITfInputScope_Impl {
     fn EnumWordList(&self) -> ::windows::core::Result<super::super::System::Com::IEnumString>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfInputScope2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfInputScope2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputScope2_Impl, const OFFSET: isize>() -> ITfInputScope2_Vtbl {
         unsafe extern "system" fn EnumWordList<Identity: ::windows::core::IUnknownImpl, Impl: ITfInputScope2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppenumstring: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -4925,6 +5075,8 @@ pub trait ITfInsertAtSelection_Impl: Sized {
     fn InsertTextAtSelection(&self, ec: u32, dwflags: INSERT_TEXT_AT_SELECTION_FLAGS, pchtext: &::windows::core::PCWSTR, cch: i32) -> ::windows::core::Result<ITfRange>;
     fn InsertEmbeddedAtSelection(&self, ec: u32, dwflags: u32, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<ITfRange>;
 }
+#[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITfInsertAtSelection {}
 #[cfg(feature = "Win32_System_Com")]
 impl ITfInsertAtSelection_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfInsertAtSelection_Impl, const OFFSET: isize>() -> ITfInsertAtSelection_Vtbl {
@@ -4968,6 +5120,8 @@ pub trait ITfIntegratableCandidateListUIElement_Impl: Sized {
     fn ShowCandidateNumbers(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn FinalizeExactCompositionString(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfIntegratableCandidateListUIElement {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfIntegratableCandidateListUIElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfIntegratableCandidateListUIElement_Impl, const OFFSET: isize>() -> ITfIntegratableCandidateListUIElement_Vtbl {
@@ -5036,6 +5190,8 @@ pub trait ITfKeyEventSink_Impl: Sized {
     fn OnKeyUp(&self, pic: &::core::option::Option<ITfContext>, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::BOOL>;
     fn OnPreservedKey(&self, pic: &::core::option::Option<ITfContext>, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfKeyEventSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfKeyEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfKeyEventSink_Impl, const OFFSET: isize>() -> ITfKeyEventSink_Vtbl {
@@ -5119,6 +5275,8 @@ pub trait ITfKeyTraceEventSink_Impl: Sized {
     fn OnKeyTraceUp(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfKeyTraceEventSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfKeyTraceEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfKeyTraceEventSink_Impl, const OFFSET: isize>() -> ITfKeyTraceEventSink_Vtbl {
         unsafe extern "system" fn OnKeyTraceDown<Identity: ::windows::core::IUnknownImpl, Impl: ITfKeyTraceEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
@@ -5158,6 +5316,8 @@ pub trait ITfKeystrokeMgr_Impl: Sized {
     fn GetPreservedKeyDescription(&self, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn SimulatePreservedKey(&self, pic: &::core::option::Option<ITfContext>, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfKeystrokeMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfKeystrokeMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfKeystrokeMgr_Impl, const OFFSET: isize>() -> ITfKeystrokeMgr_Vtbl {
@@ -5313,6 +5473,8 @@ pub trait ITfLMLattice_Impl: Sized {
     fn EnumLatticeElements(&self, dwframestart: u32, rguidtype: *const ::windows::core::GUID) -> ::windows::core::Result<IEnumTfLatticeElements>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLMLattice {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfLMLattice_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLMLattice_Impl, const OFFSET: isize>() -> ITfLMLattice_Vtbl {
         unsafe extern "system" fn QueryType<Identity: ::windows::core::IUnknownImpl, Impl: ITfLMLattice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rguidtype: *const ::windows::core::GUID, pfsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5356,6 +5518,8 @@ pub trait ITfLangBarEventSink_Impl: Sized {
     fn ShowFloating(&self, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetItemFloatingRect(&self, dwthreadid: u32, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::RECT>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLangBarEventSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfLangBarEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarEventSink_Impl, const OFFSET: isize>() -> ITfLangBarEventSink_Vtbl {
@@ -5417,6 +5581,8 @@ pub trait ITfLangBarItem_Impl: Sized {
     fn GetTooltipString(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLangBarItem {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfLangBarItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItem_Impl, const OFFSET: isize>() -> ITfLangBarItem_Vtbl {
         unsafe extern "system" fn GetInfo<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinfo: *mut TF_LANGBARITEMINFO) -> ::windows::core::HRESULT {
@@ -5476,6 +5642,8 @@ pub trait ITfLangBarItemBalloon_Impl: Sized + ITfLangBarItem_Impl {
     fn GetBalloonInfo(&self) -> ::windows::core::Result<TF_LBBALLOONINFO>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLangBarItemBalloon {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfLangBarItemBalloon_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemBalloon_Impl, const OFFSET: isize>() -> ITfLangBarItemBalloon_Vtbl {
         unsafe extern "system" fn OnClick<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemBalloon_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, click: TfLBIClick, pt: super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -5523,6 +5691,8 @@ pub trait ITfLangBarItemBitmap_Impl: Sized + ITfLangBarItem_Impl {
     fn DrawBitmap(&self, bmwidth: i32, bmheight: i32, dwflags: u32, phbmp: *mut super::super::Graphics::Gdi::HBITMAP, phbmpmask: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ITfLangBarItemBitmap {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ITfLangBarItemBitmap_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemBitmap_Impl, const OFFSET: isize>() -> ITfLangBarItemBitmap_Vtbl {
         unsafe extern "system" fn OnClick<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemBitmap_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, click: TfLBIClick, pt: super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -5566,6 +5736,8 @@ pub trait ITfLangBarItemBitmapButton_Impl: Sized + ITfLangBarItem_Impl {
     fn DrawBitmap(&self, bmwidth: i32, bmheight: i32, dwflags: u32, phbmp: *mut super::super::Graphics::Gdi::HBITMAP, phbmpmask: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::Result<()>;
     fn GetText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
+impl ::windows::core::RuntimeName for ITfLangBarItemBitmapButton {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 impl ITfLangBarItemBitmapButton_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemBitmapButton_Impl, const OFFSET: isize>() -> ITfLangBarItemBitmapButton_Vtbl {
@@ -5634,6 +5806,8 @@ pub trait ITfLangBarItemButton_Impl: Sized + ITfLangBarItem_Impl {
     fn GetText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITfLangBarItemButton {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITfLangBarItemButton_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemButton_Impl, const OFFSET: isize>() -> ITfLangBarItemButton_Vtbl {
         unsafe extern "system" fn OnClick<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemButton_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, click: TfLBIClick, pt: super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT {
@@ -5701,6 +5875,8 @@ pub trait ITfLangBarItemMgr_Impl: Sized {
     fn AdviseItemsSink(&self, ulcount: u32, ppunk: *const ::core::option::Option<ITfLangBarItemSink>, pguiditem: *const ::windows::core::GUID, pdwcookie: *mut u32) -> ::windows::core::Result<()>;
     fn UnadviseItemsSink(&self, ulcount: u32, pdwcookie: *const u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLangBarItemMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfLangBarItemMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemMgr_Impl, const OFFSET: isize>() -> ITfLangBarItemMgr_Vtbl {
@@ -5811,6 +5987,7 @@ impl ITfLangBarItemMgr_Vtbl {
 pub trait ITfLangBarItemSink_Impl: Sized {
     fn OnUpdate(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfLangBarItemSink {}
 impl ITfLangBarItemSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemSink_Impl, const OFFSET: isize>() -> ITfLangBarItemSink_Vtbl {
         unsafe extern "system" fn OnUpdate<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarItemSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT {
@@ -5836,6 +6013,8 @@ pub trait ITfLangBarMgr_Impl: Sized {
     fn ShowFloating(&self, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetShowFloatingStatus(&self) -> ::windows::core::Result<u32>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLangBarMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfLangBarMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLangBarMgr_Impl, const OFFSET: isize>() -> ITfLangBarMgr_Vtbl {
@@ -5919,6 +6098,8 @@ pub trait ITfLanguageProfileNotifySink_Impl: Sized {
     fn OnLanguageChanged(&self) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfLanguageProfileNotifySink {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfLanguageProfileNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfLanguageProfileNotifySink_Impl, const OFFSET: isize>() -> ITfLanguageProfileNotifySink_Vtbl {
         unsafe extern "system" fn OnLanguageChange<Identity: ::windows::core::IUnknownImpl, Impl: ITfLanguageProfileNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, langid: u16, pfaccept: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -5951,6 +6132,7 @@ pub trait ITfMSAAControl_Impl: Sized {
     fn SystemEnableMSAA(&self) -> ::windows::core::Result<()>;
     fn SystemDisableMSAA(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfMSAAControl {}
 impl ITfMSAAControl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfMSAAControl_Impl, const OFFSET: isize>() -> ITfMSAAControl_Vtbl {
         unsafe extern "system" fn SystemEnableMSAA<Identity: ::windows::core::IUnknownImpl, Impl: ITfMSAAControl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5978,6 +6160,8 @@ pub trait ITfMenu_Impl: Sized {
     fn AddMenuItem(&self, uid: u32, dwflags: u32, hbmp: super::super::Graphics::Gdi::HBITMAP, hbmpmask: super::super::Graphics::Gdi::HBITMAP, pch: &::windows::core::PCWSTR, cch: u32, ppmenu: *mut ::core::option::Option<ITfMenu>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
+impl ::windows::core::RuntimeName for ITfMenu {}
+#[cfg(feature = "Win32_Graphics_Gdi")]
 impl ITfMenu_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfMenu_Impl, const OFFSET: isize>() -> ITfMenu_Vtbl {
         unsafe extern "system" fn AddMenuItem<Identity: ::windows::core::IUnknownImpl, Impl: ITfMenu_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uid: u32, dwflags: u32, hbmp: super::super::Graphics::Gdi::HBITMAP, hbmpmask: super::super::Graphics::Gdi::HBITMAP, pch: ::windows::core::PCWSTR, cch: u32, ppmenu: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -5998,6 +6182,8 @@ pub trait ITfMessagePump_Impl: Sized {
     fn PeekMessageW(&self, pmsg: *mut super::WindowsAndMessaging::MSG, hwnd: super::super::Foundation::HWND, wmsgfiltermin: u32, wmsgfiltermax: u32, wremovemsg: u32, pfresult: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn GetMessageW(&self, pmsg: *mut super::WindowsAndMessaging::MSG, hwnd: super::super::Foundation::HWND, wmsgfiltermin: u32, wmsgfiltermax: u32, pfresult: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
+impl ::windows::core::RuntimeName for ITfMessagePump {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 impl ITfMessagePump_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfMessagePump_Impl, const OFFSET: isize>() -> ITfMessagePump_Vtbl {
@@ -6038,6 +6224,8 @@ pub trait ITfMouseSink_Impl: Sized {
     fn OnMouseEvent(&self, uedge: u32, uquadrant: u32, dwbtnstatus: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfMouseSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfMouseSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfMouseSink_Impl, const OFFSET: isize>() -> ITfMouseSink_Vtbl {
         unsafe extern "system" fn OnMouseEvent<Identity: ::windows::core::IUnknownImpl, Impl: ITfMouseSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uedge: u32, uquadrant: u32, dwbtnstatus: u32, pfeaten: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -6061,6 +6249,7 @@ pub trait ITfMouseTracker_Impl: Sized {
     fn AdviseMouseSink(&self, range: &::core::option::Option<ITfRange>, psink: &::core::option::Option<ITfMouseSink>) -> ::windows::core::Result<u32>;
     fn UnadviseMouseSink(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfMouseTracker {}
 impl ITfMouseTracker_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfMouseTracker_Impl, const OFFSET: isize>() -> ITfMouseTracker_Vtbl {
         unsafe extern "system" fn AdviseMouseSink<Identity: ::windows::core::IUnknownImpl, Impl: ITfMouseTracker_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, range: ::windows::core::RawPtr, psink: ::windows::core::RawPtr, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -6093,6 +6282,7 @@ pub trait ITfMouseTrackerACP_Impl: Sized {
     fn AdviseMouseSink(&self, range: &::core::option::Option<ITfRangeACP>, psink: &::core::option::Option<ITfMouseSink>) -> ::windows::core::Result<u32>;
     fn UnadviseMouseSink(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfMouseTrackerACP {}
 impl ITfMouseTrackerACP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfMouseTrackerACP_Impl, const OFFSET: isize>() -> ITfMouseTrackerACP_Vtbl {
         unsafe extern "system" fn AdviseMouseSink<Identity: ::windows::core::IUnknownImpl, Impl: ITfMouseTrackerACP_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, range: ::windows::core::RawPtr, psink: ::windows::core::RawPtr, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -6126,6 +6316,8 @@ pub trait ITfPersistentPropertyLoaderACP_Impl: Sized {
     fn LoadProperty(&self, phdr: *const TF_PERSISTENT_PROPERTY_HEADER_ACP) -> ::windows::core::Result<super::super::System::Com::IStream>;
 }
 #[cfg(feature = "Win32_System_Com")]
+impl ::windows::core::RuntimeName for ITfPersistentPropertyLoaderACP {}
+#[cfg(feature = "Win32_System_Com")]
 impl ITfPersistentPropertyLoaderACP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfPersistentPropertyLoaderACP_Impl, const OFFSET: isize>() -> ITfPersistentPropertyLoaderACP_Vtbl {
         unsafe extern "system" fn LoadProperty<Identity: ::windows::core::IUnknownImpl, Impl: ITfPersistentPropertyLoaderACP_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, phdr: *const TF_PERSISTENT_PROPERTY_HEADER_ACP, ppstream: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6148,6 +6340,7 @@ impl ITfPersistentPropertyLoaderACP_Vtbl {
 pub trait ITfPreservedKeyNotifySink_Impl: Sized {
     fn OnUpdated(&self, pprekey: *const TF_PRESERVEDKEY) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfPreservedKeyNotifySink {}
 impl ITfPreservedKeyNotifySink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfPreservedKeyNotifySink_Impl, const OFFSET: isize>() -> ITfPreservedKeyNotifySink_Vtbl {
         unsafe extern "system" fn OnUpdated<Identity: ::windows::core::IUnknownImpl, Impl: ITfPreservedKeyNotifySink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pprekey: *const TF_PRESERVEDKEY) -> ::windows::core::HRESULT {
@@ -6168,6 +6361,8 @@ pub trait ITfProperty_Impl: Sized + ITfReadOnlyProperty_Impl {
     fn SetValue(&self, ec: u32, prange: &::core::option::Option<ITfRange>, pvarvalue: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
     fn Clear(&self, ec: u32, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITfProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITfProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfProperty_Impl, const OFFSET: isize>() -> ITfProperty_Vtbl {
@@ -6215,6 +6410,8 @@ pub trait ITfPropertyStore_Impl: Sized {
     fn GetPropertyRangeCreator(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn Serialize(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<u32>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITfPropertyStore {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITfPropertyStore_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfPropertyStore_Impl, const OFFSET: isize>() -> ITfPropertyStore_Vtbl {
@@ -6339,6 +6536,8 @@ pub trait ITfQueryEmbedded_Impl: Sized {
     fn QueryInsertEmbedded(&self, pguidservice: *const ::windows::core::GUID, pformatetc: *const super::super::System::Com::FORMATETC) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfQueryEmbedded {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfQueryEmbedded_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfQueryEmbedded_Impl, const OFFSET: isize>() -> ITfQueryEmbedded_Vtbl {
         unsafe extern "system" fn QueryInsertEmbedded<Identity: ::windows::core::IUnknownImpl, Impl: ITfQueryEmbedded_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguidservice: *const ::windows::core::GUID, pformatetc: *const super::super::System::Com::FORMATETC, pfinsertable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -6383,6 +6582,8 @@ pub trait ITfRange_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<ITfRange>;
     fn GetContext(&self) -> ::windows::core::Result<ITfContext>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfRange {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfRange_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfRange_Impl, const OFFSET: isize>() -> ITfRange_Vtbl {
@@ -6604,6 +6805,8 @@ pub trait ITfRangeACP_Impl: Sized + ITfRange_Impl {
     fn SetExtent(&self, acpanchor: i32, cch: i32) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for ITfRangeACP {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl ITfRangeACP_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfRangeACP_Impl, const OFFSET: isize>() -> ITfRangeACP_Vtbl {
         unsafe extern "system" fn GetExtent<Identity: ::windows::core::IUnknownImpl, Impl: ITfRangeACP_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pacpanchor: *mut i32, pcch: *mut i32) -> ::windows::core::HRESULT {
@@ -6629,6 +6832,7 @@ impl ITfRangeACP_Vtbl {
 pub trait ITfRangeBackup_Impl: Sized {
     fn Restore(&self, ec: u32, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfRangeBackup {}
 impl ITfRangeBackup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfRangeBackup_Impl, const OFFSET: isize>() -> ITfRangeBackup_Vtbl {
         unsafe extern "system" fn Restore<Identity: ::windows::core::IUnknownImpl, Impl: ITfRangeBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ec: u32, prange: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6649,6 +6853,8 @@ pub trait ITfReadOnlyProperty_Impl: Sized {
     fn GetValue(&self, ec: u32, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
     fn GetContext(&self) -> ::windows::core::Result<ITfContext>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
+impl ::windows::core::RuntimeName for ITfReadOnlyProperty {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 impl ITfReadOnlyProperty_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfReadOnlyProperty_Impl, const OFFSET: isize>() -> ITfReadOnlyProperty_Vtbl {
@@ -6711,6 +6917,8 @@ pub trait ITfReadingInformationUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetErrorIndex(&self) -> ::windows::core::Result<u32>;
     fn IsVerticalOrderPreferred(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfReadingInformationUIElement {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfReadingInformationUIElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfReadingInformationUIElement_Impl, const OFFSET: isize>() -> ITfReadingInformationUIElement_Vtbl {
@@ -6797,6 +7005,7 @@ impl ITfReadingInformationUIElement_Vtbl {
 pub trait ITfReverseConversion_Impl: Sized {
     fn DoReverseConversion(&self, lpstr: &::windows::core::PCWSTR) -> ::windows::core::Result<ITfReverseConversionList>;
 }
+impl ::windows::core::RuntimeName for ITfReverseConversion {}
 impl ITfReverseConversion_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfReverseConversion_Impl, const OFFSET: isize>() -> ITfReverseConversion_Vtbl {
         unsafe extern "system" fn DoReverseConversion<Identity: ::windows::core::IUnknownImpl, Impl: ITfReverseConversion_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpstr: ::windows::core::PCWSTR, pplist: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6821,6 +7030,8 @@ pub trait ITfReverseConversionList_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u32>;
     fn GetString(&self, uindex: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfReverseConversionList {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfReverseConversionList_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfReverseConversionList_Impl, const OFFSET: isize>() -> ITfReverseConversionList_Vtbl {
@@ -6859,6 +7070,7 @@ impl ITfReverseConversionList_Vtbl {
 pub trait ITfReverseConversionMgr_Impl: Sized {
     fn GetReverseConversion(&self, langid: u16, guidprofile: *const ::windows::core::GUID, dwflag: u32) -> ::windows::core::Result<ITfReverseConversion>;
 }
+impl ::windows::core::RuntimeName for ITfReverseConversionMgr {}
 impl ITfReverseConversionMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfReverseConversionMgr_Impl, const OFFSET: isize>() -> ITfReverseConversionMgr_Vtbl {
         unsafe extern "system" fn GetReverseConversion<Identity: ::windows::core::IUnknownImpl, Impl: ITfReverseConversionMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, langid: u16, guidprofile: *const ::windows::core::GUID, dwflag: u32, ppreverseconversion: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -6882,6 +7094,7 @@ pub trait ITfSource_Impl: Sized {
     fn AdviseSink(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
     fn UnadviseSink(&self, dwcookie: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfSource {}
 impl ITfSource_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSource_Impl, const OFFSET: isize>() -> ITfSource_Vtbl {
         unsafe extern "system" fn AdviseSink<Identity: ::windows::core::IUnknownImpl, Impl: ITfSource_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT {
@@ -6914,6 +7127,7 @@ pub trait ITfSourceSingle_Impl: Sized {
     fn AdviseSingleSink(&self, tid: u32, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UnadviseSingleSink(&self, tid: u32, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfSourceSingle {}
 impl ITfSourceSingle_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSourceSingle_Impl, const OFFSET: isize>() -> ITfSourceSingle_Vtbl {
         unsafe extern "system" fn AdviseSingleSink<Identity: ::windows::core::IUnknownImpl, Impl: ITfSourceSingle_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, tid: u32, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6942,6 +7156,8 @@ pub trait ITfSpeechUIServer_Impl: Sized {
     fn ShowUI(&self, fshow: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn UpdateBalloon(&self, style: TfLBBalloonStyle, pch: &::windows::core::PCWSTR, cch: u32) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfSpeechUIServer {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfSpeechUIServer_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSpeechUIServer_Impl, const OFFSET: isize>() -> ITfSpeechUIServer_Vtbl {
@@ -6974,6 +7190,7 @@ impl ITfSpeechUIServer_Vtbl {
 pub trait ITfStatusSink_Impl: Sized {
     fn OnStatusChange(&self, pic: &::core::option::Option<ITfContext>, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfStatusSink {}
 impl ITfStatusSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfStatusSink_Impl, const OFFSET: isize>() -> ITfStatusSink_Vtbl {
         unsafe extern "system" fn OnStatusChange<Identity: ::windows::core::IUnknownImpl, Impl: ITfStatusSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pic: ::windows::core::RawPtr, dwflags: u32) -> ::windows::core::HRESULT {
@@ -6991,6 +7208,7 @@ pub trait ITfSystemDeviceTypeLangBarItem_Impl: Sized {
     fn SetIconMode(&self, dwflags: LANG_BAR_ITEM_ICON_MODE_FLAGS) -> ::windows::core::Result<()>;
     fn GetIconMode(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for ITfSystemDeviceTypeLangBarItem {}
 impl ITfSystemDeviceTypeLangBarItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemDeviceTypeLangBarItem_Impl, const OFFSET: isize>() -> ITfSystemDeviceTypeLangBarItem_Vtbl {
         unsafe extern "system" fn SetIconMode<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemDeviceTypeLangBarItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwflags: LANG_BAR_ITEM_ICON_MODE_FLAGS) -> ::windows::core::HRESULT {
@@ -7025,6 +7243,8 @@ pub trait ITfSystemLangBarItem_Impl: Sized {
     fn SetTooltipString(&self, pchtooltip: &::windows::core::PCWSTR, cch: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
+impl ::windows::core::RuntimeName for ITfSystemLangBarItem {}
+#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 impl ITfSystemLangBarItem_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemLangBarItem_Impl, const OFFSET: isize>() -> ITfSystemLangBarItem_Vtbl {
         unsafe extern "system" fn SetIcon<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemLangBarItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hicon: super::WindowsAndMessaging::HICON) -> ::windows::core::HRESULT {
@@ -7051,6 +7271,7 @@ pub trait ITfSystemLangBarItemSink_Impl: Sized {
     fn InitMenu(&self, pmenu: &::core::option::Option<ITfMenu>) -> ::windows::core::Result<()>;
     fn OnMenuSelect(&self, wid: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfSystemLangBarItemSink {}
 impl ITfSystemLangBarItemSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemLangBarItemSink_Impl, const OFFSET: isize>() -> ITfSystemLangBarItemSink_Vtbl {
         unsafe extern "system" fn InitMenu<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemLangBarItemSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pmenu: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7078,6 +7299,8 @@ pub trait ITfSystemLangBarItemText_Impl: Sized {
     fn SetItemText(&self, pch: &::windows::core::PCWSTR, cch: u32) -> ::windows::core::Result<()>;
     fn GetItemText(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfSystemLangBarItemText {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfSystemLangBarItemText_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfSystemLangBarItemText_Impl, const OFFSET: isize>() -> ITfSystemLangBarItemText_Vtbl {
@@ -7110,6 +7333,7 @@ impl ITfSystemLangBarItemText_Vtbl {
 pub trait ITfTextEditSink_Impl: Sized {
     fn OnEndEdit(&self, pic: &::core::option::Option<ITfContext>, ecreadonly: u32, peditrecord: &::core::option::Option<ITfEditRecord>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfTextEditSink {}
 impl ITfTextEditSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextEditSink_Impl, const OFFSET: isize>() -> ITfTextEditSink_Vtbl {
         unsafe extern "system" fn OnEndEdit<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextEditSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pic: ::windows::core::RawPtr, ecreadonly: u32, peditrecord: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7127,6 +7351,7 @@ pub trait ITfTextInputProcessor_Impl: Sized {
     fn Activate(&self, ptim: &::core::option::Option<ITfThreadMgr>, tid: u32) -> ::windows::core::Result<()>;
     fn Deactivate(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfTextInputProcessor {}
 impl ITfTextInputProcessor_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextInputProcessor_Impl, const OFFSET: isize>() -> ITfTextInputProcessor_Vtbl {
         unsafe extern "system" fn Activate<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextInputProcessor_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptim: ::windows::core::RawPtr, tid: u32) -> ::windows::core::HRESULT {
@@ -7152,6 +7377,7 @@ impl ITfTextInputProcessor_Vtbl {
 pub trait ITfTextInputProcessorEx_Impl: Sized + ITfTextInputProcessor_Impl {
     fn ActivateEx(&self, ptim: &::core::option::Option<ITfThreadMgr>, tid: u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfTextInputProcessorEx {}
 impl ITfTextInputProcessorEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextInputProcessorEx_Impl, const OFFSET: isize>() -> ITfTextInputProcessorEx_Vtbl {
         unsafe extern "system" fn ActivateEx<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextInputProcessorEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptim: ::windows::core::RawPtr, tid: u32, dwflags: u32) -> ::windows::core::HRESULT {
@@ -7168,6 +7394,7 @@ impl ITfTextInputProcessorEx_Vtbl {
 pub trait ITfTextLayoutSink_Impl: Sized {
     fn OnLayoutChange(&self, pic: &::core::option::Option<ITfContext>, lcode: TfLayoutCode, pview: &::core::option::Option<ITfContextView>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfTextLayoutSink {}
 impl ITfTextLayoutSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextLayoutSink_Impl, const OFFSET: isize>() -> ITfTextLayoutSink_Vtbl {
         unsafe extern "system" fn OnLayoutChange<Identity: ::windows::core::IUnknownImpl, Impl: ITfTextLayoutSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pic: ::windows::core::RawPtr, lcode: TfLayoutCode, pview: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7185,6 +7412,7 @@ pub trait ITfThreadFocusSink_Impl: Sized {
     fn OnSetThreadFocus(&self) -> ::windows::core::Result<()>;
     fn OnKillThreadFocus(&self) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfThreadFocusSink {}
 impl ITfThreadFocusSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadFocusSink_Impl, const OFFSET: isize>() -> ITfThreadFocusSink_Vtbl {
         unsafe extern "system" fn OnSetThreadFocus<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadFocusSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7221,6 +7449,8 @@ pub trait ITfThreadMgr_Impl: Sized {
     fn EnumFunctionProviders(&self) -> ::windows::core::Result<IEnumTfFunctionProviders>;
     fn GetGlobalCompartment(&self) -> ::windows::core::Result<ITfCompartmentMgr>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfThreadMgr {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfThreadMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadMgr_Impl, const OFFSET: isize>() -> ITfThreadMgr_Vtbl {
@@ -7369,6 +7599,8 @@ pub trait ITfThreadMgr2_Impl: Sized {
     fn SuspendKeystrokeHandling(&self) -> ::windows::core::Result<()>;
     fn ResumeKeystrokeHandling(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfThreadMgr2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfThreadMgr2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadMgr2_Impl, const OFFSET: isize>() -> ITfThreadMgr2_Vtbl {
@@ -7525,6 +7757,7 @@ pub trait ITfThreadMgrEventSink_Impl: Sized {
     fn OnPushContext(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
     fn OnPopContext(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for ITfThreadMgrEventSink {}
 impl ITfThreadMgrEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadMgrEventSink_Impl, const OFFSET: isize>() -> ITfThreadMgrEventSink_Vtbl {
         unsafe extern "system" fn OnInitDocumentMgr<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadMgrEventSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdim: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7571,6 +7804,8 @@ pub trait ITfThreadMgrEx_Impl: Sized + ITfThreadMgr_Impl {
     fn GetActiveFlags(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfThreadMgrEx {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfThreadMgrEx_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadMgrEx_Impl, const OFFSET: isize>() -> ITfThreadMgrEx_Vtbl {
         unsafe extern "system" fn ActivateEx<Identity: ::windows::core::IUnknownImpl, Impl: ITfThreadMgrEx_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptid: *mut u32, dwflags: u32) -> ::windows::core::HRESULT {
@@ -7604,6 +7839,8 @@ pub trait ITfToolTipUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetString(&self) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfToolTipUIElement {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfToolTipUIElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfToolTipUIElement_Impl, const OFFSET: isize>() -> ITfToolTipUIElement_Vtbl {
         unsafe extern "system" fn GetString<Identity: ::windows::core::IUnknownImpl, Impl: ITfToolTipUIElement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstr: *mut super::super::Foundation::BSTR) -> ::windows::core::HRESULT {
@@ -7627,6 +7864,8 @@ impl ITfToolTipUIElement_Vtbl {
 pub trait ITfTransitoryExtensionSink_Impl: Sized {
     fn OnTransitoryExtensionUpdated(&self, pic: &::core::option::Option<ITfContext>, ecreadonly: u32, presultrange: &::core::option::Option<ITfRange>, pcompositionrange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfTransitoryExtensionSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfTransitoryExtensionSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfTransitoryExtensionSink_Impl, const OFFSET: isize>() -> ITfTransitoryExtensionSink_Vtbl {
@@ -7655,6 +7894,8 @@ pub trait ITfTransitoryExtensionUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetDocumentMgr(&self) -> ::windows::core::Result<ITfDocumentMgr>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfTransitoryExtensionUIElement {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfTransitoryExtensionUIElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfTransitoryExtensionUIElement_Impl, const OFFSET: isize>() -> ITfTransitoryExtensionUIElement_Vtbl {
         unsafe extern "system" fn GetDocumentMgr<Identity: ::windows::core::IUnknownImpl, Impl: ITfTransitoryExtensionUIElement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppdim: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -7681,6 +7922,8 @@ pub trait ITfUIElement_Impl: Sized {
     fn Show(&self, bshow: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
     fn IsShown(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfUIElement {}
 #[cfg(feature = "Win32_Foundation")]
 impl ITfUIElement_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfUIElement_Impl, const OFFSET: isize>() -> ITfUIElement_Vtbl {
@@ -7743,6 +7986,8 @@ pub trait ITfUIElementMgr_Impl: Sized {
     fn EnumUIElements(&self) -> ::windows::core::Result<IEnumTfUIElements>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfUIElementMgr {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfUIElementMgr_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfUIElementMgr_Impl, const OFFSET: isize>() -> ITfUIElementMgr_Vtbl {
         unsafe extern "system" fn BeginUIElement<Identity: ::windows::core::IUnknownImpl, Impl: ITfUIElementMgr_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pelement: ::windows::core::RawPtr, pbshow: *mut super::super::Foundation::BOOL, pdwuielementid: *mut u32) -> ::windows::core::HRESULT {
@@ -7802,6 +8047,8 @@ pub trait ITfUIElementSink_Impl: Sized {
     fn EndUIElement(&self, dwuielementid: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for ITfUIElementSink {}
+#[cfg(feature = "Win32_Foundation")]
 impl ITfUIElementSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: ITfUIElementSink_Impl, const OFFSET: isize>() -> ITfUIElementSink_Vtbl {
         unsafe extern "system" fn BeginUIElement<Identity: ::windows::core::IUnknownImpl, Impl: ITfUIElementSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwuielementid: u32, pbshow: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
@@ -7839,6 +8086,8 @@ pub trait IUIManagerEventSink_Impl: Sized {
     fn OnWindowClosing(&self) -> ::windows::core::Result<()>;
     fn OnWindowClosed(&self) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IUIManagerEventSink {}
 #[cfg(feature = "Win32_Foundation")]
 impl IUIManagerEventSink_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IUIManagerEventSink_Impl, const OFFSET: isize>() -> IUIManagerEventSink_Vtbl {
@@ -7894,6 +8143,8 @@ pub trait IVersionInfo_Impl: Sized {
     fn GetComponentDescription(&self, ulsub: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
     fn GetInstanceDescription(&self, ulsub: u32) -> ::windows::core::Result<super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVersionInfo {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVersionInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVersionInfo_Impl, const OFFSET: isize>() -> IVersionInfo_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
@@ -5,6 +5,8 @@ pub trait IMILBitmapEffect_Impl: Sized {
     fn SetInputSource(&self, uiindex: u32, pbitmapsource: &::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Imaging")]
+impl ::windows::core::RuntimeName for IMILBitmapEffect {}
+#[cfg(feature = "Win32_Graphics_Imaging")]
 impl IMILBitmapEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffect_Impl, const OFFSET: isize>() -> IMILBitmapEffect_Vtbl {
         unsafe extern "system" fn GetOutput<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffect_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, pcontext: ::windows::core::RawPtr, ppbitmapsource: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -49,6 +51,7 @@ pub trait IMILBitmapEffectConnections_Impl: Sized {
     fn GetInputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
     fn GetOutputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectOutputConnector>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectConnections {}
 impl IMILBitmapEffectConnections_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnections_Impl, const OFFSET: isize>() -> IMILBitmapEffectConnections_Vtbl {
         unsafe extern "system" fn GetInputConnector<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnections_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnector: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -89,6 +92,7 @@ pub trait IMILBitmapEffectConnectionsInfo_Impl: Sized {
     fn GetInputConnectorInfo(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectConnectorInfo>;
     fn GetOutputConnectorInfo(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectConnectorInfo>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectConnectionsInfo {}
 impl IMILBitmapEffectConnectionsInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnectionsInfo_Impl, const OFFSET: isize>() -> IMILBitmapEffectConnectionsInfo_Vtbl {
         unsafe extern "system" fn GetNumberInputs<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnectionsInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puinuminputs: *mut u32) -> ::windows::core::HRESULT {
@@ -151,6 +155,7 @@ pub trait IMILBitmapEffectConnector_Impl: Sized + IMILBitmapEffectConnectorInfo_
     fn IsConnected(&self) -> ::windows::core::Result<i16>;
     fn GetBitmapEffect(&self) -> ::windows::core::Result<IMILBitmapEffect>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectConnector {}
 impl IMILBitmapEffectConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnector_Impl, const OFFSET: isize>() -> IMILBitmapEffectConnector_Vtbl {
         unsafe extern "system" fn IsConnected<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfconnected: *mut i16) -> ::windows::core::HRESULT {
@@ -191,6 +196,7 @@ pub trait IMILBitmapEffectConnectorInfo_Impl: Sized {
     fn GetNumberFormats(&self) -> ::windows::core::Result<u32>;
     fn GetFormat(&self, ulindex: u32) -> ::windows::core::Result<::windows::core::GUID>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectConnectorInfo {}
 impl IMILBitmapEffectConnectorInfo_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnectorInfo_Impl, const OFFSET: isize>() -> IMILBitmapEffectConnectorInfo_Vtbl {
         unsafe extern "system" fn GetIndex<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectConnectorInfo_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puiindex: *mut u32) -> ::windows::core::HRESULT {
@@ -255,6 +261,8 @@ pub trait IMILBitmapEffectEvents_Impl: Sized {
     fn DirtyRegion(&self, peffect: &::core::option::Option<IMILBitmapEffect>, prect: *const MilRectD) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IMILBitmapEffectEvents {}
+#[cfg(feature = "Win32_Foundation")]
 impl IMILBitmapEffectEvents_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectEvents_Impl, const OFFSET: isize>() -> IMILBitmapEffectEvents_Vtbl {
         unsafe extern "system" fn PropertyChange<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectEvents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peffect: ::windows::core::RawPtr, bstrpropertyname: ::core::mem::ManuallyDrop<super::super::Foundation::BSTR>) -> ::windows::core::HRESULT {
@@ -282,6 +290,7 @@ pub trait IMILBitmapEffectFactory_Impl: Sized {
     fn CreateContext(&self) -> ::windows::core::Result<IMILBitmapEffectRenderContext>;
     fn CreateEffectOuter(&self) -> ::windows::core::Result<IMILBitmapEffect>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectFactory {}
 impl IMILBitmapEffectFactory_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectFactory_Impl, const OFFSET: isize>() -> IMILBitmapEffectFactory_Vtbl {
         unsafe extern "system" fn CreateEffect<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pguideffect: *const ::windows::core::GUID, ppeffect: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -333,6 +342,7 @@ pub trait IMILBitmapEffectGroup_Impl: Sized {
     fn GetInteriorOutputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
     fn Add(&self, peffect: &::core::option::Option<IMILBitmapEffect>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectGroup {}
 impl IMILBitmapEffectGroup_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectGroup_Impl, const OFFSET: isize>() -> IMILBitmapEffectGroup_Vtbl {
         unsafe extern "system" fn GetInteriorInputConnector<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectGroup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnector: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -378,6 +388,7 @@ pub trait IMILBitmapEffectGroupImpl_Impl: Sized {
     fn GetNumberChildren(&self) -> ::windows::core::Result<u32>;
     fn GetChildren(&self) -> ::windows::core::Result<IMILBitmapEffects>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectGroupImpl {}
 impl IMILBitmapEffectGroupImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectGroupImpl_Impl, const OFFSET: isize>() -> IMILBitmapEffectGroupImpl_Vtbl {
         unsafe extern "system" fn Preprocess<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectGroupImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcontext: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -428,6 +439,8 @@ pub trait IMILBitmapEffectImpl_Impl: Sized {
     fn GetOutputBitmapSource(&self, uiindex: u32, prendercontext: &::core::option::Option<IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut i16, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows::core::Result<()>;
     fn Initialize(&self, pinner: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Graphics_Imaging")]
+impl ::windows::core::RuntimeName for IMILBitmapEffectImpl {}
 #[cfg(feature = "Win32_Graphics_Imaging")]
 impl IMILBitmapEffectImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectImpl_Impl, const OFFSET: isize>() -> IMILBitmapEffectImpl_Vtbl {
@@ -503,6 +516,7 @@ pub trait IMILBitmapEffectInputConnector_Impl: Sized + IMILBitmapEffectConnector
     fn ConnectTo(&self, pconnector: &::core::option::Option<IMILBitmapEffectOutputConnector>) -> ::windows::core::Result<()>;
     fn GetConnection(&self) -> ::windows::core::Result<IMILBitmapEffectOutputConnector>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectInputConnector {}
 impl IMILBitmapEffectInputConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectInputConnector_Impl, const OFFSET: isize>() -> IMILBitmapEffectInputConnector_Vtbl {
         unsafe extern "system" fn ConnectTo<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectInputConnector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnector: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -534,6 +548,7 @@ impl IMILBitmapEffectInputConnector_Vtbl {
 pub trait IMILBitmapEffectInteriorInputConnector_Impl: Sized {
     fn GetInputConnector(&self) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectInteriorInputConnector {}
 impl IMILBitmapEffectInteriorInputConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectInteriorInputConnector_Impl, const OFFSET: isize>() -> IMILBitmapEffectInteriorInputConnector_Vtbl {
         unsafe extern "system" fn GetInputConnector<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectInteriorInputConnector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinputconnector: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -556,6 +571,7 @@ impl IMILBitmapEffectInteriorInputConnector_Vtbl {
 pub trait IMILBitmapEffectInteriorOutputConnector_Impl: Sized {
     fn GetOutputConnector(&self) -> ::windows::core::Result<IMILBitmapEffectOutputConnector>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectInteriorOutputConnector {}
 impl IMILBitmapEffectInteriorOutputConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectInteriorOutputConnector_Impl, const OFFSET: isize>() -> IMILBitmapEffectInteriorOutputConnector_Vtbl {
         unsafe extern "system" fn GetOutputConnector<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectInteriorOutputConnector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, poutputconnector: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -579,6 +595,7 @@ pub trait IMILBitmapEffectOutputConnector_Impl: Sized + IMILBitmapEffectConnecto
     fn GetNumberConnections(&self) -> ::windows::core::Result<u32>;
     fn GetConnection(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectOutputConnector {}
 impl IMILBitmapEffectOutputConnector_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectOutputConnector_Impl, const OFFSET: isize>() -> IMILBitmapEffectOutputConnector_Vtbl {
         unsafe extern "system" fn GetNumberConnections<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectOutputConnector_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puinumberconnections: *mut u32) -> ::windows::core::HRESULT {
@@ -617,6 +634,7 @@ pub trait IMILBitmapEffectOutputConnectorImpl_Impl: Sized {
     fn AddBackLink(&self, pconnection: &::core::option::Option<IMILBitmapEffectInputConnector>) -> ::windows::core::Result<()>;
     fn RemoveBackLink(&self, pconnection: &::core::option::Option<IMILBitmapEffectInputConnector>) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectOutputConnectorImpl {}
 impl IMILBitmapEffectOutputConnectorImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectOutputConnectorImpl_Impl, const OFFSET: isize>() -> IMILBitmapEffectOutputConnectorImpl_Vtbl {
         unsafe extern "system" fn AddBackLink<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectOutputConnectorImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconnection: ::windows::core::RawPtr) -> ::windows::core::HRESULT {
@@ -648,6 +666,8 @@ pub trait IMILBitmapEffectPrimitive_Impl: Sized {
     fn HasInverseTransform(&self, uiindex: u32) -> ::windows::core::Result<i16>;
     fn GetAffineMatrix(&self, uiindex: u32, pmatrix: *mut super::super::Graphics::Dwm::MilMatrix3x2D) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Graphics_Dwm", feature = "Win32_Graphics_Imaging"))]
+impl ::windows::core::RuntimeName for IMILBitmapEffectPrimitive {}
 #[cfg(all(feature = "Win32_Graphics_Dwm", feature = "Win32_Graphics_Imaging"))]
 impl IMILBitmapEffectPrimitive_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectPrimitive_Impl, const OFFSET: isize>() -> IMILBitmapEffectPrimitive_Vtbl {
@@ -711,6 +731,7 @@ pub trait IMILBitmapEffectPrimitiveImpl_Impl: Sized {
     fn IsDirty(&self, uioutputindex: u32, pfdirty: *mut i16) -> ::windows::core::HRESULT;
     fn IsVolatile(&self, uioutputindex: u32) -> ::windows::core::Result<i16>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectPrimitiveImpl {}
 impl IMILBitmapEffectPrimitiveImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectPrimitiveImpl_Impl, const OFFSET: isize>() -> IMILBitmapEffectPrimitiveImpl_Vtbl {
         unsafe extern "system" fn IsDirty<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectPrimitiveImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uioutputindex: u32, pfdirty: *mut i16) -> ::windows::core::HRESULT {
@@ -749,6 +770,7 @@ pub trait IMILBitmapEffectRenderContext_Impl: Sized {
     fn GetOutputDPI(&self, pdbldpix: *mut f64, pdbldpiy: *mut f64) -> ::windows::core::Result<()>;
     fn SetRegionOfInterest(&self, prect: *const MilRectD) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectRenderContext {}
 impl IMILBitmapEffectRenderContext_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectRenderContext_Impl, const OFFSET: isize>() -> IMILBitmapEffectRenderContext_Vtbl {
         unsafe extern "system" fn SetOutputPixelFormat<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectRenderContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, format: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
@@ -826,6 +848,7 @@ pub trait IMILBitmapEffectRenderContextImpl_Impl: Sized {
     fn GetOutputBounds(&self, prect: *mut MilRectD) -> ::windows::core::Result<()>;
     fn UpdateOutputBounds(&self, prect: *const MilRectD) -> ::windows::core::Result<()>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffectRenderContextImpl {}
 impl IMILBitmapEffectRenderContextImpl_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectRenderContextImpl_Impl, const OFFSET: isize>() -> IMILBitmapEffectRenderContextImpl_Vtbl {
         unsafe extern "system" fn GetUseSoftwareRenderer<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffectRenderContextImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pfsoftware: *mut i16) -> ::windows::core::HRESULT {
@@ -878,6 +901,7 @@ pub trait IMILBitmapEffects_Impl: Sized {
     fn Item(&self, uindex: u32) -> ::windows::core::Result<IMILBitmapEffect>;
     fn Count(&self) -> ::windows::core::Result<u32>;
 }
+impl ::windows::core::RuntimeName for IMILBitmapEffects {}
 impl IMILBitmapEffects_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffects_Impl, const OFFSET: isize>() -> IMILBitmapEffects_Vtbl {
         unsafe extern "system" fn _NewEnum<Identity: ::windows::core::IUnknownImpl, Impl: IMILBitmapEffects_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppiureturn: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/impl.rs
@@ -6,6 +6,8 @@ pub trait IBitmapData_Impl: Sized {
     fn GetSourceBitmapDescription(&self) -> ::windows::core::Result<BitmapDescription>;
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
+impl ::windows::core::RuntimeName for IBitmapData {}
+#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl IBitmapData_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IBitmapData_Impl, const OFFSET: isize>() -> IBitmapData_Vtbl {
         unsafe extern "system" fn CopyBytesTo<Identity: ::windows::core::IUnknownImpl, Impl: IBitmapData_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sourceoffsetinbytes: u32, maxbytestocopy: u32, pvbytes: *mut u8, numberofbytescopied: *mut u32) -> ::windows::core::HRESULT {
@@ -73,6 +75,8 @@ pub trait IVisualTreeService_Impl: Sized {
     fn RemoveChild(&self, parent: u64, index: u32) -> ::windows::core::Result<()>;
     fn ClearChildren(&self, parent: u64) -> ::windows::core::Result<()>;
 }
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IVisualTreeService {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IVisualTreeService_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeService_Impl, const OFFSET: isize>() -> IVisualTreeService_Vtbl {
@@ -176,6 +180,8 @@ pub trait IVisualTreeService2_Impl: Sized + IVisualTreeService_Impl {
     fn RenderTargetBitmap(&self, handle: u64, options: RenderTargetBitmapOptions, maxpixelwidth: u32, maxpixelheight: u32) -> ::windows::core::Result<IBitmapData>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IVisualTreeService2 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IVisualTreeService2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeService2_Impl, const OFFSET: isize>() -> IVisualTreeService2_Vtbl {
         unsafe extern "system" fn GetPropertyIndex<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeService2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, object: u64, propertyname: ::windows::core::PCWSTR, ppropertyindex: *mut u32) -> ::windows::core::HRESULT {
@@ -236,6 +242,8 @@ pub trait IVisualTreeService3_Impl: Sized + IVisualTreeService_Impl + IVisualTre
     fn RemoveDictionaryItem(&self, dictionaryhandle: u64, resourcekey: u64) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
+impl ::windows::core::RuntimeName for IVisualTreeService3 {}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 impl IVisualTreeService3_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeService3_Impl, const OFFSET: isize>() -> IVisualTreeService3_Vtbl {
         unsafe extern "system" fn ResolveResource<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeService3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resourcecontext: u64, resourcename: ::windows::core::PCWSTR, resourcetype: ResourceType, propertyindex: u32) -> ::windows::core::HRESULT {
@@ -281,6 +289,8 @@ pub trait IVisualTreeServiceCallback_Impl: Sized {
     fn OnVisualTreeChange(&self, relation: &ParentChildRelation, element: &VisualElement, mutationtype: VisualMutationType) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVisualTreeServiceCallback {}
+#[cfg(feature = "Win32_Foundation")]
 impl IVisualTreeServiceCallback_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeServiceCallback_Impl, const OFFSET: isize>() -> IVisualTreeServiceCallback_Vtbl {
         unsafe extern "system" fn OnVisualTreeChange<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeServiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, relation: ParentChildRelation, element: ::core::mem::ManuallyDrop<VisualElement>, mutationtype: VisualMutationType) -> ::windows::core::HRESULT {
@@ -298,6 +308,8 @@ impl IVisualTreeServiceCallback_Vtbl {
 pub trait IVisualTreeServiceCallback2_Impl: Sized + IVisualTreeServiceCallback_Impl {
     fn OnElementStateChanged(&self, element: u64, elementstate: VisualElementState, context: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IVisualTreeServiceCallback2 {}
 #[cfg(feature = "Win32_Foundation")]
 impl IVisualTreeServiceCallback2_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IVisualTreeServiceCallback2_Impl, const OFFSET: isize>() -> IVisualTreeServiceCallback2_Vtbl {
@@ -323,6 +335,8 @@ pub trait IXamlDiagnostics_Impl: Sized {
     fn RegisterInstance(&self, pinstance: &::core::option::Option<::windows::core::IInspectable>) -> ::windows::core::Result<u64>;
     fn GetInitializationData(&self) -> ::windows::core::Result<super::super::super::Foundation::BSTR>;
 }
+#[cfg(feature = "Win32_Foundation")]
+impl ::windows::core::RuntimeName for IXamlDiagnostics {}
 #[cfg(feature = "Win32_Foundation")]
 impl IXamlDiagnostics_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl, Impl: IXamlDiagnostics_Impl, const OFFSET: isize>() -> IXamlDiagnostics_Vtbl {

--- a/crates/libs/windows/src/core/inspectable.rs
+++ b/crates/libs/windows/src/core/inspectable.rs
@@ -43,9 +43,7 @@ unsafe impl RuntimeType for IInspectable {
     }
 }
 
-impl RuntimeName for IInspectable {
-    const NAME: &'static str = "";
-}
+impl RuntimeName for IInspectable {}
 
 impl core::fmt::Debug for IInspectable {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/crates/libs/windows/src/core/runtime_name.rs
+++ b/crates/libs/windows/src/core/runtime_name.rs
@@ -1,4 +1,4 @@
 pub trait RuntimeName {
     // TODO: needs to use ConstBuffer like RuntimeType to allow generic interfaces to have names for GetRuntimeClassName
-    const NAME: &'static str;
+    const NAME: &'static str = "";
 }

--- a/crates/tests/nightly_component_client/src/lib.rs
+++ b/crates/tests/nightly_component_client/src/lib.rs
@@ -13,7 +13,7 @@ fn test() -> Result<()> {
 
     // This explicitly queries for IInspectable.
     let inspectable: IInspectable = class.cast()?;
-    // Notice GetRuntimeClassName returns the class name. 
+    // Notice GetRuntimeClassName returns the class name.
     assert_eq!(inspectable.GetRuntimeClassName()?, "test_nightly_component.Class");
 
     // This just casts down to IInspectable since the vtable already includes IInspectable.

--- a/crates/tests/nightly_component_client/src/lib.rs
+++ b/crates/tests/nightly_component_client/src/lib.rs
@@ -11,10 +11,14 @@ fn test() -> Result<()> {
     class.SetProperty(123)?;
     assert_eq!(class.Property()?, 123);
 
+    // This explicitly queries for IInspectable.
     let inspectable: IInspectable = class.cast()?;
+    // Notice GetRuntimeClassName returns the class name. 
     assert_eq!(inspectable.GetRuntimeClassName()?, "test_nightly_component.Class");
 
+    // This just casts down to IInspectable since the vtable already includes IInspectable.
     let inspectable: IInspectable = class.into();
+    // Notice GetRuntimeClassName returns the specific interface name.
     assert_eq!(inspectable.GetRuntimeClassName()?, "test_nightly_component.IClass");
     Ok(())
 }

--- a/crates/tests/nightly_component_client/src/lib.rs
+++ b/crates/tests/nightly_component_client/src/lib.rs
@@ -10,5 +10,11 @@ fn test() -> Result<()> {
     let class = Class::new()?;
     class.SetProperty(123)?;
     assert_eq!(class.Property()?, 123);
+
+    let inspectable: IInspectable = class.cast()?;
+    assert_eq!(inspectable.GetRuntimeClassName()?, "test_nightly_component.Class");
+
+    let inspectable: IInspectable = class.into();
+    assert_eq!(inspectable.GetRuntimeClassName()?, "test_nightly_component.IClass");
     Ok(())
 }

--- a/crates/tests/nightly_identity/tests/test.rs
+++ b/crates/tests/nightly_identity/tests/test.rs
@@ -66,7 +66,7 @@ fn identity() -> Result<()> {
         }
         {
             let a: IInspectable = Test::new("test").into();
-            assert_eq!(a.GetRuntimeClassName()?, "");
+            assert_eq!(a.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
 
             let b: IStringable = a.cast()?;
             let c: IInspectable = b.into();
@@ -77,7 +77,7 @@ fn identity() -> Result<()> {
             assert_eq!(e.GetRuntimeClassName()?, "Windows.Foundation.IClosable");
 
             let f: IInspectable = e.cast()?;
-            assert_eq!(f.GetRuntimeClassName()?, "");
+            assert_eq!(f.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
         }
         assert_eq!(COUNTER, 0);
         Ok(())


### PR DESCRIPTION
Registration-free metadata based marshaling (MBM) always queries for `IInspectable`, so the implementation of `GetRuntimeClassName` from this `IInspectable` implementation must return the class or interface type best describing the implementation. This change also ensures that the .NET interop support will be able to correctly resolve the type of a given Rust implementation. 

The identity is assumed to be the first interface or class declared by the `implement` macro. Previously, it returned an empty string if you explicitly query for `IInspectable` and then call `GetRuntimeClassName` since it doesn't know which interface you're specifically asking about. 

Original repro is here: https://github.com/kennykerr/component-rs 

Fixes #1730