### PR TITLE
Shorten IUnknown check

### DIFF
--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -284,12 +284,7 @@ impl Interface {
     }
 
     fn parent_is_iunknown(&self) -> bool {
-        let end = self.parent.segments.last();
-        let end = match end {
-            Some(e) => e,
-            None => return false,
-        };
-        end.ident == "IUnknown"
+        self.parent_ident() == "IUnknown"
     }
 
     fn parent_ident(&self) -> &syn::Ident {


### PR DESCRIPTION
After #1732 landed, I noticed the code could be written much more concisely using the existing `parent_ident` method. 