### PR TITLE
Fix `ToImpl`

### DIFF
--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -60,16 +60,16 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
                     unsafe { ::core::mem::transmute_copy(&vtable_ptr) }
                 }
             }
-            impl <#constraints> ::windows::core::ToImpl<#original_ident::<#(#generics,)*>> for #interface_ident {
+            impl <#constraints> ::windows::core::AsImpl<#original_ident::<#(#generics,)*>> for #interface_ident {
                 fn as_impl(&self) -> &#original_ident::<#(#generics,)*> {
                     let this = ::windows::core::Interface::as_raw(self);
-                    // SAFETY: the offset is guranteed to be in bounds, and the implementation struct 
+                    // SAFETY: the offset is guranteed to be in bounds, and the implementation struct
                     // is guaranteed to live at least as long as `self`.
-                    unsafe { 
-                        // Subtract away the vtable offset plus 2 (for the `base` and `identity` fields) to get 
+                    unsafe {
+                        // Subtract away the vtable offset plus 2 (for the `base` and `identity` fields) to get
                         // to the impl struct which contains that original implementation type.
                         let this = (this as *mut ::windows::core::RawPtr).sub(2 + #offset) as *mut #impl_ident::<#(#generics,)*>;
-                        &(*this).this 
+                        &(*this).this
                     }
                 }
             }

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -60,11 +60,17 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
                     unsafe { ::core::mem::transmute_copy(&vtable_ptr) }
                 }
             }
-            impl <#constraints> ::windows::core::ToImpl<#interface_ident> for #original_ident::<#(#generics,)*> {
-                unsafe fn to_impl(interface: &#interface_ident) -> &mut Self {
-                    let this: ::windows::core::RawPtr = ::windows::core::Interface::as_raw(interface);
-                    let this = (this as *mut ::windows::core::RawPtr).sub(2 + #offset) as *mut #impl_ident::<#(#generics,)*>;
-                    &mut (*this).this
+            impl <#constraints> ::windows::core::ToImpl<#original_ident::<#(#generics,)*>> for #interface_ident {
+                fn as_impl(&self) -> &#original_ident::<#(#generics,)*> {
+                    let this = ::windows::core::Interface::as_raw(self);
+                    // SAFETY: the offset is guranteed to be in bounds, and the implementation struct 
+                    // is guaranteed to live at least as long as `self`.
+                    unsafe { 
+                        // Subtract away the vtable offset plus 2 (for the `base` and `identity` fields) to get 
+                        // to the impl struct which contains that original implementation type.
+                        let this = (this as *mut ::windows::core::RawPtr).sub(2 + #offset) as *mut #impl_ident::<#(#generics,)*>;
+                        &(*this).this 
+                    }
                 }
             }
         }

--- a/crates/libs/windows/src/core/as_impl.rs
+++ b/crates/libs/windows/src/core/as_impl.rs
@@ -1,6 +1,6 @@
 /// A trait for retrieving the implementation behind a COM or WinRT interface.
 ///
 /// This trait is automatically implemented when using the `implement` macro.
-pub trait ToImpl<T> {
+pub trait AsImpl<T> {
     fn as_impl(&self) -> &T;
 }

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -1,6 +1,7 @@
 mod abi;
 mod agile_reference;
 mod array;
+mod as_impl;
 pub(crate) mod bindings;
 mod compose;
 mod delay_load;
@@ -24,7 +25,6 @@ mod ref_count;
 mod runtime_name;
 mod runtime_type;
 mod sha1;
-mod to_impl;
 mod unknown;
 mod waiter;
 mod weak;
@@ -34,6 +34,8 @@ mod weak_ref_count;
 pub use abi::*;
 pub use agile_reference::*;
 pub use array::*;
+#[doc(hidden)]
+pub use as_impl::*;
 #[doc(hidden)]
 pub use compose::*;
 pub(crate) use delay_load::*;
@@ -65,8 +67,6 @@ pub use runtime_name::*;
 pub use runtime_type::*;
 #[doc(hidden)]
 pub use sha1::*;
-#[doc(hidden)]
-pub use to_impl::*;
 pub use unknown::*;
 #[doc(hidden)]
 pub use waiter::*;

--- a/crates/libs/windows/src/core/to_impl.rs
+++ b/crates/libs/windows/src/core/to_impl.rs
@@ -1,12 +1,6 @@
-use super::*;
-
 /// A trait for retrieving the implementation behind a COM or WinRT interface.
 ///
-/// This trait is automatically implemented when using the `implement` macro but
-/// is considered unsafe since different implementations of the `from` interface
-/// may exist.
-pub trait ToImpl<T: Interface> {
-    /// # Safety
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn to_impl(from: &T) -> &mut Self;
+/// This trait is automatically implemented when using the `implement` macro.
+pub trait ToImpl<T> {
+    fn as_impl(&self) -> &T;
 }

--- a/crates/tests/nightly_data_object/tests/test.rs
+++ b/crates/tests/nightly_data_object/tests/test.rs
@@ -96,7 +96,7 @@ fn test() -> Result<()> {
         let _ = d.EnumFormatEtc(0);
         d.DAdvise(core::ptr::null_mut(), 0, None)?;
 
-        let i = Test::to_impl(&d).0.get();
+        let i = d.as_impl().0.get();
         assert!((*i).GetData);
         assert!((*i).GetDataHere);
         assert!((*i).QueryGetData);

--- a/crates/tests/nightly_implement/tests/into_impl.rs
+++ b/crates/tests/nightly_implement/tests/into_impl.rs
@@ -12,7 +12,7 @@ impl<T: RuntimeType + 'static> IIterator_Impl<T> for Iterator<T> {
     fn Current(&self) -> Result<T> {
         unsafe {
             let this = self.0.get();
-            let owner = Iterable::to_impl(&(*this).0);
+            let owner = (*this).0.as_impl();
 
             if owner.0.len() > (*this).1 {
                 Ok(owner.0[(*this).1].clone())
@@ -25,7 +25,7 @@ impl<T: RuntimeType + 'static> IIterator_Impl<T> for Iterator<T> {
     fn HasCurrent(&self) -> Result<bool> {
         unsafe {
             let this = self.0.get();
-            let owner = Iterable::to_impl(&(*this).0);
+            let owner = (*this).0.as_impl();
             Ok(owner.0.len() > (*this).1)
         }
     }
@@ -33,7 +33,7 @@ impl<T: RuntimeType + 'static> IIterator_Impl<T> for Iterator<T> {
     fn MoveNext(&self) -> Result<bool> {
         unsafe {
             let this = self.0.get();
-            let owner = Iterable::to_impl(&(*this).0);
+            let owner = (*this).0.as_impl();
             (*this).1 += 1;
             Ok(owner.0.len() > (*this).1)
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/windows-rs/issues/1615

This changes the definition of `ToImpl` (now called `AsImpl`) to take `&self` and return a reference to the underlying impl. There's no reason for this to be unsafe as implementors can be sure that if they have a reference to an interface pointer, they can get a non-exclusive reference to underlying implementation. 