### PR TITLE
Add `HSTRING` compatibility testing

### DIFF
--- a/crates/libs/windows/src/core/heap.rs
+++ b/crates/libs/windows/src/core/heap.rs
@@ -14,6 +14,13 @@ pub fn heap_alloc(bytes: usize) -> Result<RawPtr> {
     if ptr.is_null() {
         Err(E_OUTOFMEMORY.into())
     } else {
+        // HeapAlloc is not guaranteed to return zero memory but usually does. This just ensures that
+        // it predictably returns non-zero memory for testing purposes. This is similar to what MSVC's
+        // debug allocator does for the same reason.
+        #[cfg(debug_assertions)]
+        unsafe {
+            std::ptr::write_bytes(ptr, b'?', bytes);
+        }
         Ok(ptr)
     }
 }

--- a/crates/libs/windows/src/core/heap.rs
+++ b/crates/libs/windows/src/core/heap.rs
@@ -19,7 +19,7 @@ pub fn heap_alloc(bytes: usize) -> Result<RawPtr> {
         // debug allocator does for the same reason.
         #[cfg(debug_assertions)]
         unsafe {
-            std::ptr::write_bytes(ptr, b'?', bytes);
+            std::ptr::write_bytes(ptr, 0xCC, bytes);
         }
         Ok(ptr)
     }

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -4,5 +4,16 @@ version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
-[dependencies]
-windows = { path = "../../libs/windows" }
+[dependencies.windows]
+path = "../../libs/windows"
+features = [
+    "alloc",
+    "Win32_Foundation",
+    "Win32_System_WinRT",
+]
+
+[dependencies.windows-sys]
+path = "../../libs/sys"
+features = [
+    "Win32_System_WinRT",
+]

