### PR TITLE
Fix interface macro to handle qualified IUnknown parent

### DIFF
--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -284,7 +284,12 @@ impl Interface {
     }
 
     fn parent_is_iunknown(&self) -> bool {
-        self.parent.is_ident("IUnknown")
+        let end = self.parent.segments.last();
+        let end = match end {
+            Some(e) => e,
+            None => return false,
+        };
+        end.ident == "IUnknown"
     }
 
     fn parent_ident(&self) -> &syn::Ident {

--- a/crates/tests/nightly_interface/tests/com.rs
+++ b/crates/tests/nightly_interface/tests/com.rs
@@ -18,7 +18,7 @@ unsafe trait ICustomUri: IUnknown {
 
 /// A custom declaration of implementation of `IPersist`
 #[interface("0000010c-0000-0000-C000-000000000046")]
-unsafe trait ICustomPersist: IUnknown {
+unsafe trait ICustomPersist: windows::core::IUnknown {
     unsafe fn GetClassID(&self, clsid: *mut GUID) -> HRESULT;
 }
 


### PR DESCRIPTION
Fixes #1687 

We have to differentiate between `IUnknown` and any other parent COM interface. This is because `IUnknown::new` only have two generic parameters (`T: IUknownImpl` and `OFFSET`) while all other interfaces have `new` function that takes three generic parameters (`Identify: IUnknownImpl`, `Impl` the interface impl, and `OFFSET`). 

This change makes our check for `IUnknown` a bit more sophisticated. However, this is still a syntactic check and if a ident that is *semantically* equivalent to `IUnknown` (but *syntactically* equivalent) is provided  (e.g., `type MyIUnknown = windows::core::IUnknown` or `use core::windows::IUnknown as MyIUnknown`), this check will not detect that it's `IUnknown` and the user will get the bad error message again which just says we're providing three generic arguments to `new` when two are expected.

The way to actually fix this is to not special case `IUnknown` and treat it like any other parent interface, but that's a bigger change that will require moving other things around. 
 