### PR TITLE
Simplify header handling in HSTRING

### DIFF
--- a/crates/libs/windows/src/core/hstring.rs
+++ b/crates/libs/windows/src/core/hstring.rs
@@ -410,6 +410,7 @@ impl Header {
     fn alloc(len: u32) -> *mut Header {
         debug_assert!(len != 0);
         // Allocate enough space for header and two bytes per character.
+        // The space for the terminating null character is already accounted for inside of `Header`.
         let alloc_size = core::mem::size_of::<Header>() + 2 * len as usize;
 
         // TODO: allow this failure to propagate
@@ -434,8 +435,9 @@ impl Header {
             // Otherwise, allocate a new string and copy the value into the new string.
             let copy = Header::alloc(self.len);
             // SAFETY: since we are duplicating the string it is safe to copy all data from self to the initialized `copy`.
+            // We copy `len + 1` characters since `len` does not account for the terminating null character.
             unsafe {
-                core::ptr::copy_nonoverlapping(self.data, (*copy).data, self.len as usize);
+                core::ptr::copy_nonoverlapping(self.data, (*copy).data, self.len as usize + 1);
             }
             copy
         }


### PR DESCRIPTION
This simplifies the `HSTRING` header and adds more safety documentation. 