--- a/crates/tests/core/tests/hstrings.rs
+++ b/crates/tests/core/tests/hstrings.rs
@@ -175,6 +175,7 @@ fn hstring_compat() -> Result<()> {
         assert_eq!(WindowsGetStringLen(&world), 5);
         assert_eq!(WindowsGetStringLen("World"), 5);
 
+        assert_eq!(WindowsIsStringEmpty(HSTRING::new()), true);
         assert_eq!(WindowsIsStringEmpty(""), true);
         assert_eq!(WindowsIsStringEmpty(&world), false);
         assert_eq!(WindowsIsStringEmpty("World"), false);

--- a/crates/tests/core/tests/hstrings.rs
+++ b/crates/tests/core/tests/hstrings.rs
@@ -1,55 +1,54 @@
 use std::convert::TryFrom;
 use windows::core::*;
-type StringType = HSTRING;
 
 #[test]
 fn hstring_works() {
-    let empty = StringType::new();
+    let empty = HSTRING::new();
     assert!(empty.is_empty());
     assert!(empty.is_empty());
 
-    let mut hello = StringType::from("Hello");
-    assert!(!hello.is_empty());
-    assert!(hello.len() == 5);
+    let mut hey = HSTRING::from("Hello");
+    assert!(!hey.is_empty());
+    assert!(hey.len() == 5);
 
-    let rust = hello.to_string();
+    let rust = hey.to_string();
     assert!(rust == "Hello");
     assert!(rust.len() == 5);
 
-    let hello2 = hello.clone();
-    hello.clear();
-    assert!(hello.is_empty());
-    hello.clear();
-    assert!(hello.is_empty());
+    let hello2 = hey.clone();
+    hey.clear();
+    assert!(hey.is_empty());
+    hey.clear();
+    assert!(hey.is_empty());
     assert!(!hello2.is_empty());
     assert!(hello2.len() == 5);
 
-    assert!(StringType::from("Hello") == StringType::from("Hello"));
-    assert!(StringType::from("Hello") != StringType::from("World"));
+    assert!(HSTRING::from("Hello") == HSTRING::from("Hello"));
+    assert!(HSTRING::from("Hello") != HSTRING::from("World"));
 
-    assert!(StringType::from("Hello") == "Hello");
-    assert!(StringType::from("Hello") != "Hello ");
-    assert!(StringType::from("Hello") != "Hell");
-    assert!(StringType::from("Hello") != "World");
+    assert!(HSTRING::from("Hello") == "Hello");
+    assert!(HSTRING::from("Hello") != "Hello ");
+    assert!(HSTRING::from("Hello") != "Hell");
+    assert!(HSTRING::from("Hello") != "World");
 
-    assert!(StringType::from("Hello").to_string() == String::from("Hello"));
+    assert!(HSTRING::from("Hello").to_string() == String::from("Hello"));
 }
 
 #[test]
 fn display_format() {
-    let value = StringType::from("Hello world");
+    let value = HSTRING::from("Hello world");
     assert!(format!("{}", value) == "Hello world");
 }
 
 #[test]
 fn debug_format() {
-    let value = StringType::from("Hello world");
+    let value = HSTRING::from("Hello world");
     assert!(format!("{:?}", value) == "Hello world");
 }
 
 #[test]
 fn from_empty_string() {
-    let h = StringType::from("");
+    let h = HSTRING::from("");
     assert!(format!("{}", h).is_empty());
 }
 
@@ -58,14 +57,14 @@ fn from_os_string_string() {
     let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
     use std::os::windows::prelude::OsStringExt;
     let o = std::ffi::OsString::from_wide(wide_data);
-    let h = StringType::from(o);
-    let d = StringType::from_wide(wide_data);
+    let h = HSTRING::from(o);
+    let d = HSTRING::from_wide(wide_data);
     assert_eq!(h, d);
 }
 
 #[test]
 fn hstring_to_string() {
-    let h = StringType::from("test");
+    let h = HSTRING::from("test");
     let s = String::try_from(h).unwrap();
     assert!(s == "test");
 }
@@ -74,7 +73,7 @@ fn hstring_to_string() {
 fn hstring_to_string_err() {
     // 𝄞mu<invalid>ic
     let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
-    let h = StringType::from_wide(wide_data);
+    let h = HSTRING::from_wide(wide_data);
     let err = String::try_from(h);
     assert!(err.is_err());
 }
@@ -83,7 +82,7 @@ fn hstring_to_string_err() {
 fn hstring_to_string_lossy() {
     // 𝄞mu<invalid>ic
     let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
-    let h = StringType::from_wide(wide_data);
+    let h = HSTRING::from_wide(wide_data);
     let s = h.to_string_lossy();
     assert_eq!(s, "𝄞mu�ic");
 }
@@ -92,7 +91,7 @@ fn hstring_to_string_lossy() {
 fn hstring_to_os_string() {
     // 𝄞mu<invalid>ic
     let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
-    let h = StringType::from_wide(wide_data);
+    let h = HSTRING::from_wide(wide_data);
     let s = h.to_os_string();
     use std::os::windows::prelude::OsStringExt;
     assert_eq!(s, std::ffi::OsString::from_wide(wide_data));
@@ -100,7 +99,7 @@ fn hstring_to_os_string() {
 
 #[test]
 fn hstring_equality_combinations() {
-    let h = StringType::from("test");
+    let h = HSTRING::from("test");
     let s = String::from("test");
     let ss: &str = "test";
 
@@ -128,7 +127,7 @@ fn hstring_equality_combinations() {
 #[test]
 fn hstring_osstring_equality_combinations() {
     let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
-    let h = StringType::from_wide(wide_data);
+    let h = HSTRING::from_wide(wide_data);
     use std::os::windows::prelude::OsStringExt;
     let s = std::ffi::OsString::from_wide(wide_data);
     let ss = s.as_os_str();
@@ -152,4 +151,43 @@ fn hstring_osstring_equality_combinations() {
     assert_eq!(*ss, &h);
     assert_eq!(ss, h);
     assert_eq!(ss, &h);
+}
+
+#[test]
+fn hstring_compat() -> Result<()> {
+    unsafe {
+        use windows::Win32::System::WinRT::*;
+        let hey = HSTRING::from("Hey");
+        let world = HSTRING::from("World");
+        assert_eq!(WindowsCompareStringOrdinal(&hey, &world)?, -1);
+        assert_eq!(WindowsCompareStringOrdinal("Hey", "World")?, -1);
+
+        assert_eq!(WindowsConcatString(&hey, &world)?, "HeyWorld");
+        assert_eq!(WindowsConcatString("Hey", "World")?, "HeyWorld");
+
+        assert_eq!(WindowsCreateString(hey.as_wide())?, "Hey");
+
+        assert_eq!(WindowsDuplicateString(&hey)?, "Hey");
+        assert_eq!(WindowsDuplicateString("Hey")?, "Hey");
+
+        assert_eq!(WindowsGetStringLen(&hey), 3);
+        assert_eq!(WindowsGetStringLen("Hey"), 3);
+        assert_eq!(WindowsGetStringLen(&world), 5);
+        assert_eq!(WindowsGetStringLen("World"), 5);
+
+        assert_eq!(WindowsIsStringEmpty(""), true);
+        assert_eq!(WindowsIsStringEmpty(&world), false);
+        assert_eq!(WindowsIsStringEmpty("World"), false);
+
+        let mut len = 0;
+        let buffer = WindowsGetStringRawBuffer(&world, &mut len);
+        assert_eq!(std::slice::from_raw_parts(buffer.0, len as _), world.as_wide());
+
+        // We need to drop to windows-sys to call the raw WindowsDeleteString function to double-freeing the HSTRING,
+        // but this test is important as it ensures that the allocators match.
+        let hresult = windows_sys::Win32::System::WinRT::WindowsDeleteString(std::mem::transmute_copy(&*std::mem::ManuallyDrop::new(hey)));
+        assert_eq!(hresult, 0);
+
+        Ok(())
+    }
 }

--- a/crates/tests/core/tests/hstrings.rs
+++ b/crates/tests/core/tests/hstrings.rs
@@ -7,19 +7,19 @@ fn hstring_works() {
     assert!(empty.is_empty());
     assert!(empty.is_empty());
 
-    let mut hey = HSTRING::from("Hello");
-    assert!(!hey.is_empty());
-    assert!(hey.len() == 5);
+    let mut hello = HSTRING::from("Hello");
+    assert!(!hello.is_empty());
+    assert!(hello.len() == 5);
 
-    let rust = hey.to_string();
+    let rust = hello.to_string();
     assert!(rust == "Hello");
     assert!(rust.len() == 5);
 
-    let hello2 = hey.clone();
-    hey.clear();
-    assert!(hey.is_empty());
-    hey.clear();
-    assert!(hey.is_empty());
+    let hello2 = hello.clone();
+    hello.clear();
+    assert!(hello.is_empty());
+    hello.clear();
+    assert!(hello.is_empty());
     assert!(!hello2.is_empty());
     assert!(hello2.len() == 5);
 
@@ -183,7 +183,7 @@ fn hstring_compat() -> Result<()> {
         let buffer = WindowsGetStringRawBuffer(&world, &mut len);
         assert_eq!(std::slice::from_raw_parts(buffer.0, len as _), world.as_wide());
 
-        // We need to drop to windows-sys to call the raw WindowsDeleteString function to double-freeing the HSTRING,
+        // We need to drop to windows-sys to call the raw WindowsDeleteString function to avoid double-freeing the HSTRING,
         // but this test is important as it ensures that the allocators match.
         let hresult = windows_sys::Win32::System::WinRT::WindowsDeleteString(std::mem::transmute_copy(&*std::mem::ManuallyDrop::new(hey)));
         assert_eq!(hresult, 0);

--- a/crates/tests/nightly_component/src/bindings.rs
+++ b/crates/tests/nightly_component/src/bindings.rs
@@ -115,7 +115,7 @@ impl ::windows::core::RuntimeName for IClass {
 }
 impl IClass_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>() -> IClass_Vtbl {
-        unsafe extern "system" fn Property<Identity: ::windows::core::IUnknownImpl, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT {
+        unsafe extern "system" fn Property<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IClass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, result__: *mut i32) -> ::windows::core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             match this.Property() {


### PR DESCRIPTION
In support of #1747, here are some tests to ensure we preserve `HSTRING` compatibility with the OS. Call me paranoid. 😨 